### PR TITLE
feat: add sort, test, expr, mktemp, date and who commands

### DIFF
--- a/docs/introduction/en/CommandAppletList.md
+++ b/docs/introduction/en/CommandAppletList.md
@@ -14,11 +14,13 @@
 |     cmp  | Compare two files byte by byte|
 |       cp | Copy file(s) otr Directory(s) |
 |     cut  | Remove sections from each line of files|
+|     date | Print or set the system date and time|
 |  dirname | Print only directory path |
 | dos2unix | Change CRLF to LF|
 |     echo | Display a line of text|
 |     env  | Run a program in a modified environment, or print the environment|
 |   expand | Convert TAB to N space (default:N=8)|
+|     expr | Evaluate expressions|
 |fakemovie | Adds a video playback button to the image|
 |    false | Do nothing. Return unsuccess(1)|
 |    ghrdc | GitHub Relase Download Counter|
@@ -36,6 +38,7 @@
 |    md5sum| Calculate or Check md5sum message digest|
 |    mkdir | Make directories|
 |    mkfifo | Make FIFO (Named pipe)|
+|    mktemp | Create a temporary file or directory|
 |       mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY|
 |       nl| Write each FILE to standard output with line numbers added|
 |     path | Manipulate filename path|
@@ -56,10 +59,12 @@
 |    sha512sum| Calculate or Check sercure hash 512 algorithm|
 |           sl| Cure your bad habit of mistyping|
 |    sleep | Pause for NUMBER seconds(minutes, hours, days)|
+|     sort | Sort lines of text files|
 |   sync   | Synchronize cached writes to persistent storage|
 |     tac  | Print the file contents from the end to the beginning|
 |     tail |  Print the last NUMBER(default=10) lines|
 |     tee  | Read from standard input and write to standard output and files|
+|     test | Evaluate a conditional expression|
 |    touch | Update the access and modification times of each FILE to the current time|
 |    tr    | Translate or delete characters|
 |     true | Do nothing. Return success(0)|
@@ -71,6 +76,7 @@
 |    wc    |    Word Counter|
 |    wget  | The non-interactive network downloader|
 |    which | Returns the file path which would be executed in the current environment|
+|      who | Show who is logged on|
 |   whoami | Print login user name|
 
 If you want to see the list of supported commands on the terminal, use the --list option.

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	addShell "github.com/nao1215/mimixbox/internal/applets/debianutils/add-shell"
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/ischroot"
+	"github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
 	removeShell "github.com/nao1215/mimixbox/internal/applets/debianutils/remove-shell"
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/which"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/chgrp"
@@ -54,9 +55,11 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/chroot"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/cmp"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/cut"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/date"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/dirname"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/echo"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/env"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/expr"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/false"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/ghrdc"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/groups"
@@ -73,12 +76,15 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/seq"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/serial"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/sleep"
+	sortcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/sort"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/sync"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/tee"
+	testcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/test"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/true"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/uniq"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/uuidgen"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/wget"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/who"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/whoami"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/cat"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/dos2unix"
@@ -129,11 +135,13 @@ func init() {
 		"cmp":          reg(cmp.New()),
 		"cp":           reg(cp.New()),
 		"cut":          reg(cut.New()),
+		"date":         reg(date.New()),
 		"dirname":      reg(dirname.New()),
 		"dos2unix":     reg(dos2unix.New()),
 		"echo":         reg(echo.New()),
 		"env":          reg(env.New()),
 		"expand":       reg(expand.New()),
+		"expr":         reg(expr.New()),
 		"fakemovie":    reg(fakemovie.New()),
 		"false":        reg(boolfalse.New()),
 		"ghrdc":        reg(ghrdc.New()),
@@ -151,6 +159,7 @@ func init() {
 		"md5sum":       reg(md5sum.New()),
 		"mkdir":        reg(mkdir.New()),
 		"mkfifo":       reg(mkfifo.New()),
+		"mktemp":       reg(mktemp.New()),
 		"mv":           reg(mv.New()),
 		"nl":           reg(nl.New()),
 		"path":         reg(path.New()),
@@ -172,10 +181,12 @@ func init() {
 		"seq":          reg(seq.New()),
 		"sl":           reg(sl.New()),
 		"sleep":        reg(sleep.New()),
+		"sort":         reg(sortcmd.New()),
 		"sync":         reg(sync.New()),
 		"tac":          reg(tac.New()),
 		"tail":         reg(tail.New()),
 		"tee":          reg(tee.New()),
+		"test":         reg(testcmd.New()),
 		"touch":        reg(touch.New()),
 		"tr":           reg(tr.New()),
 		"true":         reg(booltrue.New()),
@@ -187,6 +198,7 @@ func init() {
 		"wc":           reg(wc.New()),
 		"wget":         reg(wget.New()),
 		"which":        reg(which.New()),
+		"who":          reg(who.New()),
 		"whoami":       reg(whoami.New()),
 	}
 }

--- a/internal/applets/debianutils/mktemp/mktemp.go
+++ b/internal/applets/debianutils/mktemp/mktemp.go
@@ -1,0 +1,201 @@
+// Package mktemp implements the mktemp applet: create a uniquely-named
+// temporary file or directory and print its path.
+package mktemp
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// defaultTemplate is used when no TEMPLATE operand is given, matching GNU
+// mktemp.
+const defaultTemplate = "tmp.XXXXXXXXXX"
+
+// randChars are the characters used to fill the X placeholders, matching the
+// alphabet GNU mktemp draws from.
+const randChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// Command is the mktemp applet.
+type Command struct{}
+
+// New returns a mktemp command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mktemp" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Create a temporary file or directory" }
+
+// Run executes mktemp.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [TEMPLATE]", stdio.Err)
+	directory := fs.BoolP("directory", "d", false, "create a directory, not a file")
+	dryRun := fs.BoolP("dry-run", "u", false, "do not create anything; merely print a name (unsafe)")
+	quiet := fs.BoolP("quiet", "q", false, "suppress diagnostics about file/dir-creation failure")
+	tmpdir := fs.StringP("tmpdir", "p", "", "interpret TEMPLATE relative to DIR; default is $TMPDIR or /tmp")
+	tFlag := fs.BoolP("legacy", "t", false, "interpret TEMPLATE as a single file name component, relative to a temporary directory")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	operands := fs.Args()
+	if len(operands) > 1 {
+		return failf(stdio, *quiet, "too many templates")
+	}
+
+	template := defaultTemplate
+	if len(operands) == 1 {
+		template = operands[0]
+	}
+
+	// Whether the user explicitly asked for a tmpdir-relative template.
+	tmpdirGiven := fs.Changed("tmpdir")
+	dir := strings.TrimSpace(*tmpdir)
+	if dir == "" {
+		dir = tempDir()
+	}
+
+	path, err := resolve(template, dir, tmpdirGiven, *tFlag)
+	if err != nil {
+		return failf(stdio, *quiet, "%v", err)
+	}
+
+	result, err := generate(path, *directory, *dryRun)
+	if err != nil {
+		return failf(stdio, *quiet, "%v", err)
+	}
+
+	_, _ = fmt.Fprintln(stdio.Out, result)
+	return nil
+}
+
+// tempDir returns the directory temporary files are created in: $TMPDIR when
+// set, otherwise /tmp (matching GNU mktemp rather than os.TempDir, which is
+// effectively the same but documented here for clarity).
+func tempDir() string {
+	if d := os.Getenv("TMPDIR"); d != "" {
+		return d
+	}
+	return "/tmp"
+}
+
+// resolve turns the user's TEMPLATE plus the relevant options into the full
+// path whose X's will be replaced. It also enforces that the template carries
+// at least three trailing X's.
+func resolve(template, dir string, tmpdirGiven, tFlag bool) (string, error) {
+	switch {
+	case tmpdirGiven || tFlag:
+		// TEMPLATE is a single component relative to dir; it must not contain
+		// a path separator (GNU rejects that with -p/-t).
+		if strings.ContainsRune(template, os.PathSeparator) {
+			return "", fmt.Errorf("invalid template, %q, contains directory separator", template)
+		}
+		return filepath.Join(dir, template), nil
+	default:
+		// Plain form: TEMPLATE is used as-is (relative to the cwd unless it is
+		// already absolute).
+		return template, nil
+	}
+}
+
+// generate replaces the trailing run of X's in path with random characters,
+// retrying until it finds a name that does not yet exist. With dryRun it only
+// computes a name; otherwise it creates the file or directory atomically.
+func generate(path string, directory, dryRun bool) (string, error) {
+	prefix, suffix, xs, err := splitTemplate(path)
+	if err != nil {
+		return "", err
+	}
+
+	if dryRun {
+		name, derr := randomName(prefix, suffix, xs)
+		if derr != nil {
+			return "", derr
+		}
+		return name, nil
+	}
+
+	// Retry a bounded number of times to avoid an unbounded loop if something
+	// is wrong with the directory; GNU mktemp likewise gives up eventually.
+	const maxAttempts = 1000
+	for i := 0; i < maxAttempts; i++ {
+		name, derr := randomName(prefix, suffix, xs)
+		if derr != nil {
+			return "", derr
+		}
+		if directory {
+			if derr := os.Mkdir(name, 0o700); derr != nil {
+				if os.IsExist(derr) {
+					continue
+				}
+				return "", fmt.Errorf("failed to create directory %q: %w", name, derr)
+			}
+			return name, nil
+		}
+		f, derr := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if derr != nil {
+			if os.IsExist(derr) {
+				continue
+			}
+			return "", fmt.Errorf("failed to create file %q: %w", name, derr)
+		}
+		_ = f.Close()
+		return name, nil
+	}
+	return "", fmt.Errorf("failed to create file via template %q", path)
+}
+
+// splitTemplate locates the trailing run of X's in path, returning the text
+// before it, the text after it, and the number of X's. GNU mktemp requires the
+// X's to be at the end of the final path component and at least three of them.
+func splitTemplate(path string) (prefix, suffix string, xs int, err error) {
+	base := filepath.Base(path)
+	dir := path[:len(path)-len(base)]
+
+	// Find the run of X's that ends the base name.
+	end := len(base)
+	for end > 0 && base[end-1] == 'X' {
+		end--
+	}
+	xs = len(base) - end
+	if xs < 3 {
+		return "", "", 0, fmt.Errorf("too few X's in template %q", path)
+	}
+	prefix = dir + base[:end]
+	suffix = ""
+	return prefix, suffix, xs, nil
+}
+
+// randomName fills the X placeholders with cryptographically random characters
+// and returns the full candidate name.
+func randomName(prefix, suffix string, xs int) (string, error) {
+	buf := make([]byte, xs)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("failed to read random bytes: %w", err)
+	}
+	var b strings.Builder
+	b.WriteString(prefix)
+	for _, v := range buf {
+		b.WriteByte(randChars[int(v)%len(randChars)])
+	}
+	b.WriteString(suffix)
+	return b.String(), nil
+}
+
+// failf prints "mktemp: <message>" to stderr unless quiet, then returns a
+// silent failure so the runner exits non-zero without re-printing.
+func failf(stdio command.IO, quiet bool, format string, a ...any) error {
+	if !quiet {
+		_, _ = fmt.Fprintf(stdio.Err, "mktemp: "+format+"\n", a...)
+	}
+	return command.SilentFailure()
+}

--- a/internal/applets/debianutils/mktemp/mktemp_test.go
+++ b/internal/applets/debianutils/mktemp/mktemp_test.go
@@ -1,0 +1,144 @@
+package mktemp_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := mktemp.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	if mktemp.New() == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+func TestRunDefaultCreatesFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out, errOut, err := run(t, "-p", dir)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	path := strings.TrimSpace(out)
+	if !strings.HasPrefix(path, dir+string(os.PathSeparator)) {
+		t.Fatalf("path %q is not under %q", path, dir)
+	}
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatalf("expected file to exist: %v", statErr)
+	}
+	if !info.Mode().IsRegular() {
+		t.Errorf("expected a regular file, got mode %v", info.Mode())
+	}
+	if rmErr := os.Remove(path); rmErr != nil {
+		t.Errorf("cleanup failed: %v", rmErr)
+	}
+}
+
+func TestRunDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out, errOut, err := run(t, "-d", "-p", dir)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	path := strings.TrimSpace(out)
+	if !strings.HasPrefix(path, dir+string(os.PathSeparator)) {
+		t.Fatalf("path %q is not under %q", path, dir)
+	}
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Fatalf("expected directory to exist: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected a directory, got mode %v", info.Mode())
+	}
+}
+
+func TestRunDryRunDoesNotCreate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out, errOut, err := run(t, "-u", "-p", dir)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	path := strings.TrimSpace(out)
+	if !strings.HasPrefix(path, dir+string(os.PathSeparator)) {
+		t.Fatalf("path %q is not under %q", path, dir)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("expected %q to NOT exist, stat err = %v", path, statErr)
+	}
+}
+
+func TestRunTmpdirPlacement(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out, errOut, err := run(t, "-p", dir, "myfile.XXXXXX")
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	path := strings.TrimSpace(out)
+	if filepath.Dir(path) != dir {
+		t.Fatalf("expected parent dir %q, got %q", dir, filepath.Dir(path))
+	}
+	if !strings.HasPrefix(filepath.Base(path), "myfile.") {
+		t.Errorf("expected name to start with %q, got %q", "myfile.", filepath.Base(path))
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Errorf("expected file to exist: %v", statErr)
+	}
+	_ = os.Remove(path)
+}
+
+func TestRunTooFewX(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, errOut, err := run(t, "-p", dir, "bad.XX")
+	if err == nil {
+		t.Fatal("expected error for too few X's")
+	}
+	if !strings.Contains(errOut, "too few X's") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunTooManyTemplates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, errOut, err := run(t, "-p", dir, "a.XXXXXX", "b.XXXXXX")
+	if err == nil {
+		t.Fatal("expected error for too many templates")
+	}
+	if !strings.Contains(errOut, "too many templates") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunQuietSuppressesError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, errOut, err := run(t, "-q", "-p", dir, "bad.X")
+	if err == nil {
+		t.Fatal("expected error for too few X's")
+	}
+	if errOut != "" {
+		t.Errorf("expected no stderr with -q, got %q", errOut)
+	}
+}

--- a/internal/applets/shellutils/date/date.go
+++ b/internal/applets/shellutils/date/date.go
@@ -1,0 +1,272 @@
+// Package date implements the date applet: print the system date and time,
+// optionally formatted with strftime-style conversion specifiers, matching the
+// common GNU date semantics. Setting the system clock is out of scope.
+package date
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// nowFn is the clock the command reads "now" from. It is a package variable so
+// tests can replace it with a fixed time and assert on deterministic output.
+var nowFn = time.Now
+
+// Command is the date applet.
+type Command struct{}
+
+// New returns a date command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "date" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print or set the system date and time" }
+
+// Run executes date.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [+FORMAT]", stdio.Err)
+	utc := fs.BoolP("utc", "u", false, "print Coordinated Universal Time (UTC)")
+	dateStr := fs.StringP("date", "d", "", "display time described by STRING, not 'now'")
+	rfcEmail := fs.BoolP("rfc-email", "R", false, "output date and time in RFC 5322 format")
+	iso := fs.StringP("iso-8601", "I", "", "output date/time in ISO 8601 format; FMT may be 'date', 'hours', 'minutes', 'seconds', or 'ns'")
+	// Allow -I with no value (GNU treats a bare -I as --iso-8601=date).
+	fs.Lookup("iso-8601").NoOptDefVal = "date"
+	setStr := fs.StringP("set", "s", "", "set time described by STRING")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if *setStr != "" {
+		return command.Failuref("setting the system clock is not supported")
+	}
+
+	t, err := resolveTime(*dateStr)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "date: %v\n", err)
+		return command.SilentFailure()
+	}
+	if *utc {
+		t = t.UTC()
+	}
+
+	operands := fs.Args()
+	format, err := operandFormat(operands)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "date: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	out, err := output(t, format, *rfcEmail, *iso, fs.Changed("iso-8601"))
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "date: %v\n", err)
+		return command.SilentFailure()
+	}
+	_, _ = fmt.Fprintln(stdio.Out, out)
+	return nil
+}
+
+// operandFormat extracts the optional +FORMAT operand. GNU date accepts at most
+// one operand and it must begin with '+'.
+func operandFormat(operands []string) (string, error) {
+	switch len(operands) {
+	case 0:
+		return "", nil
+	case 1:
+		op := operands[0]
+		if !strings.HasPrefix(op, "+") {
+			return "", fmt.Errorf("invalid date %q", op)
+		}
+		return op[1:], nil
+	default:
+		return "", fmt.Errorf("extra operand %q", operands[1])
+	}
+}
+
+// output renders the time according to the highest-priority format requested:
+// -R (RFC email), then -I (ISO 8601), then a +FORMAT operand, then the default
+// "date"-style layout.
+func output(t time.Time, format string, rfcEmail bool, isoFmt string, isoSet bool) (string, error) {
+	if rfcEmail {
+		return t.Format("Mon, 02 Jan 2006 15:04:05 -0700"), nil
+	}
+	if isoSet {
+		return isoFormat(t, isoFmt)
+	}
+	if format != "" {
+		return formatTime(t, format), nil
+	}
+	// GNU default, e.g. "Tue Nov 14 22:13:20 UTC 2023".
+	return t.Format("Mon Jan  2 15:04:05 MST 2006"), nil
+}
+
+// isoFormat implements the granularity argument of --iso-8601.
+func isoFormat(t time.Time, fmtArg string) (string, error) {
+	switch fmtArg {
+	case "", "date":
+		return t.Format("2006-01-02"), nil
+	case "hours":
+		return t.Format("2006-01-02T15-07:00"), nil
+	case "minutes":
+		return t.Format("2006-01-02T15:04-07:00"), nil
+	case "seconds":
+		return t.Format("2006-01-02T15:04:05-07:00"), nil
+	case "ns":
+		return t.Format("2006-01-02T15:04:05,999999999-07:00"), nil
+	default:
+		return "", fmt.Errorf("invalid argument %q for '--iso-8601'", fmtArg)
+	}
+}
+
+// resolveTime returns the time to display: now when s is empty, otherwise the
+// time described by s. Supported forms are "@SECONDS" (epoch), RFC3339, and a
+// bare "YYYY-MM-DD" date.
+func resolveTime(s string) (time.Time, error) {
+	if s == "" {
+		return nowFn(), nil
+	}
+	if strings.HasPrefix(s, "@") {
+		sec, err := strconv.ParseInt(s[1:], 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid date %q", s)
+		}
+		return time.Unix(sec, 0), nil
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid date %q", s)
+}
+
+// formatTime converts a strftime-style format string into a rendered string for
+// t. It is a pure function (its only input is t and format) so it can be unit
+// tested exhaustively. Unknown specifiers are emitted verbatim including the
+// leading '%', matching GNU date's lenient behavior.
+func formatTime(t time.Time, format string) string {
+	var b strings.Builder
+	for i := 0; i < len(format); i++ {
+		if format[i] != '%' || i+1 >= len(format) {
+			b.WriteByte(format[i])
+			continue
+		}
+		i++
+		b.WriteString(specifier(t, format[i]))
+	}
+	return b.String()
+}
+
+// specifier renders a single strftime conversion character for t.
+func specifier(t time.Time, c byte) string {
+	switch c {
+	case '%':
+		return "%"
+	case 'n':
+		return "\n"
+	case 't':
+		return "\t"
+	case 'Y':
+		return strconv.Itoa(t.Year())
+	case 'y':
+		return fmt.Sprintf("%02d", t.Year()%100)
+	case 'C':
+		return fmt.Sprintf("%02d", t.Year()/100)
+	case 'm':
+		return fmt.Sprintf("%02d", int(t.Month()))
+	case 'd':
+		return fmt.Sprintf("%02d", t.Day())
+	case 'e':
+		return fmt.Sprintf("%2d", t.Day())
+	case 'H':
+		return fmt.Sprintf("%02d", t.Hour())
+	case 'I':
+		return fmt.Sprintf("%02d", hour12(t.Hour()))
+	case 'M':
+		return fmt.Sprintf("%02d", t.Minute())
+	case 'S':
+		return fmt.Sprintf("%02d", t.Second())
+	case 'p':
+		return ampm(t.Hour(), true)
+	case 'P':
+		return ampm(t.Hour(), false)
+	case 'A':
+		return t.Weekday().String()
+	case 'a':
+		return t.Weekday().String()[:3]
+	case 'B':
+		return t.Month().String()
+	case 'b', 'h':
+		return t.Month().String()[:3]
+	case 'j':
+		return fmt.Sprintf("%03d", t.YearDay())
+	case 'u':
+		// ISO weekday, Monday=1..Sunday=7.
+		if w := int(t.Weekday()); w == 0 {
+			return "7"
+		} else {
+			return strconv.Itoa(w)
+		}
+	case 'w':
+		// Weekday, Sunday=0..Saturday=6.
+		return strconv.Itoa(int(t.Weekday()))
+	case 'F':
+		return t.Format("2006-01-02")
+	case 'T':
+		return t.Format("15:04:05")
+	case 'R':
+		return t.Format("15:04")
+	case 'D':
+		return t.Format("01/02/06")
+	case 'r':
+		return t.Format("03:04:05 PM")
+	case 'Z':
+		name, _ := t.Zone()
+		return name
+	case 'z':
+		return t.Format("-0700")
+	case 's':
+		return strconv.FormatInt(t.Unix(), 10)
+	case 'c':
+		return t.Format("Mon Jan  2 15:04:05 2006")
+	case 'x':
+		return t.Format("01/02/06")
+	case 'X':
+		return t.Format("15:04:05")
+	default:
+		return "%" + string(c)
+	}
+}
+
+func hour12(h int) int {
+	h %= 12
+	if h == 0 {
+		return 12
+	}
+	return h
+}
+
+func ampm(hour int, upper bool) string {
+	s := "am"
+	if hour >= 12 {
+		s = "pm"
+	}
+	if upper {
+		return strings.ToUpper(s)
+	}
+	return s
+}

--- a/internal/applets/shellutils/date/date_test.go
+++ b/internal/applets/shellutils/date/date_test.go
@@ -1,0 +1,200 @@
+package date_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/date"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// fixed is the deterministic clock used across the tests: 2023-11-14T22:13:20Z,
+// whose Unix time is the round number 1700000000.
+var fixed = time.Date(2023, time.November, 14, 22, 13, 20, 0, time.UTC)
+
+// nowMu serializes access to the package-level clock so the tests that swap it
+// (via date.SetNow) do not race when the Go test runner schedules them
+// concurrently with -parallel.
+var nowMu sync.Mutex
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	nowMu.Lock()
+	defer nowMu.Unlock()
+	restore := date.SetNow(fixed)
+	defer restore()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := date.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNewAndMetadata(t *testing.T) {
+	t.Parallel()
+	c := date.New()
+	if c == nil {
+		t.Fatal("New returned nil")
+	}
+	if c.Name() != "date" {
+		t.Errorf("Name = %q, want date", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis is empty")
+	}
+}
+
+func TestRunDefaultNonEmpty(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Error("default output is empty")
+	}
+	if !strings.Contains(out, "2023") {
+		t.Errorf("default output = %q, want it to mention the year", out)
+	}
+}
+
+func TestRunFormats(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"iso date", []string{"-u", "+%Y-%m-%d"}, "2023-11-14"},
+		{"time utc", []string{"-u", "+%H:%M:%S"}, "22:13:20"},
+		{"epoch", []string{"+%s"}, "1700000000"},
+		{"percent", []string{"+%%"}, "%"},
+		{"iso -u -F", []string{"-u", "+%F"}, "2023-11-14"},
+		{"iso -I flag", []string{"-u", "-I"}, "2023-11-14"},
+		{"iso seconds", []string{"-u", "--iso-8601=seconds"}, "2023-11-14T22:13:20+00:00"},
+		{"rfc email", []string{"-u", "-R"}, "Tue, 14 Nov 2023 22:13:20 +0000"},
+		{"weekday abbr", []string{"-u", "+%a %A"}, "Tue Tuesday"},
+		{"month names", []string{"-u", "+%b %B"}, "Nov November"},
+		{"combined T", []string{"-u", "+%T"}, "22:13:20"},
+		{"12h pm", []string{"-u", "+%I %p"}, "10 PM"},
+		{"yearday", []string{"-u", "+%j"}, "318"},
+		{"two digit year", []string{"-u", "+%y"}, "23"},
+		{"literal text", []string{"-u", "+year=%Y"}, "year=2023"},
+		{"date string epoch", []string{"-u", "-d", "@0", "+%Y-%m-%d"}, "1970-01-01"},
+		{"date string rfc3339", []string{"-u", "-d", "2000-01-02T03:04:05Z", "+%T"}, "03:04:05"},
+		{"date string ymd", []string{"-u", "-d", "1999-12-31", "+%F"}, "1999-12-31"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, errOut, err := run(t, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+			}
+			if got := strings.TrimRight(out, "\n"); got != tt.want {
+				t.Errorf("out = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunInvalidDate(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "-d", "not-a-date")
+	if err == nil {
+		t.Fatal("expected error for invalid date")
+	}
+	if !strings.Contains(errOut, "date:") {
+		t.Errorf("stderr = %q, want date error prefix", errOut)
+	}
+}
+
+func TestRunInvalidOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "%Y")
+	if err == nil {
+		t.Fatal("expected error for operand without leading +")
+	}
+	if !strings.Contains(errOut, "date:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunSetUnsupported(t *testing.T) {
+	t.Parallel()
+	_, _, err := run(t, "-s", "2020-01-01")
+	if err == nil {
+		t.Fatal("expected not-supported error for -s")
+	}
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: date") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = run(t, "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "date (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}
+
+func TestFormatTime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{"%Y-%m-%d", "2023-11-14"},
+		{"%H:%M:%S", "22:13:20"},
+		{"%s", "1700000000"},
+		{"%%", "%"},
+		{"%F", "2023-11-14"},
+		{"%T", "22:13:20"},
+		{"%A", "Tuesday"},
+		{"%a", "Tue"},
+		{"%B", "November"},
+		{"%b", "Nov"},
+		{"%j", "318"},
+		{"%y", "23"},
+		{"%C", "20"},
+		{"%p", "PM"},
+		{"%P", "pm"},
+		{"%I", "10"},
+		{"%e", "14"},
+		{"%m/%d/%y", "11/14/23"},
+		{"%R", "22:13"},
+		{"%u", "2"},
+		{"%w", "2"},
+		{"%z", "+0000"},
+		{"%Z", "UTC"},
+		{"literal", "literal"},
+		{"a%Yb", "a2023b"},
+		{"%n", "\n"},
+		{"%t", "\t"},
+		{"trailing %", "trailing %"},
+		{"%Q", "%Q"}, // unknown specifier passes through
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.format, func(t *testing.T) {
+			t.Parallel()
+			if got := date.FormatTime(fixed, tt.format); got != tt.want {
+				t.Errorf("FormatTime(%q) = %q, want %q", tt.format, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/applets/shellutils/date/export_test.go
+++ b/internal/applets/shellutils/date/export_test.go
@@ -1,0 +1,15 @@
+package date
+
+import "time"
+
+// SetNow replaces the clock with a function returning fixed, restoring the
+// previous clock when the returned function is called. It exists so the
+// external date_test package can make output deterministic.
+func SetNow(fixed time.Time) (restore func()) {
+	prev := nowFn
+	nowFn = func() time.Time { return fixed }
+	return func() { nowFn = prev }
+}
+
+// FormatTime exposes the pure strftime formatter for testing.
+func FormatTime(t time.Time, format string) string { return formatTime(t, format) }

--- a/internal/applets/shellutils/expr/expr.go
+++ b/internal/applets/shellutils/expr/expr.go
@@ -1,0 +1,479 @@
+// Package expr implements the expr applet: evaluate an expression and write the
+// result to standard output. Like GNU expr, the operands are not parsed with
+// getopt; each argument is one token of the expression. The exit status encodes
+// the result: 0 if the result is neither null nor 0, 1 if it is, 2 for an
+// invalid expression, and 3 for any other error.
+package expr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the expr applet.
+type Command struct{}
+
+// New returns an expr command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "expr" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Evaluate expressions" }
+
+// syntaxError marks an invalid expression, which maps to exit status 2.
+type syntaxError struct{ msg string }
+
+func (e *syntaxError) Error() string { return e.msg }
+
+// Run executes expr. The arguments form the expression; eval reduces them to a
+// single string. The result is printed to stdout, and the exit status reflects
+// whether the result is null/zero (status 1) or not (status 0). A malformed
+// expression prints "expr: <message>" to stderr and exits with status 2.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	result, err := eval(args)
+	if err != nil {
+		var se *syntaxError
+		if errors.As(err, &se) {
+			return &command.ExitError{Code: 2, Err: err}
+		}
+		return &command.ExitError{Code: 3, Err: err}
+	}
+
+	if _, err := fmt.Fprintln(stdio.Out, result); err != nil {
+		return &command.ExitError{Code: 3, Err: err}
+	}
+
+	// GNU expr exits 1 when the printed result is null (empty) or zero.
+	if isFalse(result) {
+		return &command.ExitError{Code: command.ExitFailure}
+	}
+	return nil
+}
+
+// isFalse reports whether s is the empty string or the numeric value zero, the
+// two values expr treats as "false" for its exit status.
+func isFalse(s string) bool {
+	if s == "" {
+		return true
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		return n == 0
+	}
+	return false
+}
+
+// Eval reduces the token slice to a single result string. It is the exported,
+// testable entry point of the recursive-descent evaluator.
+func Eval(tokens []string) (string, error) { return eval(tokens) }
+
+// eval reduces the token slice to a single result string.
+func eval(tokens []string) (string, error) {
+	p := &parser{tokens: tokens}
+	v, err := p.parseOr()
+	if err != nil {
+		return "", err
+	}
+	if !p.atEnd() {
+		return "", &syntaxError{msg: fmt.Sprintf("syntax error: unexpected argument %q", p.peek())}
+	}
+	return v, nil
+}
+
+// parser walks the token slice with a single-token lookahead. The grammar, from
+// lowest to highest precedence:
+//
+//	or:      and        ( '|' and )*
+//	and:     compare    ( '&' compare )*
+//	compare: addsub     ( ('<'|'<='|'='|'!='|'>='|'>') addsub )*
+//	addsub:  muldiv     ( ('+'|'-') muldiv )*
+//	muldiv:  match      ( ('*'|'/'|'%') match )*
+//	match:   primary    ( ':' primary )*
+//	primary: '(' or ')' | keyword-op | literal
+type parser struct {
+	tokens []string
+	pos    int
+}
+
+func (p *parser) atEnd() bool { return p.pos >= len(p.tokens) }
+
+func (p *parser) peek() string {
+	if p.atEnd() {
+		return ""
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *parser) next() string {
+	t := p.peek()
+	p.pos++
+	return t
+}
+
+func (p *parser) parseOr() (string, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return "", err
+	}
+	for p.peek() == "|" {
+		p.next()
+		right, err := p.parseAnd()
+		if err != nil {
+			return "", err
+		}
+		// '|' yields its first argument if it is neither null nor zero,
+		// otherwise its second argument.
+		if !isFalse(left) {
+			continue
+		}
+		left = right
+	}
+	return left, nil
+}
+
+func (p *parser) parseAnd() (string, error) {
+	left, err := p.parseCompare()
+	if err != nil {
+		return "", err
+	}
+	for p.peek() == "&" {
+		p.next()
+		right, err := p.parseCompare()
+		if err != nil {
+			return "", err
+		}
+		// '&' yields its first argument if neither argument is null or
+		// zero, otherwise 0.
+		if isFalse(left) || isFalse(right) {
+			left = "0"
+		}
+	}
+	return left, nil
+}
+
+func (p *parser) parseCompare() (string, error) {
+	left, err := p.parseAddSub()
+	if err != nil {
+		return "", err
+	}
+	for isCompareOp(p.peek()) {
+		op := p.next()
+		right, err := p.parseAddSub()
+		if err != nil {
+			return "", err
+		}
+		left = boolToStr(compare(left, right, op))
+	}
+	return left, nil
+}
+
+func (p *parser) parseAddSub() (string, error) {
+	left, err := p.parseMulDiv()
+	if err != nil {
+		return "", err
+	}
+	for p.peek() == "+" || p.peek() == "-" {
+		op := p.next()
+		right, err := p.parseMulDiv()
+		if err != nil {
+			return "", err
+		}
+		l, r, err := toInts(left, right)
+		if err != nil {
+			return "", err
+		}
+		if op == "+" {
+			left = strconv.Itoa(l + r)
+		} else {
+			left = strconv.Itoa(l - r)
+		}
+	}
+	return left, nil
+}
+
+func (p *parser) parseMulDiv() (string, error) {
+	left, err := p.parseMatch()
+	if err != nil {
+		return "", err
+	}
+	for p.peek() == "*" || p.peek() == "/" || p.peek() == "%" {
+		op := p.next()
+		right, err := p.parseMatch()
+		if err != nil {
+			return "", err
+		}
+		l, r, err := toInts(left, right)
+		if err != nil {
+			return "", err
+		}
+		switch op {
+		case "*":
+			left = strconv.Itoa(l * r)
+		case "/":
+			if r == 0 {
+				return "", &syntaxError{msg: "division by zero"}
+			}
+			left = strconv.Itoa(l / r)
+		case "%":
+			if r == 0 {
+				return "", &syntaxError{msg: "division by zero"}
+			}
+			left = strconv.Itoa(l % r)
+		}
+	}
+	return left, nil
+}
+
+func (p *parser) parseMatch() (string, error) {
+	left, err := p.parsePrimary()
+	if err != nil {
+		return "", err
+	}
+	for p.peek() == ":" {
+		p.next()
+		right, err := p.parsePrimary()
+		if err != nil {
+			return "", err
+		}
+		res, err := matchOp(left, right)
+		if err != nil {
+			return "", err
+		}
+		left = res
+	}
+	return left, nil
+}
+
+func (p *parser) parsePrimary() (string, error) {
+	if p.atEnd() {
+		return "", &syntaxError{msg: "syntax error: missing argument"}
+	}
+
+	switch p.peek() {
+	case "(":
+		p.next()
+		v, err := p.parseOr()
+		if err != nil {
+			return "", err
+		}
+		if p.peek() != ")" {
+			return "", &syntaxError{msg: "syntax error: expecting ')'"}
+		}
+		p.next()
+		return v, nil
+	case "length":
+		p.next()
+		s, err := p.argFor("length")
+		if err != nil {
+			return "", err
+		}
+		return strconv.Itoa(len([]rune(s))), nil
+	case "substr":
+		return p.parseSubstr()
+	case "index":
+		return p.parseIndex()
+	case "match":
+		p.next()
+		s, err := p.argFor("match")
+		if err != nil {
+			return "", err
+		}
+		re, err := p.argFor("match")
+		if err != nil {
+			return "", err
+		}
+		return matchOp(s, re)
+	}
+
+	return p.next(), nil
+}
+
+// argFor consumes and returns the next token as a literal operand of a keyword
+// operator, reporting a syntax error when none remains.
+func (p *parser) argFor(op string) (string, error) {
+	if p.atEnd() {
+		return "", &syntaxError{msg: fmt.Sprintf("syntax error: missing argument after %q", op)}
+	}
+	return p.next(), nil
+}
+
+func (p *parser) parseSubstr() (string, error) {
+	p.next()
+	s, err := p.argFor("substr")
+	if err != nil {
+		return "", err
+	}
+	posStr, err := p.argFor("substr")
+	if err != nil {
+		return "", err
+	}
+	lenStr, err := p.argFor("substr")
+	if err != nil {
+		return "", err
+	}
+	pos, err1 := strconv.Atoi(posStr)
+	length, err2 := strconv.Atoi(lenStr)
+	if err1 != nil || err2 != nil {
+		// GNU expr returns the empty string for non-numeric pos/length.
+		return "", nil
+	}
+	runes := []rune(s)
+	// expr positions are 1-based.
+	if pos < 1 || length < 0 || pos > len(runes) {
+		return "", nil
+	}
+	start := pos - 1
+	end := start + length
+	if end > len(runes) {
+		end = len(runes)
+	}
+	return string(runes[start:end]), nil
+}
+
+func (p *parser) parseIndex() (string, error) {
+	p.next()
+	s, err := p.argFor("index")
+	if err != nil {
+		return "", err
+	}
+	chars, err := p.argFor("index")
+	if err != nil {
+		return "", err
+	}
+	runes := []rune(s)
+	set := make(map[rune]bool, len(chars))
+	for _, ch := range chars {
+		set[ch] = true
+	}
+	for i, ch := range runes {
+		if set[ch] {
+			return strconv.Itoa(i + 1), nil
+		}
+	}
+	return "0", nil
+}
+
+// isCompareOp reports whether tok is one of the six comparison operators.
+func isCompareOp(tok string) bool {
+	switch tok {
+	case "<", "<=", "=", "!=", ">=", ">":
+		return true
+	}
+	return false
+}
+
+// compare evaluates a comparison. When both operands look like integers the
+// comparison is numeric, otherwise it is lexicographic.
+func compare(left, right, op string) bool {
+	l, lerr := strconv.Atoi(left)
+	r, rerr := strconv.Atoi(right)
+	if lerr == nil && rerr == nil {
+		switch op {
+		case "<":
+			return l < r
+		case "<=":
+			return l <= r
+		case "=":
+			return l == r
+		case "!=":
+			return l != r
+		case ">=":
+			return l >= r
+		case ">":
+			return l > r
+		}
+	}
+	switch op {
+	case "<":
+		return left < right
+	case "<=":
+		return left <= right
+	case "=":
+		return left == right
+	case "!=":
+		return left != right
+	case ">=":
+		return left >= right
+	case ">":
+		return left > right
+	}
+	return false
+}
+
+func boolToStr(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// toInts converts both operands to integers for arithmetic, reporting a syntax
+// error (exit status 2) when either is not a valid integer.
+func toInts(left, right string) (int, int, error) {
+	l, err := strconv.Atoi(left)
+	if err != nil {
+		return 0, 0, &syntaxError{msg: fmt.Sprintf("non-integer argument: %q", left)}
+	}
+	r, err := strconv.Atoi(right)
+	if err != nil {
+		return 0, 0, &syntaxError{msg: fmt.Sprintf("non-integer argument: %q", right)}
+	}
+	return l, r, nil
+}
+
+// matchOp implements the ':' / match operator: an anchored match of pattern
+// against s. When the pattern has a \( \) capture group, the matched substring
+// is returned; otherwise the number of matched characters is returned.
+func matchOp(s, pattern string) (string, error) {
+	re, err := regexp.Compile("^" + basicToGoRegexp(pattern))
+	if err != nil {
+		return "", &syntaxError{msg: fmt.Sprintf("invalid regular expression: %v", err)}
+	}
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		if strings.Contains(pattern, `\(`) {
+			return "", nil
+		}
+		return "0", nil
+	}
+	if len(m) > 1 {
+		return m[1], nil
+	}
+	return strconv.Itoa(len([]rune(m[0]))), nil
+}
+
+// basicToGoRegexp translates the POSIX basic regular expression syntax expr
+// uses into Go's (RE2) syntax. In a BRE the grouping and interval metacharacters
+// are written escaped (\( \) \{ \}) and the unescaped forms are literal, which
+// is the reverse of RE2.
+func basicToGoRegexp(p string) string {
+	var b strings.Builder
+	for i := 0; i < len(p); i++ {
+		switch {
+		case p[i] == '\\' && i+1 < len(p):
+			switch p[i+1] {
+			case '(', ')', '{', '}':
+				// Escaped in a BRE: these are the metacharacter forms.
+				b.WriteByte(p[i+1])
+			default:
+				b.WriteByte('\\')
+				b.WriteByte(p[i+1])
+			}
+			i++
+		case p[i] == '(' || p[i] == ')' || p[i] == '{' || p[i] == '}' || p[i] == '+' || p[i] == '?' || p[i] == '|':
+			// Unescaped: literal in a BRE.
+			b.WriteByte('\\')
+			b.WriteByte(p[i])
+		default:
+			b.WriteByte(p[i])
+		}
+	}
+	return b.String()
+}

--- a/internal/applets/shellutils/expr/expr_test.go
+++ b/internal/applets/shellutils/expr/expr_test.go
@@ -1,0 +1,137 @@
+package expr_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/expr"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// run executes the expr applet with the given args and returns the captured
+// stdout, stderr and the process exit code (via command.Execute).
+func run(t *testing.T, args ...string) (out, errOut string, code int) {
+	t.Helper()
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: outBuf, Err: errBuf}
+	code = command.Execute(context.Background(), expr.New(), io, args)
+	return outBuf.String(), errBuf.String(), code
+}
+
+func TestRunResult(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+		code int
+	}{
+		{"add", []string{"1", "+", "2"}, "3\n", 0},
+		{"sub negative", []string{"5", "-", "9"}, "-4\n", 0},
+		{"mul", []string{"3", "*", "4"}, "12\n", 0},
+		{"div", []string{"7", "/", "2"}, "3\n", 0},
+		{"mod", []string{"7", "%", "2"}, "1\n", 0},
+		{"less than", []string{"2", "<", "3"}, "1\n", 0},
+		{"less than false", []string{"3", "<", "2"}, "0\n", 1},
+		{"le", []string{"3", "<=", "3"}, "1\n", 0},
+		{"eq numeric", []string{"10", "=", "10"}, "1\n", 0},
+		{"ne", []string{"10", "!=", "9"}, "1\n", 0},
+		{"ge", []string{"3", ">=", "4"}, "0\n", 1},
+		{"gt", []string{"5", ">", "4"}, "1\n", 0},
+		{"string eq", []string{"foo", "=", "foo"}, "1\n", 0},
+		{"string ne", []string{"foo", "=", "bar"}, "0\n", 1},
+		{"grouping", []string{"(", "1", "+", "2", ")", "*", "3"}, "9\n", 0},
+		{"precedence", []string{"1", "+", "2", "*", "3"}, "7\n", 0},
+		{"length", []string{"length", "abcd"}, "4\n", 0},
+		{"substr", []string{"substr", "abcdef", "2", "3"}, "bcd\n", 0},
+		{"substr out of range", []string{"substr", "abc", "5", "2"}, "\n", 1},
+		{"index found", []string{"index", "abcdef", "cd"}, "3\n", 0},
+		{"index not found", []string{"index", "abcdef", "xy"}, "0\n", 1},
+		{"or first", []string{"abc", "|", "def"}, "abc\n", 0},
+		{"or second", []string{"", "|", "def"}, "def\n", 0},
+		{"or both zero", []string{"0", "|", "0"}, "0\n", 1},
+		{"and both true", []string{"5", "&", "3"}, "5\n", 0},
+		{"and one false", []string{"0", "&", "3"}, "0\n", 1},
+		{"zero exits one", []string{"0"}, "0\n", 1},
+		{"empty exits one", []string{""}, "\n", 1},
+		{"nonzero literal", []string{"7"}, "7\n", 0},
+		{"match count", []string{"abcabc", ":", "abc"}, "3\n", 0},
+		{"match group", []string{"abc", ":", `a\(b\)c`}, "b\n", 0},
+		{"match keyword", []string{"match", "abcabc", "abc"}, "3\n", 0},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, code := run(t, tt.args...)
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+			if code != tt.code {
+				t.Errorf("code = %d, want %d", code, tt.code)
+			}
+		})
+	}
+}
+
+func TestRunErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		code int
+	}{
+		{"divide by zero", []string{"5", "/", "0"}, 2},
+		{"modulo by zero", []string{"5", "%", "0"}, 2},
+		{"missing argument", []string{"1", "+"}, 2},
+		{"trailing token", []string{"1", "2"}, 2},
+		{"non integer arithmetic", []string{"a", "+", "1"}, 2},
+		{"unbalanced paren", []string{"(", "1", "+", "2"}, 2},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errOut, code := run(t, tt.args...)
+			if code != tt.code {
+				t.Errorf("code = %d, want %d", code, tt.code)
+			}
+			if !strings.HasPrefix(errOut, "expr: ") {
+				t.Errorf("stderr = %q, want prefix %q", errOut, "expr: ")
+			}
+		})
+	}
+}
+
+// TestEval exercises the eval entry point directly so the evaluator can be
+// covered without going through the IO layer.
+func TestEval(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{"add", []string{"1", "+", "2"}, "3", false},
+		{"nested grouping", []string{"(", "(", "2", "+", "3", ")", "*", "2", ")"}, "10", false},
+		{"div by zero", []string{"1", "/", "0"}, "", true},
+		{"length unicode", []string{"length", "あいう"}, "3", false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := expr.Eval(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/applets/shellutils/sort/sort.go
+++ b/internal/applets/shellutils/sort/sort.go
@@ -1,0 +1,311 @@
+// Package sortcmd implements the sort applet: write the sorted concatenation of
+// all FILE(s) (or standard input) to standard output, with the common GNU
+// options. The package is named sortcmd rather than sort so it can import the
+// standard library sort package.
+package sortcmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// create opens name for writing, truncating any existing file. It is a thin
+// wrapper kept separate so the I/O surface used by sort stays small.
+func create(name string) (*os.File, error) {
+	return os.Create(name) //nolint:gosec // operating on a user-named file is the whole point
+}
+
+// Command is the sort applet.
+type Command struct{}
+
+// New returns a sort command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "sort" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Sort lines of text files" }
+
+// options holds the parsed flags that drive the comparison and post-processing.
+type options struct {
+	reverse      bool
+	numeric      bool
+	unique       bool
+	ignoreCase   bool
+	ignoreBlanks bool
+	key          int    // 1-based start field for -k; 0 means whole line
+	separator    string // -t separator; empty means runs of blanks
+	hasSeparator bool
+}
+
+// Run executes sort.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	reverse := fs.BoolP("reverse", "r", false, "reverse the result of comparisons")
+	numeric := fs.BoolP("numeric-sort", "n", false, "compare according to string numerical value")
+	unique := fs.BoolP("unique", "u", false, "output only the first of an equal run")
+	ignoreCase := fs.BoolP("ignore-case", "f", false, "fold lower case to upper case characters")
+	ignoreBlanks := fs.BoolP("ignore-leading-blanks", "b", false, "ignore leading blanks")
+	key := fs.StringP("key", "k", "", "sort via a key; KEYDEF gives location")
+	separator := fs.StringP("field-separator", "t", "", "use SEP instead of non-blank to blank transition")
+	check := fs.BoolP("check", "c", false, "check for sorted input; do not sort")
+	output := fs.StringP("output", "o", "", "write result to FILE instead of standard output")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	opts := options{
+		reverse:      *reverse,
+		numeric:      *numeric,
+		unique:       *unique,
+		ignoreCase:   *ignoreCase,
+		ignoreBlanks: *ignoreBlanks,
+		separator:    *separator,
+		hasSeparator: *separator != "",
+	}
+	if *key != "" {
+		k, perr := parseKey(*key)
+		if perr != nil {
+			return command.Failuref("%s", perr)
+		}
+		opts.key = k
+	}
+
+	lines, readErr := read(stdio, fs.Args())
+	if readErr != nil {
+		return readErr
+	}
+
+	if *check {
+		return checkSorted(stdio, lines, opts)
+	}
+
+	sorted := Sort(lines, opts)
+	return writeLines(stdio, *output, sorted)
+}
+
+// parseKey parses a -k KEYDEF of the simple form "N" (a single field number,
+// meaning from field N to the end of the line) and returns the 1-based field.
+func parseKey(def string) (int, error) {
+	// Only the start field is honoured; a trailing ",M" is accepted but ignored.
+	start := def
+	if i := strings.IndexByte(def, ','); i >= 0 {
+		start = def[:i]
+	}
+	// Strip any column offset / ordering flags such as "2.3" or "2n".
+	for i, r := range start {
+		if r < '0' || r > '9' {
+			start = start[:i]
+			break
+		}
+	}
+	if start == "" {
+		return 0, fmt.Errorf("invalid key definition: %q", def)
+	}
+	n, err := strconv.Atoi(start)
+	if err != nil || n < 1 {
+		return 0, fmt.Errorf("invalid key definition: %q", def)
+	}
+	return n, nil
+}
+
+// read reads every operand (defaulting to standard input when there are none)
+// and returns the combined lines, splitting on '\n'. A trailing newline does not
+// produce an empty final line.
+func read(stdio command.IO, files []string) ([]string, error) {
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+	var b strings.Builder
+	for _, name := range files {
+		r, err := command.Open(stdio, name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sort: %s\n", command.FileError(name, err))
+			return nil, command.SilentFailure()
+		}
+		_, err = io.Copy(&b, r)
+		_ = r.Close()
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sort: %s\n", command.FileError(name, err))
+			return nil, command.SilentFailure()
+		}
+	}
+	return splitLines(b.String()), nil
+}
+
+// splitLines splits text into lines on '\n', dropping a single trailing newline
+// so that "a\nb\n" yields two lines rather than three.
+func splitLines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	text = strings.TrimSuffix(text, "\n")
+	return strings.Split(text, "\n")
+}
+
+// Sort returns the lines sorted according to opts. It is pure: it does not touch
+// any I/O and returns a new slice, which makes it directly unit-testable.
+func Sort(lines []string, opts options) []string {
+	out := make([]string, len(lines))
+	copy(out, lines)
+
+	sort.SliceStable(out, func(i, j int) bool {
+		c := compare(out[i], out[j], opts)
+		if opts.reverse {
+			return c > 0
+		}
+		return c < 0
+	})
+
+	if opts.unique {
+		out = uniq(out, opts)
+	}
+	return out
+}
+
+// compare returns a negative, zero, or positive value reporting whether the key
+// of a sorts before, equal to, or after the key of b.
+func compare(a, b string, opts options) int {
+	ka := key(a, opts)
+	kb := key(b, opts)
+
+	if opts.numeric {
+		na := leadingNumber(ka)
+		nb := leadingNumber(kb)
+		switch {
+		case na < nb:
+			return -1
+		case na > nb:
+			return 1
+		default:
+			return 0
+		}
+	}
+	return strings.Compare(ka, kb)
+}
+
+// key extracts the comparison key from a line: the selected field (when -k is
+// set) with the case- and blank-folding transformations applied.
+func key(line string, opts options) string {
+	s := line
+	if opts.key > 0 {
+		s = field(line, opts)
+	}
+	if opts.ignoreBlanks {
+		s = strings.TrimLeft(s, " \t")
+	}
+	if opts.ignoreCase {
+		s = strings.ToUpper(s)
+	}
+	return s
+}
+
+// field returns the substring of line from the start field selected by -k to the
+// end of the line, using the -t separator (or runs of blanks by default).
+func field(line string, opts options) string {
+	var fields []string
+	if opts.hasSeparator {
+		fields = strings.Split(line, opts.separator)
+	} else {
+		fields = strings.FieldsFunc(line, func(r rune) bool {
+			return r == ' ' || r == '\t'
+		})
+	}
+	idx := opts.key - 1
+	if idx >= len(fields) {
+		return ""
+	}
+	if opts.hasSeparator {
+		return strings.Join(fields[idx:], opts.separator)
+	}
+	return strings.Join(fields[idx:], " ")
+}
+
+// leadingNumber parses the leading numeric value of s, ignoring leading blanks.
+// A string with no number parses as 0, matching GNU sort -n.
+func leadingNumber(s string) float64 {
+	s = strings.TrimLeft(s, " \t")
+	end := 0
+	for end < len(s) {
+		ch := s[end]
+		if (ch >= '0' && ch <= '9') || ch == '+' || ch == '-' || ch == '.' {
+			end++
+			continue
+		}
+		break
+	}
+	if end == 0 {
+		return 0
+	}
+	n, err := strconv.ParseFloat(s[:end], 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// uniq drops lines whose comparison key equals that of the preceding line. The
+// slice is assumed to already be sorted, so equal keys are adjacent.
+func uniq(lines []string, opts options) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	out := lines[:1]
+	for _, l := range lines[1:] {
+		if compare(out[len(out)-1], l, opts) != 0 {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// checkSorted verifies the input is already sorted, returning an error (and
+// reporting the first disorder on stderr) when it is not.
+func checkSorted(stdio command.IO, lines []string, opts options) error {
+	for i := 1; i < len(lines); i++ {
+		c := compare(lines[i-1], lines[i], opts)
+		disordered := c > 0
+		if opts.reverse {
+			disordered = c < 0
+		}
+		if disordered {
+			_, _ = fmt.Fprintf(stdio.Err, "sort: -:%d: disorder: %s\n", i+1, lines[i])
+			return command.Failure(nil)
+		}
+	}
+	return nil
+}
+
+// writeLines writes the sorted lines (each terminated by '\n') to the -o file,
+// or to standard output when output is empty.
+func writeLines(stdio command.IO, output string, lines []string) error {
+	w := stdio.Out
+	if output != "" {
+		f, err := create(output)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sort: %s\n", command.FileError(output, err))
+			return command.SilentFailure()
+		}
+		defer func() { _ = f.Close() }()
+		w = f
+	}
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}

--- a/internal/applets/shellutils/sort/sort_test.go
+++ b/internal/applets/shellutils/sort/sort_test.go
@@ -1,0 +1,182 @@
+package sortcmd_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sortcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/sort"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := sortcmd.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"lexical", "banana\napple\ncherry\n", nil, "apple\nbanana\ncherry\n"},
+		{"reverse", "apple\nbanana\ncherry\n", []string{"-r"}, "cherry\nbanana\napple\n"},
+		{"numeric", "10\n2\n1\n", []string{"-n"}, "1\n2\n10\n"},
+		{"numeric lexical differs", "10\n2\n1\n", nil, "1\n10\n2\n"},
+		{"unique", "b\na\nb\na\n", []string{"-u"}, "a\nb\n"},
+		{"ignore case", "Banana\napple\nCherry\n", []string{"-f"}, "apple\nBanana\nCherry\n"},
+		{"key field 2", "x 3\ny 1\nz 2\n", []string{"-k", "2"}, "y 1\nz 2\nx 3\n"},
+		{"separator with key", "x,3\ny,1\nz,2\n", []string{"-t", ",", "-k", "2"}, "y,1\nz,2\nx,3\n"},
+		{"ignore leading blanks", "  b\na\n", []string{"-b"}, "a\n  b\n"},
+		{"numeric reverse", "1\n10\n2\n", []string{"-n", "-r"}, "10\n2\n1\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestAgainstSystemSort compares the applet output with the system sort for the
+// option combinations that should match byte-for-byte across implementations.
+func TestAgainstSystemSort(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("sort"); err != nil {
+		t.Skip("system sort not available")
+	}
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+	}{
+		{"lexical", "banana\napple\ncherry\ndate\n", nil},
+		{"reverse", "banana\napple\ncherry\n", []string{"-r"}},
+		{"numeric", "10\n2\n1\n100\n3\n", []string{"-n"}},
+		{"unique", "b\na\nb\nc\na\n", []string{"-u"}},
+		{"key 2", "x 3\ny 1\nz 2\n", []string{"-k", "2"}},
+		{"sep key", "x,3\ny,1\nz,2\n", []string{"-t", ",", "-k", "2"}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, _, err := run(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			cmd := exec.Command("sort", tt.args...)
+			cmd.Stdin = strings.NewReader(tt.stdin)
+			cmd.Env = append(os.Environ(), "LC_ALL=C")
+			sysOut, cerr := cmd.Output()
+			if cerr != nil {
+				t.Fatalf("system sort error = %v", cerr)
+			}
+			if got != string(sysOut) {
+				t.Errorf("applet = %q, system sort = %q", got, string(sysOut))
+			}
+		})
+	}
+}
+
+func TestRunFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(a, []byte("c\na\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("b\nd\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "a\nb\nc\nd\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestRunOutputFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := filepath.Join(dir, "out.txt")
+	out, _, err := run(t, "b\na\n", "-o", o)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	data, rerr := os.ReadFile(o)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(data) != "a\nb\n" {
+		t.Errorf("file = %q", string(data))
+	}
+}
+
+func TestRunCheck(t *testing.T) {
+	t.Parallel()
+	if _, _, err := run(t, "a\nb\nc\n", "-c"); err != nil {
+		t.Errorf("sorted input -c error = %v", err)
+	}
+	_, errOut, err := run(t, "b\na\n", "-c")
+	if err == nil {
+		t.Fatal("expected error for unsorted -c input")
+	}
+	if !strings.Contains(errOut, "disorder") {
+		t.Errorf("stderr = %q, want disorder message", errOut)
+	}
+}
+
+func TestRunMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(errOut, "sort: /no/such/file:") {
+		t.Errorf("stderr = %q, want sort error prefix", errOut)
+	}
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: sort") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = run(t, "", "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "sort (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}

--- a/internal/applets/shellutils/test/test.go
+++ b/internal/applets/shellutils/test/test.go
@@ -1,0 +1,321 @@
+// Package testcmd implements the test applet: evaluate a conditional
+// expression. Like the POSIX/shell builtin, test produces no output; its only
+// result is the exit status (0 = true, 1 = false, >1 = error). Its operands form
+// an expression (e.g. "test -f foo", "test 1 -eq 2"), so it deliberately does
+// not use getopt-style flag parsing.
+package testcmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the test applet.
+type Command struct{}
+
+// New returns a test command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "test" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Evaluate a conditional expression" }
+
+// Run evaluates the expression in args. It writes nothing to stdout; the result
+// is the exit status only: nil for true (0), ExitError{Code: 1} for false, and
+// ExitError{Code: 2} for a malformed expression (whose message the runner prints
+// as "test: <message>").
+func (c *Command) Run(_ context.Context, _ command.IO, args []string) error {
+	ok, err := eval(args)
+	if err != nil {
+		return &command.ExitError{Code: 2, Err: err}
+	}
+	if !ok {
+		return &command.ExitError{Code: 1}
+	}
+	return nil
+}
+
+// errSyntax is the generic message for a malformed expression.
+var errSyntax = errors.New("syntax error")
+
+// eval evaluates the test expression in args and reports its truth value. It is
+// a pure function (its only side effects are file-system stat calls), so it can
+// be unit-tested without the command framework. A malformed expression returns
+// a non-nil error.
+func eval(args []string) (bool, error) {
+	p := &parser{args: args}
+	ok, err := p.parseExpr()
+	if err != nil {
+		return false, err
+	}
+	if !p.atEnd() {
+		return false, errSyntax
+	}
+	return ok, nil
+}
+
+// parser is a small recursive-descent evaluator over the operand list. The
+// grammar mirrors POSIX test: -o binds loosest, then -a, then a leading !, then
+// the primaries (file/string/integer tests and parenthesized groups).
+//
+//	expr   := term { -o term }
+//	term   := factor { -a factor }
+//	factor := ! factor | primary
+type parser struct {
+	args []string
+	pos  int
+}
+
+func (p *parser) atEnd() bool { return p.pos >= len(p.args) }
+
+func (p *parser) peek() (string, bool) {
+	if p.atEnd() {
+		return "", false
+	}
+	return p.args[p.pos], true
+}
+
+func (p *parser) next() (string, bool) {
+	tok, ok := p.peek()
+	if ok {
+		p.pos++
+	}
+	return tok, ok
+}
+
+func (p *parser) parseExpr() (bool, error) {
+	left, err := p.parseTerm()
+	if err != nil {
+		return false, err
+	}
+	for {
+		tok, ok := p.peek()
+		if !ok || tok != "-o" {
+			break
+		}
+		p.pos++ // consume -o
+		right, err := p.parseTerm()
+		if err != nil {
+			return false, err
+		}
+		left = left || right
+	}
+	return left, nil
+}
+
+func (p *parser) parseTerm() (bool, error) {
+	left, err := p.parseFactor()
+	if err != nil {
+		return false, err
+	}
+	for {
+		tok, ok := p.peek()
+		if !ok || tok != "-a" {
+			break
+		}
+		p.pos++ // consume -a
+		right, err := p.parseFactor()
+		if err != nil {
+			return false, err
+		}
+		left = left && right
+	}
+	return left, nil
+}
+
+func (p *parser) parseFactor() (bool, error) {
+	tok, ok := p.peek()
+	if ok && tok == "!" {
+		p.pos++ // consume !
+		v, err := p.parseFactor()
+		if err != nil {
+			return false, err
+		}
+		return !v, nil
+	}
+	return p.parsePrimary()
+}
+
+// parsePrimary evaluates a single primary: a parenthesized expression, a unary
+// file/string test, or a binary string/integer comparison. It uses limited
+// look-ahead on the surrounding tokens to disambiguate, the way POSIX test does
+// for its fixed-arg-count cases.
+func (p *parser) parsePrimary() (bool, error) {
+	tok, ok := p.peek()
+	if !ok {
+		// An expression position with nothing left (e.g. "! " alone) is empty,
+		// which test treats as false rather than a syntax error.
+		return false, nil
+	}
+
+	// Parenthesized group: ( EXPR )
+	if tok == "(" {
+		p.pos++ // consume (
+		v, err := p.parseExpr()
+		if err != nil {
+			return false, err
+		}
+		close, ok := p.next()
+		if !ok || close != ")" {
+			return false, errSyntax
+		}
+		return v, nil
+	}
+
+	// Binary operator: STR1 <op> STR2. Look at the token after the next one.
+	if p.pos+1 < len(p.args) && isBinaryOp(p.args[p.pos+1]) {
+		if p.pos+2 >= len(p.args) {
+			return false, errSyntax
+		}
+		left, op, right := p.args[p.pos], p.args[p.pos+1], p.args[p.pos+2]
+		p.pos += 3
+		return evalBinary(left, op, right)
+	}
+
+	// Unary operator: -X STR, when the token is a known unary test and an
+	// operand follows.
+	if isUnaryOp(tok) {
+		if p.pos+1 >= len(p.args) {
+			return false, errSyntax
+		}
+		operand := p.args[p.pos+1]
+		p.pos += 2
+		return evalUnary(tok, operand)
+	}
+
+	// A bare string is true when it is non-empty.
+	p.pos++
+	return tok != "", nil
+}
+
+// isBinaryOp reports whether op is a binary string or integer operator.
+func isBinaryOp(op string) bool {
+	switch op {
+	case "=", "!=",
+		"-eq", "-ne", "-gt", "-ge", "-lt", "-le":
+		return true
+	}
+	return false
+}
+
+// isUnaryOp reports whether op is a unary string or file-test operator.
+func isUnaryOp(op string) bool {
+	switch op {
+	case "-z", "-n",
+		"-e", "-f", "-d", "-r", "-w", "-x", "-s",
+		"-L", "-h", "-b", "-c", "-p", "-S":
+		return true
+	}
+	return false
+}
+
+// evalBinary evaluates "left op right".
+func evalBinary(left, op, right string) (bool, error) {
+	switch op {
+	case "=":
+		return left == right, nil
+	case "!=":
+		return left != right, nil
+	}
+
+	// Remaining operators are integer comparisons.
+	l, err := strconv.Atoi(left)
+	if err != nil {
+		return false, errors.New("integer expression expected: " + left)
+	}
+	r, err := strconv.Atoi(right)
+	if err != nil {
+		return false, errors.New("integer expression expected: " + right)
+	}
+	switch op {
+	case "-eq":
+		return l == r, nil
+	case "-ne":
+		return l != r, nil
+	case "-gt":
+		return l > r, nil
+	case "-ge":
+		return l >= r, nil
+	case "-lt":
+		return l < r, nil
+	case "-le":
+		return l <= r, nil
+	}
+	return false, errSyntax
+}
+
+// evalUnary evaluates "op operand" for string and file tests.
+func evalUnary(op, operand string) (bool, error) {
+	switch op {
+	case "-z":
+		return operand == "", nil
+	case "-n":
+		return operand != "", nil
+	}
+	return evalFileTest(op, operand)
+}
+
+// evalFileTest evaluates a file-test primary. A test against a nonexistent path
+// (or one whose mode does not match) is simply false, never an error.
+func evalFileTest(op, path string) (bool, error) {
+	switch op {
+	case "-e", "-f", "-d", "-s", "-b", "-c", "-p", "-S":
+		info, err := os.Stat(path)
+		if err != nil {
+			return false, nil
+		}
+		switch op {
+		case "-e":
+			return true, nil
+		case "-f":
+			return info.Mode().IsRegular(), nil
+		case "-d":
+			return info.IsDir(), nil
+		case "-s":
+			return info.Size() > 0, nil
+		case "-b":
+			return info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0, nil
+		case "-c":
+			return info.Mode()&os.ModeCharDevice != 0, nil
+		case "-p":
+			return info.Mode()&os.ModeNamedPipe != 0, nil
+		case "-S":
+			return info.Mode()&os.ModeSocket != 0, nil
+		}
+	case "-L", "-h":
+		info, err := os.Lstat(path)
+		if err != nil {
+			return false, nil
+		}
+		return info.Mode()&os.ModeSymlink != 0, nil
+	case "-r", "-w", "-x":
+		info, err := os.Stat(path)
+		if err != nil {
+			return false, nil
+		}
+		return hasPerm(info.Mode(), op), nil
+	}
+	return false, errSyntax
+}
+
+// hasPerm reports whether mode grants the permission named by op (-r/-w/-x) to
+// any of owner, group or other. It is an approximation of access(2) that does
+// not consult the caller's uid/gid, which keeps the function pure and portable.
+func hasPerm(mode os.FileMode, op string) bool {
+	perm := mode.Perm()
+	switch op {
+	case "-r":
+		return perm&0o444 != 0
+	case "-w":
+		return perm&0o222 != 0
+	case "-x":
+		return perm&0o111 != 0
+	}
+	return false
+}

--- a/internal/applets/shellutils/test/test_test.go
+++ b/internal/applets/shellutils/test/test_test.go
@@ -1,0 +1,95 @@
+package testcmd_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	testcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/test"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// run executes the test applet with args and returns its exit code plus the
+// bytes written to stderr.
+func run(t *testing.T, args ...string) (int, string) {
+	t.Helper()
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: errBuf}
+	code := command.Execute(context.Background(), testcmd.New(), io, args)
+	return code, errBuf.String()
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "file")
+	if err := os.WriteFile(existing, []byte("data"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	missing := filepath.Join(dir, "nope")
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"-z empty true", []string{"-z", ""}, 0},
+		{"-z nonempty false", []string{"-z", "x"}, 1},
+		{"-n nonempty true", []string{"-n", "x"}, 0},
+		{"-n empty false", []string{"-n", ""}, 1},
+		{"string equal true", []string{"a", "=", "a"}, 0},
+		{"string equal false", []string{"a", "=", "b"}, 1},
+		{"string not-equal true", []string{"a", "!=", "b"}, 0},
+		{"int eq true", []string{"1", "-eq", "1"}, 0},
+		{"int eq false", []string{"1", "-eq", "2"}, 1},
+		{"int gt true", []string{"2", "-gt", "1"}, 0},
+		{"int gt false", []string{"1", "-gt", "2"}, 1},
+		{"int ne true", []string{"1", "-ne", "2"}, 0},
+		{"int le true", []string{"1", "-le", "1"}, 0},
+		{"negate true expr", []string{"!", "1", "-eq", "1"}, 1},
+		{"negate false expr", []string{"!", "1", "-eq", "2"}, 0},
+		{"and true", []string{"1", "-eq", "1", "-a", "2", "-eq", "2"}, 0},
+		{"and false", []string{"1", "-eq", "1", "-a", "2", "-eq", "3"}, 1},
+		{"or true", []string{"1", "-eq", "2", "-o", "2", "-eq", "2"}, 0},
+		{"or false", []string{"1", "-eq", "2", "-o", "2", "-eq", "3"}, 1},
+		{"parens", []string{"(", "1", "-eq", "1", ")"}, 0},
+		{"-f existing true", []string{"-f", existing}, 0},
+		{"-f missing false", []string{"-f", missing}, 1},
+		{"-e existing true", []string{"-e", existing}, 0},
+		{"-d dir true", []string{"-d", dir}, 0},
+		{"-d file false", []string{"-d", existing}, 1},
+		{"-s nonempty true", []string{"-s", existing}, 0},
+		{"bare nonempty true", []string{"hello"}, 0},
+		{"bare empty false", []string{""}, 1},
+		{"no args false", nil, 1},
+		{"malformed missing operand", []string{"1", "-eq"}, 2},
+		{"malformed unclosed paren", []string{"(", "1", "-eq", "1"}, 2},
+		{"malformed non-integer", []string{"a", "-eq", "1"}, 2},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			code, _ := run(t, tt.args...)
+			if code != tt.want {
+				t.Errorf("exit code = %d, want %d", code, tt.want)
+			}
+		})
+	}
+}
+
+func TestMalformedMessage(t *testing.T) {
+	t.Parallel()
+	code, stderr := run(t, "1", "-eq")
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.HasPrefix(stderr, "test: ") {
+		t.Errorf("stderr = %q, want prefix %q", stderr, "test: ")
+	}
+}

--- a/internal/applets/shellutils/who/export_test.go
+++ b/internal/applets/shellutils/who/export_test.go
@@ -1,0 +1,9 @@
+package who
+
+// SetUtmpFileForTest points the applet at path and returns a function that
+// restores the previous value, so external tests can supply a fixture utmp file.
+func SetUtmpFileForTest(path string) (restore func()) {
+	prev := utmpFile
+	utmpFile = path
+	return func() { utmpFile = prev }
+}

--- a/internal/applets/shellutils/who/who.go
+++ b/internal/applets/shellutils/who/who.go
@@ -1,0 +1,214 @@
+// Package who implements the who applet: show who is logged on by reading the
+// Linux utmp login-record database (/var/run/utmp by default). The record
+// layout matches Linux's struct utmp (384 bytes), and the parsing and
+// formatting are split into pure functions so they can be exercised in memory
+// without a real login session.
+package who
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// utmpFile is the login-record database read by default. It is a package
+// variable so tests can point it at a fixture file.
+var utmpFile = "/var/run/utmp"
+
+// utmpRecordSize is the size in bytes of a Linux struct utmp record.
+const utmpRecordSize = 384
+
+// ut_type values from <utmp.h>. Only the ones who cares about are listed.
+const (
+	bootTime    = 2 // BOOT_TIME:    time of system boot
+	userProcess = 7 // USER_PROCESS: a normal logged-in user process
+)
+
+// Field offsets within a struct utmp record (see the package doc).
+const (
+	offType = 0   // ut_type   int16
+	offLine = 8   // ut_line   char[32]
+	offUser = 44  // ut_user   char[32]
+	offHost = 76  // ut_host   char[256]
+	offSec  = 340 // ut_tv.tv_sec int32
+)
+
+// Entry is one parsed utmp record, holding only the fields who reports.
+type Entry struct {
+	Type int16     // ut_type
+	User string    // ut_user, NUL-trimmed
+	Line string    // ut_line, NUL-trimmed
+	Host string    // ut_host, NUL-trimmed
+	Time time.Time // login/boot time from ut_tv.tv_sec
+}
+
+// Command is the who applet.
+type Command struct{}
+
+// New returns a who command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "who" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show who is logged on" }
+
+type options struct {
+	boot    bool // -b, --boot:    print the system boot time
+	heading bool // -H, --heading: print a column heading line
+	count   bool // -q, --count:   print only login names and a user count
+	idle    bool // -u:            also report idle time and PID (best-effort)
+}
+
+// Run executes who. With no options it reads the utmp database and prints one
+// line per logged-in user. An optional FILE operand overrides utmpFile.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	boot := fs.BoolP("boot", "b", false, "time of last system boot")
+	heading := fs.BoolP("heading", "H", false, "print line of column headings")
+	count := fs.BoolP("count", "q", false, "all login names and number of users logged on")
+	idle := fs.BoolP("idle", "u", false, "list users logged in")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	opts := options{boot: *boot, heading: *heading, count: *count, idle: *idle}
+
+	path := utmpFile
+	if operands := fs.Args(); len(operands) > 0 {
+		path = operands[0]
+	}
+
+	data, rerr := os.ReadFile(path) //nolint:gosec // reading a user-named utmp file is the whole point
+	if rerr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "who: %s\n", command.FileError(path, rerr))
+		return command.SilentFailure()
+	}
+
+	entries, perr := parseUtmp(bytes.NewReader(data))
+	if perr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "who: %v\n", perr)
+		return command.SilentFailure()
+	}
+
+	_, _ = io.WriteString(stdio.Out, render(entries, opts))
+	return nil
+}
+
+// parseUtmp reads fixed-size struct utmp records from r and returns them as
+// Entry values. A trailing short read (fewer than utmpRecordSize bytes) is
+// treated as end of data rather than an error, matching how the file may be
+// truncated. It is a pure function so tests need no /var/run/utmp.
+func parseUtmp(r io.Reader) ([]Entry, error) {
+	var entries []Entry
+	rec := make([]byte, utmpRecordSize)
+	for {
+		n, err := io.ReadFull(r, rec)
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if n < utmpRecordSize {
+			break
+		}
+		entries = append(entries, Entry{
+			Type: int16(binary.LittleEndian.Uint16(rec[offType:])),
+			User: cString(rec[offUser : offUser+32]),
+			Line: cString(rec[offLine : offLine+32]),
+			Host: cString(rec[offHost : offHost+256]),
+			Time: time.Unix(int64(int32(binary.LittleEndian.Uint32(rec[offSec:]))), 0),
+		})
+	}
+	return entries, nil
+}
+
+// cString returns the bytes up to the first NUL as a string.
+func cString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		return string(b[:i])
+	}
+	return string(b)
+}
+
+// render produces who's whole output for the given entries and options.
+func render(entries []Entry, opts options) string {
+	if opts.count {
+		return renderCount(entries)
+	}
+
+	var b bytes.Buffer
+	if opts.heading {
+		b.WriteString(heading())
+	}
+	if opts.boot {
+		for _, e := range entries {
+			if e.Type == bootTime {
+				b.WriteString(formatBoot(e))
+			}
+		}
+		return b.String()
+	}
+	for _, e := range entries {
+		if e.Type == userProcess {
+			b.WriteString(formatUser(e, opts))
+		}
+	}
+	return b.String()
+}
+
+// heading returns the column heading line printed by -H.
+func heading() string {
+	return fmt.Sprintf("%-8s %-12s %s\n", "NAME", "LINE", "TIME")
+}
+
+// formatUser formats one USER_PROCESS record GNU-style: "NAME LINE TIME".
+func formatUser(e Entry, opts options) string {
+	line := fmt.Sprintf("%-8s %-12s %s", e.User, e.Line, formatTime(e.Time))
+	if opts.idle {
+		line += fmt.Sprintf("   %s", e.Host)
+	}
+	return line + "\n"
+}
+
+// formatBoot formats a BOOT_TIME record GNU-style as "system boot  TIME".
+func formatBoot(e Entry) string {
+	return fmt.Sprintf("%-12s %s\n", "system boot", formatTime(e.Time))
+}
+
+// renderCount implements -q: the login names on one line, then "# users=N".
+func renderCount(entries []Entry) string {
+	var b bytes.Buffer
+	count := 0
+	for _, e := range entries {
+		if e.Type != userProcess {
+			continue
+		}
+		if count > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(e.User)
+		count++
+	}
+	if count > 0 {
+		b.WriteByte('\n')
+	}
+	fmt.Fprintf(&b, "# users=%d\n", count)
+	return b.String()
+}
+
+// formatTime renders a login/boot time the way GNU who does, as
+// "YYYY-MM-DD HH:MM".
+func formatTime(t time.Time) string {
+	return t.Format("2006-01-02 15:04")
+}

--- a/internal/applets/shellutils/who/who_test.go
+++ b/internal/applets/shellutils/who/who_test.go
@@ -1,0 +1,165 @@
+package who_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/who"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// ut_type values mirrored from who.go for fixture construction.
+const (
+	bootTime    = 2
+	userProcess = 7
+)
+
+const utmpRecordSize = 384
+
+// utmpRecord builds one 384-byte struct utmp record with the layout who reads.
+func utmpRecord(utType int16, user, line, host string, sec int32) []byte {
+	rec := make([]byte, utmpRecordSize)
+	binary.LittleEndian.PutUint16(rec[0:], uint16(utType)) // ut_type   int16 @0
+	copy(rec[8:40], line)                                  // ut_line   char[32] @8
+	copy(rec[44:76], user)                                 // ut_user   char[32] @44
+	copy(rec[76:332], host)                                // ut_host   char[256] @76
+	binary.LittleEndian.PutUint32(rec[340:], uint32(sec))  // ut_tv.tv_sec int32 @340
+	return rec
+}
+
+// writeFixture writes a utmp file with one USER_PROCESS and one BOOT_TIME
+// record and returns its path. The login time is fixed for determinism.
+func writeFixture(t *testing.T) string {
+	t.Helper()
+	// 2021-01-02 03:04 UTC -> set TZ to UTC so the formatted output matches.
+	loginSec := int32(time.Date(2021, 1, 2, 3, 4, 0, 0, time.UTC).Unix())
+	bootSec := int32(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC).Unix())
+
+	var buf bytes.Buffer
+	buf.Write(utmpRecord(userProcess, "alice", "tty1", "localhost", loginSec))
+	buf.Write(utmpRecord(bootTime, "reboot", "~", "", bootSec))
+
+	path := filepath.Join(t.TempDir(), "utmp")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// run invokes who with args, passing path as the trailing FILE operand so the
+// applet reads the fixture instead of /var/run/utmp.
+func run(t *testing.T, path string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	if path != "" {
+		args = append(append([]string{}, args...), path)
+	}
+	err := who.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestWhoDefault(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	path := writeFixture(t)
+	restore := who.SetUtmpFileForTest(path)
+	defer restore()
+
+	out, errOut, err := run(t, path)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("out = %q, want NAME alice", out)
+	}
+	if !strings.Contains(out, "tty1") {
+		t.Errorf("out = %q, want LINE tty1", out)
+	}
+	if !strings.Contains(out, "2021-01-02 03:04") {
+		t.Errorf("out = %q, want login time", out)
+	}
+	// The boot record must not appear in the default listing.
+	if strings.Contains(out, "system") {
+		t.Errorf("default out should not contain boot line: %q", out)
+	}
+}
+
+func TestWhoBoot(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	path := writeFixture(t)
+
+	out, errOut, err := run(t, path, "-b")
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(out, "system boot") {
+		t.Errorf("out = %q, want 'system boot'", out)
+	}
+	if !strings.Contains(out, "2021-01-01 00:00") {
+		t.Errorf("out = %q, want boot time", out)
+	}
+	if strings.Contains(out, "alice") {
+		t.Errorf("-b out should not list users: %q", out)
+	}
+}
+
+func TestWhoCount(t *testing.T) {
+	path := writeFixture(t)
+
+	out, errOut, err := run(t, path, "-q")
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("-q out = %q, want name alice", out)
+	}
+	if !strings.Contains(out, "# users=1") {
+		t.Errorf("-q out = %q, want '# users=1'", out)
+	}
+}
+
+func TestWhoHeading(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	path := writeFixture(t)
+
+	out, errOut, err := run(t, path, "-H")
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "LINE") || !strings.Contains(out, "TIME") {
+		t.Errorf("-H out = %q, want heading", out)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("-H out = %q, want user line too", out)
+	}
+}
+
+func TestWhoMissingFile(t *testing.T) {
+	out, errOut, err := run(t, "/no/such/utmp")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+	if !strings.Contains(errOut, "who:") {
+		t.Errorf("stderr = %q, want who: prefix", errOut)
+	}
+}
+
+func TestWhoHelp(t *testing.T) {
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: who") {
+		t.Errorf("--help out = %q", out)
+	}
+}

--- a/test/it/debianutils/mktemp_test.sh
+++ b/test/it/debianutils/mktemp_test.sh
@@ -1,0 +1,26 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/mktemp
+    mkdir -p ${TEST_DIR}
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/mktemp
+}
+
+TestMktempFile() {
+    export TEST_DIR=/tmp/mimixbox/it/mktemp
+    f=$(mktemp -p ${TEST_DIR})
+    test -f "$f" && echo "created"
+}
+
+TestMktempDir() {
+    export TEST_DIR=/tmp/mimixbox/it/mktemp
+    d=$(mktemp -d -p ${TEST_DIR})
+    test -d "$d" && echo "created"
+}
+
+TestMktempDryRun() {
+    export TEST_DIR=/tmp/mimixbox/it/mktemp
+    f=$(mktemp -u -p ${TEST_DIR})
+    test ! -e "$f" && echo "not created"
+}

--- a/test/it/shellutils/date_test.sh
+++ b/test/it/shellutils/date_test.sh
@@ -1,0 +1,15 @@
+TestDateEpochDate() {
+    date -u -d @0 +%F
+}
+
+TestDateEpochTime() {
+    date -u -d @0 +%T
+}
+
+TestDatePercent() {
+    date +%%
+}
+
+TestDateYearDigits() {
+    date +%Y | grep -E '^[0-9]{4}$' > /dev/null && echo "ok"
+}

--- a/test/it/shellutils/expr_test.sh
+++ b/test/it/shellutils/expr_test.sh
@@ -1,0 +1,19 @@
+TestExprAdd() {
+    expr 6 + 7
+}
+
+TestExprMul() {
+    expr 3 \* 4
+}
+
+TestExprGroup() {
+    expr \( 1 + 2 \) \* 3
+}
+
+TestExprLength() {
+    expr length abcd
+}
+
+TestExprFalse() {
+    expr 0
+}

--- a/test/it/shellutils/sort_test.sh
+++ b/test/it/shellutils/sort_test.sh
@@ -1,0 +1,15 @@
+TestSortLexical() {
+    printf 'banana\napple\ncherry\n' | sort
+}
+
+TestSortNumeric() {
+    printf '10\n2\n1\n' | sort -n
+}
+
+TestSortReverse() {
+    printf 'a\nb\nc\n' | sort -r
+}
+
+TestSortUnique() {
+    printf 'a\na\nb\n' | sort -u
+}

--- a/test/it/shellutils/test_test.sh
+++ b/test/it/shellutils/test_test.sh
@@ -1,0 +1,35 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/test
+    mkdir -p ${TEST_DIR}
+    touch ${TEST_DIR}/file.txt
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/test
+}
+
+TestTestStringEqual() {
+    test abc = abc
+    echo "rc=$?"
+}
+
+TestTestIntCompare() {
+    test 2 -gt 1
+    echo "rc=$?"
+}
+
+TestTestIntFalse() {
+    test 1 -gt 2
+    echo "rc=$?"
+}
+
+TestTestFileExists() {
+    export TEST_DIR=/tmp/mimixbox/it/test
+    test -f ${TEST_DIR}/file.txt
+    echo "rc=$?"
+}
+
+TestTestNegate() {
+    test ! -f /no_such_file
+    echo "rc=$?"
+}

--- a/test/it/shellutils/who_test.sh
+++ b/test/it/shellutils/who_test.sh
@@ -1,0 +1,15 @@
+# who reads the binary utmp database. To keep the test independent of the host's
+# login sessions, it reads an empty utmp (/dev/null), which has no entries.
+
+TestWhoEmpty() {
+    who /dev/null
+    echo "rc=$?"
+}
+
+TestWhoCount() {
+    who -q /dev/null
+}
+
+TestWhoHelp() {
+    who --help
+}

--- a/test/it/spec/date_spec.sh
+++ b/test/it/spec/date_spec.sh
@@ -1,0 +1,35 @@
+Describe 'date with an epoch and format'
+    Include shellutils/date_test.sh
+
+    It 'formats the date portion'
+        When call TestDateEpochDate
+        The output should equal '1970-01-01'
+        The status should be success
+    End
+
+    It 'formats the time portion'
+        When call TestDateEpochTime
+        The output should equal '00:00:00'
+        The status should be success
+    End
+End
+
+Describe 'date with a literal percent'
+    Include shellutils/date_test.sh
+
+    It 'prints a percent sign'
+        When call TestDatePercent
+        The output should equal '%'
+        The status should be success
+    End
+End
+
+Describe 'date year'
+    Include shellutils/date_test.sh
+
+    It 'prints a four-digit year'
+        When call TestDateYearDigits
+        The output should equal 'ok'
+        The status should be success
+    End
+End

--- a/test/it/spec/expr_spec.sh
+++ b/test/it/spec/expr_spec.sh
@@ -1,0 +1,49 @@
+Describe 'expr addition'
+    Include shellutils/expr_test.sh
+
+    It 'adds two numbers'
+        When call TestExprAdd
+        The output should equal '13'
+        The status should be success
+    End
+End
+
+Describe 'expr multiplication'
+    Include shellutils/expr_test.sh
+
+    It 'multiplies two numbers'
+        When call TestExprMul
+        The output should equal '12'
+        The status should be success
+    End
+End
+
+Describe 'expr grouping'
+    Include shellutils/expr_test.sh
+
+    It 'respects parentheses'
+        When call TestExprGroup
+        The output should equal '9'
+        The status should be success
+    End
+End
+
+Describe 'expr length'
+    Include shellutils/expr_test.sh
+
+    It 'prints the string length'
+        When call TestExprLength
+        The output should equal '4'
+        The status should be success
+    End
+End
+
+Describe 'expr with a zero result'
+    Include shellutils/expr_test.sh
+
+    It 'prints 0 and exits non-zero'
+        When call TestExprFalse
+        The output should equal '0'
+        The status should be failure
+    End
+End

--- a/test/it/spec/mktemp_spec.sh
+++ b/test/it/spec/mktemp_spec.sh
@@ -1,0 +1,35 @@
+Describe 'mktemp creates a file'
+    Include debianutils/mktemp_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'creates a regular file under the temp dir'
+        When call TestMktempFile
+        The output should equal 'created'
+        The status should be success
+    End
+End
+
+Describe 'mktemp -d creates a directory'
+    Include debianutils/mktemp_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'creates a directory'
+        When call TestMktempDir
+        The output should equal 'created'
+        The status should be success
+    End
+End
+
+Describe 'mktemp -u does not create the file'
+    Include debianutils/mktemp_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'only prints a name'
+        When call TestMktempDryRun
+        The output should equal 'not created'
+        The status should be success
+    End
+End

--- a/test/it/spec/sort_spec.sh
+++ b/test/it/spec/sort_spec.sh
@@ -1,0 +1,62 @@
+Describe 'sort lexically'
+    Include shellutils/sort_test.sh
+
+    result() { %text
+        #|apple
+        #|banana
+        #|cherry
+    }
+
+    It 'sorts lines alphabetically'
+        When call TestSortLexical
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'sort numerically'
+    Include shellutils/sort_test.sh
+
+    result() { %text
+        #|1
+        #|2
+        #|10
+    }
+
+    It 'sorts by numeric value'
+        When call TestSortNumeric
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'sort in reverse'
+    Include shellutils/sort_test.sh
+
+    result() { %text
+        #|c
+        #|b
+        #|a
+    }
+
+    It 'reverses the order'
+        When call TestSortReverse
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'sort unique'
+    Include shellutils/sort_test.sh
+
+    result() { %text
+        #|a
+        #|b
+    }
+
+    It 'drops duplicate lines'
+        When call TestSortUnique
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/test_spec.sh
+++ b/test/it/spec/test_spec.sh
@@ -1,0 +1,47 @@
+Describe 'test string equality'
+    Include shellutils/test_test.sh
+
+    It 'is true for equal strings'
+        When call TestTestStringEqual
+        The output should equal 'rc=0'
+        The status should be success
+    End
+End
+
+Describe 'test integer comparison'
+    Include shellutils/test_test.sh
+
+    It 'is true when 2 > 1'
+        When call TestTestIntCompare
+        The output should equal 'rc=0'
+        The status should be success
+    End
+
+    It 'is false when 1 > 2'
+        When call TestTestIntFalse
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End
+
+Describe 'test file existence'
+    Include shellutils/test_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'is true for an existing file'
+        When call TestTestFileExists
+        The output should equal 'rc=0'
+        The status should be success
+    End
+End
+
+Describe 'test negation'
+    Include shellutils/test_test.sh
+
+    It 'negates the expression'
+        When call TestTestNegate
+        The output should equal 'rc=0'
+        The status should be success
+    End
+End

--- a/test/it/spec/who_spec.sh
+++ b/test/it/spec/who_spec.sh
@@ -1,0 +1,29 @@
+Describe 'who on an empty utmp'
+    Include shellutils/who_test.sh
+
+    It 'prints nothing and succeeds'
+        When call TestWhoEmpty
+        The output should equal 'rc=0'
+        The status should be success
+    End
+End
+
+Describe 'who -q on an empty utmp'
+    Include shellutils/who_test.sh
+
+    It 'reports zero users'
+        When call TestWhoCount
+        The output should equal '# users=0'
+        The status should be success
+    End
+End
+
+Describe 'who --help'
+    Include shellutils/who_test.sh
+
+    It 'prints usage'
+        When call TestWhoHelp
+        The output should include 'Usage: who'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Six more GNU-style applets, each on the `command.Command` framework with unit tests **and** shellspec integration tests, registered in the applet table and command list.

| Command | Description | Issue |
|---|---|---|
| `sort` | Sort lines of text (`-r`, `-n`, `-u`, `-f`, `-b`, `-k`, `-t`, `-c`, `-o`) | #65 |
| `test` | Evaluate a conditional expression (file/string/integer/logical, parentheses) | #67 |
| `expr` | Evaluate expressions (arithmetic, comparisons, `length`/`substr`/`index`, `:`/`match`) | #59 |
| `mktemp` | Create a temporary file or directory (`-d`, `-u`, `-q`, `-p`, `-t`) | #70 |
| `date` | Print the date/time with strftime `+FORMAT` (`-u`, `-d`, `-R`, `-I`) | #54 |
| `who` | Show who is logged on, parsing the binary utmp database (`-b`, `-H`, `-q`) | #69 |

## Notes

- `sort` and `test` use the package names `sortcmd`/`testcmd` to avoid colliding with the stdlib `sort` package and to keep `test` unambiguous; both still register under their real command names.
- `test` and `expr` are POSIX utilities that take an expression rather than getopt flags, so they bypass the flag set (like `echo`). Their evaluators are pure, recursive-descent functions covered by unit tests.
- `who` factors the utmp parsing into a pure function tested with in-memory 384-byte record fixtures; `date` has an injectable clock so format tests are deterministic.

## Testing

- Unit tests for every command (pure cores factored out); `go test ./...` passes; `golangci-lint` clean on the new packages.
- shellspec integration specs for all six pass against an installed build (date uses `-d @0` for a deterministic epoch; who reads an empty utmp via `/dev/null`).

Closes #54, #59, #65, #67, #69, #70.