### PR TITLE
fix: correct hostid algorithm and align halt/poweroff/reboot with the man page

### DIFF
--- a/internal/applets/pmutils/halt/export_test.go
+++ b/internal/applets/pmutils/halt/export_test.go
@@ -20,3 +20,21 @@ func SetIsRootForTest(t *testing.T, fn func() bool) {
 	isRoot = fn
 	t.Cleanup(func() { isRoot = orig })
 }
+
+// SetWtmpFileForTest points the shutdown-record file at path for the duration of
+// a test, so tests never touch the real /var/log/wtmp.
+func SetWtmpFileForTest(t *testing.T, path string) {
+	t.Helper()
+	orig := wtmpFile
+	wtmpFile = path
+	t.Cleanup(func() { wtmpFile = orig })
+}
+
+// SetSyncFnForTest replaces the filesystem sync with fn for the duration of a
+// test, so a test can observe whether sync was requested.
+func SetSyncFnForTest(t *testing.T, fn func()) {
+	t.Helper()
+	orig := syncFn
+	syncFn = fn
+	t.Cleanup(func() { syncFn = orig })
+}

--- a/internal/applets/pmutils/halt/halt.go
+++ b/internal/applets/pmutils/halt/halt.go
@@ -17,14 +17,17 @@
 
 // Package halt implements the halt, poweroff and reboot applets: stop the
 // system. The same package backs all three command names; the action performed
-// depends on the name the command was constructed with.
+// depends on the name the command was constructed with. The options follow the
+// util-linux/sysvinit man pages (-f, -n, -w, -d, and -p for halt).
 package halt
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
@@ -36,15 +39,25 @@ const (
 	nameReboot   = "reboot"
 )
 
+// wtmpFile is the login-record file a shutdown event is written to. It is a
+// package variable so tests can point it at a temporary file.
+var wtmpFile = "/var/log/wtmp"
+
 // rebootFn is the dangerous syscall, behind a package variable so tests can
 // stub it and never actually stop the machine.
 var rebootFn = syscall.Reboot
+
+// syncFn flushes filesystem buffers; a variable so tests observe it.
+var syncFn = syscall.Sync
 
 // isRoot reports whether the current process has the privilege required to stop
 // the system. It is a package variable so tests can simulate root.
 var isRoot = func() bool {
 	return os.Geteuid() == 0 && os.Getuid() == 0
 }
+
+// nowFn returns the current time; a variable so tests get a deterministic clock.
+var nowFn = time.Now
 
 // Command is the halt/poweroff/reboot applet. It carries the name it was
 // invoked as so the same type can serve all three commands.
@@ -80,14 +93,26 @@ func (c *Command) Synopsis() string {
 	}
 }
 
-// action returns the syscall.Reboot command constant for this command name.
-func (c *Command) action() int {
+type options struct {
+	force    bool // -f: force, do not sync or wait
+	noSync   bool // -n: do not sync before the action
+	wtmpOnly bool // -w: only write the wtmp record, do not stop the system
+	noWtmp   bool // -d: do not write the wtmp record
+	poweroff bool // -p: when called as halt, power off instead of halting
+}
+
+// action returns the syscall.Reboot command constant for this command, honoring
+// "halt -p" (power off instead of halt).
+func (c *Command) action(opts options) int {
 	switch c.name {
 	case nameReboot:
 		return syscall.LINUX_REBOOT_CMD_RESTART
 	case namePoweroff:
 		return syscall.LINUX_REBOOT_CMD_POWER_OFF
 	default:
+		if opts.poweroff {
+			return syscall.LINUX_REBOOT_CMD_POWER_OFF
+		}
 		return syscall.LINUX_REBOOT_CMD_HALT
 	}
 }
@@ -96,9 +121,23 @@ func (c *Command) action() int {
 // permission message and returns a silent failure without touching rebootFn.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
 	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	force := fs.BoolP("force", "f", false, "force immediate halt/power-off/reboot; do not sync")
+	noSync := fs.BoolP("no-sync", "n", false, "do not sync before halt or reboot")
+	wtmpOnly := fs.BoolP("wtmp-only", "w", false, "only write the wtmp shutdown record, do not stop the system")
+	noWtmp := fs.BoolP("no-wtmp", "d", false, "do not write the wtmp shutdown record")
+	var poweroff *bool
+	if c.name == nameHalt {
+		poweroff = fs.BoolP("poweroff", "p", false, "power off the machine instead of halting")
+	}
+
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
+	}
+
+	opts := options{force: *force, noSync: *noSync, wtmpOnly: *wtmpOnly, noWtmp: *noWtmp}
+	if poweroff != nil {
+		opts.poweroff = *poweroff
 	}
 
 	if !isRoot() {
@@ -106,15 +145,59 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.SilentFailure()
 	}
 
-	return stop(c.action())
+	if !opts.noWtmp {
+		if werr := writeWtmp(wtmpFile, nowFn()); werr != nil {
+			// Match util-linux: a wtmp failure is reported but does not abort.
+			_, _ = fmt.Fprintf(stdio.Err, "%s: cannot write %s: %v\n", c.Name(), wtmpFile, werr)
+		}
+	}
+
+	if opts.wtmpOnly {
+		return nil
+	}
+
+	return c.stop(opts)
 }
 
-// stop synchronizes filesystems and performs the requested reboot action via
-// the replaceable rebootFn so tests stay safe.
-func stop(action int) error {
-	syscall.Sync()
-	if err := rebootFn(action); err != nil {
+// stop syncs filesystems (unless suppressed) and performs the requested action
+// via the replaceable rebootFn so tests stay safe.
+func (c *Command) stop(opts options) error {
+	if !opts.noSync && !opts.force {
+		syncFn()
+	}
+	if err := rebootFn(c.action(opts)); err != nil {
 		return command.Failure(err)
 	}
 	return nil
+}
+
+// utmpRecordSize is the size of a Linux struct utmp record.
+const utmpRecordSize = 384
+
+// utmp record type for a run-level (shutdown) entry.
+const runLevel = 1
+
+// writeWtmp appends a "shutdown" login record to path, as sysvinit's halt does,
+// so utilities such as "who" and "last" can report the shutdown time. The
+// record layout matches Linux's struct utmp.
+func writeWtmp(path string, now time.Time) error {
+	rec := make([]byte, utmpRecordSize)
+	binary.LittleEndian.PutUint16(rec[0:], runLevel)                        // ut_type
+	copy(rec[8:40], "~~")                                                   // ut_line[32]
+	copy(rec[40:44], "~~")                                                  // ut_id[4]
+	copy(rec[44:76], "shutdown")                                            // ut_user[32]
+	binary.LittleEndian.PutUint32(rec[340:], uint32(now.Unix()))            // ut_tv.tv_sec
+	binary.LittleEndian.PutUint32(rec[344:], uint32(now.Nanosecond()/1000)) // ut_tv.tv_usec
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644) //nolint:gosec // wtmp is world-readable
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+	_, err = f.Write(rec)
+	return err
 }

--- a/internal/applets/pmutils/halt/halt_internal_test.go
+++ b/internal/applets/pmutils/halt/halt_internal_test.go
@@ -1,0 +1,63 @@
+package halt
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteWtmpRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wtmp")
+	now := time.Unix(1700000000, 123000)
+
+	if err := writeWtmp(path, now); err != nil {
+		t.Fatalf("writeWtmp error = %v", err)
+	}
+
+	rec, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rec) != utmpRecordSize {
+		t.Fatalf("record size = %d, want %d", len(rec), utmpRecordSize)
+	}
+	if got := binary.LittleEndian.Uint16(rec[0:]); got != runLevel {
+		t.Errorf("ut_type = %d, want %d (RUN_LVL)", got, runLevel)
+	}
+	if got := cstr(rec[44:76]); got != "shutdown" {
+		t.Errorf("ut_user = %q, want %q", got, "shutdown")
+	}
+	if got := cstr(rec[8:40]); got != "~~" {
+		t.Errorf("ut_line = %q, want %q", got, "~~")
+	}
+	if got := binary.LittleEndian.Uint32(rec[340:]); got != uint32(now.Unix()) {
+		t.Errorf("ut_tv.tv_sec = %d, want %d", got, now.Unix())
+	}
+}
+
+func TestWriteWtmpAppends(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wtmp")
+	now := time.Unix(1700000000, 0)
+	if err := writeWtmp(path, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWtmp(path, now); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 2*utmpRecordSize {
+		t.Errorf("size after two writes = %d, want %d", info.Size(), 2*utmpRecordSize)
+	}
+}
+
+// cstr returns the NUL-terminated string at the start of b.
+func cstr(b []byte) string {
+	before, _, _ := bytes.Cut(b, []byte{0})
+	return string(before)
+}

--- a/internal/applets/pmutils/halt/halt_test.go
+++ b/internal/applets/pmutils/halt/halt_test.go
@@ -3,6 +3,8 @@ package halt_test
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -31,6 +33,7 @@ func run(t *testing.T, cmd *halt.Command, args ...string) (rec *recorder, out, e
 	rec = &recorder{}
 	halt.SetRebootFnForTest(t, rec.reboot)
 	halt.SetIsRootForTest(t, func() bool { return true })
+	halt.SetWtmpFileForTest(t, filepath.Join(t.TempDir(), "wtmp"))
 
 	outBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
@@ -104,6 +107,78 @@ func TestRunNotRoot(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "root") {
 		t.Errorf("stderr = %q, want a permission message mentioning root", errBuf.String())
+	}
+}
+
+func TestRunHaltPoweroffOption(t *testing.T) {
+	rec, _, _, err := run(t, halt.NewHalt(), "-p")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !rec.called {
+		t.Fatal("reboot function was not called")
+	}
+	if rec.action != syscall.LINUX_REBOOT_CMD_POWER_OFF {
+		t.Errorf("halt -p action = %#x, want POWER_OFF %#x", rec.action, syscall.LINUX_REBOOT_CMD_POWER_OFF)
+	}
+}
+
+func TestRunWtmpOnly(t *testing.T) {
+	rec := &recorder{}
+	halt.SetRebootFnForTest(t, rec.reboot)
+	halt.SetIsRootForTest(t, func() bool { return true })
+	wtmp := filepath.Join(t.TempDir(), "wtmp")
+	halt.SetWtmpFileForTest(t, wtmp)
+
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := halt.NewReboot().Run(context.Background(), io, []string{"-w"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if rec.called {
+		t.Fatal("-w (wtmp-only) must NOT stop the system")
+	}
+	info, statErr := os.Stat(wtmp)
+	if statErr != nil {
+		t.Fatalf("wtmp not written: %v", statErr)
+	}
+	if info.Size() != 384 {
+		t.Errorf("wtmp size = %d, want 384 (one utmp record)", info.Size())
+	}
+}
+
+func TestRunNoWtmp(t *testing.T) {
+	rec := &recorder{}
+	halt.SetRebootFnForTest(t, rec.reboot)
+	halt.SetIsRootForTest(t, func() bool { return true })
+	wtmp := filepath.Join(t.TempDir(), "wtmp")
+	halt.SetWtmpFileForTest(t, wtmp)
+
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := halt.NewHalt().Run(context.Background(), io, []string{"-d"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if _, statErr := os.Stat(wtmp); !os.IsNotExist(statErr) {
+		t.Errorf("-d must not write wtmp, stat error = %v", statErr)
+	}
+}
+
+func TestRunNoSync(t *testing.T) {
+	synced := false
+	halt.SetSyncFnForTest(t, func() { synced = true })
+
+	if _, _, _, err := run(t, halt.NewHalt(), "-n"); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if synced {
+		t.Error("-n must not sync before halt")
+	}
+
+	synced = false
+	if _, _, _, err := run(t, halt.NewHalt()); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !synced {
+		t.Error("default halt must sync before halt")
 	}
 }
 

--- a/internal/applets/shellutils/hostid/hostid.go
+++ b/internal/applets/shellutils/hostid/hostid.go
@@ -1,18 +1,21 @@
-// Package hostid implements the hostid applet: print the numeric identifier
-// (in hexadecimal) of the current host. The computation is preserved from the
-// original applet and, as its description warns, does not match the Coreutils
-// hostid command.
+// Package hostid implements the hostid applet: print the numeric identifier of
+// the current host as a zero-padded 8-digit hexadecimal number, matching GNU
+// coreutils' hostid (which prints gethostid() & 0xffffffff).
 package hostid
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
-	"strconv"
-	"strings"
+	"net"
+	"os"
 
 	"github.com/nao1215/mimixbox/internal/command"
-	mb "github.com/nao1215/mimixbox/internal/lib"
 )
+
+// hostidFile is the path glibc's gethostid() consults first. It is a variable
+// so tests can point it at a temporary file.
+var hostidFile = "/etc/hostid"
 
 // Command is the hostid applet.
 type Command struct{}
@@ -25,7 +28,7 @@ func (c *Command) Name() string { return "hostid" }
 
 // Synopsis returns the one-line description shown in the applet list.
 func (c *Command) Synopsis() string {
-	return "Print hostid (Host Identity Number, hex)!!!Does not work properly!!!"
+	return "Print the numeric identifier (in hexadecimal) for the current host"
 }
 
 // Run executes hostid.
@@ -37,26 +40,50 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return err
 	}
 
-	ip4, err := mb.Ip4()
-	if err != nil {
-		_, _ = fmt.Fprintf(stdio.Err, "hostid: %v\n", err)
-		return command.SilentFailure()
-	}
-
-	// NOTE: The output doesn't match the Coreutils version of hostid command.
-	// First, the IP address should be calculated from the hostname.
-	// Next, the process of converting the IP address to hexadecimal does not
-	// match. This computation is preserved from the original implementation.
-	for _, ip := range ip4 {
-		ipList := strings.Split(ip, ".")
-		_, _ = fmt.Fprintf(stdio.Out, "%02x%02x%02x%02x\n",
-			atoi(ipList[1]), atoi(ipList[0]), atoi(ipList[3]), atoi(ipList[2]))
-	}
-
+	// POSIX says gethostid returns a 32-bit identifier; coreutils masks off any
+	// sign extension and prints it zero-padded to 8 hex digits.
+	_, _ = fmt.Fprintf(stdio.Out, "%08x\n", hostID()&0xffffffff)
 	return nil
 }
 
-func atoi(decimal string) int {
-	i, _ := strconv.Atoi(decimal)
-	return i
+// hostID reproduces glibc's gethostid(): if /etc/hostid holds at least four
+// bytes, those are the host id; otherwise it is derived from the host name's
+// IPv4 address by swapping its two 16-bit halves.
+func hostID() uint32 {
+	if id, ok := hostIDFromFile(hostidFile); ok {
+		return id
+	}
+	return hostIDFromHostname(os.Hostname, net.LookupIP)
+}
+
+// hostIDFromFile reads the first four bytes of path as a host-byte-order
+// (little-endian on the supported platforms) unsigned 32-bit integer.
+func hostIDFromFile(path string) (uint32, bool) {
+	b, err := os.ReadFile(path) //nolint:gosec // /etc/hostid is a well-known system file
+	if err != nil || len(b) < 4 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(b[:4]), true
+}
+
+// hostIDFromHostname derives the id from the first IPv4 address the host name
+// resolves to, with the two 16-bit halves of the address swapped (the glibc
+// fallback). It returns 0 when the name cannot be resolved to an IPv4 address,
+// matching glibc/coreutils, which then print "00000000".
+func hostIDFromHostname(hostname func() (string, error), lookup func(string) ([]net.IP, error)) uint32 {
+	name, err := hostname()
+	if err != nil {
+		return 0
+	}
+	ips, err := lookup(name)
+	if err != nil {
+		return 0
+	}
+	for _, ip := range ips {
+		if v4 := ip.To4(); v4 != nil {
+			s := binary.LittleEndian.Uint32(v4)
+			return (s << 16) | (s >> 16)
+		}
+	}
+	return 0
 }

--- a/internal/applets/shellutils/hostid/hostid_internal_test.go
+++ b/internal/applets/shellutils/hostid/hostid_internal_test.go
@@ -1,0 +1,95 @@
+package hostid
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHostIDFromFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hostid")
+	// Little-endian 0x078bbefa -> bytes fa be 8b 07.
+	if err := os.WriteFile(path, []byte{0xfa, 0xbe, 0x8b, 0x07}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := hostIDFromFile(path)
+	if !ok {
+		t.Fatal("hostIDFromFile ok = false, want true")
+	}
+	if got != 0x078bbefa {
+		t.Errorf("hostIDFromFile = %08x, want 078bbefa", got)
+	}
+}
+
+func TestHostIDFromFileMissingOrShort(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := hostIDFromFile(filepath.Join(t.TempDir(), "absent")); ok {
+		t.Error("missing file: ok = true, want false")
+	}
+
+	short := filepath.Join(t.TempDir(), "short")
+	if err := os.WriteFile(short, []byte{0x01, 0x02}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := hostIDFromFile(short); ok {
+		t.Error("short file: ok = true, want false")
+	}
+}
+
+func TestHostIDFromHostname(t *testing.T) {
+	t.Parallel()
+
+	hostname := func() (string, error) { return "host", nil }
+	lookup := func(string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("127.0.0.1")}, nil
+	}
+
+	// 127.0.0.1 little-endian = 0x0100007f; swapping halves -> 0x007f0100.
+	if got := hostIDFromHostname(hostname, lookup); got != 0x007f0100 {
+		t.Errorf("hostIDFromHostname = %08x, want 007f0100", got)
+	}
+}
+
+func TestHostIDFromHostnameErrors(t *testing.T) {
+	t.Parallel()
+
+	noName := func() (string, error) { return "", os.ErrInvalid }
+	okLookup := func(string) ([]net.IP, error) { return []net.IP{net.ParseIP("10.0.0.1")}, nil }
+	if got := hostIDFromHostname(noName, okLookup); got != 0 {
+		t.Errorf("hostname error: got %08x, want 0", got)
+	}
+
+	okName := func() (string, error) { return "host", nil }
+	noLookup := func(string) ([]net.IP, error) { return nil, os.ErrNotExist }
+	if got := hostIDFromHostname(okName, noLookup); got != 0 {
+		t.Errorf("lookup error: got %08x, want 0", got)
+	}
+
+	// No IPv4 address available -> 0.
+	v6Only := func(string) ([]net.IP, error) { return []net.IP{net.ParseIP("::1")}, nil }
+	if got := hostIDFromHostname(okName, v6Only); got != 0 {
+		t.Errorf("ipv6 only: got %08x, want 0", got)
+	}
+}
+
+func TestHostIDPrefersFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hostid")
+	if err := os.WriteFile(path, []byte{0x78, 0x56, 0x34, 0x12}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	old := hostidFile
+	hostidFile = path
+	defer func() { hostidFile = old }()
+
+	if got := hostID(); got != 0x12345678 {
+		t.Errorf("hostID = %08x, want 12345678", got)
+	}
+}

--- a/internal/applets/shellutils/hostid/hostid_test.go
+++ b/internal/applets/shellutils/hostid/hostid_test.go
@@ -28,14 +28,8 @@ func TestRun(t *testing.T) {
 		t.Fatalf("Run error = %v, stderr = %q", err, errOut)
 	}
 
-	hex8 := regexp.MustCompile(`^[0-9a-f]{8}$`)
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line == "" {
-			// Host has no non-loopback IPv4 address; nothing to print.
-			continue
-		}
-		if !hex8.MatchString(line) {
-			t.Errorf("hostid output line = %q, want 8 hex digits", line)
-		}
+	// Like coreutils, hostid prints exactly one line of 8 lowercase hex digits.
+	if !regexp.MustCompile(`^[0-9a-f]{8}\n$`).MatchString(out) {
+		t.Errorf("hostid output = %q, want one line of 8 hex digits", out)
 	}
 }

--- a/test/it/pmutils/halt_test.sh
+++ b/test/it/pmutils/halt_test.sh
@@ -1,0 +1,20 @@
+# NOTE: these tests intentionally only exercise --help / --version. Running halt,
+# poweroff or reboot without those flags would actually stop the machine, so the
+# real shutdown behaviour is covered by the Go unit tests (which stub the
+# syscall) rather than here.
+
+TestHaltHelp() {
+    halt --help
+}
+
+TestPoweroffHelp() {
+    poweroff --help
+}
+
+TestRebootHelp() {
+    reboot --help
+}
+
+TestHaltVersion() {
+    halt --version
+}

--- a/test/it/shellutils/hostid_test.sh
+++ b/test/it/shellutils/hostid_test.sh
@@ -1,0 +1,9 @@
+TestHostidFormat() {
+    hostid
+}
+
+TestHostidStable() {
+    a=$(hostid)
+    b=$(hostid)
+    test "$a" = "$b" && echo "stable"
+}

--- a/test/it/spec/halt_spec.sh
+++ b/test/it/spec/halt_spec.sh
@@ -1,0 +1,41 @@
+Describe 'halt --help'
+    Include pmutils/halt_test.sh
+
+    It 'prints usage and lists the options'
+        When call TestHaltHelp
+        The output should include 'Usage: halt'
+        The output should include '--poweroff'
+        The output should include '--wtmp-only'
+        The status should be success
+    End
+End
+
+Describe 'poweroff --help'
+    Include pmutils/halt_test.sh
+
+    It 'prints usage'
+        When call TestPoweroffHelp
+        The output should include 'Usage: poweroff'
+        The status should be success
+    End
+End
+
+Describe 'reboot --help'
+    Include pmutils/halt_test.sh
+
+    It 'prints usage'
+        When call TestRebootHelp
+        The output should include 'Usage: reboot'
+        The status should be success
+    End
+End
+
+Describe 'halt --version'
+    Include pmutils/halt_test.sh
+
+    It 'prints the version'
+        When call TestHaltVersion
+        The output should include 'halt (mimixbox)'
+        The status should be success
+    End
+End

--- a/test/it/spec/hostid_spec.sh
+++ b/test/it/spec/hostid_spec.sh
@@ -1,0 +1,19 @@
+Describe 'hostid output format'
+    Include shellutils/hostid_test.sh
+
+    It 'prints 8 hexadecimal digits'
+        When call TestHostidFormat
+        The output should match pattern "[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*"
+        The status should be success
+    End
+End
+
+Describe 'hostid is stable'
+    Include shellutils/hostid_test.sh
+
+    It 'prints the same value on repeated calls'
+        When call TestHostidStable
+        The output should equal 'stable'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Two bug fixes with unit and integration tests, in GNU/util-linux style.

### hostid (Closes #3)
The previous implementation used an ad-hoc byte ordering and printed one line per network interface, which did not match coreutils. It now reproduces glibc's `gethostid()`:
- read `/etc/hostid` (a 4-byte host id) when it exists;
- otherwise derive the id from the host name's first IPv4 address with its two 16-bit halves swapped;
- print it as a single zero-padded 8-digit hex number (`gethostid() & 0xffffffff`).

The `/etc/hostid` path, hostname and resolver are injectable, so the file path, the swap, the missing/short-file and the no-IPv4 fallbacks are all unit-tested. The misleading `!!!Does not work properly!!!` synopsis is gone.

### halt / poweroff / reboot (Closes #81)
Adds the util-linux/sysvinit options the man page documents:
- `-f, --force` (force, skip sync), `-n, --no-sync`, `-w, --wtmp-only`, `-d, --no-wtmp`, and `-p, --poweroff` (halt powers off).
- A `shutdown` login record (Linux `struct utmp`, RUN_LVL) is appended to `/var/log/wtmp` by default so `who`/`last` can report the shutdown; `-d` skips it and `-w` writes it without stopping the system.

The reboot syscall, the wtmp path, the sync call and the clock are all injectable package variables, so every path (action selection, `-p`, `-w`, `-d`, `-n`, the wtmp record layout, the non-root error) is unit-tested **without ever stopping the machine**.

## Testing

- Unit tests: `go test ./internal/applets/pmutils/halt/... ./internal/applets/shellutils/hostid/...` pass; `golangci-lint` clean.
- Integration tests (shellspec): `hostid_spec.sh` checks the 8-hex-digit format and stability; `halt_spec.sh` deliberately only exercises `--help`/`--version` for halt/poweroff/reboot, because invoking them for real would stop the machine (the real behaviour is covered by the stubbed unit tests).

Closes #3, #81.