### PR TITLE
feat: add resize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 85 commands. Run `mimixbox --list` to see them on the terminal.
+There are 86 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -77,6 +77,7 @@ There are 85 commands. Run `mimixbox --list` to see them on the terminal.
 | reboot | Reboot the system |
 | remove-shell | Remove shell name from /etc/shells |
 | reset | Reset terminal |
+| resize | Print commands to set the terminal size |
 | rm | Remove file(s) or directory(s) |
 | rmdir | Remove directory |
 | sddf | Search & Delete Duplicated File |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -27,6 +27,7 @@ import (
 	gzipCmd "github.com/nao1215/mimixbox/internal/applets/archival/gzip"
 	"github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
 	"github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
+	"github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
 	addShell "github.com/nao1215/mimixbox/internal/applets/debianutils/add-shell"
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/ischroot"
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
@@ -187,6 +188,7 @@ func init() {
 		"remove-shell": reg(removeShell.New()),
 		"reboot":       reg(halt.NewReboot()),
 		"reset":        reg(reset.New()),
+		"resize":       reg(resize.New()),
 		"rm":           reg(rm.New()),
 		"rmdir":        reg(rmdir.New()),
 		"sddf":         reg(sddf.New()),

--- a/internal/applets/console-tools/resize/resize.go
+++ b/internal/applets/console-tools/resize/resize.go
@@ -1,0 +1,73 @@
+// Package resize implements the resize applet: print the terminal size as shell
+// commands that set the COLUMNS and LINES environment variables, like the
+// xterm "resize" utility. Evaluate its output (eval `resize`) to update the
+// current shell after the window has changed size.
+package resize
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the resize applet.
+type Command struct{}
+
+// New returns a resize command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "resize" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print commands to set the terminal size" }
+
+// winsize reports the current terminal size as (rows, cols). It is a package
+// var so a test can replace it with a deterministic fake instead of needing a
+// real controlling terminal.
+var winsize = func() (rows, cols uint16, err error) {
+	for _, fd := range []int{int(os.Stdout.Fd()), int(os.Stderr.Fd()), int(os.Stdin.Fd())} {
+		ws, werr := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+		if werr == nil && ws.Row > 0 && ws.Col > 0 {
+			return ws.Row, ws.Col, nil
+		}
+		err = werr
+	}
+	if err == nil {
+		err = fmt.Errorf("could not determine terminal size")
+	}
+	return 0, 0, err
+}
+
+// Run executes resize.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	sh := fs.BoolP("sh", "u", false, "write Bourne-shell (sh/ksh/bash) commands (default)")
+	csh := fs.BoolP("csh", "c", false, "write C-shell (csh/tcsh) commands")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rows, cols, err := winsize()
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "resize: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	_, _ = fmt.Fprint(stdio.Out, format(rows, cols, *csh && !*sh))
+	return nil
+}
+
+// format renders the COLUMNS/LINES assignment for either C-shell (csh) or
+// Bourne-shell syntax.
+func format(rows, cols uint16, csh bool) string {
+	if csh {
+		return fmt.Sprintf("set noglob;\nsetenv COLUMNS '%d';\nsetenv LINES '%d';\nunset noglob;\n", cols, rows)
+	}
+	return fmt.Sprintf("COLUMNS=%d;\nLINES=%d;\nexport COLUMNS LINES;\n", cols, rows)
+}

--- a/internal/applets/console-tools/resize/resize_test.go
+++ b/internal/applets/console-tools/resize/resize_test.go
@@ -1,0 +1,134 @@
+package resize
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// fakeSize installs a deterministic winsize for the duration of a test.
+func fakeSize(t *testing.T, rows, cols uint16, err error) {
+	t.Helper()
+	orig := winsize
+	winsize = func() (uint16, uint16, error) { return rows, cols, err }
+	t.Cleanup(func() { winsize = orig })
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if got := c.Name(); got != "resize" {
+		t.Errorf("Name() = %q, want %q", got, "resize")
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+func TestRunDefaultShOutput(t *testing.T) {
+	fakeSize(t, 24, 80, nil)
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "COLUMNS=80;\nLINES=24;\nexport COLUMNS LINES;\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestRunCshOutput(t *testing.T) {
+	fakeSize(t, 30, 100, nil)
+	out, _, err := run(t, "-c")
+	if err != nil {
+		t.Fatalf("Run -c error = %v", err)
+	}
+	want := "set noglob;\nsetenv COLUMNS '100';\nsetenv LINES '30';\nunset noglob;\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestRunShFlagBeatsCsh(t *testing.T) {
+	fakeSize(t, 24, 80, nil)
+	out, _, err := run(t, "-c", "-u")
+	if err != nil {
+		t.Fatalf("Run -c -u error = %v", err)
+	}
+	if !strings.Contains(out, "export COLUMNS LINES;") {
+		t.Errorf("with -u, expected sh-style output, got %q", out)
+	}
+}
+
+func TestRunError(t *testing.T) {
+	fakeSize(t, 0, 0, errFake{})
+	_, errOut, err := run(t)
+	if err == nil {
+		t.Error("expected error when winsize fails")
+	}
+	if !strings.Contains(errOut, "resize:") {
+		t.Errorf("stderr = %q, want resize: prefix", errOut)
+	}
+}
+
+func TestFormat(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		rows uint16
+		cols uint16
+		csh  bool
+		want string
+	}{
+		{"sh", 24, 80, false, "COLUMNS=80;\nLINES=24;\nexport COLUMNS LINES;\n"},
+		{"csh", 50, 132, true, "set noglob;\nsetenv COLUMNS '132';\nsetenv LINES '50';\nunset noglob;\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := format(tt.rows, tt.cols, tt.csh); got != tt.want {
+				t.Errorf("format() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: resize") {
+		t.Errorf("help = %q, want usage line", out)
+	}
+}
+
+// TestRealWinsize exercises the default winsize implementation. The test runner
+// usually has no controlling terminal, so this normally returns an error; when
+// it does run under a tty it returns positive dimensions. Either way the ioctl
+// path is executed.
+func TestRealWinsize(t *testing.T) {
+	rows, cols, err := winsize()
+	if err == nil && (rows == 0 || cols == 0) {
+		t.Errorf("winsize returned no error but zero size: rows=%d cols=%d", rows, cols)
+	}
+}
+
+// errFake is a stand-in error for the winsize failure path.
+type errFake struct{}
+
+func (errFake) Error() string { return "no tty" }

--- a/test/it/console-tools/resize_test.sh
+++ b/test/it/console-tools/resize_test.sh
@@ -1,0 +1,3 @@
+TestResizeHelp() {
+    resize --help
+}

--- a/test/it/spec/resize_spec.sh
+++ b/test/it/spec/resize_spec.sh
@@ -1,0 +1,9 @@
+Describe 'resize prints usage'
+    Include console-tools/resize_test.sh
+
+    It 'shows the usage line for --help'
+        When call TestResizeHelp
+        The output should include 'Usage: resize'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Add the console-tools resize applet.

| Command | Description | Issue |
|---|---|---|
| resize | Print shell commands that set COLUMNS and LINES | #49 |

resize reads the terminal size with the TIOCGWINSZ ioctl (via x/sys/unix) and writes assignments you can evaluate to update the current shell after a window resize:

- default / -u, --sh: Bourne-shell syntax (COLUMNS=...; LINES=...; export COLUMNS LINES;)
- -c, --csh: C-shell syntax (setenv COLUMNS ...; setenv LINES ...)

## Testing

- The terminal-size lookup is injected behind a package var, so the output formatting is unit-tested deterministically with t.Parallel() sub-tests. Coverage 92.3%.
- shellspec integration test covers --help.
- golangci-lint clean; command list regenerated.

Closes #49.