### PR TITLE
"Failuer" -> "Failure"

### DIFF
--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -58,7 +58,7 @@ const version = "0.33.0"
 
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func main() {
@@ -102,7 +102,7 @@ func showSupportAppletAndExitFailure(userInputCmdName string) {
 	fmt.Fprintf(os.Stderr, "%s is not provided by mimixbox.\n\n", userInputCmdName)
 	fmt.Fprintln(os.Stderr, "[Commands supported by MimixBox]")
 	applets.ShowAppletsBySpaceSeparated()
-	osExit(ExitFailuer)
+	osExit(ExitFailure)
 }
 
 // If the mimixbox option exists, execute the processing for the option and exit.
@@ -125,12 +125,12 @@ func handleMimixBoxOptionsIfNeeded(parser *flags.Parser, opts *options) {
 	// Only mimixbox. no option and no argument.
 	if len(os.Args) == 1 {
 		showHelp(parser)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	args, err := parser.Parse()
 	if err != nil {
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	if len(args) == 0 && opts.Version {
@@ -146,7 +146,7 @@ func handleMimixBoxOptionsIfNeeded(parser *flags.Parser, opts *options) {
 	if len(args) == 1 && opts.Install {
 		if err = minimumInstall(mimixBoxPath, args[0]); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			osExit(ExitFailuer)
+			osExit(ExitFailure)
 		}
 		osExit(ExitSuccess)
 	}
@@ -154,7 +154,7 @@ func handleMimixBoxOptionsIfNeeded(parser *flags.Parser, opts *options) {
 	if len(args) == 1 && opts.Remove {
 		if err = remove(args[0]); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			osExit(ExitFailuer)
+			osExit(ExitFailure)
 		}
 		osExit(ExitSuccess)
 	}
@@ -162,14 +162,14 @@ func handleMimixBoxOptionsIfNeeded(parser *flags.Parser, opts *options) {
 	if len(args) == 1 && opts.FullInstall {
 		if err = fullInstall(mimixBoxPath, args[0]); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			osExit(ExitFailuer)
+			osExit(ExitFailure)
 		}
 		osExit(ExitSuccess)
 	}
 
 	if len(args) == 0 && (opts.FullInstall || opts.Install || opts.Remove) {
 		showHelp(parser)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 }
 

--- a/internal/applets/archival/gzip/gzip.go
+++ b/internal/applets/archival/gzip/gzip.go
@@ -38,7 +38,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -53,7 +53,7 @@ func Run() (int, error) {
 	var args []string
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return __gzip(args, opts)
 }
@@ -69,13 +69,13 @@ func __gzip(args []string, opts options) (int, error) {
 
 		if !mb.Exists(path) {
 			fmt.Fprintln(os.Stderr, cmdName+": No such file or directory")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 
 		if mb.IsDir(path) {
 			fmt.Fprintln(os.Stderr, cmdName+": "+v+" is a directory -- ignored")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 
@@ -83,13 +83,13 @@ func __gzip(args []string, opts options) (int, error) {
 			err := decompress(path, opts)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, cmdName+": "+err.Error())
-				status = ExitFailuer
+				status = ExitFailure
 			}
 		} else {
 			err := compress(path, opts)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, cmdName+": "+err.Error())
-				status = ExitFailuer
+				status = ExitFailure
 			}
 		}
 	}
@@ -194,7 +194,7 @@ func parseArgs(opts *options) ([]string, error) {
 	}
 	if !isValidArgNr(args) {
 		fmt.Fprintln(os.Stderr, cmdName+": compressed data not written to a terminal")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/console-tools/clear/clear.go
+++ b/internal/applets/console-tools/clear/clear.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -46,7 +46,7 @@ func Run() (int, error) {
 	var err error
 
 	if _, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return clear()
 }

--- a/internal/applets/console-tools/reset/reset.go
+++ b/internal/applets/console-tools/reset/reset.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -48,7 +48,7 @@ func Run() (int, error) {
 	var err error
 
 	if _, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return reset()
 }

--- a/internal/applets/debianutils/add-shell/add-shell.go
+++ b/internal/applets/debianutils/add-shell/add-shell.go
@@ -37,7 +37,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -46,7 +46,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	return addShell(args)
@@ -57,11 +57,11 @@ func addShell(args []string) (int, error) {
 	// add-shell can also write the names of non-existent shells in /etc/shells.
 	err := mb.Copy(mb.ShellsFilePath, mb.TmpShellsFile())
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	f, err := os.OpenFile(mb.TmpShellsFile(), os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	defer f.Close()
 
@@ -72,7 +72,7 @@ func addShell(args []string) (int, error) {
 	err = mb.Copy(mb.TmpShellsFile(), mb.ShellsFilePath)
 	if err != nil {
 		mb.RemoveFile(mb.TmpShellsFile(), false) // Original add-shell does not remove tmp file.
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	mb.RemoveFile(mb.TmpShellsFile(), false)
@@ -94,7 +94,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		fmt.Fprintln(os.Stderr, cmdName+": shellname [shellname ...]")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/debianutils/ischroot/ischroot.go
+++ b/internal/applets/debianutils/ischroot/ischroot.go
@@ -40,7 +40,7 @@ type options struct {
 // Exit code
 const (
 	Jail    int = iota // 0
-	NotJail            // NotJail = ExitFailuer
+	NotJail            // NotJail = ExitFailure
 	NotSuperUser
 )
 

--- a/internal/applets/debianutils/remove-shell/remove-shell.go
+++ b/internal/applets/debianutils/remove-shell/remove-shell.go
@@ -37,7 +37,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -46,7 +46,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return removeShell(args)
 }
@@ -54,13 +54,13 @@ func Run() (int, error) {
 func removeShell(args []string) (int, error) {
 	f, err := os.OpenFile(mb.TmpShellsFile(), os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	defer f.Close()
 
 	lines, err := mb.ReadFileToStrList(mb.ShellsFilePath)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	lines = mb.ChopAll(lines)
@@ -74,7 +74,7 @@ func removeShell(args []string) (int, error) {
 	err = mb.Copy(mb.TmpShellsFile(), mb.ShellsFilePath)
 	if err != nil {
 		mb.RemoveFile(mb.TmpShellsFile(), false)
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	mb.RemoveFile(mb.TmpShellsFile(), false)
@@ -96,7 +96,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		fmt.Fprintln(os.Stderr, cmdName+": shellname [shellname ...]")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/debianutils/valid-shell/valid-shell.go
+++ b/internal/applets/debianutils/valid-shell/valid-shell.go
@@ -41,7 +41,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -49,7 +49,7 @@ func Run() (int, error) {
 	var err error
 
 	if _, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	return validShell(opts)
@@ -67,7 +67,7 @@ func validShell(opts options) (int, error) {
 func printShellsFile() (int, error) {
 	lines, err := mb.ReadFileToStrList(mb.ShellsFilePath)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	for _, v := range lines {
 		fmt.Fprintf(os.Stdout, "%s", v)
@@ -78,13 +78,13 @@ func printShellsFile() (int, error) {
 func fix() (int, error) {
 	f, err := os.OpenFile(mb.TmpShellsFile(), os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	defer f.Close()
 
 	lines, err := mb.ReadFileToStrList(mb.ShellsFilePath)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	lines = mb.ChopAll(lines)
@@ -104,7 +104,7 @@ func fix() (int, error) {
 	err = mb.Copy(mb.TmpShellsFile(), mb.ShellsFilePath)
 	if err != nil {
 		mb.RemoveFile(mb.TmpShellsFile(), false)
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	mb.RemoveFile(mb.TmpShellsFile(), false)
 
@@ -114,7 +114,7 @@ func fix() (int, error) {
 func valid() (int, error) {
 	lines, err := mb.ReadFileToStrList(mb.ShellsFilePath)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	lines = mb.ChopAll(lines)

--- a/internal/applets/debianutils/which/which.go
+++ b/internal/applets/debianutils/which/which.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -47,7 +47,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	status := ExitSuccess
@@ -56,11 +56,11 @@ func Run() (int, error) {
 		if err != nil {
 			e, ok := err.(*exec.Error)
 			if ok && e.Err == exec.ErrNotFound {
-				status = ExitFailuer
+				status = ExitFailure
 				continue // Don't print error like coreutils.
 			}
 			fmt.Fprintln(os.Stderr, e)
-			status = ExitFailuer
+			status = ExitFailure
 		}
 		fmt.Fprintln(os.Stdout, p)
 	}
@@ -81,7 +81,7 @@ func parseArgs(opts *options) ([]string, error) {
 	}
 
 	if !isValidArgNr(args) {
-		osExit(ExitFailuer) // Do not display help messages because it behaves the same as Coreutils
+		osExit(ExitFailure) // Do not display help messages because it behaves the same as Coreutils
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/chgrp/chgrp.go
+++ b/internal/applets/fileutils/chgrp/chgrp.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type groupInfo struct {
@@ -55,7 +55,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	groupInfo := groupInfo{args[0], args[1:]}
@@ -65,7 +65,7 @@ func Run() (int, error) {
 func chgrp(gInfo groupInfo, opts options) (int, error) {
 	gid, err := mb.LookupGid(gInfo.group)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	status := ExitSuccess
@@ -73,13 +73,13 @@ func chgrp(gInfo groupInfo, opts options) (int, error) {
 		path = os.ExpandEnv(path)
 		if opts.Recursive {
 			if err := changeGroupRecursive(path, gid); err != nil {
-				status = ExitFailuer
+				status = ExitFailure
 				fmt.Fprintln(os.Stderr, cmdName+": "+path+": "+err.Error())
 				continue
 			}
 		} else {
 			if err := changeGroup(path, gid); err != nil {
-				status = ExitFailuer
+				status = ExitFailure
 				fmt.Fprintln(os.Stderr, cmdName+": "+path+": "+err.Error())
 				continue
 			}
@@ -129,7 +129,7 @@ func parseArgs(opts *options) ([]string, error) {
 		} else if len(args) == 1 {
 			fmt.Fprintln(os.Stderr, cmdName+": no operand after "+args[0])
 		}
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/chown/chown.go
+++ b/internal/applets/fileutils/chown/chown.go
@@ -37,7 +37,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type idInfo struct {
@@ -56,7 +56,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	return chown(ids(args[0]), args[1:], opts)
@@ -78,14 +78,14 @@ func ids(ids string) idInfo {
 func chown(ids idInfo, files []string, opts options) (int, error) {
 	owner, err := mb.LookupUid(ids.owner)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	var gid int = -1
 	if ids.group != "" {
 		gid, err = mb.LookupGid(ids.group)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 	}
 
@@ -96,7 +96,7 @@ func chown(ids idInfo, files []string, opts options) (int, error) {
 		if ids.group == "" {
 			var st syscall.Stat_t
 			if err := syscall.Stat(path, &st); err != nil {
-				status = ExitFailuer
+				status = ExitFailure
 				fmt.Fprintln(os.Stderr, cmdName+": "+path+": "+err.Error())
 				continue
 			}
@@ -105,13 +105,13 @@ func chown(ids idInfo, files []string, opts options) (int, error) {
 
 		if opts.Recursive {
 			if err := changeOwnerRecursive(path, owner, gid); err != nil {
-				status = ExitFailuer
+				status = ExitFailure
 				fmt.Fprintln(os.Stderr, cmdName+": "+path+": "+err.Error())
 				continue
 			}
 		} else {
 			if err := os.Chown(path, owner, gid); err != nil {
-				status = ExitFailuer
+				status = ExitFailure
 				fmt.Fprintln(os.Stderr, cmdName+": "+path+": "+err.Error())
 				continue
 			}
@@ -152,7 +152,7 @@ func parseArgs(opts *options) ([]string, error) {
 		} else if len(args) == 1 {
 			fmt.Fprintln(os.Stderr, cmdName+": no operand after "+args[0])
 		}
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/cp/cp.go
+++ b/internal/applets/fileutils/cp/cp.go
@@ -38,7 +38,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -54,12 +54,12 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	err = cp(args, opts)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return ExitSuccess, nil
@@ -178,7 +178,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/ln/ln.go
+++ b/internal/applets/fileutils/ln/ln.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -49,12 +49,12 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	err = ln(args, opts)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return ExitSuccess, nil
@@ -126,7 +126,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/mkdir/mkdir.go
+++ b/internal/applets/fileutils/mkdir/mkdir.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 var ErrNoOperand = errors.New("no operand")
@@ -51,9 +51,9 @@ func Run() (int, error) {
 
 	if args, err = parseArgs(&opts); err != nil {
 		if err == ErrNoOperand {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	status := ExitSuccess
@@ -66,7 +66,7 @@ func Run() (int, error) {
 		}
 
 		if err != nil {
-			status = ExitFailuer
+			status = ExitFailure
 			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	}

--- a/internal/applets/fileutils/mkfifo/mkfifo.go
+++ b/internal/applets/fileutils/mkfifo/mkfifo.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -49,18 +49,18 @@ func Run() (int, error) {
 	status := ExitSuccess
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	for _, path := range args {
 		p := os.ExpandEnv(path)
 		if mb.Exists(p) {
-			status = ExitFailuer
+			status = ExitFailure
 			fmt.Fprintln(os.Stderr, cmdName+": can't make "+p+": already exist")
 			continue
 		}
 		if err := syscall.Mkfifo(p, 0644); err != nil {
-			status = ExitFailuer
+			status = ExitFailure
 			fmt.Fprintln(os.Stderr, cmdName+": "+p+": "+err.Error())
 			continue
 		}
@@ -83,7 +83,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/mv/mv.go
+++ b/internal/applets/fileutils/mv/mv.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -53,21 +53,21 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	srcPaths, err := getSrcAbsPaths(args)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	destPath, err := getDestAbsPath(args)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	if err := validArgs(srcPaths, destPath, opts); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return move(srcPaths, destPath, opts)
@@ -97,21 +97,21 @@ func move(srcPaths []string, dest string, opts options) (int, error) {
 	for _, src := range srcPaths {
 		if !mb.Exists(src) {
 			fmt.Fprintln(os.Stderr, cmdName+": "+src+" doesn't exist")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 
 		// If SRC and DEST are the same, the option(-f, -b, -i) is ignored.
 		if isSameFilePath(src, dest) {
 			fmt.Fprintln(os.Stderr, cmdName+": source '"+src+"' and destination '"+dest+"' is same")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 
 		if opts.NoClobber {
 			if err := noclobberMove(src, dest); err != nil {
 				fmt.Fprintln(os.Stderr, cmdName+": "+err.Error())
-				status = ExitFailuer
+				status = ExitFailure
 			}
 			continue
 		}
@@ -119,7 +119,7 @@ func move(srcPaths []string, dest string, opts options) (int, error) {
 		if opts.Force || (opts.Backup && opts.Interactive) {
 			if err := forceMove(src, dest, opts); err != nil {
 				fmt.Fprintln(os.Stderr, cmdName+": "+err.Error())
-				status = ExitFailuer
+				status = ExitFailure
 			}
 			continue
 		}
@@ -127,7 +127,7 @@ func move(srcPaths []string, dest string, opts options) (int, error) {
 		if opts.Interactive {
 			if err := interactiveMove(src, dest, opts); err != nil {
 				fmt.Fprintln(os.Stderr, cmdName+": "+err.Error())
-				status = ExitFailuer
+				status = ExitFailure
 			}
 			continue
 		}
@@ -135,7 +135,7 @@ func move(srcPaths []string, dest string, opts options) (int, error) {
 		destPath := decideDestAbsPath(src, dest, opts)
 		if err := os.Rename(src, destPath); err != nil {
 			fmt.Fprintln(os.Stderr, cmdName+": "+err.Error())
-			status = ExitFailuer
+			status = ExitFailure
 		}
 	}
 	return status, nil
@@ -270,7 +270,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/rm/rm.go
+++ b/internal/applets/fileutils/rm/rm.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -54,7 +54,7 @@ func Run() (int, error) {
 	status := ExitSuccess
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	for _, path := range args {
@@ -75,12 +75,12 @@ func rm(path string, opts options) (int, error) {
 
 	if mb.IsFile(p) {
 		if err := mb.RemoveFile(p, opts.Interactive); err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 	}
 
 	if err := mb.RemoveDir(p, opts.Interactive); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return ExitSuccess, nil
@@ -88,18 +88,18 @@ func rm(path string, opts options) (int, error) {
 
 func validBeforeRemove(path string, opts options) (int, error) {
 	if mb.IsRootDir(path) && !opts.NoPreserve {
-		return ExitFailuer, errors.New("do not remove the root directory")
+		return ExitFailure, errors.New("do not remove the root directory")
 	}
 
 	if !mb.Exists(path) {
 		if !opts.Force {
-			return ExitFailuer, errors.New("can't remove " + path + ": No such file or directory exists")
+			return ExitFailure, errors.New("can't remove " + path + ": No such file or directory exists")
 		}
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.IsDir(path) && !opts.Recursive {
-		return ExitFailuer, errors.New("can't remove " + path + ": It's directory")
+		return ExitFailure, errors.New("can't remove " + path + ": It's directory")
 	}
 
 	return ExitSuccess, nil
@@ -129,7 +129,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/rmdir/rmdir.go
+++ b/internal/applets/fileutils/rmdir/rmdir.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -52,7 +52,7 @@ func Run() (int, error) {
 	var status int
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	// Coremb will continue to delete files as much as possible.
@@ -68,7 +68,7 @@ func Run() (int, error) {
 func rmdir(path string, opts options) (int, error) {
 	p := os.ExpandEnv(path)
 	if err := validBeforeRemove(p); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	var target string
@@ -80,18 +80,18 @@ func rmdir(path string, opts options) (int, error) {
 
 	_, files, err := mb.Walk(target, false)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	if len(files) != 0 {
 		if opts.Ignore {
 			return ExitSuccess, nil
 		}
-		return ExitFailuer, errors.New("Can't remove " + path + ": It's not empty directory")
+		return ExitFailure, errors.New("Can't remove " + path + ": It's not empty directory")
 	}
 
 	// The contents of the directory are empty. Delete directories at once
 	if err := os.RemoveAll(target); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	return ExitSuccess, nil
 }
@@ -128,7 +128,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/fileutils/touch/touch.go
+++ b/internal/applets/fileutils/touch/touch.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -49,14 +49,14 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	status := ExitSuccess
 	for _, file := range args {
 		if err = touch(file, opts); err != nil {
 			fmt.Fprintln(os.Stderr, "touch: "+err.Error())
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 	}
@@ -99,7 +99,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/games/lifegame/lifegame.go
+++ b/internal/applets/games/lifegame/lifegame.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -70,14 +70,14 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return lifegame(args, opts)
 }
 
 func lifegame(args []string, opts options) (int, error) {
 	if err := termbox.Init(); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	defer termbox.Close()
 

--- a/internal/applets/jokeutils/cowsay/cowsay.go
+++ b/internal/applets/jokeutils/cowsay/cowsay.go
@@ -40,14 +40,14 @@ const cow = `   \
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
 	var messages string
 	args, err := parseArgs(os.Args)
 	if err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() {

--- a/internal/applets/jokeutils/fakemovie/fakemovie.go
+++ b/internal/applets/jokeutils/fakemovie/fakemovie.go
@@ -86,7 +86,7 @@ const version = "1.0.4"
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -105,12 +105,12 @@ func Run() (int, error) {
 
 	if !isValidExt(inputFileName) {
 		err := errors.New("fakemovie command only support jpg or png")
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	img, err := openImage(inputFileName)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	if radius <= 0 {
@@ -128,7 +128,7 @@ func Run() (int, error) {
 	}
 	err = writeImage(img, outputFileName)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return ExitSuccess, nil
@@ -255,7 +255,7 @@ func parseArgs(opts *options) []string {
 
 	args, err := p.Parse()
 	if err != nil {
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	if opts.Version {
@@ -265,7 +265,7 @@ func parseArgs(opts *options) []string {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args
 }

--- a/internal/applets/jokeutils/sl/sl.go
+++ b/internal/applets/jokeutils/sl/sl.go
@@ -41,7 +41,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 var slAA = [][][]string{
@@ -118,7 +118,7 @@ func Run() (int, error) {
 
 	_, err := parseArgs(&opts)
 	if err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return sl()
 }
@@ -126,11 +126,11 @@ func Run() (int, error) {
 func sl() (int, error) {
 	width, _, err := term.GetSize(0)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	if width < 80 {
-		return ExitFailuer, errors.New("terminal width is too small")
+		return ExitFailure, errors.New("terminal width is too small")
 	}
 	for _, ll := range slAA {
 		for _, l := range ll {

--- a/internal/applets/loginutils/chsh/chsh.go
+++ b/internal/applets/loginutils/chsh/chsh.go
@@ -40,7 +40,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -53,7 +53,7 @@ func Run() (int, error) {
 	var args []string
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return chsh(args, opts)
 }
@@ -72,10 +72,10 @@ func interactiveChangeShell(opts options) (int, error) {
 	/*
 		user, err := user.Current()
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 			if err = mb.AuthByPasswordWithPam(user.Username); err != nil {
-				return ExitFailuer, err
+				return ExitFailure, err
 			}
 	*/
 	return ExitSuccess, nil

--- a/internal/applets/pmutils/halt/halt.go
+++ b/internal/applets/pmutils/halt/halt.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type haltOpts struct {
@@ -64,7 +64,7 @@ func Run() (int, error) {
 
 	setCmdName(os.Args[0])
 	if args, err = parseArgs(&allOpts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	switch cmdName {
@@ -75,7 +75,7 @@ func Run() (int, error) {
 	case "reboot":
 		return reboot(args, allOpts.reboot)
 	}
-	return ExitFailuer, errors.New("mimixbox failed to parse the argument (not halt, poweroff, reboot error)")
+	return ExitFailure, errors.New("mimixbox failed to parse the argument (not halt, poweroff, reboot error)")
 }
 
 func halt(args []string, opts haltOpts) (int, error) {
@@ -83,21 +83,21 @@ func halt(args []string, opts haltOpts) (int, error) {
 
 	recordWtmp()
 	if err := powerOffSystem(); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	return ExitSuccess, nil
 }
 
 func poweroff(args []string, opts poweroffOpts) (int, error) {
 	if err := powerOffSystem(); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	return ExitSuccess, nil
 }
 
 func reboot(args []string, opts rebootOpts) (int, error) {
 	if err := rebootSystem(); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	return ExitSuccess, nil
 }

--- a/internal/applets/shellutils/base64/base64.go
+++ b/internal/applets/shellutils/base64/base64.go
@@ -39,7 +39,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -56,17 +56,17 @@ func Run() (int, error) {
 	var resultByte []byte
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	input, err := inputByte(args)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	if opts.Decode {
 		resultByte, err = base64.StdEncoding.DecodeString(string(input))
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		fmt.Fprintln(os.Stdout, mb.WrapString(string(resultByte), opts.Wrap))
 	} else {
@@ -133,7 +133,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	if opts.Wrap < 0 {

--- a/internal/applets/shellutils/basename/basename.go
+++ b/internal/applets/shellutils/basename/basename.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -51,7 +51,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	for _, path := range args {
@@ -94,7 +94,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		fmt.Fprintln(os.Stderr, "basename: no operand")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/shellutils/chroot/chroot.go
+++ b/internal/applets/shellutils/chroot/chroot.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type command struct {
@@ -56,13 +56,13 @@ func Run() (int, error) {
 
 	err = syscall.Chroot(os.ExpandEnv(os.Args[1]))
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	//----------------From here, in the prison-------------------
 	err = os.Chdir("/")
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	decideExecCommand(&cmd)
@@ -73,7 +73,7 @@ func Run() (int, error) {
 
 	err = syscall.Exec(cmd.name, cmd.withOption, cmd.env)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	return ExitSuccess, nil
 }
@@ -114,7 +114,7 @@ func parseArgs(opts *options) {
 	}
 	if !isValidArgNr(os.Args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 }
 

--- a/internal/applets/shellutils/dirname/dirname.go
+++ b/internal/applets/shellutils/dirname/dirname.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -48,7 +48,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	return dirname(args, opts)
@@ -82,7 +82,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		fmt.Fprintln(os.Stderr, "dirname: no operand")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/shellutils/echo/echo.go
+++ b/internal/applets/shellutils/echo/echo.go
@@ -37,7 +37,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -47,7 +47,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if len(args) == 0 {

--- a/internal/applets/shellutils/false/false.go
+++ b/internal/applets/shellutils/false/false.go
@@ -35,7 +35,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -43,9 +43,9 @@ func Run() (int, error) {
 	var err error
 
 	if _, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
-	return ExitFailuer, nil
+	return ExitFailure, nil
 }
 
 func parseArgs(opts *options) ([]string, error) {

--- a/internal/applets/shellutils/ghrdc/ghrdc.go
+++ b/internal/applets/shellutils/ghrdc/ghrdc.go
@@ -38,7 +38,7 @@ const version = "1.0.2"
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -129,7 +129,7 @@ func Run() (int, error) {
 	var repository string = args[0]
 	data, err := fetchGitHubReleaseData(repository)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	if len(data) == 0 {
 		// Because the ghrdc command does not authenticate with GitHub API,
@@ -139,7 +139,7 @@ func Run() (int, error) {
 		// URL: https://github.com/google/go-github
 		err := fmt.Errorf("Release Data is nothing. If %s is organization repository,\n"+
 			"gdrdc commant can't get release data.\n", repository)
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	var totalSrcCnt int = 0
@@ -233,7 +233,7 @@ func parseArgs(opts *options) []string {
 
 	args, err := p.Parse()
 	if err != nil {
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	if opts.Version {
@@ -243,7 +243,7 @@ func parseArgs(opts *options) []string {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args
 }

--- a/internal/applets/shellutils/groups/groups.go
+++ b/internal/applets/shellutils/groups/groups.go
@@ -37,7 +37,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -62,7 +62,7 @@ func groups(args []string) (int, error) {
 		groups, err := mb.Groups(uname)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "can't get "+uname+" groups information")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 		fmt.Fprint(os.Stdout, uname+" : ")
@@ -74,12 +74,12 @@ func groups(args []string) (int, error) {
 func showCurrentUserGroups() (int, error) {
 	u, err := user.Current()
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	groups, err := mb.Groups(u.Username)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	mb.DumpGroups(groups, true)
 	return ExitSuccess, nil

--- a/internal/applets/shellutils/hostid/hostid.go
+++ b/internal/applets/shellutils/hostid/hostid.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -54,7 +54,7 @@ func Run() (int, error) {
 func hostid() (int, error) {
 	ip4, err := mb.Ip4()
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	//TODO: The output doesn't match the Coreutils version of hostid command.

--- a/internal/applets/shellutils/id/id.go
+++ b/internal/applets/shellutils/id/id.go
@@ -43,7 +43,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -59,12 +59,12 @@ func Run() (int, error) {
 func id(opts options) (int, error) {
 	user, err := user.Current()
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	groups, err := mb.Groups(user.Username)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	if opts.Group {
@@ -78,7 +78,7 @@ func id(opts options) (int, error) {
 
 	err = dumpAllId(*user, groups)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	return ExitSuccess, nil
 }
@@ -87,7 +87,7 @@ func dumpGid(u user.User, showName bool) (int, error) {
 	if showName {
 		g, err := user.LookupGroup(u.Username)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		fmt.Fprintln(os.Stdout, g.Name)
 	} else {

--- a/internal/applets/shellutils/kill/kill.go
+++ b/internal/applets/shellutils/kill/kill.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -70,14 +70,14 @@ func kill(process []string, opts options) (int, error) {
 		pid, err := strconv.Atoi(v)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "kill: "+err.Error()+": "+v)
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 
 		p, err := os.FindProcess(pid)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "kill: "+err.Error()+": "+v)
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 
@@ -85,7 +85,7 @@ func kill(process []string, opts options) (int, error) {
 		err = p.Signal(syscall.Signal(signal))
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "kill: "+err.Error())
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 	}
@@ -116,21 +116,21 @@ func decideSignal(opts options) int32 {
 func valid(process []string, opts options) {
 	if len(process) == 0 && !opts.listFlg {
 		showHelp()
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	if opts.nameFlg && !mb.IsSignalName(opts.signalName) {
 		fmt.Fprintln(os.Stderr, "kill: -s: invalid signal specification:"+opts.signalName)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	if opts.numberFlg && !mb.IsSignalName(opts.signalNumber) {
 		fmt.Fprintln(os.Stderr, "kill: -n: invalid signal specification:"+opts.signalNumber)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	trim := strings.TrimLeft(opts.direct, "-")
 	if opts.directFlg && !mb.IsSignalName(trim) && !mb.IsSignalNumber(trim) {
 		fmt.Fprintln(os.Stderr, "kill: "+opts.direct+": invalid signal specification")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 }
 
@@ -154,7 +154,7 @@ func parseArgs(args []string) ([]string, options) {
 				opts.signalName = args[i+1]
 			} else {
 				fmt.Fprintln(os.Stderr, "kill: -s: option requires an argument")
-				osExit(ExitFailuer)
+				osExit(ExitFailure)
 			}
 			continue
 		} else if v == "-n" {
@@ -163,7 +163,7 @@ func parseArgs(args []string) ([]string, options) {
 				opts.signalNumber = args[i+1]
 			} else {
 				fmt.Fprintln(os.Stderr, "kill: -n: option requires an argument")
-				osExit(ExitFailuer)
+				osExit(ExitFailure)
 			}
 			continue
 		} else if v == "-l" {

--- a/internal/applets/shellutils/mbsh/mbsh.go
+++ b/internal/applets/shellutils/mbsh/mbsh.go
@@ -40,7 +40,7 @@ const version = "0.0.2"
 
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -95,7 +95,7 @@ func parseArgs() ([]string, options) {
 
 	args, err := p.Parse()
 	if err != nil {
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	if opts.Version {

--- a/internal/applets/shellutils/path/path.go
+++ b/internal/applets/shellutils/path/path.go
@@ -36,7 +36,7 @@ var errNotGetAbsPath = errors.New("can't get absolute path")
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -54,14 +54,14 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	path := args[0]
 
 	if opts.Abs {
 		abs, err := filepath.Abs(path)
 		if err != nil {
-			return ExitFailuer, errNotGetAbsPath
+			return ExitFailure, errNotGetAbsPath
 		}
 		fmt.Fprintf(os.Stdout, "%s\n", abs)
 	}
@@ -100,7 +100,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 	return args, nil
 }

--- a/internal/applets/shellutils/printenv/printenv.go
+++ b/internal/applets/shellutils/printenv/printenv.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -48,7 +48,7 @@ func Run() (int, error) {
 	var args []string
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return printenv(args, opts)
 }

--- a/internal/applets/shellutils/pwd/pwd.go
+++ b/internal/applets/shellutils/pwd/pwd.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -49,7 +49,7 @@ func Run() (int, error) {
 	var err error
 
 	if _, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return pwd(opts)
 }
@@ -64,7 +64,7 @@ func pwd(opts options) (int, error) {
 	} else if opts.Physical {
 		path, err := filepath.EvalSymlinks(os.Getenv("PWD"))
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		fmt.Fprintln(os.Stdout, path)
 	}

--- a/internal/applets/shellutils/sddf/sddf.go
+++ b/internal/applets/shellutils/sddf/sddf.go
@@ -47,7 +47,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -61,14 +61,14 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return sddfMainSeq(os.ExpandEnv(args[0]), opts)
 }
 
 func sddfMainSeq(path string, opts options) (int, error) {
 	if !mb.Exists(path) {
-		return ExitFailuer, errors.New(path + " does not exists")
+		return ExitFailure, errors.New(path + " does not exists")
 	}
 
 	if mb.IsFile(path) {
@@ -79,12 +79,12 @@ func sddfMainSeq(path string, opts options) (int, error) {
 
 func restoreAndDelete(path string) (int, error) {
 	if !strings.HasSuffix(path, ext) {
-		return ExitFailuer, errors.New(path + ": file format is not *.sddf")
+		return ExitFailure, errors.New(path + ": file format is not *.sddf")
 	}
 
 	df, err := restore(path)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return deleteFiles(df)
@@ -98,7 +98,7 @@ func deleteFiles(df map[string]Paths) (int, error) {
 	for _, v := range df {
 		list, err := decideDeleteTarget(v)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		deleteFileList = append(deleteFileList, list...)
 	}
@@ -108,15 +108,15 @@ func deleteFiles(df map[string]Paths) (int, error) {
 	for _, v := range deleteFileList {
 		size, err := mb.Size(v)
 		if err != nil {
-			status = ExitFailuer
-			fmt.Fprintln(os.Stdout, "Delete(Failuer): "+v)
+			status = ExitFailure
+			fmt.Fprintln(os.Stdout, "Delete(Failure): "+v)
 			continue
 		}
 
 		err = mb.RemoveFile(v, false)
 		if err != nil {
-			status = ExitFailuer
-			fmt.Fprintln(os.Stdout, "Delete(Failuer): "+v)
+			status = ExitFailure
+			fmt.Fprintln(os.Stdout, "Delete(Failure): "+v)
 		} else {
 			fmt.Fprintln(os.Stdout, "Delete(Success): "+v+": "+strconv.FormatInt(size, 10)+"Byte")
 		}
@@ -279,7 +279,7 @@ func dumpToFile(df map[string]Paths, output string) (int, error) {
 	fmt.Fprintln(os.Stdout, "Write down duplicated file list to "+output)
 	f, err := os.Create(output)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	defer f.Close()
 
@@ -299,7 +299,7 @@ func dumpToFile(df map[string]Paths, output string) (int, error) {
 	b := []byte(data)
 	_, err = f.Write(b)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	fmt.Fprintln(os.Stdout, "See duplicated file list: "+output)
@@ -394,7 +394,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArg(args, *opts) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	return args, nil

--- a/internal/applets/shellutils/seq/seq.go
+++ b/internal/applets/shellutils/seq/seq.go
@@ -44,7 +44,7 @@ type seqInfo struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 // Not support arguments containing float numbers
@@ -56,7 +56,7 @@ func Run() (int, error) {
 func seq(args []string) (int, error) {
 	si, err := parseSeqInfo(args)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	for i := si.first.num; i <= si.last.num; i = increment(i, si.increment) {

--- a/internal/applets/shellutils/serial/serial.go
+++ b/internal/applets/shellutils/serial/serial.go
@@ -39,7 +39,7 @@ const version = "1.0.2"
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -59,13 +59,13 @@ func Run() (int, error) {
 
 	if !mb.Exists(dirPath) {
 		err := fmt.Errorf("%s doesn't exist.", dirPath)
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	var files = getFilePathsInDir(dirPath)
 	if len(files) == 0 {
 		err := fmt.Errorf("No files in %s directory.", dirPath)
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	newFileNames := newNames(opts, files)
@@ -127,13 +127,13 @@ func copy(newFileNames map[string]string, dryRun bool) {
 		if mb.Exists(dest) {
 			if err := os.Remove(dest); err != nil {
 				fmt.Fprintf(os.Stderr, "Can't copy %s to %s\n", org, dest)
-				osExit(ExitFailuer)
+				osExit(ExitFailure)
 			}
 		}
 
 		if err := os.Link(org, dest); err != nil {
 			fmt.Fprintf(os.Stderr, "Can't copy %s to %s\n", org, dest)
-			osExit(ExitFailuer)
+			osExit(ExitFailure)
 		}
 	}
 }
@@ -143,7 +143,7 @@ func parseArgs(opts *options) []string {
 
 	args, err := p.Parse()
 	if err != nil {
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	if opts.Version {
@@ -153,12 +153,12 @@ func parseArgs(opts *options) []string {
 
 	if len(opts.Name) != 0 && !existFilenameInPath(opts.Name) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	if !isValidArgNr(args) {
 		showHelp(p)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	return args
@@ -191,7 +191,7 @@ func getFilePathsInDir(dir string) []string {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't get file list.")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	var path string
@@ -260,7 +260,7 @@ func dieIfExistSameNameFile(force bool, fileNames map[string]string) {
 			fmt.Fprintf(os.Stderr, "%s (file name which is after renaming) is already exists.\n", file)
 			fmt.Fprintf(os.Stderr, "Renaming may erase the contents of the file. ")
 			fmt.Fprintf(os.Stderr, "So, nothing to do.\n")
-			osExit(ExitFailuer)
+			osExit(ExitFailure)
 		}
 	}
 }
@@ -274,6 +274,6 @@ func makeDirIfNeeded(filePath string) {
 
 	if err := os.MkdirAll(dirPath, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "Can't make %s directory\n", dirPath)
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 }

--- a/internal/applets/shellutils/sleep/sleep.go
+++ b/internal/applets/shellutils/sleep/sleep.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type duration struct {
@@ -51,7 +51,7 @@ func Run() (int, error) {
 	args = parseArgs(os.Args)
 
 	if waitTime, err = getWaitTime(args); err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	for _, d := range waitTime {

--- a/internal/applets/shellutils/sync/sync.go
+++ b/internal/applets/shellutils/sync/sync.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -46,7 +46,7 @@ func Run() (int, error) {
 	var err error
 
 	if _, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return sync()
 }

--- a/internal/applets/shellutils/true/true.go
+++ b/internal/applets/shellutils/true/true.go
@@ -35,7 +35,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {

--- a/internal/applets/shellutils/uuidgen/uuidgen.go
+++ b/internal/applets/shellutils/uuidgen/uuidgen.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -46,7 +46,7 @@ func Run() (int, error) {
 	var err error
 
 	if _, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return uuidgen()
 }
@@ -88,14 +88,14 @@ func initParser(opts *options) *flags.Parser {
 func uuidgen() (int, error) {
 	fp, err := os.Open("/proc/sys/kernel/random/uuid")
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	defer fp.Close()
 
 	reader := bufio.NewReaderSize(fp, 38) // UUID's format sample: 333f899e-5dbf-41ec-8c42-e3b3ddbe2e68
 	line, _, err := reader.ReadLine()
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	fmt.Fprintln(os.Stdout, string(line))

--- a/internal/applets/shellutils/wget/wget.go
+++ b/internal/applets/shellutils/wget/wget.go
@@ -42,7 +42,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -51,7 +51,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 	return wget(args)
 }
@@ -62,7 +62,7 @@ func wget(args []string) (int, error) {
 		target, err := openTargetFile(v)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, cmdName+": "+err.Error()+": v")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 		defer target.Close()
@@ -71,7 +71,7 @@ func wget(args []string) (int, error) {
 		response, err := client.Get(v)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, cmdName+": "+err.Error()+": v")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 		defer response.Body.Close()
@@ -79,7 +79,7 @@ func wget(args []string) (int, error) {
 		_, err = io.Copy(target, response.Body)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, cmdName+": "+err.Error()+": v")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 	}
@@ -137,7 +137,7 @@ func parseArgs(opts *options) ([]string, error) {
 
 	if !isValidArgNr(args) {
 		fmt.Fprintln(os.Stderr, "wget: missing URL")
-		osExit(ExitFailuer)
+		osExit(ExitFailure)
 	}
 
 	return args, nil

--- a/internal/applets/shellutils/whoami/whoami.go
+++ b/internal/applets/shellutils/whoami/whoami.go
@@ -37,7 +37,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -53,7 +53,7 @@ func Run() (int, error) {
 func whoami() (int, error) {
 	user, err := user.Current()
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 	fmt.Fprintln(os.Stdout, user.Username)
 	return ExitSuccess, nil

--- a/internal/applets/textutils/cat/cat.go
+++ b/internal/applets/textutils/cat/cat.go
@@ -33,7 +33,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -47,7 +47,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
@@ -66,7 +66,7 @@ func Run() (int, error) {
 
 	strLisr, err := mb.Concatenate(args)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	mb.Dump(strLisr, opts.Number)

--- a/internal/applets/textutils/dos2unix/dos2unix.go
+++ b/internal/applets/textutils/dos2unix/dos2unix.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 	ExitNoSuchFile
 )
 
@@ -48,7 +48,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
@@ -77,14 +77,14 @@ func dos2unix(files []string) (int, error) {
 		lines, err := mb.ReadFileToStrList(target)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, cmdName+": "+target+": can't read file and convert CRLF to LF")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 		fmt.Fprintln(os.Stdout, cmdName+": converting file "+target+" to Unix format...")
 		lines = toLF(lines)
 		if err := mb.ListToFile(target, lines); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 	}

--- a/internal/applets/textutils/expand/expand.go
+++ b/internal/applets/textutils/expand/expand.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -69,13 +69,13 @@ func expand(args []string, opts options) (int, error) {
 		target := os.ExpandEnv(file)
 		if !mb.IsFile(target) {
 			fmt.Fprintln(os.Stderr, target+": No such file. Skip it")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 		lines, err := mb.ReadFileToStrList(target)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 

--- a/internal/applets/textutils/head/head.go
+++ b/internal/applets/textutils/head/head.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -48,7 +48,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if len(args) == 0 || mb.Contains(args, "-") {
@@ -58,7 +58,7 @@ func Run() (int, error) {
 
 	err = head(args, opts)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return ExitSuccess, nil

--- a/internal/applets/textutils/md5sum/md5sum.go
+++ b/internal/applets/textutils/md5sum/md5sum.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -50,13 +50,13 @@ func Run() (int, error) {
 	hash := md5.New()
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
 		err = mb.ChecksumOutput(hash, strings.NewReader(args[0]), "-")
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}
@@ -72,7 +72,7 @@ func Run() (int, error) {
 	if opts.Check {
 		err = mb.CompareChecksum(hash, args)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}

--- a/internal/applets/textutils/nl/nl.go
+++ b/internal/applets/textutils/nl/nl.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -47,7 +47,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
@@ -80,7 +80,7 @@ func Run() (int, error) {
 
 	lines, err := mb.Concatenate(args)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	if len(pipeData) >= 1 {

--- a/internal/applets/textutils/sha1sum/sha1sum.go
+++ b/internal/applets/textutils/sha1sum/sha1sum.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -50,13 +50,13 @@ func Run() (int, error) {
 	hash := sha1.New()
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
 		err = mb.ChecksumOutput(hash, strings.NewReader(args[0]), "-")
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}
@@ -72,7 +72,7 @@ func Run() (int, error) {
 	if opts.Check {
 		err = mb.CompareChecksum(hash, args)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}

--- a/internal/applets/textutils/sha256sum/sha256sum.go
+++ b/internal/applets/textutils/sha256sum/sha256sum.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -50,13 +50,13 @@ func Run() (int, error) {
 	hash := sha256.New()
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
 		err = mb.ChecksumOutput(hash, strings.NewReader(args[0]), "-")
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}
@@ -72,7 +72,7 @@ func Run() (int, error) {
 	if opts.Check {
 		err = mb.CompareChecksum(hash, args)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}

--- a/internal/applets/textutils/sha512sum/sha512sum.go
+++ b/internal/applets/textutils/sha512sum/sha512sum.go
@@ -35,7 +35,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -50,13 +50,13 @@ func Run() (int, error) {
 	hash := sha512.New()
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
 		err = mb.ChecksumOutput(hash, strings.NewReader(args[0]), "-")
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}
@@ -72,7 +72,7 @@ func Run() (int, error) {
 	if opts.Check {
 		err = mb.CompareChecksum(hash, args)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 		return ExitSuccess, nil
 	}

--- a/internal/applets/textutils/tac/tac.go
+++ b/internal/applets/textutils/tac/tac.go
@@ -36,7 +36,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -49,7 +49,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() {
@@ -66,7 +66,7 @@ func Run() (int, error) {
 		target := os.ExpandEnv(file)
 		err := tac(target)
 		if err != nil {
-			return ExitFailuer, err
+			return ExitFailure, err
 		}
 	}
 

--- a/internal/applets/textutils/tail/tail.go
+++ b/internal/applets/textutils/tail/tail.go
@@ -34,7 +34,7 @@ var osExit = os.Exit
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 type options struct {
@@ -48,7 +48,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if len(args) == 0 || mb.Contains(args, "-") {
@@ -58,7 +58,7 @@ func Run() (int, error) {
 
 	err = tail(args, opts)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	return ExitSuccess, nil

--- a/internal/applets/textutils/tr/tr.go
+++ b/internal/applets/textutils/tr/tr.go
@@ -44,7 +44,7 @@ type convert struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -69,7 +69,7 @@ func tr(args []string, opts options) (int, error) {
 func fileterTranslate(args []string, opts options) (int, error) {
 	cnv, err := parseConvertCharSet(args, opts)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	data := args[len(args)-1]
@@ -85,7 +85,7 @@ func fileterTranslate(args []string, opts options) (int, error) {
 func interactiveTranslate(args []string, opts options) (int, error) {
 	cnv, err := parseConvertCharSet(args, opts)
 	if err != nil {
-		return ExitFailuer, err
+		return ExitFailure, err
 	}
 
 	for {

--- a/internal/applets/textutils/unexpand/unexpand.go
+++ b/internal/applets/textutils/unexpand/unexpand.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -69,13 +69,13 @@ func unexpand(args []string, opts options) (int, error) {
 		target := os.ExpandEnv(file)
 		if !mb.IsFile(target) {
 			fmt.Fprintln(os.Stderr, target+": No such file. Skip it")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 		lines, err := mb.ReadFileToStrList(target)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 

--- a/internal/applets/textutils/unix2dos/unix2dos.go
+++ b/internal/applets/textutils/unix2dos/unix2dos.go
@@ -38,7 +38,7 @@ type options struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 	ExitNoSuchFile
 )
 
@@ -48,7 +48,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
@@ -77,14 +77,14 @@ func unix2dos(files []string) (int, error) {
 		lines, err := mb.ReadFileToStrList(target)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, cmdName+": "+target+": Can't read file and convert LF to CRLF")
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 		fmt.Fprintln(os.Stdout, cmdName+": converting file "+target+" to DOS format...")
 		lines = toCRLF(lines)
 		if err := mb.ListToFile(target, lines); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			status = ExitFailuer
+			status = ExitFailure
 			continue
 		}
 	}

--- a/internal/applets/textutils/wc/wc.go
+++ b/internal/applets/textutils/wc/wc.go
@@ -52,7 +52,7 @@ type wordCount struct {
 // Exit code
 const (
 	ExitSuccess int = iota // 0
-	ExitFailuer
+	ExitFailure
 )
 
 func Run() (int, error) {
@@ -61,7 +61,7 @@ func Run() (int, error) {
 	var err error
 
 	if args, err = parseArgs(&opts); err != nil {
-		return ExitFailuer, nil
+		return ExitFailure, nil
 	}
 
 	if mb.HasPipeData() && mb.HasNoOperand(os.Args, cmdName) {
@@ -105,13 +105,13 @@ func wcAll(args []string, opts options) (int, error) {
 
 		if mb.IsDir(target) {
 			fmt.Fprintln(os.Stderr, "wc: "+target+": this path is directory")
-			status = ExitFailuer
+			status = ExitFailure
 			results = append(results, wordCount{0, 0, 0, 0, target})
 			continue
 		}
 		if !mb.IsFile(target) {
 			fmt.Fprintln(os.Stderr, "wc: "+target+": no such File")
-			status = ExitFailuer
+			status = ExitFailure
 			results = append(results, wordCount{0, 0, 0, 0, target})
 			continue
 		}
@@ -119,7 +119,7 @@ func wcAll(args []string, opts options) (int, error) {
 		lines, err := mb.ReadFileToStrList(target)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "wc: "+target+": can't read file")
-			status = ExitFailuer
+			status = ExitFailure
 			results = append(results, wordCount{0, 0, 0, 0, target})
 			continue
 		}


### PR DESCRIPTION
This was only done with `find ./ -type f -exec sed -i -e 's/Failuer/Failure/g' {} \;`, so don't need to add me to every file's copyright 😅.

Nothing seems to break when building, so I assume this is ok. You may want to check further, but it is a lot of files.

I'd recommend moving
```
const (
	ExitSuccess int = iota // 0
	ExitFailure
)
```
to `internal/lib`, and using mb.ExitSuccess / mb.ExitFailure instead; it's kind of just boilerplate right now.