### PR TITLE
feat: add env, tee, uniq, realpath, cut and cmp commands

### DIFF
--- a/docs/introduction/en/CommandAppletList.md
+++ b/docs/introduction/en/CommandAppletList.md
@@ -11,10 +11,13 @@
 |   chroot | Run command or interactive shell with special root directory|
 |chsh      | Change login shell|
 |   clear  | Clear teminal |
+|     cmp  | Compare two files byte by byte|
 |       cp | Copy file(s) otr Directory(s) |
+|     cut  | Remove sections from each line of files|
 |  dirname | Print only directory path |
 | dos2unix | Change CRLF to LF|
 |     echo | Display a line of text|
+|     env  | Run a program in a modified environment, or print the environment|
 |   expand | Convert TAB to N space (default:N=8)|
 |fakemovie | Adds a video playback button to the image|
 |    false | Do nothing. Return unsuccess(1)|
@@ -39,6 +42,7 @@
 |    poweroff| Power off the system|
 |    printenv| Print environment variable|
 |     pwd  | Print Working Directory|
+|  realpath| Print the resolved absolute file name|
 |    reboot| Reboot the system|
 |   remove-shell|Remove shell name from /etc/shells|
 |     reset| Reset terminal|
@@ -55,10 +59,12 @@
 |   sync   | Synchronize cached writes to persistent storage|
 |     tac  | Print the file contents from the end to the beginning|
 |     tail |  Print the last NUMBER(default=10) lines|
+|     tee  | Read from standard input and write to standard output and files|
 |    touch | Update the access and modification times of each FILE to the current time|
 |    tr    | Translate or delete characters|
 |     true | Do nothing. Return success(0)|
 |  unexpand| Convert N space to TAB (default:N=8)|
+|    uniq  | Report or omit repeated lines|
 |  unix2dos| Change LF to CRLF|
 |   uuidgeb| Print UUID (Universal Unique IDentifier|
 |  valid-shell| Verify if /etc/shells is valid|

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -52,8 +52,11 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/base64"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/basename"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/chroot"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/cmp"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/cut"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/dirname"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/echo"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/env"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/false"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/ghrdc"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/groups"
@@ -65,12 +68,15 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/printenv"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/printf"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/pwd"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/realpath"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/sddf"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/seq"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/serial"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/sleep"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/sync"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/tee"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/true"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/uniq"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/uuidgen"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/wget"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/whoami"
@@ -120,10 +126,13 @@ func init() {
 		"chroot":    reg(chroot.New()),
 		//"chsh":         {chsh.Run, "Cqhange login shell"},
 		"clear":        reg(clear.New()),
+		"cmp":          reg(cmp.New()),
 		"cp":           reg(cp.New()),
+		"cut":          reg(cut.New()),
 		"dirname":      reg(dirname.New()),
 		"dos2unix":     reg(dos2unix.New()),
 		"echo":         reg(echo.New()),
+		"env":          reg(env.New()),
 		"expand":       reg(expand.New()),
 		"fakemovie":    reg(fakemovie.New()),
 		"false":        reg(boolfalse.New()),
@@ -149,6 +158,7 @@ func init() {
 		"printenv":     reg(printenv.New()),
 		"printf":       reg(printf.New()),
 		"pwd":          reg(pwd.New()),
+		"realpath":     reg(realpath.New()),
 		"remove-shell": reg(removeShell.New()),
 		"reboot":       reg(halt.NewReboot()),
 		"reset":        reg(reset.New()),
@@ -165,10 +175,12 @@ func init() {
 		"sync":         reg(sync.New()),
 		"tac":          reg(tac.New()),
 		"tail":         reg(tail.New()),
+		"tee":          reg(tee.New()),
 		"touch":        reg(touch.New()),
 		"tr":           reg(tr.New()),
 		"true":         reg(booltrue.New()),
 		"unexpand":     reg(unexpand.New()),
+		"uniq":         reg(uniq.New()),
 		"unix2dos":     reg(unix2dos.New()),
 		"uuidgen":      reg(uuidgen.New()),
 		"valid-shell":  reg(validShell.New()),

--- a/internal/applets/shellutils/cmp/cmp.go
+++ b/internal/applets/shellutils/cmp/cmp.go
@@ -1,0 +1,172 @@
+// Package cmp implements the cmp applet: compare two files byte by byte and
+// report the offset and line number of the first difference.
+package cmp
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the cmp applet.
+type Command struct{}
+
+// New returns a cmp command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "cmp" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Compare two files byte by byte" }
+
+// result is the outcome of comparing two byte streams.
+type result struct {
+	// equal is true when both streams held exactly the same bytes.
+	equal bool
+	// eofOn names which side hit EOF first when one stream is a proper prefix
+	// of the other: 0 means neither, 1 means the first reader, 2 the second.
+	eofOn int
+	// byteOffset is the 1-based offset of the first differing byte (only
+	// meaningful when there is a real difference, not an EOF).
+	byteOffset int64
+	// line is the 1-based line number containing the first differing byte.
+	line int64
+	// a and b are the differing byte values at byteOffset.
+	a, b byte
+}
+
+// compare reads r1 and r2 byte by byte and reports the first difference, or
+// that one stream is a prefix of the other, or that they are equal. It is the
+// pure, unit-testable core of cmp: it touches no files, flags, or streams of
+// its own.
+func compare(r1, r2 io.Reader) (result, error) {
+	br1 := bufio.NewReader(r1)
+	br2 := bufio.NewReader(r2)
+
+	var offset int64
+	var line int64 = 1
+	for {
+		b1, err1 := br1.ReadByte()
+		b2, err2 := br2.ReadByte()
+
+		eof1 := errors.Is(err1, io.EOF)
+		eof2 := errors.Is(err2, io.EOF)
+		// Surface any non-EOF read error to the caller.
+		if err1 != nil && !eof1 {
+			return result{}, err1
+		}
+		if err2 != nil && !eof2 {
+			return result{}, err2
+		}
+
+		switch {
+		case eof1 && eof2:
+			return result{equal: true}, nil
+		case eof1:
+			// r1 ended first: r1 is a prefix of r2.
+			return result{eofOn: 1}, nil
+		case eof2:
+			// r2 ended first: r2 is a prefix of r1.
+			return result{eofOn: 2}, nil
+		}
+
+		offset++
+		if b1 != b2 {
+			return result{
+				byteOffset: offset,
+				line:       line,
+				a:          b1,
+				b:          b2,
+			}, nil
+		}
+		if b1 == '\n' {
+			line++
+		}
+	}
+}
+
+// Run executes cmp.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 [FILE2]", stdio.Err)
+	silent := fs.BoolP("silent", "s", false, "suppress all normal output")
+	_ = fs.Bool("quiet", false, "suppress all normal output")
+	verbose := fs.BoolP("verbose", "l", false, "output byte numbers and differing byte values")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	quiet, _ := fs.GetBool("quiet")
+	silentMode := *silent || quiet
+
+	operands := fs.Args()
+	if len(operands) < 1 {
+		_, _ = fmt.Fprintln(stdio.Err, "cmp: missing operand")
+		return &command.ExitError{Code: 2}
+	}
+	if len(operands) > 2 {
+		_, _ = fmt.Fprintf(stdio.Err, "cmp: extra operand '%s'\n", operands[2])
+		return &command.ExitError{Code: 2}
+	}
+
+	name1 := operands[0]
+	name2 := "-"
+	if len(operands) == 2 {
+		name2 = operands[1]
+	}
+	if name1 == "-" && name2 == "-" {
+		_, _ = fmt.Fprintln(stdio.Err, "cmp: at most one operand may be '-'")
+		return &command.ExitError{Code: 2}
+	}
+
+	r1, err := command.Open(stdio, name1)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "cmp: %s\n", command.FileError(name1, err))
+		return &command.ExitError{Code: 2}
+	}
+	defer func() { _ = r1.Close() }()
+
+	r2, err := command.Open(stdio, name2)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "cmp: %s\n", command.FileError(name2, err))
+		return &command.ExitError{Code: 2}
+	}
+	defer func() { _ = r2.Close() }()
+
+	res, err := compare(r1, r2)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "cmp: %v\n", err)
+		return &command.ExitError{Code: 2}
+	}
+
+	if res.equal {
+		return nil
+	}
+
+	if res.eofOn != 0 {
+		if !silentMode {
+			shorter := name1
+			if res.eofOn == 2 {
+				shorter = name2
+			}
+			_, _ = fmt.Fprintf(stdio.Err, "cmp: EOF on %s\n", shorter)
+		}
+		return &command.ExitError{Code: 1}
+	}
+
+	// Files differ at a concrete byte.
+	if !silentMode {
+		if *verbose {
+			_, _ = fmt.Fprintf(stdio.Out, "%d %o %o\n", res.byteOffset, res.a, res.b)
+		} else {
+			_, _ = fmt.Fprintf(stdio.Out, "%s %s differ: byte %d, line %d\n",
+				name1, name2, res.byteOffset, res.line)
+		}
+	}
+	return &command.ExitError{Code: 1}
+}

--- a/internal/applets/shellutils/cmp/cmp_test.go
+++ b/internal/applets/shellutils/cmp/cmp_test.go
@@ -1,0 +1,176 @@
+package cmp_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/cmp"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// run executes the cmp command with empty stdin and returns stdout, stderr and
+// the process exit code (via command.Execute).
+func run(t *testing.T, args ...string) (string, string, int) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	code := command.Execute(context.Background(), cmp.New(), io, args)
+	return out.String(), errBuf.String(), code
+}
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestIdentical(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "hello\nworld\n")
+	b := writeFile(t, dir, "b", "hello\nworld\n")
+
+	out, errOut, code := run(t, a, b)
+	if code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("output = %q / %q, want empty", out, errOut)
+	}
+}
+
+func TestDiffer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// First difference is the 9th byte: "second" vs "SECOND"; the difference
+	// is on line 2 (one newline precedes it). Verified against system cmp.
+	a := writeFile(t, dir, "a", "first\nsecond\n")
+	b := writeFile(t, dir, "b", "first\nSECOND\n")
+
+	out, _, code := run(t, a, b)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	want := a + " " + b + " differ: byte 7, line 2\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestDifferMatchesSystemCmp cross-checks the byte/line numbers against the
+// system cmp binary so the implementation can't silently drift.
+func TestDifferMatchesSystemCmp(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "alpha\nbravo\ncharlie\n")
+	b := writeFile(t, dir, "b", "alpha\nbravX\ncharlie\n")
+
+	sysOut, ok := systemCmp(t, a, b)
+	if !ok {
+		t.Skip("system cmp not available")
+	}
+
+	out, _, code := run(t, a, b)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	// system cmp: "<a> <b> differ: byte N, line L". Compare the "byte N, line L"
+	// tail, which is path-independent.
+	wantTail := tail(sysOut)
+	gotTail := tail(out)
+	if gotTail != wantTail {
+		t.Errorf("differ tail = %q, want %q (system cmp: %q)", gotTail, wantTail, sysOut)
+	}
+}
+
+func TestPrefix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	short := writeFile(t, dir, "short", "abc")
+	long := writeFile(t, dir, "long", "abcd")
+
+	out, errOut, code := run(t, short, long)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	if !strings.Contains(errOut, "cmp: EOF on "+short) {
+		t.Errorf("stderr = %q, want EOF on %q", errOut, short)
+	}
+}
+
+func TestSilent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "abc\n")
+	b := writeFile(t, dir, "b", "abd\n")
+
+	out, errOut, code := run(t, "-s", a, b)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1", code)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("output = %q / %q, want empty with -s", out, errOut)
+	}
+
+	// Identical files with -s still exit 0 silently.
+	c := writeFile(t, dir, "c", "abc\n")
+	out, errOut, code = run(t, "-s", a, c)
+	if code != 0 {
+		t.Errorf("exit = %d, want 0", code)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("output = %q / %q, want empty", out, errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "abc\n")
+
+	out, errOut, code := run(t, a, filepath.Join(dir, "nope"))
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	if !strings.Contains(errOut, "cmp: ") {
+		t.Errorf("stderr = %q, want cmp error prefix", errOut)
+	}
+}
+
+// tail returns the substring starting at "byte " from a cmp differ line.
+func tail(s string) string {
+	i := strings.Index(s, "byte ")
+	if i < 0 {
+		return strings.TrimSpace(s)
+	}
+	return strings.TrimSpace(s[i:])
+}
+
+// systemCmp runs the host's cmp and returns its stdout and whether it ran.
+func systemCmp(t *testing.T, a, b string) (string, bool) {
+	t.Helper()
+	path, err := exec.LookPath("cmp")
+	if err != nil {
+		return "", false
+	}
+	var out bytes.Buffer
+	c := exec.Command(path, a, b)
+	c.Stdout = &out
+	_ = c.Run() // exit 1 on differ is expected; ignore.
+	return out.String(), true
+}

--- a/internal/applets/shellutils/cut/cut.go
+++ b/internal/applets/shellutils/cut/cut.go
@@ -1,0 +1,387 @@
+// Package cut implements the cut applet: remove sections from each line of
+// files (or standard input) and print the result on the standard output, with
+// the common GNU options for selecting bytes, characters, or fields.
+package cut
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the cut applet.
+type Command struct{}
+
+// New returns a cut command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "cut" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Remove sections from each line of files" }
+
+// mode is the selection unit chosen by exactly one of -b, -c or -f.
+type mode int
+
+const (
+	modeNone mode = iota
+	modeBytes
+	modeChars
+	modeFields
+)
+
+// options holds the resolved, validated cut configuration.
+type options struct {
+	mode            mode
+	ranges          []rng
+	delimiter       string
+	outputDelimiter string
+	onlyDelimited   bool
+}
+
+// Run executes cut.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "OPTION... [FILE]...", stdio.Err)
+	bytesList := fs.StringP("bytes", "b", "", "select only these bytes")
+	charsList := fs.StringP("characters", "c", "", "select only these characters")
+	fieldsList := fs.StringP("fields", "f", "", "select only these fields")
+	delimiter := fs.StringP("delimiter", "d", "\t", "use DELIM instead of TAB for field delimiter")
+	onlyDelimited := fs.BoolP("only-delimited", "s", false, "do not print lines not containing delimiters")
+	outputDelimiter := fs.String("output-delimiter", "", "use STRING as the output delimiter")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	opts, err := buildOptions(stdio, *bytesList, *charsList, *fieldsList,
+		*delimiter, *outputDelimiter, *onlyDelimited, fs.Changed("output-delimiter"))
+	if err != nil {
+		return err
+	}
+
+	return run(stdio, opts, fs.Args())
+}
+
+// buildOptions validates the mutually exclusive selection flags and parses the
+// range list, returning the resolved options. Errors are written to stderr and
+// reported as silent failures so the runner only sets the exit code.
+func buildOptions(stdio command.IO, bytesList, charsList, fieldsList,
+	delimiter, outputDelimiter string, onlyDelimited, outDelimSet bool) (options, error) {
+	m, list, err := selectMode(stdio, bytesList, charsList, fieldsList)
+	if err != nil {
+		return options{}, err
+	}
+
+	ranges, perr := parseRanges(list)
+	if perr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "cut: %v\n", perr)
+		return options{}, command.SilentFailure()
+	}
+
+	outDelim := outputDelimiter
+	if !outDelimSet {
+		// Default output delimiter: the input delimiter for fields, empty
+		// otherwise (bytes/characters are simply concatenated).
+		if m == modeFields {
+			outDelim = delimiter
+		} else {
+			outDelim = ""
+		}
+	}
+
+	return options{
+		mode:            m,
+		ranges:          ranges,
+		delimiter:       delimiter,
+		outputDelimiter: outDelim,
+		onlyDelimited:   onlyDelimited,
+	}, nil
+}
+
+// selectMode enforces that exactly one of -b/-c/-f is given and returns the
+// chosen mode together with its range list string.
+func selectMode(stdio command.IO, bytesList, charsList, fieldsList string) (mode, string, error) {
+	count := 0
+	var m mode
+	var list string
+	if bytesList != "" {
+		count++
+		m, list = modeBytes, bytesList
+	}
+	if charsList != "" {
+		count++
+		m, list = modeChars, charsList
+	}
+	if fieldsList != "" {
+		count++
+		m, list = modeFields, fieldsList
+	}
+
+	switch {
+	case count == 0:
+		_, _ = fmt.Fprintln(stdio.Err, "cut: you must specify a list of bytes, characters, or fields")
+		return modeNone, "", command.SilentFailure()
+	case count > 1:
+		_, _ = fmt.Fprintln(stdio.Err, "cut: only one type of list may be specified")
+		return modeNone, "", command.SilentFailure()
+	default:
+		return m, list, nil
+	}
+}
+
+// run reads every operand (defaulting to standard input) and cuts each line.
+func run(stdio command.IO, opts options, files []string) error {
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+	var firstErr error
+	for _, name := range files {
+		r, err := command.Open(stdio, name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "cut: %s\n", command.FileError(name, err))
+			firstErr = keep(firstErr)
+			continue
+		}
+		cerr := cutReader(stdio.Out, r, opts)
+		_ = r.Close()
+		if cerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "cut: %s\n", command.FileError(name, cerr))
+			firstErr = keep(firstErr)
+		}
+	}
+	return firstErr
+}
+
+// cutReader processes r line by line, writing the cut output to w.
+func cutReader(w io.Writer, r io.Reader, opts options) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	bw := bufio.NewWriter(w)
+	for sc.Scan() {
+		out, emit := cutLine(sc.Text(), opts)
+		if !emit {
+			continue
+		}
+		if _, err := bw.WriteString(out); err != nil {
+			return err
+		}
+		if err := bw.WriteByte('\n'); err != nil {
+			return err
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+// rng is a 1-based inclusive range from a cut list. A zero hi means the range
+// is open-ended ("N-").
+type rng struct {
+	lo int
+	hi int // 0 means "to end of line"
+}
+
+// open reports whether the range extends to the end of the line.
+func (r rng) open() bool { return r.hi == 0 }
+
+// parseRanges parses a comma-separated cut LIST such as "1,3-5,7-" into a
+// sorted, merged slice of ranges. Each item is one of N, N-, N-M or -M, all
+// 1-based and inclusive.
+func parseRanges(list string) ([]rng, error) {
+	var ranges []rng
+	for _, item := range strings.Split(list, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			return nil, fmt.Errorf("invalid byte, character or field list")
+		}
+		r, err := parseRange(item)
+		if err != nil {
+			return nil, err
+		}
+		ranges = append(ranges, r)
+	}
+	return mergeRanges(ranges), nil
+}
+
+// parseRange parses a single list item.
+func parseRange(item string) (rng, error) {
+	dash := strings.IndexByte(item, '-')
+	if dash < 0 {
+		n, err := parsePos(item)
+		if err != nil {
+			return rng{}, err
+		}
+		return rng{lo: n, hi: n}, nil
+	}
+
+	loStr := item[:dash]
+	hiStr := item[dash+1:]
+
+	var lo, hi int
+	var err error
+	if loStr == "" {
+		lo = 1 // "-M" means from the first
+	} else if lo, err = parsePos(loStr); err != nil {
+		return rng{}, err
+	}
+
+	if hiStr == "" {
+		hi = 0 // "N-" means to the end
+	} else if hi, err = parsePos(hiStr); err != nil {
+		return rng{}, err
+	}
+
+	if hi != 0 && lo > hi {
+		return rng{}, fmt.Errorf("invalid decreasing range")
+	}
+	return rng{lo: lo, hi: hi}, nil
+}
+
+// parsePos parses a positive (>= 1) integer position from a list.
+func parsePos(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid byte, character or field list")
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("byte, character or field positions are numbered from 1")
+	}
+	return n, nil
+}
+
+// mergeRanges sorts ranges by their start and merges overlapping or adjacent
+// ones so the selection is emitted in ascending order without duplication.
+func mergeRanges(ranges []rng) []rng {
+	if len(ranges) == 0 {
+		return ranges
+	}
+	sort.Slice(ranges, func(i, j int) bool {
+		if ranges[i].lo != ranges[j].lo {
+			return ranges[i].lo < ranges[j].lo
+		}
+		// Open-ended ranges sort last among equal starts.
+		return !ranges[i].open() && ranges[j].open()
+	})
+
+	merged := []rng{ranges[0]}
+	for _, r := range ranges[1:] {
+		last := &merged[len(merged)-1]
+		if last.open() {
+			// Nothing can extend past an open-ended range.
+			continue
+		}
+		if r.lo <= last.hi+1 {
+			if r.open() {
+				last.hi = 0
+			} else if r.hi > last.hi {
+				last.hi = r.hi
+			}
+			continue
+		}
+		merged = append(merged, r)
+	}
+	return merged
+}
+
+// selected reports whether the 1-based position pos is covered by any range.
+func selected(ranges []rng, pos int) bool {
+	for _, r := range ranges {
+		if pos < r.lo {
+			return false // ranges are sorted; no later range can match a smaller pos
+		}
+		if r.open() || pos <= r.hi {
+			return true
+		}
+	}
+	return false
+}
+
+// cutLine applies the selection to a single input line (without its trailing
+// newline). The second result reports whether the line should be emitted at
+// all (false only for -s lines that contain no delimiter).
+func cutLine(line string, opts options) (string, bool) {
+	switch opts.mode {
+	case modeFields:
+		return cutFields(line, opts)
+	case modeChars:
+		return cutRunes(line, opts), true
+	default: // modeBytes
+		return cutBytes(line, opts), true
+	}
+}
+
+// cutBytes selects bytes from line, joining selected ranges with the output
+// delimiter.
+func cutBytes(line string, opts options) string {
+	var b strings.Builder
+	for i, r := range opts.ranges {
+		if i > 0 {
+			b.WriteString(opts.outputDelimiter)
+		}
+		end := r.hi
+		if r.open() || end > len(line) {
+			end = len(line)
+		}
+		if r.lo > len(line) || r.lo > end {
+			continue
+		}
+		b.WriteString(line[r.lo-1 : end])
+	}
+	return b.String()
+}
+
+// cutRunes selects characters (runes) from line, joining selected ranges with
+// the output delimiter.
+func cutRunes(line string, opts options) string {
+	runes := []rune(line)
+	var b strings.Builder
+	for i, r := range opts.ranges {
+		if i > 0 {
+			b.WriteString(opts.outputDelimiter)
+		}
+		end := r.hi
+		if r.open() || end > len(runes) {
+			end = len(runes)
+		}
+		if r.lo > len(runes) || r.lo > end {
+			continue
+		}
+		b.WriteString(string(runes[r.lo-1 : end]))
+	}
+	return b.String()
+}
+
+// cutFields selects fields from line split on the delimiter. Lines with no
+// delimiter are passed through unchanged unless -s suppresses them.
+func cutFields(line string, opts options) (string, bool) {
+	if !strings.Contains(line, opts.delimiter) {
+		if opts.onlyDelimited {
+			return "", false
+		}
+		return line, true
+	}
+	fields := strings.Split(line, opts.delimiter)
+	var selectedFields []string
+	for i := range fields {
+		if selected(opts.ranges, i+1) {
+			selectedFields = append(selectedFields, fields[i])
+		}
+	}
+	return strings.Join(selectedFields, opts.outputDelimiter), true
+}
+
+func keep(existing error) error {
+	if existing != nil {
+		return existing
+	}
+	return command.SilentFailure()
+}

--- a/internal/applets/shellutils/cut/cut_test.go
+++ b/internal/applets/shellutils/cut/cut_test.go
@@ -1,0 +1,130 @@
+package cut_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/cut"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func runStdin(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := cut.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunCut(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"field 1 default tab", "a\tb\tc\n", []string{"-f", "1"}, "a\n"},
+		{"field 2 comma delim", "a,b,c\n", []string{"-f", "2", "-d", ","}, "b\n"},
+		{"fields 1,3 comma", "a,b,c\n", []string{"-f", "1,3", "-d", ","}, "a,c\n"},
+		{"fields 2- comma", "a,b,c\n", []string{"-f", "2-", "-d", ","}, "b,c\n"},
+		{"chars 1-3", "abcdef\n", []string{"-c", "1-3"}, "abc\n"},
+		{"byte 1", "abc\n", []string{"-b", "1"}, "a\n"},
+		{
+			"only delimited suppresses",
+			"nodelim\na,b\n",
+			[]string{"-f", "1", "-d", ",", "-s"},
+			"a\n",
+		},
+		{
+			"output delimiter",
+			"a,b,c\n",
+			[]string{"-f", "1,3", "-d", ",", "--output-delimiter=:"},
+			"a:c\n",
+		},
+		{
+			"no delimiter line passes through",
+			"nodelim\na,b\n",
+			[]string{"-f", "1", "-d", ","},
+			"nodelim\na\n",
+		},
+		{
+			"long flags",
+			"a,b,c\n",
+			[]string{"--fields=2", "--delimiter=,"},
+			"b\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunNoListSpecified(t *testing.T) {
+	t.Parallel()
+	out, errOut, err := runStdin(t, "a,b\n")
+	if err == nil {
+		t.Fatal("expected error when no list is specified")
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+	want := "cut: you must specify a list of bytes, characters, or fields"
+	if !strings.Contains(errOut, want) {
+		t.Errorf("stderr = %q, want to contain %q", errOut, want)
+	}
+}
+
+func TestRunMultipleListsError(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "a,b\n", "-b", "1", "-f", "1")
+	if err == nil {
+		t.Fatal("expected error when more than one list is specified")
+	}
+	if !strings.Contains(errOut, "only one type of list may be specified") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunInvalidList(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "abc\n", "-c", "0")
+	if err == nil {
+		t.Fatal("expected error for position 0")
+	}
+	if !strings.Contains(errOut, "numbered from 1") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := runStdin(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: cut") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = runStdin(t, "", "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "cut (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}

--- a/internal/applets/shellutils/env/env.go
+++ b/internal/applets/shellutils/env/env.go
@@ -1,0 +1,151 @@
+// Package env implements the env applet: run a program in a modified
+// environment, or print the current environment.
+package env
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the env applet.
+type Command struct{}
+
+// New returns an env command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "env" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	return "Run a program in a modified environment / print the environment"
+}
+
+// Run executes env.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]", stdio.Err)
+	// Options stop at the first operand so that flags meant for COMMAND (such as
+	// "sh -c") are passed through untouched instead of parsed by env.
+	fs.SetInterspersed(false)
+	ignore := fs.BoolP("ignore-environment", "i", false, "start with an empty environment")
+	unset := fs.StringArrayP("unset", "u", nil, "remove variable from the environment")
+	null := fs.BoolP("null", "0", false, "end each output line with NUL, not newline")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	// Build the base environment: empty for -i, otherwise the inherited one.
+	var environ []string
+	if !*ignore {
+		environ = os.Environ()
+	}
+
+	// Leading NAME=VALUE operands set variables; the first operand that is not
+	// an assignment begins the command and its arguments.
+	rest := fs.Args()
+	var idx int
+	for idx = 0; idx < len(rest); idx++ {
+		name, _, ok := splitAssignment(rest[idx])
+		if !ok {
+			break
+		}
+		environ = setEnv(environ, name, rest[idx])
+	}
+
+	// Apply -u removals after the assignments so an explicit assignment can be
+	// unset and a later assignment is honored.
+	for _, name := range *unset {
+		environ = unsetEnv(environ, name)
+	}
+
+	argv := rest[idx:]
+	if len(argv) == 0 {
+		printEnviron(stdio, environ, *null)
+		return nil
+	}
+
+	return runCommand(ctx, stdio, environ, argv)
+}
+
+// splitAssignment reports whether operand has the form NAME=VALUE and, if so,
+// returns its NAME and VALUE. An operand with an empty name (e.g. "=x") is not
+// treated as an assignment.
+func splitAssignment(operand string) (name, value string, ok bool) {
+	i := strings.IndexByte(operand, '=')
+	if i <= 0 {
+		return "", "", false
+	}
+	return operand[:i], operand[i+1:], true
+}
+
+// setEnv replaces the entry whose name matches assignment ("NAME=VALUE") or
+// appends it when the name is not present.
+func setEnv(environ []string, name, assignment string) []string {
+	prefix := name + "="
+	for i, e := range environ {
+		if strings.HasPrefix(e, prefix) {
+			environ[i] = assignment
+			return environ
+		}
+	}
+	return append(environ, assignment)
+}
+
+// unsetEnv removes every entry whose name matches.
+func unsetEnv(environ []string, name string) []string {
+	prefix := name + "="
+	out := environ[:0]
+	for _, e := range environ {
+		if strings.HasPrefix(e, prefix) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// printEnviron writes each NAME=VALUE entry, terminated by newline (or NUL when
+// null is set).
+func printEnviron(stdio command.IO, environ []string, null bool) {
+	end := byte('\n')
+	if null {
+		end = 0
+	}
+	for _, e := range environ {
+		_, _ = fmt.Fprintf(stdio.Out, "%s%c", e, end)
+	}
+}
+
+// runCommand execs argv[0] with the remaining args and the modified
+// environment, mirroring its exit status. A command that cannot be found is
+// reported GNU-style and maps to exit status 127.
+func runCommand(ctx context.Context, stdio command.IO, environ, argv []string) error {
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec // running a user-named command is the whole point
+	cmd.Env = environ
+	cmd.Stdin = stdio.In
+	cmd.Stdout = stdio.Out
+	cmd.Stderr = stdio.Err
+
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return &command.ExitError{Code: exitErr.ExitCode()}
+	}
+
+	// Anything else (most commonly "executable file not found") means the
+	// command could not be started.
+	_, _ = fmt.Fprintf(stdio.Err, "env: '%s': No such file or directory\n", argv[0])
+	return &command.ExitError{Code: 127}
+}

--- a/internal/applets/shellutils/env/env_test.go
+++ b/internal/applets/shellutils/env/env_test.go
@@ -1,0 +1,160 @@
+package env_test
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/env"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := env.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunPrintEnviron(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "assignment operand appears in output",
+			args:        []string{"FOO=bar"},
+			wantContain: []string{"FOO=bar", "MIMIX_BASE=present"},
+		},
+		{
+			name:        "ignore-environment prints only the assignment",
+			args:        []string{"-i", "ONLY=one"},
+			wantContain: []string{"ONLY=one"},
+			wantAbsent:  []string{"MIMIX_BASE="},
+		},
+		{
+			name:        "unset removes a variable",
+			args:        []string{"-u", "MIMIX_BASE"},
+			wantContain: []string{},
+			wantAbsent:  []string{"MIMIX_BASE="},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MIMIX_BASE", "present")
+			out, _, err := run(t, "", tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(out, want) {
+					t.Errorf("output %q does not contain %q", out, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Errorf("output %q unexpectedly contains %q", out, absent)
+				}
+			}
+		})
+	}
+}
+
+func TestRunNullSeparator(t *testing.T) {
+	out, _, err := run(t, "", "-i", "-0", "A=1", "B=2")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "A=1\x00B=2\x00"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+	if strings.Contains(out, "\n") {
+		t.Errorf("out = %q, want no newline separators", out)
+	}
+}
+
+func TestRunCommand(t *testing.T) {
+	echo, err := exec.LookPath("echo")
+	if err != nil {
+		t.Skipf("echo not found: %v", err)
+	}
+	out, _, runErr := run(t, "", echo, "hello")
+	if runErr != nil {
+		t.Fatalf("Run error = %v", runErr)
+	}
+	if out != "hello\n" {
+		t.Errorf("out = %q, want %q", out, "hello\n")
+	}
+}
+
+func TestRunCommandSeesModifiedEnv(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not found: %v", err)
+	}
+	out, _, runErr := run(t, "", "GREETING=hi", sh, "-c", "printf %s \"$GREETING\"")
+	if runErr != nil {
+		t.Fatalf("Run error = %v", runErr)
+	}
+	if out != "hi" {
+		t.Errorf("out = %q, want %q", out, "hi")
+	}
+}
+
+func TestRunCommandExitStatus(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not found: %v", err)
+	}
+	_, _, runErr := run(t, "", sh, "-c", "exit 3")
+	exitErr, ok := runErr.(*command.ExitError)
+	if !ok {
+		t.Fatalf("error = %v (%T), want *command.ExitError", runErr, runErr)
+	}
+	if exitErr.Code != 3 {
+		t.Errorf("exit code = %d, want 3", exitErr.Code)
+	}
+}
+
+func TestRunCommandNotFound(t *testing.T) {
+	out, errOut, runErr := run(t, "", "no_such_command_xyz")
+	exitErr, ok := runErr.(*command.ExitError)
+	if !ok {
+		t.Fatalf("error = %v (%T), want *command.ExitError", runErr, runErr)
+	}
+	if exitErr.Code != 127 {
+		t.Errorf("exit code = %d, want 127", exitErr.Code)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+	if !strings.Contains(errOut, "env: 'no_such_command_xyz': No such file or directory") {
+		t.Errorf("stderr = %q, want not-found message", errOut)
+	}
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: env") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = run(t, "", "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "env (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}

--- a/internal/applets/shellutils/realpath/realpath.go
+++ b/internal/applets/shellutils/realpath/realpath.go
@@ -1,0 +1,95 @@
+// Package realpath implements the realpath applet: print the resolved absolute
+// file name for each operand.
+package realpath
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the realpath applet.
+type Command struct{}
+
+// New returns a realpath command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "realpath" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the resolved absolute file name" }
+
+// Run executes realpath.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	existing := fs.BoolP("canonicalize-existing", "e", false, "all components of the path must exist")
+	missing := fs.BoolP("canonicalize-missing", "m", false, "no path components need exist or be a directory")
+	noSymlinks := fs.BoolP("no-symlinks", "s", false, "don't expand symlinks")
+	zero := fs.BoolP("zero", "z", false, "end each output line with NUL, not newline")
+	quiet := fs.BoolP("quiet", "q", false, "suppress most error messages")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	names := fs.Args()
+	if len(names) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "realpath: missing operand")
+		return command.SilentFailure()
+	}
+
+	end := byte('\n')
+	if *zero {
+		end = 0
+	}
+
+	var failed bool
+	for _, name := range names {
+		resolved, rerr := resolve(name, *missing, *noSymlinks)
+		if rerr != nil {
+			if !*quiet {
+				_, _ = fmt.Fprintf(stdio.Err, "realpath: %s\n", command.FileError(name, rerr))
+			}
+			failed = true
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%s%c", resolved, end)
+	}
+
+	// existing is accepted for GNU compatibility; it matches the default
+	// behavior of requiring every path component to exist.
+	_ = existing
+
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// resolve canonicalizes name to an absolute path. With noSymlinks it only
+// cleans the path (filepath.Abs + filepath.Clean) without expanding symlinks.
+// With missing it does not require the path to exist. Otherwise every path
+// component must exist and all symlinks are resolved.
+func resolve(name string, missing, noSymlinks bool) (string, error) {
+	abs, err := filepath.Abs(name)
+	if err != nil {
+		return "", err
+	}
+
+	if noSymlinks {
+		return filepath.Clean(abs), nil
+	}
+
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		if missing {
+			return filepath.Clean(abs), nil
+		}
+		return "", err
+	}
+	return resolved, nil
+}

--- a/internal/applets/shellutils/realpath/realpath_test.go
+++ b/internal/applets/shellutils/realpath/realpath_test.go
@@ -1,0 +1,130 @@
+package realpath_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/realpath"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := realpath.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunExistingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := run(t, file)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != want+"\n" {
+		t.Errorf("out = %q, want %q", out, want+"\n")
+	}
+}
+
+func TestRunNoSymlinks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	// -s keeps the link path (only cleaning it), but resolves the dir symlink
+	// that t.TempDir() may itself sit under.
+	cleanDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLink := filepath.Join(cleanDir, "link.txt")
+
+	out, _, err := run(t, "-s", link)
+	if err != nil {
+		t.Fatalf("Run -s error = %v", err)
+	}
+	if out != wantLink+"\n" {
+		t.Errorf("-s out = %q, want %q", out, wantLink+"\n")
+	}
+
+	// Default resolves the symlink to the target.
+	wantTarget, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _, err = run(t, link)
+	if err != nil {
+		t.Fatalf("Run default error = %v", err)
+	}
+	if out != wantTarget+"\n" {
+		t.Errorf("default out = %q, want %q", out, wantTarget+"\n")
+	}
+}
+
+func TestRunMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cleanDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonexistent := filepath.Join(dir, "does", "not", "exist")
+	want := filepath.Join(cleanDir, "does", "not", "exist")
+
+	out, _, err := run(t, "-m", nonexistent)
+	if err != nil {
+		t.Fatalf("Run -m error = %v", err)
+	}
+	if out != want+"\n" {
+		t.Errorf("-m out = %q, want %q", out, want+"\n")
+	}
+}
+
+func TestRunMissingWithoutFlagErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	nonexistent := filepath.Join(dir, "nope")
+
+	_, errOut, err := run(t, nonexistent)
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+	if !strings.Contains(errOut, "realpath:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunMissingOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "missing operand") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}

--- a/internal/applets/shellutils/tee/tee.go
+++ b/internal/applets/shellutils/tee/tee.go
@@ -1,0 +1,88 @@
+// Package tee implements the tee applet: read from standard input and write to
+// standard output and to each named file, fanning the stream out with the
+// common GNU options.
+package tee
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the tee applet.
+type Command struct{}
+
+// New returns a tee command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "tee" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	return "Read from standard input and write to standard output and files"
+}
+
+// Run executes tee.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	appendMode := fs.BoolP("append", "a", false, "append to the given FILEs, do not overwrite")
+	// -i/--ignore-interrupts is accepted for GNU compatibility; in this
+	// in-memory model there is no SIGINT to ignore, so it is a no-op.
+	_ = fs.BoolP("ignore-interrupts", "i", false, "ignore interrupt signals")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	return tee(stdio, fs.Args(), *appendMode)
+}
+
+// tee copies standard input to standard output and to each named file. A file
+// that cannot be opened or written is reported on stderr GNU-style and sets the
+// exit status to failure, but does not stop writing to standard output or the
+// remaining files.
+func tee(stdio command.IO, files []string, appendMode bool) error {
+	flags := os.O_CREATE | os.O_WRONLY
+	if appendMode {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+
+	writers := []io.Writer{stdio.Out}
+	var opened []*os.File
+	var failed bool
+	for _, name := range files {
+		f, err := os.OpenFile(name, flags, 0o644) //nolint:gosec // operating on a user-named file is the whole point
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "tee: %s\n", command.FileError(name, err))
+			failed = true
+			continue
+		}
+		writers = append(writers, f)
+		opened = append(opened, f)
+	}
+
+	mw := io.MultiWriter(writers...)
+	if _, err := io.Copy(mw, stdio.In); err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "tee: %s\n", err)
+		failed = true
+	}
+
+	for _, f := range opened {
+		if cerr := f.Close(); cerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "tee: %s\n", command.FileError(f.Name(), cerr))
+			failed = true
+		}
+	}
+
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}

--- a/internal/applets/shellutils/tee/tee_test.go
+++ b/internal/applets/shellutils/tee/tee_test.go
@@ -1,0 +1,139 @@
+package tee_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/tee"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := tee.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunStdoutAndFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "out.txt")
+
+	out, errOut, err := run(t, "hello\nworld\n", f)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if out != "hello\nworld\n" {
+		t.Errorf("stdout = %q, want %q", out, "hello\nworld\n")
+	}
+	got, rerr := os.ReadFile(f)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(got) != "hello\nworld\n" {
+		t.Errorf("file = %q, want %q", string(got), "hello\nworld\n")
+	}
+}
+
+func TestRunMultipleFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+
+	out, _, err := run(t, "data\n", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "data\n" {
+		t.Errorf("stdout = %q, want %q", out, "data\n")
+	}
+	for _, f := range []string{a, b} {
+		got, rerr := os.ReadFile(f)
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		if string(got) != "data\n" {
+			t.Errorf("file %s = %q, want %q", f, string(got), "data\n")
+		}
+	}
+}
+
+func TestRunAppend(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(f, []byte("first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := run(t, "second\n", "-a", f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "second\n" {
+		t.Errorf("stdout = %q, want %q", out, "second\n")
+	}
+	got, rerr := os.ReadFile(f)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(got) != "first\nsecond\n" {
+		t.Errorf("file = %q, want %q", string(got), "first\nsecond\n")
+	}
+}
+
+func TestRunTruncateByDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(f, []byte("old content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := run(t, "new\n", f); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got, rerr := os.ReadFile(f)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(got) != "new\n" {
+		t.Errorf("file = %q, want %q", string(got), "new\n")
+	}
+}
+
+func TestRunInvalidFile(t *testing.T) {
+	t.Parallel()
+	// A path whose parent directory does not exist cannot be opened.
+	bad := filepath.Join(t.TempDir(), "missing-dir", "out.txt")
+
+	out, errOut, err := run(t, "payload\n", bad)
+	if err == nil {
+		t.Fatal("expected error for invalid file path")
+	}
+	if out != "payload\n" {
+		t.Errorf("stdout = %q, want %q (stdout must still receive input)", out, "payload\n")
+	}
+	if !strings.Contains(errOut, "tee: "+bad+":") {
+		t.Errorf("stderr = %q, want tee error prefix for %q", errOut, bad)
+	}
+}
+
+func TestRunIgnoreInterruptsAccepted(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "x\n", "-i")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "x\n" {
+		t.Errorf("stdout = %q, want %q", out, "x\n")
+	}
+}

--- a/internal/applets/shellutils/uniq/uniq.go
+++ b/internal/applets/shellutils/uniq/uniq.go
@@ -1,0 +1,164 @@
+// Package uniq implements the uniq applet: filter adjacent matching lines from
+// INPUT (or standard input), writing the result to OUTPUT (or standard output),
+// with the common GNU options.
+package uniq
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the uniq applet.
+type Command struct{}
+
+// New returns a uniq command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "uniq" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report or omit repeated lines" }
+
+type options struct {
+	count      bool
+	repeated   bool
+	unique     bool
+	ignoreCase bool
+}
+
+// Run executes uniq.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [INPUT [OUTPUT]]", stdio.Err)
+	count := fs.BoolP("count", "c", false, "prefix lines by the number of occurrences")
+	repeated := fs.BoolP("repeated", "d", false, "only print duplicate lines, one for each group")
+	unique := fs.BoolP("unique", "u", false, "only print unique lines")
+	ignoreCase := fs.BoolP("ignore-case", "i", false, "ignore differences in case when comparing")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	opts := options{
+		count:      *count,
+		repeated:   *repeated,
+		unique:     *unique,
+		ignoreCase: *ignoreCase,
+	}
+
+	operands := fs.Args()
+	inputName := "-"
+	if len(operands) >= 1 {
+		inputName = operands[0]
+	}
+
+	r, err := command.Open(stdio, inputName)
+	if err != nil {
+		return command.Failuref("%s", command.FileError(inputName, err))
+	}
+	defer func() { _ = r.Close() }()
+
+	lines, readErr := readLines(r)
+	if readErr != nil {
+		return command.Failuref("%s", command.FileError(inputName, readErr))
+	}
+
+	out := filter(lines, opts)
+
+	w, closeW, err := openOutput(stdio, operands)
+	if err != nil {
+		return command.Failuref("%s", command.FileError(operands[1], err))
+	}
+	defer closeW()
+
+	if _, err := io.WriteString(w, out); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// openOutput resolves the optional OUTPUT operand to a writer, defaulting to
+// standard output. The returned func closes the writer (a no-op for stdout).
+func openOutput(stdio command.IO, operands []string) (io.Writer, func(), error) {
+	if len(operands) < 2 || operands[1] == "-" {
+		return stdio.Out, func() {}, nil
+	}
+	f, err := os.Create(operands[1]) //nolint:gosec // operating on a user-named file is the whole point
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+// readLines reads r into its lines, dropping the trailing newline of each line.
+func readLines(r io.Reader) ([]string, error) {
+	var lines []string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}
+
+// group is a run of adjacent lines that compared equal.
+type group struct {
+	line  string // the line as first seen (original case preserved)
+	count int
+}
+
+// filter applies GNU uniq's grouping and option logic to lines, returning the
+// rendered output text (each emitted line terminated by a newline). This is the
+// pure core, exercised directly by the unit tests.
+func filter(lines []string, opts options) string {
+	groups := makeGroups(lines, opts.ignoreCase)
+
+	var b strings.Builder
+	for _, g := range groups {
+		if opts.repeated && g.count < 2 {
+			continue
+		}
+		if opts.unique && g.count > 1 {
+			continue
+		}
+		if opts.count {
+			fmt.Fprintf(&b, "%7d %s\n", g.count, g.line)
+			continue
+		}
+		b.WriteString(g.line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// makeGroups collapses adjacent equal lines into groups. With ignoreCase the
+// comparison is case-insensitive, but the first line of each group is emitted
+// verbatim, matching GNU uniq.
+func makeGroups(lines []string, ignoreCase bool) []group {
+	var groups []group
+	for _, l := range lines {
+		if n := len(groups); n > 0 && equal(groups[n-1].line, l, ignoreCase) {
+			groups[n-1].count++
+			continue
+		}
+		groups = append(groups, group{line: l, count: 1})
+	}
+	return groups
+}
+
+func equal(a, b string, ignoreCase bool) bool {
+	if ignoreCase {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}

--- a/internal/applets/shellutils/uniq/uniq_test.go
+++ b/internal/applets/shellutils/uniq/uniq_test.go
@@ -1,0 +1,163 @@
+package uniq_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/uniq"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func runStdin(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := uniq.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunStdin(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{
+			name:  "basic adjacent dedup",
+			stdin: "a\na\nb\nc\nc\nc\n",
+			args:  nil,
+			want:  "a\nb\nc\n",
+		},
+		{
+			name:  "count prefixes occurrences",
+			stdin: "a\na\nb\nc\nc\nc\n",
+			args:  []string{"-c"},
+			want:  "      2 a\n      1 b\n      3 c\n",
+		},
+		{
+			name:  "repeated only prints duplicates",
+			stdin: "a\na\nb\nc\nc\nc\n",
+			args:  []string{"-d"},
+			want:  "a\nc\n",
+		},
+		{
+			name:  "unique only prints non-repeated",
+			stdin: "a\na\nb\nc\nc\nc\n",
+			args:  []string{"-u"},
+			want:  "b\n",
+		},
+		{
+			name:  "ignore case",
+			stdin: "A\na\nB\n",
+			args:  []string{"-i"},
+			want:  "A\nB\n",
+		},
+		{
+			name:  "long flags",
+			stdin: "a\na\nb\n",
+			args:  []string{"--count"},
+			want:  "      2 a\n      1 b\n",
+		},
+		{
+			name:  "non-adjacent are not merged",
+			stdin: "a\nb\na\n",
+			args:  nil,
+			want:  "a\nb\na\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunInputFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(in, []byte("x\nx\ny\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runStdin(t, "", in)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "x\ny\n" {
+		t.Errorf("out = %q, want %q", out, "x\ny\n")
+	}
+}
+
+func TestRunOutputFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := filepath.Join(dir, "in.txt")
+	outPath := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(in, []byte("p\np\nq\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runStdin(t, "", in, outPath)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty (written to OUTPUT)", stdout)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "p\nq\n" {
+		t.Errorf("output file = %q, want %q", string(got), "p\nq\n")
+	}
+}
+
+func TestRunMissingInput(t *testing.T) {
+	t.Parallel()
+	out, _, err := runStdin(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error for missing input")
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+	if !strings.Contains(err.Error(), "/no/such/file:") {
+		t.Errorf("error = %q, want file error", err.Error())
+	}
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := runStdin(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: uniq") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = runStdin(t, "", "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "uniq (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}

--- a/test/it/shellutils/cmp_test.sh
+++ b/test/it/shellutils/cmp_test.sh
@@ -1,0 +1,28 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/cmp
+    mkdir -p ${TEST_DIR}
+    printf 'abc\n' > ${TEST_DIR}/a.txt
+    printf 'abc\n' > ${TEST_DIR}/same.txt
+    printf 'abd\n' > ${TEST_DIR}/diff.txt
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/cmp
+}
+
+TestCmpEqual() {
+    export TEST_DIR=/tmp/mimixbox/it/cmp
+    cmp ${TEST_DIR}/a.txt ${TEST_DIR}/same.txt
+    echo "rc=$?"
+}
+
+TestCmpDiffer() {
+    export TEST_DIR=/tmp/mimixbox/it/cmp
+    cmp ${TEST_DIR}/a.txt ${TEST_DIR}/diff.txt
+}
+
+TestCmpSilent() {
+    export TEST_DIR=/tmp/mimixbox/it/cmp
+    cmp -s ${TEST_DIR}/a.txt ${TEST_DIR}/diff.txt
+    echo "rc=$?"
+}

--- a/test/it/shellutils/cut_test.sh
+++ b/test/it/shellutils/cut_test.sh
@@ -1,0 +1,19 @@
+TestCutField() {
+    printf 'a,b,c\n' | cut -f 2 -d ,
+}
+
+TestCutFields() {
+    printf 'a,b,c,d\n' | cut -f 1,3 -d ,
+}
+
+TestCutFieldRange() {
+    printf 'a,b,c,d\n' | cut -f 2- -d ,
+}
+
+TestCutChars() {
+    printf 'abcdef\n' | cut -c 1-3
+}
+
+TestCutNoList() {
+    printf 'a,b\n' | cut -d ,
+}

--- a/test/it/shellutils/env_test.sh
+++ b/test/it/shellutils/env_test.sh
@@ -1,0 +1,11 @@
+TestEnvAssign() {
+    env FOO=bar | grep '^FOO=bar$'
+}
+
+TestEnvIgnore() {
+    env -i ONLY=here
+}
+
+TestEnvRunCommand() {
+    env GREETING=hi sh -c 'echo $GREETING'
+}

--- a/test/it/shellutils/realpath_test.sh
+++ b/test/it/shellutils/realpath_test.sh
@@ -1,0 +1,23 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/realpath
+    mkdir -p ${TEST_DIR}
+    touch ${TEST_DIR}/file.txt
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/realpath
+}
+
+TestRealpathExisting() {
+    export TEST_DIR=/tmp/mimixbox/it/realpath
+    cd ${TEST_DIR}
+    realpath file.txt
+}
+
+TestRealpathMissing() {
+    realpath -m /tmp/mimixbox/it/realpath/does/not/exist
+}
+
+TestRealpathNoOperand() {
+    realpath
+}

--- a/test/it/shellutils/tee_test.sh
+++ b/test/it/shellutils/tee_test.sh
@@ -1,0 +1,26 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/tee
+    mkdir -p ${TEST_DIR}
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/tee
+}
+
+TestTeeStdoutAndFile() {
+    export TEST_DIR=/tmp/mimixbox/it/tee
+    printf 'hello\n' | tee ${TEST_DIR}/out.txt
+}
+
+TestTeeFileContents() {
+    export TEST_DIR=/tmp/mimixbox/it/tee
+    printf 'hello\n' | tee ${TEST_DIR}/out.txt > /dev/null
+    cat ${TEST_DIR}/out.txt
+}
+
+TestTeeAppend() {
+    export TEST_DIR=/tmp/mimixbox/it/tee
+    printf 'one\n' | tee ${TEST_DIR}/log.txt > /dev/null
+    printf 'two\n' | tee -a ${TEST_DIR}/log.txt > /dev/null
+    cat ${TEST_DIR}/log.txt
+}

--- a/test/it/shellutils/uniq_test.sh
+++ b/test/it/shellutils/uniq_test.sh
@@ -1,0 +1,15 @@
+TestUniqBasic() {
+    printf 'a\na\nb\nc\nc\nc\n' | uniq
+}
+
+TestUniqCount() {
+    printf 'a\na\nb\nc\nc\nc\n' | uniq -c
+}
+
+TestUniqRepeated() {
+    printf 'a\na\nb\nc\nc\n' | uniq -d
+}
+
+TestUniqUnique() {
+    printf 'a\na\nb\nc\nc\n' | uniq -u
+}

--- a/test/it/spec/cmp_spec.sh
+++ b/test/it/spec/cmp_spec.sh
@@ -1,0 +1,35 @@
+Describe 'cmp on identical files'
+    Include shellutils/cmp_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints nothing and succeeds'
+        When call TestCmpEqual
+        The output should equal 'rc=0'
+        The status should be success
+    End
+End
+
+Describe 'cmp on differing files'
+    Include shellutils/cmp_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'reports the first differing byte and line'
+        When call TestCmpDiffer
+        The output should equal '/tmp/mimixbox/it/cmp/a.txt /tmp/mimixbox/it/cmp/diff.txt differ: byte 3, line 1'
+        The status should be failure
+    End
+End
+
+Describe 'cmp -s on differing files'
+    Include shellutils/cmp_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints nothing but exits non-zero'
+        When call TestCmpSilent
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/spec/cut_spec.sh
+++ b/test/it/spec/cut_spec.sh
@@ -1,0 +1,49 @@
+Describe 'cut selects a field'
+    Include shellutils/cut_test.sh
+
+    It 'prints the chosen field'
+        When call TestCutField
+        The output should equal 'b'
+        The status should be success
+    End
+End
+
+Describe 'cut selects multiple fields'
+    Include shellutils/cut_test.sh
+
+    It 'prints the chosen fields joined by the delimiter'
+        When call TestCutFields
+        The output should equal 'a,c'
+        The status should be success
+    End
+End
+
+Describe 'cut selects a field range'
+    Include shellutils/cut_test.sh
+
+    It 'prints from the field to the end'
+        When call TestCutFieldRange
+        The output should equal 'b,c,d'
+        The status should be success
+    End
+End
+
+Describe 'cut selects characters'
+    Include shellutils/cut_test.sh
+
+    It 'prints the chosen character range'
+        When call TestCutChars
+        The output should equal 'abc'
+        The status should be success
+    End
+End
+
+Describe 'cut without a list'
+    Include shellutils/cut_test.sh
+
+    It 'reports an error'
+        When call TestCutNoList
+        The error should equal 'cut: you must specify a list of bytes, characters, or fields'
+        The status should be failure
+    End
+End

--- a/test/it/spec/env_spec.sh
+++ b/test/it/spec/env_spec.sh
@@ -1,0 +1,29 @@
+Describe 'env sets a variable'
+    Include shellutils/env_test.sh
+
+    It 'adds the assignment to the printed environment'
+        When call TestEnvAssign
+        The output should equal 'FOO=bar'
+        The status should be success
+    End
+End
+
+Describe 'env -i starts from an empty environment'
+    Include shellutils/env_test.sh
+
+    It 'prints only the given assignment'
+        When call TestEnvIgnore
+        The output should equal 'ONLY=here'
+        The status should be success
+    End
+End
+
+Describe 'env runs a command with the modified environment'
+    Include shellutils/env_test.sh
+
+    It 'passes the variable to the command'
+        When call TestEnvRunCommand
+        The output should equal 'hi'
+        The status should be success
+    End
+End

--- a/test/it/spec/realpath_spec.sh
+++ b/test/it/spec/realpath_spec.sh
@@ -1,0 +1,31 @@
+Describe 'realpath resolves an existing file'
+    Include shellutils/realpath_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints the absolute path'
+        When call TestRealpathExisting
+        The output should equal '/tmp/mimixbox/it/realpath/file.txt'
+        The status should be success
+    End
+End
+
+Describe 'realpath -m on a missing path'
+    Include shellutils/realpath_test.sh
+
+    It 'prints the cleaned absolute path'
+        When call TestRealpathMissing
+        The output should equal '/tmp/mimixbox/it/realpath/does/not/exist'
+        The status should be success
+    End
+End
+
+Describe 'realpath with no operand'
+    Include shellutils/realpath_test.sh
+
+    It 'reports an error'
+        When call TestRealpathNoOperand
+        The error should equal 'realpath: missing operand'
+        The status should be failure
+    End
+End

--- a/test/it/spec/tee_spec.sh
+++ b/test/it/spec/tee_spec.sh
@@ -1,0 +1,40 @@
+Describe 'tee writes to stdout'
+    Include shellutils/tee_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'echoes standard input to stdout'
+        When call TestTeeStdoutAndFile
+        The output should equal 'hello'
+        The status should be success
+    End
+End
+
+Describe 'tee writes to a file'
+    Include shellutils/tee_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'also writes the input to the file'
+        When call TestTeeFileContents
+        The output should equal 'hello'
+        The status should be success
+    End
+End
+
+Describe 'tee -a appends to a file'
+    Include shellutils/tee_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|one
+        #|two
+    }
+
+    It 'keeps the existing content'
+        When call TestTeeAppend
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/uniq_spec.sh
+++ b/test/it/spec/uniq_spec.sh
@@ -1,0 +1,56 @@
+Describe 'uniq removes adjacent duplicate lines'
+    Include shellutils/uniq_test.sh
+
+    result() { %text
+        #|a
+        #|b
+        #|c
+    }
+
+    It 'collapses repeated lines'
+        When call TestUniqBasic
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'uniq -c counts occurrences'
+    Include shellutils/uniq_test.sh
+
+    result() { %text
+        #|      2 a
+        #|      1 b
+        #|      3 c
+    }
+
+    It 'prefixes each line with its count'
+        When call TestUniqCount
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'uniq -d prints only repeated lines'
+    Include shellutils/uniq_test.sh
+
+    result() { %text
+        #|a
+        #|c
+    }
+
+    It 'prints duplicated lines once'
+        When call TestUniqRepeated
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'uniq -u prints only unique lines'
+    Include shellutils/uniq_test.sh
+
+    It 'prints lines that never repeat'
+        When call TestUniqUnique
+        The output should equal 'b'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Adds six new GNU-style applets, each on the `command.Command` framework with unit tests **and** shellspec integration tests, registered in the applet table and the command list.

| Command | Description | Issue |
|---|---|---|
| `env` | Run a program in a modified environment, or print the environment (`-i`, `-u`, `-0`) | #58 |
| `tee` | Read stdin and write to stdout and files (`-a`, `-i`) | #66 |
| `uniq` | Report or omit repeated lines (`-c`, `-d`, `-u`, `-i`) | #68 |
| `realpath` | Print the resolved absolute file name (`-e`, `-m`, `-s`, `-z`, `-q`) | #64 |
| `cut` | Remove sections from each line (`-b`, `-c`, `-f`, `-d`, `-s`, `--output-delimiter`) | #53 |
| `cmp` | Compare two files byte by byte (`-s`, `-l`; GNU exit codes 0/1/2) | #52 |

## Testing

- Unit tests for every command (pure cores factored out where useful: range parsing for cut, the comparison core for cmp, the filter for uniq); `go test ./...` passes.
- `golangci-lint` clean on the new packages.
- shellspec integration specs for all six drive the installed applets by name; all examples pass against an installed build.

Closes #52, #53, #58, #64, #66, #68.