### PR TITLE
feat: add chmod, du, df, dd, od and cal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 77 commands. Run `mimixbox --list` to see them on the terminal.
+There are 83 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
 | add-shell | Add shell name to /etc/shells |
 | base64 | Base64 encode/decode from FILR(or STDIN) to STDOUT |
 | basename | Print basename (PATH without "/") from file path |
+| cal | Display a calendar |
 | cat | Concatenate files and print on the standard output |
 | chgrp | Change the group of each FILE to GROUP |
+| chmod | Change file mode bits |
 | chown | Change the owner and/or group of each FILE to OWNER and/or GROUP |
 | chroot | Run command or interactive shell with special root directory |
 | clear | Clear terminal |
@@ -34,8 +36,11 @@ There are 77 commands. Run `mimixbox --list` to see them on the terminal.
 | cp | Copy file(s) otr Directory(s) |
 | cut | Remove sections from each line of files |
 | date | Print or set the system date and time |
+| dd | Convert and copy a file |
+| df | Report file system disk space usage |
 | dirname | Print only directory path |
 | dos2unix | Change CRLF to LF |
+| du | Estimate file space usage |
 | echo | Display a line of text |
 | env | Run a program in a modified environment / print the environment |
 | expand | Convert TAB to N space (default:N=8) |
@@ -60,6 +65,7 @@ There are 77 commands. Run `mimixbox --list` to see them on the terminal.
 | mktemp | Create a temporary file or directory |
 | mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY |
 | nl | Write each FILE to standard output with line numbers added |
+| od | Dump files in octal and other formats |
 | path | Manipulate filename path |
 | poweroff | Power off the system |
 | printenv | Print environment variable |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -52,11 +52,16 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/base64"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/basename"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/cal"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/chmod"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/chroot"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/cmp"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/cut"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/date"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/dd"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/df"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/dirname"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/du"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/echo"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/env"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/expr"
@@ -67,6 +72,7 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/id"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/kill"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/od"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/path"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/printenv"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/printf"
@@ -125,7 +131,9 @@ func init() {
 		"add-shell": reg(addShell.New()),
 		"base64":    reg(base64.New()),
 		"basename":  reg(basename.New()),
+		"cal":       reg(cal.New()),
 		"cat":       reg(cat.New()),
+		"chmod":     reg(chmod.New()),
 		"cowsay":    reg(cowsay.New()),
 		"chgrp":     reg(chgrp.New()),
 		"chown":     reg(chown.New()),
@@ -136,7 +144,10 @@ func init() {
 		"cp":           reg(cp.New()),
 		"cut":          reg(cut.New()),
 		"date":         reg(date.New()),
+		"dd":           reg(dd.New()),
+		"df":           reg(df.New()),
 		"dirname":      reg(dirname.New()),
+		"du":           reg(du.New()),
 		"dos2unix":     reg(dos2unix.New()),
 		"echo":         reg(echo.New()),
 		"env":          reg(env.New()),
@@ -162,6 +173,7 @@ func init() {
 		"mktemp":       reg(mktemp.New()),
 		"mv":           reg(mv.New()),
 		"nl":           reg(nl.New()),
+		"od":           reg(od.New()),
 		"path":         reg(path.New()),
 		"poweroff":     reg(halt.NewPoweroff()),
 		"printenv":     reg(printenv.New()),

--- a/internal/applets/shellutils/cal/cal.go
+++ b/internal/applets/shellutils/cal/cal.go
@@ -1,0 +1,197 @@
+// Package cal implements the cal applet: display a simple calendar for a
+// month (or a whole year), in the layout of util-linux cal.
+package cal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// nowFn returns the current time. It is a package variable so tests can pin
+// "today" and exercise the no-operand (current month) and -y (current year)
+// paths deterministically.
+var nowFn = time.Now
+
+// calWidth is the printed width of a week row: seven day columns of two
+// characters each, separated by single spaces (7*2 + 6 = 20).
+const calWidth = 7*2 + 6
+
+// Command is the cal applet.
+type Command struct{}
+
+// New returns a cal command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "cal" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Display a calendar" }
+
+// Run executes cal.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [[MONTH] YEAR]", stdio.Err)
+	monday := fs.BoolP("monday", "m", false, "Monday as the first day of the week")
+	yearMode := fs.BoolP("year", "y", false, "display a calendar for the whole current year")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	now := nowFn()
+	mondayFirst := *monday
+
+	operands := fs.Args()
+	switch {
+	case *yearMode && len(operands) == 0:
+		_, _ = io.WriteString(stdio.Out, year(now.Year(), mondayFirst))
+		return nil
+	case len(operands) == 0:
+		_, _ = io.WriteString(stdio.Out, month(now.Year(), now.Month(), mondayFirst))
+		return nil
+	case len(operands) == 1:
+		y, perr := parseYear(operands[0])
+		if perr != nil {
+			return usageErr(stdio, c.Name(), perr)
+		}
+		_, _ = io.WriteString(stdio.Out, year(y, mondayFirst))
+		return nil
+	case len(operands) == 2:
+		m, perr := parseMonth(operands[0])
+		if perr != nil {
+			return usageErr(stdio, c.Name(), perr)
+		}
+		y, perr := parseYear(operands[1])
+		if perr != nil {
+			return usageErr(stdio, c.Name(), perr)
+		}
+		_, _ = io.WriteString(stdio.Out, month(y, m, mondayFirst))
+		return nil
+	default:
+		return usageErr(stdio, c.Name(), fmt.Errorf("too many arguments"))
+	}
+}
+
+func usageErr(stdio command.IO, name string, err error) error {
+	_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", name, err)
+	_, _ = fmt.Fprintf(stdio.Err, "Try '%s --help' for more information.\n", name)
+	return command.SilentFailure()
+}
+
+func parseYear(s string) (int, error) {
+	y, err := strconv.Atoi(s)
+	if err != nil || y < 1 || y > 9999 {
+		return 0, fmt.Errorf("illegal year value: use 1-9999")
+	}
+	return y, nil
+}
+
+func parseMonth(s string) (time.Month, error) {
+	m, err := strconv.Atoi(s)
+	if err != nil || m < 1 || m > 12 {
+		return 0, fmt.Errorf("illegal month value: use 1-12")
+	}
+	return time.Month(m), nil
+}
+
+// month renders one month block: a centered "Month YYYY" header, a weekday
+// header, then one line per week with right-aligned two-digit days. Days sit in
+// three-character columns (a space separator plus two digits); trailing spaces
+// on each line are trimmed, matching util-linux cal. The block ends with a
+// trailing newline. When mondayFirst is true the week starts on Monday.
+func month(y int, m time.Month, mondayFirst bool) string {
+	var b strings.Builder
+
+	title := fmt.Sprintf("%s %d", m.String(), y)
+	b.WriteString(center(title, calWidth))
+	b.WriteByte('\n')
+
+	b.WriteString(weekdayHeader(mondayFirst))
+	b.WriteByte('\n')
+
+	// Number of leading blank columns before the 1st of the month.
+	first := time.Date(y, m, 1, 0, 0, 0, 0, time.UTC)
+	lead := weekdayIndex(first.Weekday(), mondayFirst)
+
+	daysInMonth := time.Date(y, m+1, 1, 0, 0, 0, 0, time.UTC).Add(-24 * time.Hour).Day()
+
+	col := 0
+	var line strings.Builder
+	writeCell := func(s string) {
+		if col > 0 {
+			line.WriteByte(' ')
+		}
+		line.WriteString(s)
+		col++
+		if col == 7 {
+			b.WriteString(strings.TrimRight(line.String(), " "))
+			b.WriteByte('\n')
+			line.Reset()
+			col = 0
+		}
+	}
+
+	for i := 0; i < lead; i++ {
+		writeCell("  ")
+	}
+	for d := 1; d <= daysInMonth; d++ {
+		writeCell(fmt.Sprintf("%2d", d))
+	}
+	if col > 0 {
+		b.WriteString(strings.TrimRight(line.String(), " "))
+		b.WriteByte('\n')
+	}
+
+	return b.String()
+}
+
+// year renders all twelve months of y, one month block per stanza separated by
+// a blank line, preceded by a centered year header.
+func year(y int, mondayFirst bool) string {
+	var b strings.Builder
+	b.WriteString(center(strconv.Itoa(y), calWidth))
+	b.WriteString("\n\n")
+	for m := time.January; m <= time.December; m++ {
+		b.WriteString(month(y, m, mondayFirst))
+		if m != time.December {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// weekdayHeader returns the "Su Mo Tu We Th Fr Sa" line (or its Monday-first
+// rotation).
+func weekdayHeader(mondayFirst bool) string {
+	sunFirst := []string{"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+	if mondayFirst {
+		return "Mo Tu We Th Fr Sa Su"
+	}
+	return strings.Join(sunFirst, " ")
+}
+
+// weekdayIndex maps a weekday to its column (0..6) given the week start.
+func weekdayIndex(w time.Weekday, mondayFirst bool) int {
+	if mondayFirst {
+		return (int(w) + 6) % 7
+	}
+	return int(w)
+}
+
+// center returns s padded with leading spaces so it sits centered in width.
+// Like util-linux, the extra odd space goes on the right (floor division for
+// the left padding), and the result is not right-padded.
+func center(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	left := (width - len(s)) / 2
+	return strings.Repeat(" ", left) + s
+}

--- a/internal/applets/shellutils/cal/cal_test.go
+++ b/internal/applets/shellutils/cal/cal_test.go
@@ -1,0 +1,173 @@
+package cal_test
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/cal"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	stdio := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := cal.New().Run(context.Background(), stdio, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNewAndMetadata(t *testing.T) {
+	t.Parallel()
+	c := cal.New()
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+	if c.Name() != "cal" {
+		t.Errorf("Name() = %q, want cal", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+func TestMonthNovember2023Sunday(t *testing.T) {
+	t.Parallel()
+	want := "   November 2023\n" +
+		"Su Mo Tu We Th Fr Sa\n" +
+		"          1  2  3  4\n" +
+		" 5  6  7  8  9 10 11\n" +
+		"12 13 14 15 16 17 18\n" +
+		"19 20 21 22 23 24 25\n" +
+		"26 27 28 29 30\n"
+	if got := cal.Month(2023, time.November, false); got != want {
+		t.Errorf("Month() mismatch.\n got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestMonthNovember2023Monday(t *testing.T) {
+	t.Parallel()
+	want := "   November 2023\n" +
+		"Mo Tu We Th Fr Sa Su\n" +
+		"       1  2  3  4  5\n" +
+		" 6  7  8  9 10 11 12\n" +
+		"13 14 15 16 17 18 19\n" +
+		"20 21 22 23 24 25 26\n" +
+		"27 28 29 30\n"
+	if got := cal.Month(2023, time.November, true); got != want {
+		t.Errorf("Month() mismatch.\n got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestRunMonthYearOperands(t *testing.T) {
+	t.Parallel()
+	want := "   November 2023\n" +
+		"Su Mo Tu We Th Fr Sa\n" +
+		"          1  2  3  4\n" +
+		" 5  6  7  8  9 10 11\n" +
+		"12 13 14 15 16 17 18\n" +
+		"19 20 21 22 23 24 25\n" +
+		"26 27 28 29 30\n"
+	out, errOut, err := run(t, "11", "2023")
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if out != want {
+		t.Errorf("Run out = %q, want %q", out, want)
+	}
+}
+
+func TestRunMondayOption(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "-m", "11", "2023")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.HasPrefix(out, "   November 2023\nMo Tu We Th Fr Sa Su\n") {
+		t.Errorf("Run -m out = %q", out)
+	}
+}
+
+func TestRunCurrentMonth(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	now := time.Now()
+	header := now.Month().String()
+	if !strings.Contains(out, header) {
+		t.Errorf("current month out = %q, want to contain %q", out, header)
+	}
+	if !strings.Contains(out, "Su Mo Tu We Th Fr Sa") {
+		t.Errorf("current month out missing weekday header: %q", out)
+	}
+}
+
+func TestRunYearOperand(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "2023")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	for _, m := range []string{"January 2023", "December 2023"} {
+		if !strings.Contains(out, m) {
+			t.Errorf("year out missing %q:\n%s", m, out)
+		}
+	}
+}
+
+func TestRunYearOption(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "-y")
+	if err != nil {
+		t.Fatalf("Run -y error = %v", err)
+	}
+	now := time.Now()
+	if !strings.Contains(out, "January "+strconv.Itoa(now.Year())) {
+		t.Errorf("year -y out missing January of current year:\n%s", out)
+	}
+}
+
+func TestRunInvalidOperands(t *testing.T) {
+	t.Parallel()
+	tests := [][]string{
+		{"abc"},
+		{"13", "2023"},
+		{"11", "notyear"},
+		{"1", "2", "3"},
+	}
+	for _, args := range tests {
+		args := args
+		_, errOut, err := run(t, args...)
+		if err == nil {
+			t.Errorf("args %v: expected error", args)
+		}
+		if !strings.Contains(errOut, "cal:") {
+			t.Errorf("args %v: stderr = %q, want cal: prefix", args, errOut)
+		}
+	}
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: cal") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = run(t, "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "cal (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}

--- a/internal/applets/shellutils/cal/export_test.go
+++ b/internal/applets/shellutils/cal/export_test.go
@@ -1,0 +1,8 @@
+package cal
+
+import "time"
+
+// Month exposes the unexported month renderer to the external test package.
+func Month(year int, m time.Month, mondayFirst bool) string {
+	return month(year, m, mondayFirst)
+}

--- a/internal/applets/shellutils/chmod/chmod.go
+++ b/internal/applets/shellutils/chmod/chmod.go
@@ -1,0 +1,357 @@
+// Package chmod implements the chmod applet: change the file mode bits of each
+// FILE, with the common GNU options. MODE is either an octal number (e.g. 755)
+// or a comma-separated list of symbolic clauses (e.g. u+x,go-w).
+package chmod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the chmod applet.
+type Command struct{}
+
+// New returns a chmod command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "chmod" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Change file mode bits" }
+
+type options struct {
+	recursive bool
+	verbose   bool
+	changes   bool
+	silent    bool
+}
+
+// Run executes chmod.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... MODE FILE...", stdio.Err)
+	recursive := fs.BoolP("recursive", "R", false, "change files and directories recursively")
+	verbose := fs.BoolP("verbose", "v", false, "output a diagnostic for every file processed")
+	changes := fs.BoolP("changes", "c", false, "like verbose but report only when a change is made")
+	silent := fs.BoolP("silent", "f", false, "suppress most error messages")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: missing operand\n", c.Name())
+		return command.SilentFailure()
+	}
+
+	opts := options{
+		recursive: *recursive,
+		verbose:   *verbose,
+		changes:   *changes,
+		silent:    *silent,
+	}
+
+	mode := rest[0]
+	return c.chmod(stdio, mode, rest[1:], opts)
+}
+
+// chmod changes the mode of every file, continuing past any failures. A failed
+// file is reported GNU-style on stderr; the returned error only sets the exit
+// code, because its message was already printed.
+func (c *Command) chmod(stdio command.IO, mode string, files []string, opts options) error {
+	var failErr error
+	for _, path := range files {
+		path = os.ExpandEnv(path)
+		var err error
+		if opts.recursive {
+			err = c.changeModeRecursive(stdio, path, mode, opts)
+		} else {
+			err = c.changeMode(stdio, path, mode, opts)
+		}
+		if err != nil {
+			failErr = command.SilentFailure()
+		}
+	}
+	return failErr
+}
+
+func (c *Command) changeModeRecursive(stdio command.IO, path, mode string, opts options) error {
+	// Collect every path first, then apply modes children-before-parent. Doing
+	// the walk up front means changing a directory's bits (which may drop the
+	// execute bit needed to traverse it) cannot break the descent into its own
+	// children.
+	var paths []string
+	var walkErr error
+	err := filepath.WalkDir(path, func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			c.reportAccess(stdio, p, opts)
+			walkErr = err
+			return nil
+		}
+		paths = append(paths, p)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// Deepest paths first so a directory is modified after its contents.
+	for i := len(paths) - 1; i >= 0; i-- {
+		if cerr := c.changeMode(stdio, paths[i], mode, opts); cerr != nil {
+			walkErr = cerr
+		}
+	}
+	return walkErr
+}
+
+func (c *Command) changeMode(stdio command.IO, path, mode string, opts options) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		c.reportAccess(stdio, path, opts)
+		return err
+	}
+
+	cur := info.Mode()
+	newMode, err := applyMode(cur, mode, info.IsDir())
+	if err != nil {
+		if !opts.silent {
+			_, _ = fmt.Fprintf(stdio.Err, "%s: invalid mode: '%s'\n", c.Name(), mode)
+		}
+		return err
+	}
+
+	if err := os.Chmod(path, newMode); err != nil {
+		if !opts.silent {
+			_, _ = fmt.Fprintf(stdio.Err, "%s: changing permissions of '%s': %v\n", c.Name(), path, unwrap(err))
+		}
+		return err
+	}
+
+	changed := cur.Perm() != newMode.Perm()
+	if opts.verbose || (opts.changes && changed) {
+		if changed {
+			_, _ = fmt.Fprintf(stdio.Out, "mode of '%s' changed from %s (%s) to %s (%s)\n",
+				path, octal(cur), cur.Perm().String(), octal(newMode), newMode.Perm().String())
+		} else {
+			_, _ = fmt.Fprintf(stdio.Out, "mode of '%s' retained as %s (%s)\n",
+				path, octal(newMode), newMode.Perm().String())
+		}
+	}
+	return nil
+}
+
+// reportAccess writes the GNU "cannot access" diagnostic for a missing file.
+func (c *Command) reportAccess(stdio command.IO, path string, opts options) {
+	if opts.silent {
+		return
+	}
+	_, _ = fmt.Fprintf(stdio.Err, "%s: cannot access '%s': No such file or directory\n", c.Name(), path)
+}
+
+func unwrap(err error) error {
+	var pe *os.PathError
+	if errors.As(err, &pe) {
+		return pe.Err
+	}
+	return err
+}
+
+// octal renders the permission bits (including setuid/setgid/sticky) as a
+// 4-digit octal string, e.g. "0755".
+func octal(m os.FileMode) string {
+	return fmt.Sprintf("%04o", permBits(m))
+}
+
+// permBits extracts the 12 permission bits (rwx for ugo plus setuid, setgid and
+// sticky) from a FileMode as a plain integer in the conventional octal layout.
+func permBits(m os.FileMode) uint32 {
+	bits := uint32(m.Perm())
+	if m&os.ModeSetuid != 0 {
+		bits |= 0o4000
+	}
+	if m&os.ModeSetgid != 0 {
+		bits |= 0o2000
+	}
+	if m&os.ModeSticky != 0 {
+		bits |= 0o1000
+	}
+	return bits
+}
+
+// modeFromBits converts the 12 conventional permission bits back into the
+// os.FileMode flags, preserving the non-permission bits of base (file type
+// etc.).
+func modeFromBits(base os.FileMode, bits uint32) os.FileMode {
+	m := base &^ (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky)
+	m |= os.FileMode(bits & 0o777)
+	if bits&0o4000 != 0 {
+		m |= os.ModeSetuid
+	}
+	if bits&0o2000 != 0 {
+		m |= os.ModeSetgid
+	}
+	if bits&0o1000 != 0 {
+		m |= os.ModeSticky
+	}
+	return m
+}
+
+// applyMode computes the new FileMode for a file whose current mode is cur, given
+// a chmod MODE string. mode is either an octal number (e.g. "755", "0644") or a
+// comma-separated list of symbolic clauses "[ugoa]*[-+=][rwxXst]*". isDir selects
+// the behaviour of the "X" perm (execute only for directories or files that are
+// already executable). The non-permission bits of cur are preserved.
+func applyMode(cur os.FileMode, mode string, isDir bool) (os.FileMode, error) {
+	if mode == "" {
+		return cur, errors.New("empty mode")
+	}
+
+	if isOctal(mode) {
+		v, err := strconv.ParseUint(mode, 8, 32)
+		if err != nil {
+			return cur, fmt.Errorf("invalid octal mode: %q", mode)
+		}
+		return modeFromBits(cur, uint32(v)), nil
+	}
+
+	bits := permBits(cur)
+	for _, clause := range strings.Split(mode, ",") {
+		var err error
+		bits, err = applyClause(bits, clause, isDir)
+		if err != nil {
+			return cur, err
+		}
+	}
+	return modeFromBits(cur, bits), nil
+}
+
+// isOctal reports whether s is a pure octal number (chmod's numeric form).
+func isOctal(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '7' {
+			return false
+		}
+	}
+	return true
+}
+
+// applyClause applies one symbolic clause "[ugoa]*[-+=][rwxXst]*" to the current
+// permission bits and returns the result. bits holds the 12 conventional
+// permission bits (see permBits).
+func applyClause(bits uint32, clause string, isDir bool) (uint32, error) {
+	// Parse the "who" part: which of user/group/other is affected.
+	i := 0
+	var hasU, hasG, hasO bool
+whoLoop:
+	for i < len(clause) {
+		switch clause[i] {
+		case 'u':
+			hasU = true
+		case 'g':
+			hasG = true
+		case 'o':
+			hasO = true
+		case 'a':
+			hasU, hasG, hasO = true, true, true
+		default:
+			break whoLoop
+		}
+		i++
+	}
+
+	if i >= len(clause) {
+		return bits, fmt.Errorf("invalid mode: %q", clause)
+	}
+	op := clause[i]
+	if op != '+' && op != '-' && op != '=' {
+		return bits, fmt.Errorf("invalid mode: %q", clause)
+	}
+	i++
+
+	// When no "who" is given, the clause applies to all three.
+	allWho := !hasU && !hasG && !hasO
+	if allWho {
+		hasU, hasG, hasO = true, true, true
+	}
+
+	// rwxMask is the 9-bit window of ordinary permission bits selected by who.
+	var rwxMask uint32
+	if hasU {
+		rwxMask |= 0o700
+	}
+	if hasG {
+		rwxMask |= 0o070
+	}
+	if hasO {
+		rwxMask |= 0o007
+	}
+	// specMask is the special bits (setuid/setgid/sticky) that this who can set.
+	var specMask uint32
+	if hasU {
+		specMask |= 0o4000
+	}
+	if hasG {
+		specMask |= 0o2000
+	}
+	// Sticky (t) is conventionally tied to "other"/all rather than a who letter.
+
+	perm, err := permMask(clause[i:], bits, isDir, hasU, hasG, allWho)
+	if err != nil {
+		return bits, err
+	}
+
+	set := perm & (rwxMask | specMask | 0o1000)
+	switch op {
+	case '+':
+		bits |= set
+	case '-':
+		bits &^= set
+	case '=':
+		// Clear the affected who's ordinary and special bits, then apply.
+		bits &^= rwxMask | specMask | 0o1000
+		bits |= set
+	}
+	return bits, nil
+}
+
+// permMask builds a permission-bit mask from the perms part of a clause (the
+// "[rwxXst]*" portion), expressed in the full ugo layout. cur and isDir drive
+// the "X" perm; the who flags decide which setuid/setgid bits "s" sets.
+func permMask(perms string, cur uint32, isDir, hasU, hasG, allWho bool) (uint32, error) {
+	var mask uint32
+	for _, p := range perms {
+		switch p {
+		case 'r':
+			mask |= 0o0444
+		case 'w':
+			mask |= 0o0222
+		case 'x':
+			mask |= 0o0111
+		case 'X':
+			if isDir || cur&0o0111 != 0 {
+				mask |= 0o0111
+			}
+		case 's':
+			if hasU || allWho {
+				mask |= 0o4000
+			}
+			if hasG || allWho {
+				mask |= 0o2000
+			}
+		case 't':
+			mask |= 0o1000
+		default:
+			return 0, fmt.Errorf("invalid mode perm: %q", string(p))
+		}
+	}
+	return mask, nil
+}

--- a/internal/applets/shellutils/chmod/chmod.go
+++ b/internal/applets/shellutils/chmod/chmod.go
@@ -208,7 +208,7 @@ func modeFromBits(base os.FileMode, bits uint32) os.FileMode {
 // applyMode computes the new FileMode for a file whose current mode is cur, given
 // a chmod MODE string. mode is either an octal number (e.g. "755", "0644") or a
 // comma-separated list of symbolic clauses "[ugoa]*[-+=][rwxXst]*". isDir selects
-// the behaviour of the "X" perm (execute only for directories or files that are
+// the behavior of the "X" perm (execute only for directories or files that are
 // already executable). The non-permission bits of cur are preserved.
 func applyMode(cur os.FileMode, mode string, isDir bool) (os.FileMode, error) {
 	if mode == "" {

--- a/internal/applets/shellutils/chmod/chmod.go
+++ b/internal/applets/shellutils/chmod/chmod.go
@@ -94,7 +94,7 @@ func (c *Command) changeModeRecursive(stdio command.IO, path, mode string, opts 
 	var walkErr error
 	err := filepath.WalkDir(path, func(p string, _ fs.DirEntry, err error) error {
 		if err != nil {
-			c.reportAccess(stdio, p, opts)
+			c.reportAccess(stdio, p, opts, err)
 			walkErr = err
 			return nil
 		}
@@ -116,7 +116,7 @@ func (c *Command) changeModeRecursive(stdio command.IO, path, mode string, opts 
 func (c *Command) changeMode(stdio command.IO, path, mode string, opts options) error {
 	info, err := os.Stat(path)
 	if err != nil {
-		c.reportAccess(stdio, path, opts)
+		c.reportAccess(stdio, path, opts, err)
 		return err
 	}
 
@@ -136,7 +136,7 @@ func (c *Command) changeMode(stdio command.IO, path, mode string, opts options) 
 		return err
 	}
 
-	changed := cur.Perm() != newMode.Perm()
+	changed := permBits(cur) != permBits(newMode)
 	if opts.verbose || (opts.changes && changed) {
 		if changed {
 			_, _ = fmt.Fprintf(stdio.Out, "mode of '%s' changed from %s (%s) to %s (%s)\n",
@@ -149,12 +149,14 @@ func (c *Command) changeMode(stdio command.IO, path, mode string, opts options) 
 	return nil
 }
 
-// reportAccess writes the GNU "cannot access" diagnostic for a missing file.
-func (c *Command) reportAccess(stdio command.IO, path string, opts options) {
+// reportAccess writes the GNU "cannot access" diagnostic for a path that could
+// not be reached, reflecting the real underlying error (missing file,
+// permission denied, not a directory, etc.).
+func (c *Command) reportAccess(stdio command.IO, path string, opts options, err error) {
 	if opts.silent {
 		return
 	}
-	_, _ = fmt.Fprintf(stdio.Err, "%s: cannot access '%s': No such file or directory\n", c.Name(), path)
+	_, _ = fmt.Fprintf(stdio.Err, "%s: cannot access '%s': %v\n", c.Name(), path, unwrap(err))
 }
 
 func unwrap(err error) error {

--- a/internal/applets/shellutils/chmod/chmod_test.go
+++ b/internal/applets/shellutils/chmod/chmod_test.go
@@ -1,0 +1,249 @@
+package chmod_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/chmod"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := chmod.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestMetadata(t *testing.T) {
+	c := chmod.New()
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+	if c.Name() != "chmod" {
+		t.Errorf("Name() = %q, want chmod", c.Name())
+	}
+	if c.Synopsis() != "Change file mode bits" {
+		t.Errorf("Synopsis() = %q", c.Synopsis())
+	}
+}
+
+// TestApplyModeOctal checks the numeric form.
+func TestApplyModeOctal(t *testing.T) {
+	tests := []struct {
+		name string
+		cur  os.FileMode
+		mode string
+		want os.FileMode
+	}{
+		{"644", 0o600, "644", 0o644},
+		{"0644 leading zero", 0o600, "0644", 0o644},
+		{"755", 0o644, "755", 0o755},
+		{"600", 0o777, "600", 0o600},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := chmod.ApplyModeForTest(tt.cur, tt.mode, false)
+			if err != nil {
+				t.Fatalf("ApplyMode error: %v", err)
+			}
+			if got.Perm() != tt.want {
+				t.Errorf("ApplyMode(%v,%q) = %o, want %o", tt.cur, tt.mode, got.Perm(), tt.want)
+			}
+		})
+	}
+}
+
+// TestApplyModeSymbolic checks symbolic clauses against known starting modes.
+func TestApplyModeSymbolic(t *testing.T) {
+	tests := []struct {
+		name  string
+		cur   os.FileMode
+		mode  string
+		isDir bool
+		want  os.FileMode
+	}{
+		{"u+x adds owner execute", 0o644, "u+x", false, 0o744},
+		{"go-w removes group/other write", 0o666, "go-w", false, 0o644},
+		{"a=r sets all to read only", 0o755, "a=r", false, 0o444},
+		{"+x adds execute to all", 0o644, "+x", false, 0o755},
+		{"u-x removes owner execute", 0o755, "u-x", false, 0o655},
+		{"comma list", 0o600, "u+x,g+r", false, 0o740},
+		{"X on dir adds execute", 0o644, "+X", true, 0o755},
+		{"X on plain file no execute", 0o644, "+X", false, 0o644},
+		{"X on already-exec file", 0o744, "g+X", false, 0o754},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := chmod.ApplyModeForTest(tt.cur, tt.mode, tt.isDir)
+			if err != nil {
+				t.Fatalf("ApplyMode error: %v", err)
+			}
+			if got.Perm() != tt.want {
+				t.Errorf("ApplyMode(%o,%q) = %o, want %o", tt.cur.Perm(), tt.mode, got.Perm(), tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyModeSpecialBits(t *testing.T) {
+	got, err := chmod.ApplyModeForTest(0o755, "u+s", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got&os.ModeSetuid == 0 {
+		t.Errorf("u+s did not set setuid: %v", got)
+	}
+	got, err = chmod.ApplyModeForTest(0o755, "+t", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got&os.ModeSticky == 0 {
+		t.Errorf("+t did not set sticky: %v", got)
+	}
+}
+
+func TestApplyModeInvalid(t *testing.T) {
+	if _, err := chmod.ApplyModeForTest(0o644, "u?x", false); err == nil {
+		t.Error("expected error for invalid mode")
+	}
+	if _, err := chmod.ApplyModeForTest(0o644, "", false); err == nil {
+		t.Error("expected error for empty mode")
+	}
+}
+
+// TestRunOctal exercises Run end-to-end with an octal mode.
+func TestRunOctal(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := run(t, "644", file)
+	if err != nil {
+		t.Fatalf("Run error = %v, stderr = %q", err, errOut)
+	}
+	st, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode().Perm() != 0o644 {
+		t.Errorf("perm = %o, want 0644", st.Mode().Perm())
+	}
+}
+
+// TestRunSymbolic exercises Run end-to-end with symbolic clauses.
+func TestRunSymbolic(t *testing.T) {
+	tests := []struct {
+		mode  string
+		start os.FileMode
+		want  os.FileMode
+	}{
+		{"u+x", 0o644, 0o744},
+		{"go-w", 0o666, 0o644},
+		{"a=r", 0o755, 0o444},
+		{"+x", 0o644, 0o755},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			dir := t.TempDir()
+			file := filepath.Join(dir, "f.txt")
+			if err := os.WriteFile(file, []byte("x\n"), tt.start); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(file, tt.start); err != nil {
+				t.Fatal(err)
+			}
+			_, errOut, err := run(t, tt.mode, file)
+			if err != nil {
+				t.Fatalf("Run error = %v, stderr = %q", err, errOut)
+			}
+			st, err := os.Stat(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if st.Mode().Perm() != tt.want {
+				t.Errorf("mode %q: perm = %o, want %o", tt.mode, st.Mode().Perm(), tt.want)
+			}
+		})
+	}
+}
+
+// TestRunRecursive applies a mode to a directory tree.
+func TestRunRecursive(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f1 := filepath.Join(dir, "a.txt")
+	f2 := filepath.Join(sub, "b.txt")
+	for _, f := range []string{f1, f2} {
+		if err := os.WriteFile(f, []byte("x\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Use a mode that keeps directories traversable (0755) so the post-change
+	// stats below, and TempDir cleanup, can still descend the tree.
+	_, errOut, err := run(t, "-R", "755", dir)
+	if err != nil {
+		t.Fatalf("Run error = %v, stderr = %q", err, errOut)
+	}
+	for _, p := range []string{dir, sub, f1, f2} {
+		st, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.Mode().Perm() != 0o755 {
+			t.Errorf("%s perm = %o, want 0755", p, st.Mode().Perm())
+		}
+	}
+}
+
+// TestRunMissingFile reports an error and non-zero exit for a missing file.
+func TestRunMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.txt")
+
+	_, errOut, err := run(t, "644", missing)
+	if err == nil {
+		t.Fatal("expected error (exit 1) for missing file")
+	}
+	if !strings.Contains(errOut, "cannot access") {
+		t.Errorf("stderr = %q, want to contain 'cannot access'", errOut)
+	}
+}
+
+// TestRunMissingOperand checks the missing operand error.
+func TestRunMissingOperand(t *testing.T) {
+	if _, errOut, err := run(t); err == nil {
+		t.Errorf("expected error for no operands, stderr=%q", errOut)
+	}
+	if _, errOut, err := run(t, "644"); err == nil {
+		t.Errorf("expected error for missing file operand, stderr=%q", errOut)
+	}
+}
+
+// TestRunVerbose checks that -v emits a diagnostic.
+func TestRunVerbose(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "-v", "755", file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "mode of") {
+		t.Errorf("verbose stdout = %q, want diagnostic", out)
+	}
+}

--- a/internal/applets/shellutils/chmod/export_test.go
+++ b/internal/applets/shellutils/chmod/export_test.go
@@ -1,0 +1,8 @@
+package chmod
+
+import "os"
+
+// ApplyModeForTest exposes the unexported applyMode for external package tests.
+func ApplyModeForTest(cur os.FileMode, mode string, isDir bool) (os.FileMode, error) {
+	return applyMode(cur, mode, isDir)
+}

--- a/internal/applets/shellutils/dd/dd.go
+++ b/internal/applets/shellutils/dd/dd.go
@@ -1,0 +1,409 @@
+// Package dd implements the dd applet: convert and copy a file. Unlike the
+// other applets, dd takes its arguments as key=value operands (if=, of=, bs=,
+// conv=, ...) rather than getopt-style flags, so it parses them by hand.
+package dd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the dd applet.
+type Command struct{}
+
+// New returns a dd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "dd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Convert and copy a file" }
+
+// statusMode controls how much of the transfer summary dd writes to stderr.
+type statusMode int
+
+const (
+	statusDefault  statusMode = iota // full summary
+	statusNone                       // suppress everything
+	statusNoxfer                     // suppress the final "N bytes" transfer line
+	statusProgress                   // like default (progress reporting is best-effort)
+)
+
+// options holds the parsed dd operands.
+type options struct {
+	inputFile  string // if=, empty means stdin
+	outputFile string // of=, empty means stdout
+	ibs        int64  // input block size
+	obs        int64  // output block size
+	count      int64  // copy only this many input blocks; -1 means all
+	skip       int64  // skip this many ibs-sized blocks of input
+	seek       int64  // skip this many obs-sized blocks of output
+	lcase      bool   // conv=lcase
+	ucase      bool   // conv=ucase
+	notrunc    bool   // conv=notrunc
+	sync       bool   // conv=sync: pad each input block to ibs with NUL
+	status     statusMode
+}
+
+// defaultOptions returns options seeded with dd's defaults.
+func defaultOptions() options {
+	return options{
+		ibs:    512,
+		obs:    512,
+		count:  -1,
+		skip:   0,
+		seek:   0,
+		status: statusDefault,
+	}
+}
+
+// result records the block counts and byte total of a copy, used both to build
+// the summary and to let tests assert on the work performed.
+type result struct {
+	inFull   int64 // complete input blocks read
+	inPart   int64 // partial input blocks read
+	outFull  int64 // complete output blocks written
+	outPart  int64 // partial output blocks written
+	bytesOut int64 // total bytes written
+}
+
+// Run executes dd.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	opts, err := parseArgs(args)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "dd: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	in, closeIn, err := openInput(stdio, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "dd: %s\n", command.FileError(opts.inputFile, err))
+		return command.SilentFailure()
+	}
+	defer closeIn()
+
+	out, closeOut, err := openOutput(stdio, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "dd: %s\n", command.FileError(opts.outputFile, err))
+		return command.SilentFailure()
+	}
+	defer closeOut()
+
+	res, err := copyDD(in, out, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "dd: %v\n", err)
+		return command.Failure(err)
+	}
+
+	writeSummary(stdio.Err, res, opts)
+	return nil
+}
+
+// openInput resolves the if= operand to a reader. Skipping is applied here.
+func openInput(stdio command.IO, opts options) (io.Reader, func(), error) {
+	var r io.Reader
+	closeFn := func() {}
+	if opts.inputFile == "" {
+		r = stdio.In
+	} else {
+		f, err := os.Open(opts.inputFile) //nolint:gosec // operating on a user-named file is the point
+		if err != nil {
+			return nil, closeFn, err
+		}
+		r = f
+		closeFn = func() { _ = f.Close() }
+	}
+	if opts.skip > 0 {
+		if _, err := io.CopyN(io.Discard, r, opts.skip*opts.ibs); err != nil && err != io.EOF {
+			closeFn()
+			return nil, func() {}, err
+		}
+	}
+	return r, closeFn, nil
+}
+
+// openOutput resolves the of= operand to a writer. Seeking is applied here.
+func openOutput(stdio command.IO, opts options) (io.Writer, func(), error) {
+	if opts.outputFile == "" {
+		w := stdio.Out
+		if opts.seek > 0 {
+			if _, err := w.Write(bytes.Repeat([]byte{0}, int(opts.seek*opts.obs))); err != nil {
+				return nil, func() {}, err
+			}
+		}
+		return w, func() {}, nil
+	}
+
+	flag := os.O_WRONLY | os.O_CREATE
+	if !opts.notrunc {
+		flag |= os.O_TRUNC
+	}
+	f, err := os.OpenFile(opts.outputFile, flag, 0o644) //nolint:gosec // user-named file
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if opts.seek > 0 {
+		if _, err := f.Seek(opts.seek*opts.obs, io.SeekStart); err != nil {
+			_ = f.Close()
+			return nil, func() {}, err
+		}
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+// copyDD performs the core copy from r to w according to opts. It is pure with
+// respect to its reader and writer, so a test can drive it with bytes.Buffer.
+func copyDD(r io.Reader, w io.Writer, opts options) (result, error) {
+	var res result
+	buf := make([]byte, opts.ibs)
+
+	for opts.count < 0 || res.inFull+res.inPart < opts.count {
+		n, err := io.ReadFull(r, buf)
+		if n == 0 {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			if err != nil {
+				return res, err
+			}
+		}
+
+		block := buf[:n]
+		if int64(n) == opts.ibs {
+			res.inFull++
+		} else if n > 0 {
+			res.inPart++
+			if opts.sync {
+				padded := make([]byte, opts.ibs)
+				copy(padded, block)
+				block = padded
+			}
+		}
+
+		block = applyConv(block, opts)
+
+		if werr := writeBlock(w, block, opts, &res); werr != nil {
+			return res, werr
+		}
+
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			break
+		}
+		if err != nil && err != io.ErrUnexpectedEOF {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+// writeBlock writes a single converted block, recording the output counts.
+func writeBlock(w io.Writer, block []byte, opts options, res *result) error {
+	if len(block) == 0 {
+		return nil
+	}
+	n, err := w.Write(block)
+	res.bytesOut += int64(n)
+	if int64(len(block)) == opts.obs {
+		res.outFull++
+	} else {
+		res.outPart++
+	}
+	return err
+}
+
+// applyConv applies the byte-level conv transforms (lcase/ucase) to a block and
+// returns the transformed bytes. It is pure and unit-testable.
+func applyConv(block []byte, opts options) []byte {
+	if !opts.lcase && !opts.ucase {
+		return block
+	}
+	out := make([]byte, len(block))
+	for i, b := range block {
+		switch {
+		case opts.ucase && b >= 'a' && b <= 'z':
+			out[i] = b - ('a' - 'A')
+		case opts.lcase && b >= 'A' && b <= 'Z':
+			out[i] = b + ('a' - 'A')
+		default:
+			out[i] = b
+		}
+	}
+	return out
+}
+
+// writeSummary prints the standard dd records-in/records-out summary to w
+// unless status=none suppresses it.
+func writeSummary(w io.Writer, res result, opts options) {
+	if opts.status == statusNone {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%d+%d records in\n", res.inFull, res.inPart)
+	_, _ = fmt.Fprintf(w, "%d+%d records out\n", res.outFull, res.outPart)
+	if opts.status != statusNoxfer {
+		_, _ = fmt.Fprintf(w, "%d bytes copied\n", res.bytesOut)
+	}
+}
+
+// parseArgs parses dd's key=value operands into options.
+func parseArgs(args []string) (options, error) {
+	opts := defaultOptions()
+	bsSet := false
+
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return opts, fmt.Errorf("unrecognized operand %q", arg)
+		}
+		switch key {
+		case "if":
+			opts.inputFile = value
+		case "of":
+			opts.outputFile = value
+		case "bs":
+			n, err := parseSize(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid bs=%q: %w", value, err)
+			}
+			opts.ibs = n
+			opts.obs = n
+			bsSet = true
+		case "ibs":
+			n, err := parseSize(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid ibs=%q: %w", value, err)
+			}
+			if !bsSet {
+				opts.ibs = n
+			}
+		case "obs":
+			n, err := parseSize(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid obs=%q: %w", value, err)
+			}
+			if !bsSet {
+				opts.obs = n
+			}
+		case "count":
+			n, err := parseSize(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid count=%q: %w", value, err)
+			}
+			opts.count = n
+		case "skip":
+			n, err := parseSize(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid skip=%q: %w", value, err)
+			}
+			opts.skip = n
+		case "seek":
+			n, err := parseSize(value)
+			if err != nil {
+				return opts, fmt.Errorf("invalid seek=%q: %w", value, err)
+			}
+			opts.seek = n
+		case "conv":
+			if err := applyConvFlags(&opts, value); err != nil {
+				return opts, err
+			}
+		case "status":
+			if err := applyStatus(&opts, value); err != nil {
+				return opts, err
+			}
+		default:
+			return opts, fmt.Errorf("unrecognized operand %q", arg)
+		}
+	}
+
+	if opts.ibs <= 0 {
+		return opts, fmt.Errorf("invalid input block size %d", opts.ibs)
+	}
+	if opts.obs <= 0 {
+		return opts, fmt.Errorf("invalid output block size %d", opts.obs)
+	}
+	return opts, nil
+}
+
+// applyConvFlags parses a comma-separated conv= list into opts.
+func applyConvFlags(opts *options, value string) error {
+	for _, c := range strings.Split(value, ",") {
+		switch c {
+		case "lcase":
+			opts.lcase = true
+		case "ucase":
+			opts.ucase = true
+		case "notrunc":
+			opts.notrunc = true
+		case "sync":
+			opts.sync = true
+		case "":
+			// ignore empty entries
+		default:
+			return fmt.Errorf("unknown conversion %q", c)
+		}
+	}
+	if opts.lcase && opts.ucase {
+		return fmt.Errorf("cannot combine conv=lcase and conv=ucase")
+	}
+	return nil
+}
+
+// applyStatus parses the status= operand.
+func applyStatus(opts *options, value string) error {
+	switch value {
+	case "none":
+		opts.status = statusNone
+	case "noxfer":
+		opts.status = statusNoxfer
+	case "progress":
+		opts.status = statusProgress
+	default:
+		return fmt.Errorf("unknown status %q", value)
+	}
+	return nil
+}
+
+// ParseSize is the exported entry point for parseSize, used by tests in the
+// external dd_test package.
+func ParseSize(s string) (int64, error) { return parseSize(s) }
+
+// parseSize parses a dd block-size string such as "512", "1k", or "2M" into a
+// byte count. Recognized suffixes: c=1, w=2, b=512, k/K=1024, M=1024*1024,
+// G=1024*1024*1024. It is pure and unit-testable.
+func parseSize(s string) (int64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+
+	var mult int64 = 1
+	switch s[len(s)-1] {
+	case 'c':
+		mult, s = 1, s[:len(s)-1]
+	case 'w':
+		mult, s = 2, s[:len(s)-1]
+	case 'b':
+		mult, s = 512, s[:len(s)-1]
+	case 'k', 'K':
+		mult, s = 1024, s[:len(s)-1]
+	case 'M':
+		mult, s = 1024*1024, s[:len(s)-1]
+	case 'G':
+		mult, s = 1024*1024*1024, s[:len(s)-1]
+	}
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("not a number")
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("negative size")
+	}
+	return n * mult, nil
+}

--- a/internal/applets/shellutils/dd/dd.go
+++ b/internal/applets/shellutils/dd/dd.go
@@ -4,16 +4,28 @@
 package dd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
+
+// zeroReader is an io.Reader that yields an endless stream of zero bytes. It is
+// used to seek on a non-seekable writer (stdout) by streaming the zero padding
+// instead of allocating it all up front.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
 
 // Command is the dd applet.
 type Command struct{}
@@ -135,7 +147,7 @@ func openOutput(stdio command.IO, opts options) (io.Writer, func(), error) {
 	if opts.outputFile == "" {
 		w := stdio.Out
 		if opts.seek > 0 {
-			if _, err := w.Write(bytes.Repeat([]byte{0}, int(opts.seek*opts.obs))); err != nil {
+			if _, err := io.CopyN(w, zeroReader{}, opts.seek*opts.obs); err != nil {
 				return nil, func() {}, err
 			}
 		}
@@ -211,9 +223,9 @@ func writeBlock(w io.Writer, block []byte, opts options, res *result) error {
 	}
 	n, err := w.Write(block)
 	res.bytesOut += int64(n)
-	if int64(len(block)) == opts.obs {
+	if n == len(block) && int64(len(block)) == opts.obs {
 		res.outFull++
-	} else {
+	} else if n > 0 {
 		res.outPart++
 	}
 	return err
@@ -404,6 +416,9 @@ func parseSize(s string) (int64, error) {
 	}
 	if n < 0 {
 		return 0, fmt.Errorf("negative size")
+	}
+	if mult > 1 && n > math.MaxInt64/mult {
+		return 0, fmt.Errorf("size too large (overflow)")
 	}
 	return n * mult, nil
 }

--- a/internal/applets/shellutils/dd/dd_test.go
+++ b/internal/applets/shellutils/dd/dd_test.go
@@ -1,0 +1,169 @@
+package dd_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/dd"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// run executes dd with the given stdin string and arguments, returning the
+// captured stdout, stderr, and the error.
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	io := command.IO{
+		In:  strings.NewReader(stdin),
+		Out: &out,
+		Err: &errBuf,
+	}
+	err := dd.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNew(t *testing.T) {
+	c := dd.New()
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+	if c.Name() != "dd" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "dd")
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+func TestRun_StdinToStdout(t *testing.T) {
+	input := "hello, world\nsecond line\n"
+	out, errOut, err := run(t, input)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != input {
+		t.Errorf("stdout = %q, want %q", out, input)
+	}
+	if !strings.Contains(errOut, "records in") || !strings.Contains(errOut, "records out") {
+		t.Errorf("stderr missing records summary: %q", errOut)
+	}
+}
+
+func TestRun_BsCount(t *testing.T) {
+	input := "abcdefghij"
+	out, errOut, err := run(t, input, "bs=1", "count=5")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "abcde" {
+		t.Errorf("stdout = %q, want %q", out, "abcde")
+	}
+	if !strings.Contains(errOut, "5+0 records in") {
+		t.Errorf("stderr = %q, want to contain %q", errOut, "5+0 records in")
+	}
+}
+
+func TestRun_FileToFile(t *testing.T) {
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "in.txt")
+	outPath := filepath.Join(dir, "out.txt")
+	content := []byte("the quick brown fox\njumps over the lazy dog\n")
+	if err := os.WriteFile(inPath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := run(t, "", "if="+inPath, "of="+outPath)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("output file = %q, want %q", got, content)
+	}
+}
+
+func TestRun_ConvUcase(t *testing.T) {
+	out, _, err := run(t, "Hello World 123", "conv=ucase")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "HELLO WORLD 123" {
+		t.Errorf("stdout = %q, want %q", out, "HELLO WORLD 123")
+	}
+}
+
+func TestRun_ConvLcase(t *testing.T) {
+	out, _, err := run(t, "Hello World 123", "conv=lcase")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "hello world 123" {
+		t.Errorf("stdout = %q, want %q", out, "hello world 123")
+	}
+}
+
+func TestRun_StatusNoneSuppressesSummary(t *testing.T) {
+	out, errOut, err := run(t, "data", "status=none")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "data" {
+		t.Errorf("stdout = %q, want %q", out, "data")
+	}
+	if errOut != "" {
+		t.Errorf("stderr = %q, want empty (status=none)", errOut)
+	}
+}
+
+func TestRun_InvalidOperand(t *testing.T) {
+	_, _, err := run(t, "data", "bogus")
+	if err == nil {
+		t.Fatal("Run() error = nil, want non-nil for invalid operand")
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		want    int64
+		wantErr bool
+	}{
+		{"512", 512, false},
+		{"1k", 1024, false},
+		{"1K", 1024, false},
+		{"2b", 1024, false},
+		{"1M", 1024 * 1024, false},
+		{"1c", 1, false},
+		{"2w", 4, false},
+		{"1G", 1024 * 1024 * 1024, false},
+		{"0", 0, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"-5", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := dd.ParseSize(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ParseSize(%q) error = nil, want error", tt.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseSize(%q) error = %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseSize(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/applets/shellutils/df/df.go
+++ b/internal/applets/shellutils/df/df.go
@@ -29,6 +29,7 @@ func (c *Command) Synopsis() string { return "Report file system disk space usag
 type statfsResult struct {
 	Bsize  int64  // fundamental block size
 	Blocks uint64 // total data blocks
+	Bfree  uint64 // free blocks in filesystem
 	Bavail uint64 // free blocks available to unprivileged users
 	Files  uint64 // total file nodes (inodes)
 	Ffree  uint64 // free file nodes (inodes)
@@ -44,6 +45,7 @@ var statfs = func(path string) (statfsResult, error) {
 	return statfsResult{
 		Bsize:  int64(s.Bsize),
 		Blocks: s.Blocks,
+		Bfree:  s.Bfree,
 		Bavail: s.Bavail,
 		Files:  s.Files,
 		Ffree:  s.Ffree,
@@ -76,8 +78,9 @@ type inodeUsage struct {
 func computeUsage(s statfsResult) usage {
 	bsize := uint64(s.Bsize)
 	total := s.Blocks * bsize
+	free := s.Bfree * bsize
 	avail := s.Bavail * bsize
-	used := total - avail
+	used := total - free
 	return usage{
 		total:  total,
 		used:   used,

--- a/internal/applets/shellutils/df/df.go
+++ b/internal/applets/shellutils/df/df.go
@@ -1,0 +1,215 @@
+// Package df implements the df applet: report file system disk space usage for
+// the file system that contains each FILE operand (or the current directory's
+// file system when no operand is given).
+package df
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the df applet.
+type Command struct{}
+
+// New returns a df command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "df" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report file system disk space usage" }
+
+// statfsResult is the subset of syscall.Statfs_t that df cares about. Wrapping
+// it lets a test inject a fake without touching the real filesystem.
+type statfsResult struct {
+	Bsize  int64  // fundamental block size
+	Blocks uint64 // total data blocks
+	Bavail uint64 // free blocks available to unprivileged users
+	Files  uint64 // total file nodes (inodes)
+	Ffree  uint64 // free file nodes (inodes)
+}
+
+// statfs resolves path to its file system statistics. It is a package var so a
+// test can replace it with a deterministic fake.
+var statfs = func(path string) (statfsResult, error) {
+	var s syscall.Statfs_t
+	if err := syscall.Statfs(path, &s); err != nil {
+		return statfsResult{}, err
+	}
+	return statfsResult{
+		Bsize:  int64(s.Bsize),
+		Blocks: s.Blocks,
+		Bavail: s.Bavail,
+		Files:  s.Files,
+		Ffree:  s.Ffree,
+	}, nil
+}
+
+type options struct {
+	human  bool
+	inodes bool
+}
+
+// usage is the computed disk usage of a file system, in bytes.
+type usage struct {
+	total  uint64
+	used   uint64
+	avail  uint64
+	usePct int
+}
+
+// inodeUsage is the computed inode usage of a file system.
+type inodeUsage struct {
+	files  uint64
+	used   uint64
+	free   uint64
+	usePct int
+}
+
+// computeUsage turns a Statfs result into byte-based disk usage figures. It is a
+// pure function so it can be unit-tested without a real filesystem.
+func computeUsage(s statfsResult) usage {
+	bsize := uint64(s.Bsize)
+	total := s.Blocks * bsize
+	avail := s.Bavail * bsize
+	used := total - avail
+	return usage{
+		total:  total,
+		used:   used,
+		avail:  avail,
+		usePct: percent(used, used+avail),
+	}
+}
+
+// computeInodeUsage turns a Statfs result into inode usage figures.
+func computeInodeUsage(s statfsResult) inodeUsage {
+	used := s.Files - s.Ffree
+	return inodeUsage{
+		files:  s.Files,
+		used:   used,
+		free:   s.Ffree,
+		usePct: percent(used, s.Files),
+	}
+}
+
+// percent computes the rounded-up "Use%" the way GNU df does: used out of the
+// usable total (used+available), rounded toward the next whole percent.
+func percent(used, total uint64) int {
+	if total == 0 {
+		return 0
+	}
+	// Round up: ceil(used*100/total).
+	return int((used*100 + total - 1) / total)
+}
+
+// humanReadable formats n bytes using powers of 1024 (e.g. 1024 -> "1.0K",
+// 1048576 -> "1.0M"). It is a pure function so it can be unit-tested directly.
+func humanReadable(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d", n)
+	}
+	units := []string{"K", "M", "G", "T", "P", "E"}
+	value := float64(n)
+	i := -1
+	for value >= unit && i < len(units)-1 {
+		value /= unit
+		i++
+	}
+	return fmt.Sprintf("%.1f%s", value, units[i])
+}
+
+// formatSize renders a byte count either human-readable or in 1K blocks.
+func formatSize(bytes uint64, human bool) string {
+	if human {
+		return humanReadable(bytes)
+	}
+	// 1K blocks, rounded up so a non-empty filesystem never shows 0.
+	return fmt.Sprintf("%d", (bytes+1023)/1024)
+}
+
+// Run executes df.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	human := fs.BoolP("human-readable", "h", false, "print sizes in powers of 1024 (e.g., 1023M)")
+	_ = fs.BoolP("kilobytes", "k", false, "use 1024-byte (1K) blocks (default)")
+	inodes := fs.BoolP("inodes", "i", false, "list inode information instead of block usage")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	opts := options{human: *human, inodes: *inodes}
+
+	operands := fs.Args()
+	if len(operands) == 0 {
+		operands = []string{"."}
+	}
+
+	writeHeader(stdio.Out, opts)
+
+	var firstErr error
+	for _, path := range operands {
+		s, serr := statfs(path)
+		if serr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "df: %s\n", command.FileError(path, serr))
+			firstErr = keep(firstErr)
+			continue
+		}
+		writeRow(stdio.Out, path, s, opts)
+	}
+	return firstErr
+}
+
+// writeHeader prints the column header appropriate for the selected mode.
+func writeHeader(w io.Writer, opts options) {
+	if opts.inodes {
+		_, _ = fmt.Fprintf(w, "%-20s %10s %10s %10s %4s %s\n",
+			"Filesystem", "Inodes", "IUsed", "IFree", "IUse%", "Mounted on")
+		return
+	}
+	size := "1K-blocks"
+	if opts.human {
+		size = "Size"
+	}
+	_, _ = fmt.Fprintf(w, "%-20s %10s %10s %10s %4s %s\n",
+		"Filesystem", size, "Used", "Available", "Use%", "Mounted on")
+}
+
+// writeRow prints one data row for path using the file system statistics in s.
+func writeRow(w io.Writer, path string, s statfsResult, opts options) {
+	_, _ = io.WriteString(w, formatRow(path, s, opts))
+}
+
+// formatRow renders a single df row as a string. Kept separate from writeRow so
+// it is straightforward to assert on in a unit test.
+func formatRow(path string, s statfsResult, opts options) string {
+	if opts.inodes {
+		u := computeInodeUsage(s)
+		return fmt.Sprintf("%-20s %10d %10d %10d %3d%% %s\n",
+			path, u.files, u.used, u.free, u.usePct, path)
+	}
+	u := computeUsage(s)
+	return fmt.Sprintf("%-20s %10s %10s %10s %3d%% %s\n",
+		path,
+		formatSize(u.total, opts.human),
+		formatSize(u.used, opts.human),
+		formatSize(u.avail, opts.human),
+		u.usePct,
+		path)
+}
+
+// keep preserves the first error so the exit code reflects a failure while the
+// message has already been printed to stderr.
+func keep(existing error) error {
+	if existing != nil {
+		return existing
+	}
+	return command.SilentFailure()
+}

--- a/internal/applets/shellutils/df/df_test.go
+++ b/internal/applets/shellutils/df/df_test.go
@@ -35,9 +35,11 @@ func TestNameSynopsis(t *testing.T) {
 
 func TestComputeUsage(t *testing.T) {
 	t.Parallel()
-	// 1000 blocks of 1024 bytes = 1,024,000 total; 250 available = 256,000;
-	// used = 768,000; usable total = used+avail = 1,024,000; use% = 75.
-	s := df.StatfsResult{Bsize: 1024, Blocks: 1000, Bavail: 250}
+	// 1000 blocks of 1024 bytes = 1,024,000 total. 300 free blocks (307,200)
+	// but only 250 available to non-root (256,000); the 50-block difference is
+	// reserved. Used = total - free = 716,800 (GNU df counts reserved blocks as
+	// used). Usable total = used+avail = 972,800; use% = ceil(73.68) = 74.
+	s := df.StatfsResult{Bsize: 1024, Blocks: 1000, Bfree: 300, Bavail: 250}
 	u := df.ComputeUsage(s)
 
 	if u.Total() != 1024000 {
@@ -46,18 +48,19 @@ func TestComputeUsage(t *testing.T) {
 	if u.Avail() != 256000 {
 		t.Errorf("Avail = %d, want 256000", u.Avail())
 	}
-	if u.Used() != 768000 {
-		t.Errorf("Used = %d, want 768000", u.Used())
+	if u.Used() != 716800 {
+		t.Errorf("Used = %d, want 716800", u.Used())
 	}
-	if u.UsePct() != 75 {
-		t.Errorf("UsePct = %d, want 75", u.UsePct())
+	if u.UsePct() != 74 {
+		t.Errorf("UsePct = %d, want 74", u.UsePct())
 	}
 }
 
 func TestComputeUsagePercentRoundsUp(t *testing.T) {
 	t.Parallel()
-	// used=1, total(usable)=3 -> 1*100/3 = 33.3 -> rounds up to 34.
-	s := df.StatfsResult{Bsize: 1, Blocks: 3, Bavail: 2}
+	// used = blocks-bfree = 1, total(usable) = used+avail = 3 ->
+	// 1*100/3 = 33.3 -> rounds up to 34.
+	s := df.StatfsResult{Bsize: 1, Blocks: 3, Bfree: 2, Bavail: 2}
 	u := df.ComputeUsage(s)
 	if u.UsePct() != 34 {
 		t.Errorf("UsePct = %d, want 34", u.UsePct())
@@ -123,7 +126,7 @@ func TestFormatSize(t *testing.T) {
 // the numeric output is deterministic.
 func TestRunWithFake(t *testing.T) {
 	restore := df.SetStatfs(func(path string) (df.StatfsResult, error) {
-		return df.StatfsResult{Bsize: 1024, Blocks: 1000, Bavail: 250, Files: 100, Ffree: 60}, nil
+		return df.StatfsResult{Bsize: 1024, Blocks: 1000, Bfree: 250, Bavail: 250, Files: 100, Ffree: 60}, nil
 	})
 	defer restore()
 

--- a/internal/applets/shellutils/df/df_test.go
+++ b/internal/applets/shellutils/df/df_test.go
@@ -1,0 +1,241 @@
+package df_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/df"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := df.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := df.New()
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+	if got := c.Name(); got != "df" {
+		t.Errorf("Name() = %q, want %q", got, "df")
+	}
+	if got := c.Synopsis(); got != "Report file system disk space usage" {
+		t.Errorf("Synopsis() = %q", got)
+	}
+}
+
+func TestComputeUsage(t *testing.T) {
+	t.Parallel()
+	// 1000 blocks of 1024 bytes = 1,024,000 total; 250 available = 256,000;
+	// used = 768,000; usable total = used+avail = 1,024,000; use% = 75.
+	s := df.StatfsResult{Bsize: 1024, Blocks: 1000, Bavail: 250}
+	u := df.ComputeUsage(s)
+
+	if u.Total() != 1024000 {
+		t.Errorf("Total = %d, want 1024000", u.Total())
+	}
+	if u.Avail() != 256000 {
+		t.Errorf("Avail = %d, want 256000", u.Avail())
+	}
+	if u.Used() != 768000 {
+		t.Errorf("Used = %d, want 768000", u.Used())
+	}
+	if u.UsePct() != 75 {
+		t.Errorf("UsePct = %d, want 75", u.UsePct())
+	}
+}
+
+func TestComputeUsagePercentRoundsUp(t *testing.T) {
+	t.Parallel()
+	// used=1, total(usable)=3 -> 1*100/3 = 33.3 -> rounds up to 34.
+	s := df.StatfsResult{Bsize: 1, Blocks: 3, Bavail: 2}
+	u := df.ComputeUsage(s)
+	if u.UsePct() != 34 {
+		t.Errorf("UsePct = %d, want 34", u.UsePct())
+	}
+}
+
+func TestComputeInodeUsage(t *testing.T) {
+	t.Parallel()
+	s := df.StatfsResult{Files: 1000, Ffree: 600}
+	u := df.ComputeInodeUsage(s)
+	if u.Files() != 1000 {
+		t.Errorf("Files = %d, want 1000", u.Files())
+	}
+	if u.IUsed() != 400 {
+		t.Errorf("IUsed = %d, want 400", u.IUsed())
+	}
+	if u.IFree() != 600 {
+		t.Errorf("IFree = %d, want 600", u.IFree())
+	}
+	if u.IUsePct() != 40 {
+		t.Errorf("IUsePct = %d, want 40", u.IUsePct())
+	}
+}
+
+func TestHumanReadable(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   uint64
+		want string
+	}{
+		{0, "0"},
+		{512, "512"},
+		{1023, "1023"},
+		{1024, "1.0K"},
+		{1536, "1.5K"},
+		{1048576, "1.0M"},
+		{1073741824, "1.0G"},
+		{1099511627776, "1.0T"},
+	}
+	for _, tt := range tests {
+		if got := df.HumanReadable(tt.in); got != tt.want {
+			t.Errorf("HumanReadable(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	t.Parallel()
+	// 1K blocks: 1,024,000 bytes / 1024 = 1000.
+	if got := df.FormatSize(1024000, false); got != "1000" {
+		t.Errorf("FormatSize(1024000,false) = %q, want %q", got, "1000")
+	}
+	// Rounds up partial blocks.
+	if got := df.FormatSize(1, false); got != "1" {
+		t.Errorf("FormatSize(1,false) = %q, want %q", got, "1")
+	}
+	if got := df.FormatSize(1048576, true); got != "1.0M" {
+		t.Errorf("FormatSize(1048576,true) = %q, want %q", got, "1.0M")
+	}
+}
+
+// TestRunWithFake exercises the full Run path against an injected fake statfs so
+// the numeric output is deterministic.
+func TestRunWithFake(t *testing.T) {
+	restore := df.SetStatfs(func(path string) (df.StatfsResult, error) {
+		return df.StatfsResult{Bsize: 1024, Blocks: 1000, Bavail: 250, Files: 100, Ffree: 60}, nil
+	})
+	defer restore()
+
+	out, errOut, err := run(t, "/data")
+	if err != nil {
+		t.Fatalf("Run error: %v (stderr=%q)", err, errOut)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected header + 1 row, got %d lines: %q", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "Filesystem") {
+		t.Errorf("header = %q, want it to start with Filesystem", lines[0])
+	}
+	if !strings.Contains(lines[0], "1K-blocks") {
+		t.Errorf("header = %q, want 1K-blocks column", lines[0])
+	}
+	fields := strings.Fields(lines[1])
+	// /data 1000 750 250 75% /data
+	want := []string{"/data", "1000", "750", "250", "75%", "/data"}
+	if len(fields) != len(want) {
+		t.Fatalf("row fields = %v, want %v", fields, want)
+	}
+	for i := range want {
+		if fields[i] != want[i] {
+			t.Errorf("row field %d = %q, want %q (row=%q)", i, fields[i], want[i], lines[1])
+		}
+	}
+}
+
+func TestRunHumanReadable(t *testing.T) {
+	restore := df.SetStatfs(func(path string) (df.StatfsResult, error) {
+		// 1 MiB total, 0 available.
+		return df.StatfsResult{Bsize: 1024, Blocks: 1024, Bavail: 0}, nil
+	})
+	defer restore()
+
+	out, _, err := run(t, "-h", "/data")
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if !strings.Contains(lines[0], "Size") {
+		t.Errorf("human header = %q, want Size column", lines[0])
+	}
+	fields := strings.Fields(lines[1])
+	if fields[1] != "1.0M" {
+		t.Errorf("human size = %q, want 1.0M", fields[1])
+	}
+}
+
+func TestRunInodes(t *testing.T) {
+	restore := df.SetStatfs(func(path string) (df.StatfsResult, error) {
+		return df.StatfsResult{Files: 100, Ffree: 60}, nil
+	})
+	defer restore()
+
+	out, _, err := run(t, "-i", "/data")
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if !strings.Contains(lines[0], "Inodes") {
+		t.Errorf("inode header = %q, want Inodes column", lines[0])
+	}
+	fields := strings.Fields(lines[1])
+	// /data 100 40 60 40% /data
+	want := []string{"/data", "100", "40", "60", "40%", "/data"}
+	for i := range want {
+		if fields[i] != want[i] {
+			t.Errorf("inode row field %d = %q, want %q", i, fields[i], want[i])
+		}
+	}
+}
+
+// TestRunRealEndToEnd checks that "df ." against the real filesystem succeeds
+// and prints a header. Numeric values are not asserted here.
+func TestRunRealEndToEnd(t *testing.T) {
+	out, errOut, err := run(t, ".")
+	if err != nil {
+		t.Fatalf("Run(.) error: %v (stderr=%q)", err, errOut)
+	}
+	if !strings.HasPrefix(out, "Filesystem") {
+		t.Errorf("output should start with header, got %q", out)
+	}
+}
+
+func TestRunNoOperandDefaultsToCwd(t *testing.T) {
+	restore := df.SetStatfs(func(path string) (df.StatfsResult, error) {
+		if path != "." {
+			t.Errorf("expected default operand %q, got %q", ".", path)
+		}
+		return df.StatfsResult{Bsize: 1024, Blocks: 10, Bavail: 5}, nil
+	})
+	defer restore()
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if !strings.HasPrefix(out, "Filesystem") {
+		t.Errorf("output should start with header, got %q", out)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("Run(--help) error: %v", err)
+	}
+	if !strings.Contains(out, "Usage: df") {
+		t.Errorf("help output missing usage, got %q", out)
+	}
+}

--- a/internal/applets/shellutils/df/export_test.go
+++ b/internal/applets/shellutils/df/export_test.go
@@ -1,0 +1,45 @@
+package df
+
+// This file exposes unexported internals to the external df_test package so the
+// pure computations can be asserted directly and the syscall can be faked.
+
+// StatfsResult mirrors the unexported statfsResult for use in tests.
+type StatfsResult = statfsResult
+
+// Usage mirrors the unexported usage for use in tests.
+type Usage = usage
+
+// InodeUsage mirrors the unexported inodeUsage for use in tests.
+type InodeUsage = inodeUsage
+
+// HumanReadable exposes humanReadable.
+func HumanReadable(n uint64) string { return humanReadable(n) }
+
+// FormatSize exposes formatSize.
+func FormatSize(bytes uint64, human bool) string { return formatSize(bytes, human) }
+
+// ComputeUsage exposes computeUsage.
+func ComputeUsage(s StatfsResult) Usage { return computeUsage(s) }
+
+// ComputeInodeUsage exposes computeInodeUsage.
+func ComputeInodeUsage(s StatfsResult) InodeUsage { return computeInodeUsage(s) }
+
+// Total/Used/Avail/UsePct expose the unexported usage fields.
+func (u Usage) Total() uint64 { return u.total }
+func (u Usage) Used() uint64  { return u.used }
+func (u Usage) Avail() uint64 { return u.avail }
+func (u Usage) UsePct() int   { return u.usePct }
+
+// Files/IUsed/IFree/IUsePct expose the unexported inodeUsage fields.
+func (u InodeUsage) Files() uint64 { return u.files }
+func (u InodeUsage) IUsed() uint64 { return u.used }
+func (u InodeUsage) IFree() uint64 { return u.free }
+func (u InodeUsage) IUsePct() int  { return u.usePct }
+
+// SetStatfs replaces the package statfs func and returns a restore func, letting
+// a test inject a deterministic fake.
+func SetStatfs(fake func(path string) (StatfsResult, error)) (restore func()) {
+	orig := statfs
+	statfs = fake
+	return func() { statfs = orig }
+}

--- a/internal/applets/shellutils/du/du.go
+++ b/internal/applets/shellutils/du/du.go
@@ -1,0 +1,260 @@
+// Package du implements the du applet: estimate file space usage for files and
+// directory trees, with the common GNU options.
+package du
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// blockSize is the unit du reports in by default. GNU du historically reports
+// 1024-byte blocks; MimixBox computes every entry from the file's apparent
+// size rounded up to this many bytes so the result is deterministic and does
+// not depend on the underlying filesystem's st_blocks.
+const blockSize = 1024
+
+// Command is the du applet.
+type Command struct{}
+
+// New returns a du command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "du" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Estimate file space usage" }
+
+type options struct {
+	summarize bool // -s: print only a total for each operand
+	all       bool // -a: write a line for every file, not just directories
+	human     bool // -h: print sizes in human-readable form (1K, 234M, 2G)
+	bytes     bool // -b: print the apparent size in bytes
+	total     bool // -c: print a grand total
+}
+
+// entry is one accumulated path/size pair produced by the size walk.
+type entry struct {
+	path  string // path as it should be printed
+	bytes int64  // apparent size in bytes of the subtree rooted at path
+	isDir bool   // whether path is a directory
+}
+
+// Run executes du.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	summarize := fs.BoolP("summarize", "s", false, "display only a total for each argument")
+	all := fs.BoolP("all", "a", false, "write counts for all files, not just directories")
+	human := fs.BoolP("human-readable", "h", false, "print sizes in human readable format (e.g., 1K 234M 2G)")
+	bytesFlag := fs.BoolP("bytes", "b", false, "equivalent to apparent size in bytes")
+	total := fs.BoolP("total", "c", false, "produce a grand total")
+	fs.BoolP("block-size-1k", "k", true, "like --block-size=1K (the default)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	opts := options{
+		summarize: *summarize,
+		all:       *all,
+		human:     *human,
+		bytes:     *bytesFlag,
+		total:     *total,
+	}
+
+	operands := fs.Args()
+	if len(operands) == 0 {
+		operands = []string{"."}
+	}
+
+	return run(stdio, operands, opts)
+}
+
+// run walks each operand and prints the requested report. A failed walk is
+// reported on stderr but does not stop the remaining operands; the returned
+// error only sets the exit code.
+func run(stdio command.IO, operands []string, opts options) error {
+	var grand int64
+	var firstErr error
+
+	for _, operand := range operands {
+		entries, err := walk(operand)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "du: %s\n", command.FileError(operand, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+			continue
+		}
+		printed := report(entries, opts)
+		for _, e := range printed {
+			writeLine(stdio.Out, e, opts)
+		}
+		if len(entries) > 0 {
+			// The total for the operand is the size of its root entry, which
+			// walk always places last.
+			grand += entries[len(entries)-1].bytes
+		}
+	}
+
+	if opts.total {
+		writeLine(stdio.Out, entry{path: "total", bytes: grand}, opts)
+	}
+	return firstErr
+}
+
+// walk computes the apparent size of every file and directory under root and
+// returns the accumulated entries in post-order (children before their parent,
+// the root last). It is a pure function of the filesystem: it does not touch
+// stdout, so it can be unit-tested directly.
+func walk(root string) ([]entry, error) {
+	type acc struct {
+		bytes int64
+		isDir bool
+	}
+	sizes := map[string]*acc{}
+	var order []string // directory paths in the order they were entered
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			sizes[path] = &acc{bytes: 0, isDir: true}
+			order = append(order, path)
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return ierr
+		}
+		// Count only regular-file content: a directory's own inode size is
+		// filesystem-dependent and would make the result nondeterministic.
+		// Store the apparent (raw) byte size; rounding to 1K blocks happens
+		// only when the block count is printed.
+		size := info.Size()
+		// Add this file's size to every ancestor directory up to root.
+		for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
+			if a, ok := sizes[dir]; ok {
+				a.bytes += size
+			}
+			if dir == root || filepath.Dir(dir) == dir {
+				break
+			}
+		}
+		sizes[path] = &acc{bytes: size, isDir: false}
+		order = append(order, path)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	// Emit children before parents (deeper paths first), with the root last,
+	// matching GNU du's default ordering.
+	sort.SliceStable(order, func(i, j int) bool {
+		return depth(order[i]) > depth(order[j])
+	})
+	entries := make([]entry, 0, len(order))
+	for _, p := range order {
+		a := sizes[p]
+		entries = append(entries, entry{path: p, bytes: a.bytes, isDir: a.isDir})
+	}
+	return entries, nil
+}
+
+// report filters the accumulated entries down to the lines that should be
+// printed given the options, preserving order.
+func report(entries []entry, opts options) []entry {
+	if len(entries) == 0 {
+		return nil
+	}
+	if opts.summarize {
+		// Only the root (always last) is printed.
+		return entries[len(entries)-1:]
+	}
+	if opts.all {
+		return entries
+	}
+	root := entries[len(entries)-1]
+	out := make([]entry, 0, len(entries))
+	for _, e := range entries {
+		// Print every directory, and always print the operand itself even
+		// when it is a single regular file (GNU du behaves this way).
+		if e.isDir || e.path == root.path {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// writeLine prints a single "SIZE\tPATH" line for e.
+func writeLine(w io.Writer, e entry, opts options) {
+	_, _ = fmt.Fprintf(w, "%s\t%s\n", formatSize(e.bytes, opts), e.path)
+}
+
+// formatSize renders a byte count according to the active output mode: bytes
+// (-b), human-readable (-h), or the default 1024-byte block count.
+func formatSize(bytes int64, opts options) string {
+	switch {
+	case opts.bytes:
+		return strconv.FormatInt(bytes, 10)
+	case opts.human:
+		return humanReadable(bytes)
+	default:
+		return strconv.FormatInt(blocks(bytes), 10)
+	}
+}
+
+// blocks converts an apparent byte count to a count of 1024-byte blocks,
+// rounding up (so any nonzero file occupies at least one block).
+func blocks(bytes int64) int64 {
+	if bytes <= 0 {
+		return 0
+	}
+	return (bytes + blockSize - 1) / blockSize
+}
+
+// depth returns the number of path separators in p, used to order children
+// before their parents.
+func depth(p string) int {
+	n := 0
+	for _, r := range p {
+		if r == filepath.Separator {
+			n++
+		}
+	}
+	return n
+}
+
+// humanReadable formats a byte count the way GNU du -h does: the largest unit
+// for which the value is at least 1, with one decimal place below 10 (e.g.
+// 1536 -> "1.5K", 2147483648 -> "2.0G").
+func humanReadable(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return strconv.FormatInt(bytes, 10)
+	}
+	units := []string{"K", "M", "G", "T", "P", "E"}
+	value := float64(bytes)
+	var suffix string
+	for _, u := range units {
+		value /= unit
+		suffix = u
+		if value < unit {
+			break
+		}
+	}
+	if value < 10 {
+		return fmt.Sprintf("%.1f%s", value, suffix)
+	}
+	return fmt.Sprintf("%.0f%s", value, suffix)
+}

--- a/internal/applets/shellutils/du/du_test.go
+++ b/internal/applets/shellutils/du/du_test.go
@@ -1,0 +1,253 @@
+package du_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/du"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// runDu runs the du applet against the given args and returns stdout, stderr,
+// and the error.
+func runDu(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := du.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// buildTree creates a known directory tree:
+//
+//	root/a.txt      1000 bytes -> 1 block
+//	root/b.txt      2000 bytes -> 2 blocks
+//	root/sub/c.txt  3000 bytes -> 3 blocks
+//
+// Total apparent size: 6000 bytes -> 6 blocks (ceil(6000/1024) = 6).
+func buildTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.Mkdir(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path string, n int) {
+		if err := os.WriteFile(path, bytes.Repeat([]byte("x"), n), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(root, "a.txt"), 1000)
+	write(filepath.Join(root, "b.txt"), 2000)
+	write(filepath.Join(sub, "c.txt"), 3000)
+	return root
+}
+
+func TestSummarizePrintsSingleTotal(t *testing.T) {
+	t.Parallel()
+	root := buildTree(t)
+
+	out, errOut, err := runDu(t, "-s", root)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	lines := nonEmptyLines(out)
+	if len(lines) != 1 {
+		t.Fatalf("-s should print exactly one line, got %d: %q", len(lines), out)
+	}
+	size, path := splitLine(t, lines[0])
+	if size != "6" {
+		t.Errorf("size = %q, want %q (6 blocks)", size, "6")
+	}
+	if path != root {
+		t.Errorf("path = %q, want %q", path, root)
+	}
+}
+
+func TestBytesPrintsByteSizes(t *testing.T) {
+	t.Parallel()
+	root := buildTree(t)
+
+	out, errOut, err := runDu(t, "-s", "-b", root)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	lines := nonEmptyLines(out)
+	if len(lines) != 1 {
+		t.Fatalf("expected one line, got %d: %q", len(lines), out)
+	}
+	size, _ := splitLine(t, lines[0])
+	// Apparent bytes: 1000 + 2000 + 3000 = 6000.
+	if size != "6000" {
+		t.Errorf("size = %q, want %q bytes", size, "6000")
+	}
+}
+
+func TestAllListsIndividualFiles(t *testing.T) {
+	t.Parallel()
+	root := buildTree(t)
+
+	out, errOut, err := runDu(t, "-a", root)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+
+	want := map[string]string{
+		filepath.Join(root, "a.txt"):        "1",
+		filepath.Join(root, "b.txt"):        "2",
+		filepath.Join(root, "sub", "c.txt"): "3",
+		filepath.Join(root, "sub"):          "3",
+		root:                                "6",
+	}
+	got := map[string]string{}
+	for _, l := range nonEmptyLines(out) {
+		size, path := splitLine(t, l)
+		got[path] = size
+	}
+	for path, size := range want {
+		if got[path] != size {
+			t.Errorf("path %q size = %q, want %q (full output:\n%s)", path, got[path], size, out)
+		}
+	}
+	// -a must include the individual files, which the default mode omits.
+	if _, ok := got[filepath.Join(root, "a.txt")]; !ok {
+		t.Errorf("-a did not list individual file a.txt: %q", out)
+	}
+}
+
+func TestDefaultListsOnlyDirectories(t *testing.T) {
+	t.Parallel()
+	root := buildTree(t)
+
+	out, errOut, err := runDu(t, root)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	for _, l := range nonEmptyLines(out) {
+		_, path := splitLine(t, l)
+		if strings.HasSuffix(path, ".txt") {
+			t.Errorf("default mode listed a file: %q", l)
+		}
+	}
+}
+
+func TestTotalPrintsGrandTotal(t *testing.T) {
+	t.Parallel()
+	root := buildTree(t)
+
+	out, errOut, err := runDu(t, "-s", "-c", root)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	lines := nonEmptyLines(out)
+	last := lines[len(lines)-1]
+	size, path := splitLine(t, last)
+	if path != "total" {
+		t.Fatalf("last line path = %q, want %q", path, "total")
+	}
+	if size != "6" {
+		t.Errorf("grand total = %q, want %q", size, "6")
+	}
+}
+
+func TestHumanReadableFlag(t *testing.T) {
+	t.Parallel()
+	root := buildTree(t)
+
+	out, errOut, err := runDu(t, "-s", "-h", root)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	size, _ := splitLine(t, nonEmptyLines(out)[0])
+	// 6000 bytes -> 5.9K (6000/1024 = 5.86).
+	if size != "5.9K" {
+		t.Errorf("human size = %q, want %q", size, "5.9K")
+	}
+}
+
+// TestHumanReadableFormatter exercises the human-readable formatting directly
+// through the -h output for several deterministic sizes.
+func TestHumanReadableFormatter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		size int
+		want string
+	}{
+		{1536, "1.5K"},        // 1536 bytes -> 1.5K
+		{1024, "1.0K"},        // exactly one block -> 1.0K
+		{1024 * 1024, "1.0M"}, // one mebibyte
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			f := filepath.Join(dir, "f.bin")
+			if err := os.WriteFile(f, bytes.Repeat([]byte("y"), tt.size), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			out, _, err := runDu(t, "-h", f)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			size, _ := splitLine(t, nonEmptyLines(out)[0])
+			if size != tt.want {
+				t.Errorf("size for %d bytes = %q, want %q", tt.size, size, tt.want)
+			}
+		})
+	}
+}
+
+func TestMissingOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runDu(t, "/no/such/path")
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+	if !strings.Contains(errOut, "du: /no/such/path:") {
+		t.Errorf("stderr = %q, want du error prefix", errOut)
+	}
+}
+
+func TestHelpAndVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := runDu(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: du") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = runDu(t, "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "du (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}
+
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimSpace(l) != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func splitLine(t *testing.T, line string) (size, path string) {
+	t.Helper()
+	parts := strings.SplitN(line, "\t", 2)
+	if len(parts) != 2 {
+		t.Fatalf("line %q is not in SIZE\\tPATH form", line)
+	}
+	return parts[0], parts[1]
+}

--- a/internal/applets/shellutils/od/od.go
+++ b/internal/applets/shellutils/od/od.go
@@ -1,0 +1,339 @@
+// Package od implements the od applet: dump files (or standard input) in octal
+// and other formats. It mirrors the common behaviour of GNU od, including an
+// address (offset) column followed by formatted byte groups and a final address
+// line giving the total length.
+package od
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// bytesPerLine is the number of input bytes dumped on each output line.
+const bytesPerLine = 16
+
+// Command is the od applet.
+type Command struct{}
+
+// New returns an od command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "od" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Dump files in octal and other formats" }
+
+// Run executes od.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	addr := fs.StringP("address-radix", "A", "o", "decide how file offsets are printed (o, x, d, n)")
+	typ := fs.StringP("format", "t", "", "select output format")
+	b := fs.BoolP("octal-bytes", "b", false, "same as -t o1")
+	cFlag := fs.BoolP("chars", "c", false, "same as -t c")
+	x := fs.BoolP("hex-words", "x", false, "same as -t x2")
+	o := fs.BoolP("octal-words", "o", false, "same as -t o2")
+	d := fs.BoolP("decimal-words", "d", false, "same as -t u2")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	radix, rerr := parseRadix(*addr)
+	if rerr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "od: %v\n", rerr)
+		return command.Failure(rerr)
+	}
+
+	format := selectFormat(*typ, *b, *cFlag, *x, *o, *d)
+	ft, ferr := parseType(format)
+	if ferr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "od: %v\n", ferr)
+		return command.Failure(ferr)
+	}
+
+	data, readErr := readAll(stdio, fs.Args())
+	if _, werr := io.WriteString(stdio.Out, dump(data, radix, ft)); werr != nil {
+		return command.Failure(werr)
+	}
+	return readErr
+}
+
+// selectFormat resolves the effective output type. An explicit -t wins;
+// otherwise the convenience flags map to their type strings, defaulting to the
+// GNU default of "o2" (2-byte octal words).
+func selectFormat(typ string, b, c, x, o, d bool) string {
+	switch {
+	case typ != "":
+		return typ
+	case b:
+		return "o1"
+	case c:
+		return "c"
+	case x:
+		return "x2"
+	case o:
+		return "o2"
+	case d:
+		return "u2"
+	default:
+		return "o2"
+	}
+}
+
+// readAll reads every operand (defaulting to standard input when there are
+// none) and returns the concatenated bytes. A failed open or read is reported
+// on stderr but does not stop the remaining files; the returned error only sets
+// the exit code, because its message was already printed.
+func readAll(stdio command.IO, files []string) ([]byte, error) {
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+	var data []byte
+	var firstErr error
+	for _, name := range files {
+		r, err := command.Open(stdio, name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "od: %s\n", command.FileError(name, err))
+			firstErr = keep(firstErr)
+			continue
+		}
+		b, err := io.ReadAll(r)
+		_ = r.Close()
+		data = append(data, b...)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "od: %s\n", command.FileError(name, err))
+			firstErr = keep(firstErr)
+		}
+	}
+	return data, firstErr
+}
+
+func keep(existing error) error {
+	if existing != nil {
+		return existing
+	}
+	return command.SilentFailure()
+}
+
+// radix selects how the address (offset) column is rendered.
+type radix int
+
+const (
+	radixOctal radix = iota
+	radixHex
+	radixDecimal
+	radixNone
+)
+
+// parseRadix maps an -A argument to a radix value.
+func parseRadix(s string) (radix, error) {
+	switch s {
+	case "o":
+		return radixOctal, nil
+	case "x":
+		return radixHex, nil
+	case "d":
+		return radixDecimal, nil
+	case "n":
+		return radixNone, nil
+	default:
+		return 0, fmt.Errorf("invalid output address radix '%s'; it must be one character from [doxn]", s)
+	}
+}
+
+// address renders offset in the given radix, padded to the GNU column width
+// (octal/decimal use 7 digits, hex uses 6). When the radix is none the empty
+// string is returned.
+func address(offset int, r radix) string {
+	switch r {
+	case radixOctal:
+		return fmt.Sprintf("%07o", offset)
+	case radixHex:
+		return fmt.Sprintf("%06x", offset)
+	case radixDecimal:
+		return fmt.Sprintf("%07d", offset)
+	default: // radixNone
+		return ""
+	}
+}
+
+// formatType describes one -t output type: the size of each unit in bytes and
+// how a unit is rendered into a fixed-width field.
+type formatType struct {
+	unit  int // number of bytes consumed per value
+	width int // field width (excluding the leading space separator)
+	value func(b []byte) string
+}
+
+// parseType maps a -t argument to a formatType. Supported types are o1/o2,
+// x1/x2, d1/d2, u1/u2, c and a.
+func parseType(s string) (formatType, error) {
+	switch s {
+	case "o1":
+		return formatType{unit: 1, width: 3, value: octalUnit}, nil
+	case "o2":
+		return formatType{unit: 2, width: 6, value: octalUnit}, nil
+	case "x1":
+		return formatType{unit: 1, width: 2, value: hexUnit}, nil
+	case "x2":
+		return formatType{unit: 2, width: 4, value: hexUnit}, nil
+	case "d1":
+		return formatType{unit: 1, width: 4, value: signedUnit}, nil
+	case "d2":
+		return formatType{unit: 2, width: 6, value: signedUnit}, nil
+	case "u1":
+		return formatType{unit: 1, width: 3, value: unsignedUnit}, nil
+	case "u2":
+		return formatType{unit: 2, width: 5, value: unsignedUnit}, nil
+	case "c":
+		return formatType{unit: 1, width: 3, value: charUnit}, nil
+	case "a":
+		return formatType{unit: 1, width: 3, value: namedUnit}, nil
+	default:
+		return formatType{}, fmt.Errorf("invalid type string '%s'", s)
+	}
+}
+
+// little assembles up to unit bytes (little-endian) into an unsigned integer,
+// treating missing high bytes as zero (matching GNU od on a trailing partial
+// unit).
+func little(b []byte) uint64 {
+	var v uint64
+	for i := len(b) - 1; i >= 0; i-- {
+		v = v<<8 | uint64(b[i])
+	}
+	return v
+}
+
+func octalUnit(b []byte) string {
+	switch len(b) {
+	case 1:
+		return fmt.Sprintf("%03o", b[0])
+	default:
+		return fmt.Sprintf("%06o", little(b))
+	}
+}
+
+func hexUnit(b []byte) string {
+	switch len(b) {
+	case 1:
+		return fmt.Sprintf("%02x", b[0])
+	default:
+		return fmt.Sprintf("%04x", little(b))
+	}
+}
+
+func signedUnit(b []byte) string {
+	if len(b) == 1 {
+		return fmt.Sprintf("%d", int8(b[0]))
+	}
+	return fmt.Sprintf("%d", int16(little(b)))
+}
+
+func unsignedUnit(b []byte) string {
+	return fmt.Sprintf("%d", little(b))
+}
+
+// cEscapes maps the bytes that -t c renders with a C-style escape.
+var cEscapes = map[byte]string{
+	0x00: `\0`,
+	0x07: `\a`,
+	0x08: `\b`,
+	0x09: `\t`,
+	0x0a: `\n`,
+	0x0b: `\v`,
+	0x0c: `\f`,
+	0x0d: `\r`,
+}
+
+// charUnit renders a single byte the way -t c does: a C escape for the well
+// known control characters, the character itself when printable, otherwise a
+// 3-digit octal value.
+func charUnit(b []byte) string {
+	c := b[0]
+	if esc, ok := cEscapes[c]; ok {
+		return esc
+	}
+	if c >= 0x20 && c < 0x7f {
+		return string(c)
+	}
+	return fmt.Sprintf("%03o", c)
+}
+
+// asciiNames holds the named-character spellings used by -t a for the low 128
+// bytes (control characters plus space).
+var asciiNames = [...]string{
+	"nul", "soh", "stx", "etx", "eot", "enq", "ack", "bel",
+	"bs", "ht", "nl", "vt", "ff", "cr", "so", "si",
+	"dle", "dc1", "dc2", "dc3", "dc4", "nak", "syn", "etb",
+	"can", "em", "sub", "esc", "fs", "gs", "rs", "us",
+}
+
+// namedUnit renders a single byte the way -t a does: a short name for control
+// characters, "sp" for space, "del" for 0x7f, and the printable character
+// itself otherwise. The high bit is ignored, as in GNU od.
+func namedUnit(b []byte) string {
+	c := b[0] & 0x7f
+	switch {
+	case int(c) < len(asciiNames):
+		return asciiNames[c]
+	case c == 0x20:
+		return "sp"
+	case c == 0x7f:
+		return "del"
+	default:
+		return string(c)
+	}
+}
+
+// dump renders the whole input: one line per bytesPerLine bytes, each line an
+// address column (unless the radix is none) followed by space-prefixed,
+// right-justified value fields, then a final line giving the total length in
+// the address radix.
+func dump(data []byte, r radix, ft formatType) string {
+	var b strings.Builder
+	for off := 0; off < len(data); off += bytesPerLine {
+		end := off + bytesPerLine
+		if end > len(data) {
+			end = len(data)
+		}
+		b.WriteString(line(data[off:end], off, r, ft))
+		b.WriteByte('\n')
+	}
+	if addr := address(len(data), r); addr != "" {
+		b.WriteString(addr)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// line renders a single output line: the address for offset (when shown)
+// followed by the formatted units for the (already sliced) chunk of bytes.
+func line(chunk []byte, offset int, r radix, ft formatType) string {
+	var b strings.Builder
+	b.WriteString(address(offset, r))
+	for i := 0; i < len(chunk); i += ft.unit {
+		end := i + ft.unit
+		if end > len(chunk) {
+			end = len(chunk)
+		}
+		b.WriteByte(' ')
+		b.WriteString(pad(ft.value(chunk[i:end]), ft.width))
+	}
+	return b.String()
+}
+
+// pad right-justifies s in a field of the given width (no truncation when s is
+// already wider).
+func pad(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return strings.Repeat(" ", width-len(s)) + s
+}

--- a/internal/applets/shellutils/od/od.go
+++ b/internal/applets/shellutils/od/od.go
@@ -1,5 +1,5 @@
 // Package od implements the od applet: dump files (or standard input) in octal
-// and other formats. It mirrors the common behaviour of GNU od, including an
+// and other formats. It mirrors the common behavior of GNU od, including an
 // address (offset) column followed by formatted byte groups and a final address
 // line giving the total length.
 package od

--- a/internal/applets/shellutils/od/od_test.go
+++ b/internal/applets/shellutils/od/od_test.go
@@ -1,0 +1,186 @@
+package od_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/od"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func runStdin(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := od.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// Expected outputs are verified against GNU od, e.g. `printf 'ABC\n' | od -c`.
+func TestRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{
+			name:  "char dump",
+			stdin: "ABC\n",
+			args:  []string{"-c"},
+			want:  "0000000   A   B   C  \\n\n0000004\n",
+		},
+		{
+			name:  "hex address hex bytes",
+			stdin: "ABC\n",
+			args:  []string{"-A", "x", "-t", "x1"},
+			want:  "000000 41 42 43 0a\n000004\n",
+		},
+		{
+			name:  "octal bytes",
+			stdin: "ABC\n",
+			args:  []string{"-t", "o1"},
+			want:  "0000000 101 102 103 012\n0000004\n",
+		},
+		{
+			name:  "no addresses",
+			stdin: "ABC\n",
+			args:  []string{"-A", "n", "-t", "x1"},
+			want:  " 41 42 43 0a\n",
+		},
+		{
+			name:  "default is octal words",
+			stdin: "ABC\n",
+			args:  nil,
+			want:  "0000000 041101 005103\n0000004\n",
+		},
+		{
+			name:  "shortcut -b",
+			stdin: "ABC\n",
+			args:  []string{"-b"},
+			want:  "0000000 101 102 103 012\n0000004\n",
+		},
+		{
+			name:  "shortcut -x",
+			stdin: "ABC\n",
+			args:  []string{"-x"},
+			want:  "0000000 4241 0a43\n0000004\n",
+		},
+		{
+			name:  "shortcut -o",
+			stdin: "ABC\n",
+			args:  []string{"-o"},
+			want:  "0000000 041101 005103\n0000004\n",
+		},
+		{
+			name:  "decimal address",
+			stdin: "ABC\n",
+			args:  []string{"-A", "d", "-t", "x1"},
+			want:  "0000000 41 42 43 0a\n0000004\n",
+		},
+		{
+			name:  "empty input",
+			stdin: "",
+			args:  []string{"-c"},
+			want:  "0000000\n",
+		},
+		{
+			name:  "two lines wrap at 16 bytes",
+			stdin: "Hello, World!\nThis is a test of more than sixteen bytes here.\n",
+			args:  []string{"-c"},
+			want: "0000000   H   e   l   l   o   ,       W   o   r   l   d   !  \\n   T   h\n" +
+				"0000020   i   s       i   s       a       t   e   s   t       o   f    \n" +
+				"0000040   m   o   r   e       t   h   a   n       s   i   x   t   e   e\n" +
+				"0000060   n       b   y   t   e   s       h   e   r   e   .  \\n\n" +
+				"0000076\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "a.bin")
+	if err := os.WriteFile(f, []byte("ABC\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runStdin(t, "", "-A", "x", "-t", "x1", f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "000000 41 42 43 0a\n000004\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestRunMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(errOut, "od: /no/such/file:") {
+		t.Errorf("stderr = %q, want od error prefix", errOut)
+	}
+}
+
+func TestRunInvalidRadix(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "ABC\n", "-A", "z")
+	if err == nil {
+		t.Fatal("expected error for invalid radix")
+	}
+	if !strings.Contains(errOut, "od: invalid output address radix") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunInvalidType(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "ABC\n", "-t", "z9")
+	if err == nil {
+		t.Fatal("expected error for invalid type")
+	}
+	if !strings.Contains(errOut, "od: invalid type string") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := runStdin(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: od") {
+		t.Errorf("--help out = %q", out)
+	}
+
+	out, _, err = runStdin(t, "", "--version")
+	if err != nil {
+		t.Fatalf("--version error = %v", err)
+	}
+	if !strings.Contains(out, "od (mimixbox)") {
+		t.Errorf("--version out = %q", out)
+	}
+}

--- a/test/it/shellutils/cal_test.sh
+++ b/test/it/shellutils/cal_test.sh
@@ -1,0 +1,3 @@
+TestCalMonthYear() {
+    cal 11 2023
+}

--- a/test/it/shellutils/chmod_test.sh
+++ b/test/it/shellutils/chmod_test.sh
@@ -1,0 +1,26 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/chmod
+    mkdir -p ${TEST_DIR}
+    touch ${TEST_DIR}/file.txt
+    chmod 600 ${TEST_DIR}/file.txt
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/chmod
+}
+
+TestChmodOctal() {
+    export TEST_DIR=/tmp/mimixbox/it/chmod
+    chmod 644 ${TEST_DIR}/file.txt
+    stat -c '%a' ${TEST_DIR}/file.txt
+}
+
+TestChmodSymbolic() {
+    export TEST_DIR=/tmp/mimixbox/it/chmod
+    chmod u+x ${TEST_DIR}/file.txt
+    stat -c '%a' ${TEST_DIR}/file.txt
+}
+
+TestChmodMissing() {
+    chmod 644 /no_such_file
+}

--- a/test/it/shellutils/dd_test.sh
+++ b/test/it/shellutils/dd_test.sh
@@ -1,0 +1,11 @@
+TestDdCopy() {
+    printf 'hello world' | dd status=none
+}
+
+TestDdCount() {
+    printf 'hello world' | dd bs=1 count=5 status=none
+}
+
+TestDdUcase() {
+    printf 'abc' | dd conv=ucase status=none
+}

--- a/test/it/shellutils/df_test.sh
+++ b/test/it/shellutils/df_test.sh
@@ -1,0 +1,8 @@
+TestDfHeader() {
+    df . | head -n 1
+}
+
+TestDfStatus() {
+    df . > /dev/null
+    echo "rc=$?"
+}

--- a/test/it/shellutils/du_test.sh
+++ b/test/it/shellutils/du_test.sh
@@ -1,0 +1,20 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/du
+    mkdir -p ${TEST_DIR}/sub
+    printf '%0.s.' $(seq 1 100) > ${TEST_DIR}/a.txt
+    printf '%0.s.' $(seq 1 50) > ${TEST_DIR}/sub/b.txt
+}
+
+CleanUp() {
+    rm -rf /tmp/mimixbox/it/du
+}
+
+TestDuBytes() {
+    export TEST_DIR=/tmp/mimixbox/it/du
+    du -s -b ${TEST_DIR}
+}
+
+TestDuBlocks() {
+    export TEST_DIR=/tmp/mimixbox/it/du
+    du -s ${TEST_DIR}
+}

--- a/test/it/shellutils/od_test.sh
+++ b/test/it/shellutils/od_test.sh
@@ -1,0 +1,11 @@
+TestOdChar() {
+    printf 'ABC\n' | od -c
+}
+
+TestOdHex() {
+    printf 'AB' | od -A x -t x1
+}
+
+TestOdNoAddr() {
+    printf 'A' | od -A n -t o1
+}

--- a/test/it/spec/cal_spec.sh
+++ b/test/it/spec/cal_spec.sh
@@ -1,0 +1,19 @@
+Describe 'cal for a given month and year'
+    Include shellutils/cal_test.sh
+
+    result() { %text
+        #|   November 2023
+        #|Su Mo Tu We Th Fr Sa
+        #|          1  2  3  4
+        #| 5  6  7  8  9 10 11
+        #|12 13 14 15 16 17 18
+        #|19 20 21 22 23 24 25
+        #|26 27 28 29 30
+    }
+
+    It 'prints the month calendar'
+        When call TestCalMonthYear
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/chmod_spec.sh
+++ b/test/it/spec/chmod_spec.sh
@@ -1,0 +1,33 @@
+Describe 'chmod with an octal mode'
+    Include shellutils/chmod_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'sets the permission bits'
+        When call TestChmodOctal
+        The output should equal '644'
+        The status should be success
+    End
+End
+
+Describe 'chmod with a symbolic mode'
+    Include shellutils/chmod_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'adds owner execute to mode 600'
+        When call TestChmodSymbolic
+        The output should equal '700'
+        The status should be success
+    End
+End
+
+Describe 'chmod on a missing file'
+    Include shellutils/chmod_test.sh
+
+    It 'reports an error'
+        When call TestChmodMissing
+        The error should equal "chmod: cannot access '/no_such_file': No such file or directory"
+        The status should be failure
+    End
+End

--- a/test/it/spec/chmod_spec.sh
+++ b/test/it/spec/chmod_spec.sh
@@ -27,7 +27,7 @@ Describe 'chmod on a missing file'
 
     It 'reports an error'
         When call TestChmodMissing
-        The error should equal "chmod: cannot access '/no_such_file': No such file or directory"
+        The error should equal "chmod: cannot access '/no_such_file': no such file or directory"
         The status should be failure
     End
 End

--- a/test/it/spec/dd_spec.sh
+++ b/test/it/spec/dd_spec.sh
@@ -1,0 +1,29 @@
+Describe 'dd copies stdin to stdout'
+    Include shellutils/dd_test.sh
+
+    It 'reproduces the input'
+        When call TestDdCopy
+        The output should equal 'hello world'
+        The status should be success
+    End
+End
+
+Describe 'dd with count'
+    Include shellutils/dd_test.sh
+
+    It 'copies only the requested blocks'
+        When call TestDdCount
+        The output should equal 'hello'
+        The status should be success
+    End
+End
+
+Describe 'dd conv=ucase'
+    Include shellutils/dd_test.sh
+
+    It 'upper-cases the data'
+        When call TestDdUcase
+        The output should equal 'ABC'
+        The status should be success
+    End
+End

--- a/test/it/spec/df_spec.sh
+++ b/test/it/spec/df_spec.sh
@@ -1,0 +1,19 @@
+Describe 'df prints a header'
+    Include shellutils/df_test.sh
+
+    It 'shows the column header'
+        When call TestDfHeader
+        The output should include 'Filesystem'
+        The status should be success
+    End
+End
+
+Describe 'df succeeds for the current directory'
+    Include shellutils/df_test.sh
+
+    It 'exits zero'
+        When call TestDfStatus
+        The output should equal 'rc=0'
+        The status should be success
+    End
+End

--- a/test/it/spec/du_spec.sh
+++ b/test/it/spec/du_spec.sh
@@ -1,0 +1,23 @@
+Describe 'du -b summarizes apparent bytes'
+    Include shellutils/du_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'reports the total byte size'
+        When call TestDuBytes
+        The output should equal "$(printf '150\t/tmp/mimixbox/it/du')"
+        The status should be success
+    End
+End
+
+Describe 'du -s summarizes in 1K blocks'
+    Include shellutils/du_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'reports the total in blocks'
+        When call TestDuBlocks
+        The output should equal "$(printf '1\t/tmp/mimixbox/it/du')"
+        The status should be success
+    End
+End

--- a/test/it/spec/od_spec.sh
+++ b/test/it/spec/od_spec.sh
@@ -1,0 +1,39 @@
+Describe 'od -c'
+    Include shellutils/od_test.sh
+
+    result() { %text
+        #|0000000   A   B   C  \n
+        #|0000004
+    }
+
+    It 'dumps characters with C escapes'
+        When call TestOdChar
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'od -A x -t x1'
+    Include shellutils/od_test.sh
+
+    result() { %text
+        #|000000 41 42
+        #|000002
+    }
+
+    It 'dumps hex bytes with hex addresses'
+        When call TestOdHex
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'od -A n'
+    Include shellutils/od_test.sh
+
+    It 'suppresses the address column'
+        When call TestOdNoAddr
+        The output should equal ' 101'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Six more GNU-style applets on the `command.Command` framework, each with unit tests and shellspec integration tests, registered in the applet table (README list regenerated by `make command-list`).

| Command | Description | Issue |
|---|---|---|
| `chmod` | Change file mode bits (octal + symbolic `u+x`/`go-w`/`a=r`, `-R`, `-v`) | #51 |
| `du` | Estimate file space usage (`-s`, `-a`, `-h`, `-b`, `-c`, 1K blocks) | #57 |
| `df` | Report file system disk space (`-h`, `-k`, `-i`; injectable statfs) | #56 |
| `dd` | Convert and copy (`if=`/`of=`/`bs=`/`count=`/`skip=`/`seek=`/`conv=`/`status=`) | #55 |
| `od` | Dump files (`-A o\|x\|d\|n`, `-t`, `-b`/`-c`/`-x`/`-o`) | #62 |
| `cal` | Display a calendar (`MONTH YEAR`, `-m`, `-y`; injectable clock) | #50 |

## Testing

- Unit tests for every command, with pure cores factored out (chmod's `applyMode`, du's size walk, df's usage computation behind an injectable `statfs`, dd's `parseSize`/conv, od's formatter, cal's `month` renderer with an injectable clock).
- `golangci-lint` clean on the new packages; `go test ./...` passes.
- shellspec integration specs for all six pass against an installed build (deterministic fixtures: `cal 11 2023`, `od -c`, controlled `du` sizes, `dd` byte counts).

Closes #50, #51, #55, #56, #57, #62.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added six shell utilities: `cal` for displaying calendars, `chmod` for modifying file permissions with octal and symbolic modes, `dd` for copying and converting data, `df` for displaying filesystem disk usage, `du` for calculating directory sizes, and `od` for dumping data in multiple formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->