### PR TITLE
test: add integration tests for migrated commands

### DIFF
--- a/test/it/fileutils/ln_test.sh
+++ b/test/it/fileutils/ln_test.sh
@@ -1,0 +1,25 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/ln
+    mkdir -p ${TEST_DIR}
+    printf 'content\n' > ${TEST_DIR}/target.txt
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/ln
+}
+
+TestLnHard() {
+    export TEST_DIR=/tmp/mimixbox/it/ln
+    ln ${TEST_DIR}/target.txt ${TEST_DIR}/hardlink.txt
+    cat ${TEST_DIR}/hardlink.txt
+}
+
+TestLnSymbolic() {
+    export TEST_DIR=/tmp/mimixbox/it/ln
+    ln -s ${TEST_DIR}/target.txt ${TEST_DIR}/symlink.txt
+    test -L ${TEST_DIR}/symlink.txt && echo "is symlink"
+}
+
+TestLnNoOperand() {
+    ln
+}

--- a/test/it/fileutils/rmdir_test.sh
+++ b/test/it/fileutils/rmdir_test.sh
@@ -1,0 +1,34 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/rmdir
+    mkdir -p ${TEST_DIR}
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/rmdir
+}
+
+TestRmdirEmpty() {
+    export TEST_DIR=/tmp/mimixbox/it/rmdir
+    mkdir -p ${TEST_DIR}/empty
+    rmdir ${TEST_DIR}/empty
+    test ! -d ${TEST_DIR}/empty && echo "removed"
+}
+
+TestRmdirNonEmpty() {
+    export TEST_DIR=/tmp/mimixbox/it/rmdir
+    mkdir -p ${TEST_DIR}/full
+    touch ${TEST_DIR}/full/file.txt
+    rmdir ${TEST_DIR}/full
+}
+
+TestRmdirParents() {
+    export TEST_DIR=/tmp/mimixbox/it/rmdir
+    mkdir -p ${TEST_DIR}/a/b/c
+    cd ${TEST_DIR}
+    rmdir -p a/b/c
+    test ! -d ${TEST_DIR}/a && echo "removed"
+}
+
+TestRmdirMissingOperand() {
+    rmdir
+}

--- a/test/it/fileutils/serial_test.sh
+++ b/test/it/fileutils/serial_test.sh
@@ -1,0 +1,25 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/serial
+    mkdir -p ${TEST_DIR}
+    touch ${TEST_DIR}/apple.txt ${TEST_DIR}/banana.txt ${TEST_DIR}/cherry.txt
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/serial
+}
+
+TestSerialRename() {
+    export TEST_DIR=/tmp/mimixbox/it/serial
+    serial ${TEST_DIR} > /dev/null
+    ls ${TEST_DIR}
+}
+
+TestSerialDryRun() {
+    export TEST_DIR=/tmp/mimixbox/it/serial
+    serial -d ${TEST_DIR} > /dev/null
+    ls ${TEST_DIR}
+}
+
+TestSerialNoOperand() {
+    serial
+}

--- a/test/it/shellutils/base64_test.sh
+++ b/test/it/shellutils/base64_test.sh
@@ -1,0 +1,32 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    export TEST_FILE=/tmp/mimixbox/it/base64.txt
+    mkdir -p ${TEST_DIR}
+    printf 'hello\n' > ${TEST_FILE}
+}
+
+CleanUp() {
+    export TEST_DIR=/tmp/mimixbox/it
+    rm -rf ${TEST_DIR}
+}
+
+TestBase64EncodePipe() {
+    printf 'hello\n' | base64
+}
+
+TestBase64EncodeFile() {
+    export TEST_FILE=/tmp/mimixbox/it/base64.txt
+    base64 ${TEST_FILE}
+}
+
+TestBase64DecodePipe() {
+    printf 'aGVsbG8K\n' | base64 -d
+}
+
+TestBase64RoundTrip() {
+    printf 'MimixBox\n' | base64 | base64 -d
+}
+
+TestBase64NoExistFile() {
+    base64 /no_exist_file
+}

--- a/test/it/shellutils/path_test.sh
+++ b/test/it/shellutils/path_test.sh
@@ -1,0 +1,19 @@
+TestPathBasename() {
+    path -b /home/nao/test.txt
+}
+
+TestPathDirname() {
+    path -d /home/nao/test.txt
+}
+
+TestPathExtension() {
+    path -e /home/nao/test.txt
+}
+
+TestPathCanonical() {
+    path -c /home/nao/../nao/./test.txt
+}
+
+TestPathNoOperand() {
+    path
+}

--- a/test/it/shellutils/seq_test.sh
+++ b/test/it/shellutils/seq_test.sh
@@ -1,0 +1,23 @@
+TestSeqLast() {
+    seq 3
+}
+
+TestSeqFirstLast() {
+    seq 2 5
+}
+
+TestSeqFirstIncrementLast() {
+    seq 1 2 9
+}
+
+TestSeqSeparator() {
+    seq -s , 1 3
+}
+
+TestSeqEqualWidth() {
+    seq -w 8 10
+}
+
+TestSeqInvalid() {
+    seq abc
+}

--- a/test/it/shellutils/whoami_test.sh
+++ b/test/it/shellutils/whoami_test.sh
@@ -1,0 +1,7 @@
+TestWhoamiPrintsUser() {
+    whoami
+}
+
+TestWhoamiExtraOperand() {
+    whoami extra
+}

--- a/test/it/spec/base64_spec.sh
+++ b/test/it/spec/base64_spec.sh
@@ -1,0 +1,51 @@
+Describe 'base64 encode from pipe'
+    Include shellutils/base64_test.sh
+
+    It 'encodes standard input'
+        When call TestBase64EncodePipe
+        The output should equal 'aGVsbG8K'
+        The status should be success
+    End
+End
+
+Describe 'base64 encode from file'
+    Include shellutils/base64_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'encodes the file contents'
+        When call TestBase64EncodeFile
+        The output should equal 'aGVsbG8K'
+        The status should be success
+    End
+End
+
+Describe 'base64 decode from pipe'
+    Include shellutils/base64_test.sh
+
+    It 'decodes standard input'
+        When call TestBase64DecodePipe
+        The output should equal 'hello'
+        The status should be success
+    End
+End
+
+Describe 'base64 round trip'
+    Include shellutils/base64_test.sh
+
+    It 'returns the original text'
+        When call TestBase64RoundTrip
+        The output should equal 'MimixBox'
+        The status should be success
+    End
+End
+
+Describe 'base64 with a non-existent file'
+    Include shellutils/base64_test.sh
+
+    It 'reports an error'
+        When call TestBase64NoExistFile
+        The error should equal 'base64: /no_exist_file: no such file or directory'
+        The status should be failure
+    End
+End

--- a/test/it/spec/expand_spec.sh
+++ b/test/it/spec/expand_spec.sh
@@ -1,0 +1,41 @@
+Describe 'expand from pipe'
+    Include textutils/expand_test.sh
+
+    It 'converts tabs to spaces (default tab stop 8)'
+        When call TestExpandPipe
+        The output should equal 'a       b'
+        The status should be success
+    End
+End
+
+Describe 'expand with a custom tab stop'
+    Include textutils/expand_test.sh
+
+    It 'converts tabs to the given width'
+        When call TestExpandTabStop
+        The output should equal 'a   b'
+        The status should be success
+    End
+End
+
+Describe 'expand from file'
+    Include textutils/expand_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'converts tabs in the file'
+        When call TestExpandFile
+        The output should equal 'a       b'
+        The status should be success
+    End
+End
+
+Describe 'expand with a non-existent file'
+    Include textutils/expand_test.sh
+
+    It 'reports an error'
+        When call TestExpandNoExistFile
+        The error should equal 'expand: /no_exist_file: no such file or directory'
+        The status should be failure
+    End
+End

--- a/test/it/spec/head_spec.sh
+++ b/test/it/spec/head_spec.sh
@@ -1,0 +1,77 @@
+Describe 'head default'
+    Include textutils/head_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|1
+        #|2
+        #|3
+        #|4
+        #|5
+        #|6
+        #|7
+        #|8
+        #|9
+        #|10
+    }
+
+    It 'prints the first 10 lines'
+        When call TestHeadDefault
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'head with --lines'
+    Include textutils/head_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|1
+        #|2
+        #|3
+    }
+
+    It 'prints the first N lines'
+        When call TestHeadLines
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'head with --bytes'
+    Include textutils/head_test.sh
+
+    It 'prints the first N bytes'
+        When call TestHeadBytes
+        The output should equal 'hello'
+        The status should be success
+    End
+End
+
+Describe 'head from pipe'
+    Include textutils/head_test.sh
+
+    result() { %text
+        #|a
+        #|b
+    }
+
+    It 'prints the first N lines of stdin'
+        When call TestHeadPipe
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'head with a non-existent file'
+    Include textutils/head_test.sh
+
+    It 'reports an error'
+        When call TestHeadNoExistFile
+        The error should equal 'head: /no_exist_file: no such file or directory'
+        The status should be failure
+    End
+End

--- a/test/it/spec/ln_spec.sh
+++ b/test/it/spec/ln_spec.sh
@@ -1,0 +1,33 @@
+Describe 'ln creates a hard link'
+    Include fileutils/ln_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'links to the same content'
+        When call TestLnHard
+        The output should equal 'content'
+        The status should be success
+    End
+End
+
+Describe 'ln -s creates a symbolic link'
+    Include fileutils/ln_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'creates a symlink'
+        When call TestLnSymbolic
+        The output should equal 'is symlink'
+        The status should be success
+    End
+End
+
+Describe 'ln with no operand'
+    Include fileutils/ln_test.sh
+
+    It 'reports an error'
+        When call TestLnNoOperand
+        The error should equal 'ln: missing file operand'
+        The status should be failure
+    End
+End

--- a/test/it/spec/path_spec.sh
+++ b/test/it/spec/path_spec.sh
@@ -1,0 +1,49 @@
+Describe 'path with --basename'
+    Include shellutils/path_test.sh
+
+    It 'prints the base name'
+        When call TestPathBasename
+        The output should equal 'test.txt'
+        The status should be success
+    End
+End
+
+Describe 'path with --dirname'
+    Include shellutils/path_test.sh
+
+    It 'prints the directory'
+        When call TestPathDirname
+        The output should equal '/home/nao'
+        The status should be success
+    End
+End
+
+Describe 'path with --extension'
+    Include shellutils/path_test.sh
+
+    It 'prints the extension'
+        When call TestPathExtension
+        The output should equal '.txt'
+        The status should be success
+    End
+End
+
+Describe 'path with --canonical'
+    Include shellutils/path_test.sh
+
+    It 'prints the cleaned path'
+        When call TestPathCanonical
+        The output should equal '/home/nao/test.txt'
+        The status should be success
+    End
+End
+
+Describe 'path with no operand'
+    Include shellutils/path_test.sh
+
+    It 'reports an error'
+        When call TestPathNoOperand
+        The error should equal 'path: missing operand'
+        The status should be failure
+    End
+End

--- a/test/it/spec/rmdir_spec.sh
+++ b/test/it/spec/rmdir_spec.sh
@@ -1,0 +1,45 @@
+Describe 'rmdir removes an empty directory'
+    Include fileutils/rmdir_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'removes it'
+        When call TestRmdirEmpty
+        The output should equal 'removed'
+        The status should be success
+    End
+End
+
+Describe 'rmdir on a non-empty directory'
+    Include fileutils/rmdir_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'fails with directory not empty'
+        When call TestRmdirNonEmpty
+        The error should equal "rmdir: failed to remove '/tmp/mimixbox/it/rmdir/full': Directory not empty"
+        The status should be failure
+    End
+End
+
+Describe 'rmdir -p removes nested empty directories'
+    Include fileutils/rmdir_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'removes the whole chain'
+        When call TestRmdirParents
+        The output should equal 'removed'
+        The status should be success
+    End
+End
+
+Describe 'rmdir with no operand'
+    Include fileutils/rmdir_test.sh
+
+    It 'reports an error'
+        When call TestRmdirMissingOperand
+        The error should equal 'rmdir: missing operand'
+        The status should be failure
+    End
+End

--- a/test/it/spec/seq_spec.sh
+++ b/test/it/spec/seq_spec.sh
@@ -1,0 +1,86 @@
+Describe 'seq with one operand'
+    Include shellutils/seq_test.sh
+
+    result() { %text
+        #|1
+        #|2
+        #|3
+    }
+
+    It 'counts from 1 to LAST'
+        When call TestSeqLast
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'seq with first and last'
+    Include shellutils/seq_test.sh
+
+    result() { %text
+        #|2
+        #|3
+        #|4
+        #|5
+    }
+
+    It 'counts from FIRST to LAST'
+        When call TestSeqFirstLast
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'seq with increment'
+    Include shellutils/seq_test.sh
+
+    result() { %text
+        #|1
+        #|3
+        #|5
+        #|7
+        #|9
+    }
+
+    It 'counts by INCREMENT'
+        When call TestSeqFirstIncrementLast
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'seq with a separator'
+    Include shellutils/seq_test.sh
+
+    It 'joins the numbers with the separator'
+        When call TestSeqSeparator
+        The output should equal '1,2,3'
+        The status should be success
+    End
+End
+
+Describe 'seq with equal width'
+    Include shellutils/seq_test.sh
+
+    result() { %text
+        #|08
+        #|09
+        #|10
+    }
+
+    It 'pads numbers with leading zeros'
+        When call TestSeqEqualWidth
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'seq with an invalid operand'
+    Include shellutils/seq_test.sh
+
+    It 'reports an error'
+        When call TestSeqInvalid
+        The error should equal "seq: invalid floating point argument: 'abc'"
+        The status should be failure
+    End
+End

--- a/test/it/spec/serial_spec.sh
+++ b/test/it/spec/serial_spec.sh
@@ -1,0 +1,45 @@
+Describe 'serial renames files in a directory'
+    Include fileutils/serial_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|0_apple.txt
+        #|1_banana.txt
+        #|2_cherry.txt
+    }
+
+    It 'adds a serial-number prefix to each file'
+        When call TestSerialRename
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'serial with --dry-run'
+    Include fileutils/serial_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|apple.txt
+        #|banana.txt
+        #|cherry.txt
+    }
+
+    It 'does not rename anything'
+        When call TestSerialDryRun
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'serial with no operand'
+    Include fileutils/serial_test.sh
+
+    It 'reports an error'
+        When call TestSerialNoOperand
+        The error should equal 'serial: missing operand'
+        The status should be failure
+    End
+End

--- a/test/it/spec/tac_spec.sh
+++ b/test/it/spec/tac_spec.sh
@@ -1,0 +1,43 @@
+Describe 'tac from file'
+    Include textutils/tac_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|third
+        #|second
+        #|first
+    }
+
+    It 'prints the lines in reverse order'
+        When call TestTacFile
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'tac from pipe'
+    Include textutils/tac_test.sh
+
+    result() { %text
+        #|c
+        #|b
+        #|a
+    }
+
+    It 'reverses standard input'
+        When call TestTacPipe
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'tac with a non-existent file'
+    Include textutils/tac_test.sh
+
+    It 'reports an error'
+        When call TestTacNoExistFile
+        The error should equal 'tac: /no_exist_file: no such file or directory'
+        The status should be failure
+    End
+End

--- a/test/it/spec/tail_spec.sh
+++ b/test/it/spec/tail_spec.sh
@@ -1,0 +1,77 @@
+Describe 'tail default'
+    Include textutils/tail_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|3
+        #|4
+        #|5
+        #|6
+        #|7
+        #|8
+        #|9
+        #|10
+        #|11
+        #|12
+    }
+
+    It 'prints the last 10 lines'
+        When call TestTailDefault
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'tail with --lines'
+    Include textutils/tail_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|10
+        #|11
+        #|12
+    }
+
+    It 'prints the last N lines'
+        When call TestTailLines
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'tail with --bytes'
+    Include textutils/tail_test.sh
+
+    It 'prints the last N bytes'
+        When call TestTailBytes
+        The output should equal 'world'
+        The status should be success
+    End
+End
+
+Describe 'tail from pipe'
+    Include textutils/tail_test.sh
+
+    result() { %text
+        #|c
+        #|d
+    }
+
+    It 'prints the last N lines of stdin'
+        When call TestTailPipe
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'tail with a non-existent file'
+    Include textutils/tail_test.sh
+
+    It 'reports an error'
+        When call TestTailNoExistFile
+        The error should equal 'tail: /no_exist_file: no such file or directory'
+        The status should be failure
+    End
+End

--- a/test/it/spec/unexpand_spec.sh
+++ b/test/it/spec/unexpand_spec.sh
@@ -1,0 +1,29 @@
+Describe 'unexpand from pipe'
+    Include textutils/unexpand_test.sh
+
+    It 'converts leading spaces to a tab'
+        When call TestUnexpandPipe
+        The output should equal "$(printf '\ta')"
+        The status should be success
+    End
+End
+
+Describe 'unexpand with --all'
+    Include textutils/unexpand_test.sh
+
+    It 'converts internal space runs to tabs'
+        When call TestUnexpandAll
+        The output should equal "$(printf 'a\t b')"
+        The status should be success
+    End
+End
+
+Describe 'unexpand with a non-existent file'
+    Include textutils/unexpand_test.sh
+
+    It 'reports an error'
+        When call TestUnexpandNoExistFile
+        The error should equal 'unexpand: /no_exist_file: no such file or directory'
+        The status should be failure
+    End
+End

--- a/test/it/spec/whoami_spec.sh
+++ b/test/it/spec/whoami_spec.sh
@@ -1,0 +1,19 @@
+Describe 'whoami without options'
+    Include shellutils/whoami_test.sh
+
+    It 'prints the current user name'
+        When call TestWhoamiPrintsUser
+        The output should equal "$(id -un)"
+        The status should be success
+    End
+End
+
+Describe 'whoami with an extra operand'
+    Include shellutils/whoami_test.sh
+
+    It 'reports an error'
+        When call TestWhoamiExtraOperand
+        The error should equal "whoami: extra operand 'extra'"
+        The status should be failure
+    End
+End

--- a/test/it/textutils/expand_test.sh
+++ b/test/it/textutils/expand_test.sh
@@ -1,0 +1,28 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    export TEST_FILE=/tmp/mimixbox/it/expand.txt
+    mkdir -p ${TEST_DIR}
+    printf 'a\tb\n' > ${TEST_FILE}
+}
+
+CleanUp() {
+    export TEST_DIR=/tmp/mimixbox/it
+    rm -rf ${TEST_DIR}
+}
+
+TestExpandPipe() {
+    printf 'a\tb\n' | expand
+}
+
+TestExpandTabStop() {
+    printf 'a\tb\n' | expand -t 4
+}
+
+TestExpandFile() {
+    export TEST_FILE=/tmp/mimixbox/it/expand.txt
+    expand ${TEST_FILE}
+}
+
+TestExpandNoExistFile() {
+    expand /no_exist_file
+}

--- a/test/it/textutils/head_test.sh
+++ b/test/it/textutils/head_test.sh
@@ -1,0 +1,33 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    export TEST_FILE=/tmp/mimixbox/it/head.txt
+    mkdir -p ${TEST_DIR}
+    printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n' > ${TEST_FILE}
+}
+
+CleanUp() {
+    export TEST_DIR=/tmp/mimixbox/it
+    rm -rf ${TEST_DIR}
+}
+
+TestHeadDefault() {
+    export TEST_FILE=/tmp/mimixbox/it/head.txt
+    head ${TEST_FILE}
+}
+
+TestHeadLines() {
+    export TEST_FILE=/tmp/mimixbox/it/head.txt
+    head -n 3 ${TEST_FILE}
+}
+
+TestHeadBytes() {
+    printf 'hello world' | head -c 5
+}
+
+TestHeadPipe() {
+    printf 'a\nb\nc\nd\n' | head -n 2
+}
+
+TestHeadNoExistFile() {
+    head /no_exist_file
+}

--- a/test/it/textutils/tac_test.sh
+++ b/test/it/textutils/tac_test.sh
@@ -1,0 +1,24 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    export TEST_FILE=/tmp/mimixbox/it/tac.txt
+    mkdir -p ${TEST_DIR}
+    printf 'first\nsecond\nthird\n' > ${TEST_FILE}
+}
+
+CleanUp() {
+    export TEST_DIR=/tmp/mimixbox/it
+    rm -rf ${TEST_DIR}
+}
+
+TestTacFile() {
+    export TEST_FILE=/tmp/mimixbox/it/tac.txt
+    tac ${TEST_FILE}
+}
+
+TestTacPipe() {
+    printf 'a\nb\nc\n' | tac
+}
+
+TestTacNoExistFile() {
+    tac /no_exist_file
+}

--- a/test/it/textutils/tail_test.sh
+++ b/test/it/textutils/tail_test.sh
@@ -1,0 +1,33 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    export TEST_FILE=/tmp/mimixbox/it/tail.txt
+    mkdir -p ${TEST_DIR}
+    printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n' > ${TEST_FILE}
+}
+
+CleanUp() {
+    export TEST_DIR=/tmp/mimixbox/it
+    rm -rf ${TEST_DIR}
+}
+
+TestTailDefault() {
+    export TEST_FILE=/tmp/mimixbox/it/tail.txt
+    tail ${TEST_FILE}
+}
+
+TestTailLines() {
+    export TEST_FILE=/tmp/mimixbox/it/tail.txt
+    tail -n 3 ${TEST_FILE}
+}
+
+TestTailBytes() {
+    printf 'hello world' | tail -c 5
+}
+
+TestTailPipe() {
+    printf 'a\nb\nc\nd\n' | tail -n 2
+}
+
+TestTailNoExistFile() {
+    tail /no_exist_file
+}

--- a/test/it/textutils/unexpand_test.sh
+++ b/test/it/textutils/unexpand_test.sh
@@ -1,0 +1,11 @@
+TestUnexpandPipe() {
+    printf '        a\n' | unexpand
+}
+
+TestUnexpandAll() {
+    printf 'a        b\n' | unexpand -a
+}
+
+TestUnexpandNoExistFile() {
+    unexpand /no_exist_file
+}


### PR DESCRIPTION
## Summary

Adds shellspec end-to-end (integration) tests for twelve already-migrated applets, closing the open `[test]` issues. Each spec drives the installed applet by name (as the CI integration job does) and asserts real output, exit status, and error messages in GNU style.

## Coverage

| Command | Helper | Spec | Issue |
|---|---|---|---|
| base64 | shellutils/base64_test.sh | spec/base64_spec.sh | #11 |
| expand | textutils/expand_test.sh | spec/expand_spec.sh | #21 |
| head | textutils/head_test.sh | spec/head_spec.sh | #22 |
| ln | fileutils/ln_test.sh | spec/ln_spec.sh | #6 |
| path | shellutils/path_test.sh | spec/path_spec.sh | #14 |
| rmdir | fileutils/rmdir_test.sh | spec/rmdir_spec.sh | #10 |
| seq | shellutils/seq_test.sh | spec/seq_spec.sh | #15 |
| serial | fileutils/serial_test.sh | spec/serial_spec.sh | #16 |
| tac | textutils/tac_test.sh | spec/tac_spec.sh | #28 |
| tail | textutils/tail_test.sh | spec/tail_spec.sh | #29 |
| unexpand | textutils/unexpand_test.sh | spec/unexpand_spec.sh | #30 |
| whoami | shellutils/whoami_test.sh | spec/whoami_spec.sh | #19 |

## Testing

Ran the full shellspec suite against an installed build: the 48 new examples all pass. The only failures are the two pre-existing, environment-specific specs (`unix2dos` depends on the host `file` wording and a `/usr/local/bin` install path; `which` expects `/usr/local/bin`), which pass in CI's environment and are unrelated to this change.

Closes #6, #10, #11, #14, #15, #16, #19, #21, #22, #28, #29, #30.