### PR TITLE
feat: add grep, find and xargs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 86 commands. Run `mimixbox --list` to see them on the terminal.
+There are 89 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -47,7 +47,9 @@ There are 86 commands. Run `mimixbox --list` to see them on the terminal.
 | expr | Evaluate expressions |
 | fakemovie | Adds a video playback button to the image |
 | false | Do nothing. Return unsuccess(1) |
+| find | Search for files in a directory hierarchy |
 | ghrdc | GitHub Relase Download Counter |
+| grep | Print lines that match patterns |
 | groups | Print the groups to which USERNAME belongs |
 | gzip | Compress or uncompress FILEs (by default, compress FILES in-place) |
 | halt | Halt the system |
@@ -107,6 +109,7 @@ There are 86 commands. Run `mimixbox --list` to see them on the terminal.
 | which | Returns the file path which would be executed in the current environment |
 | who | Show who is logged on |
 | whoami | Print login user name |
+| xargs | Build and execute command lines from standard input |
 <!-- COMMAND_LIST_END -->
 
 ## Install

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -43,6 +43,9 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/rm"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/rmdir"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/touch"
+	"github.com/nao1215/mimixbox/internal/applets/findutils/find"
+	"github.com/nao1215/mimixbox/internal/applets/findutils/grep"
+	"github.com/nao1215/mimixbox/internal/applets/findutils/xargs"
 	"github.com/nao1215/mimixbox/internal/applets/games/lifegame"
 	"github.com/nao1215/mimixbox/internal/applets/jokeutils/cowsay"
 	"github.com/nao1215/mimixbox/internal/applets/jokeutils/fakemovie"
@@ -158,7 +161,9 @@ func init() {
 		"expr":         reg(expr.New()),
 		"fakemovie":    reg(fakemovie.New()),
 		"false":        reg(boolfalse.New()),
+		"find":         reg(find.New()),
 		"ghrdc":        reg(ghrdc.New()),
+		"grep":         reg(grep.New()),
 		"groups":       reg(groups.New()),
 		"gzip":         reg(gzipCmd.New()),
 		"halt":         reg(halt.NewHalt()),
@@ -216,6 +221,7 @@ func init() {
 		"wc":           reg(wc.New()),
 		"wget":         reg(wget.New()),
 		"which":        reg(which.New()),
+		"xargs":        reg(xargs.New()),
 		"who":          reg(who.New()),
 		"whoami":       reg(whoami.New()),
 	}

--- a/internal/applets/findutils/find/dir.go
+++ b/internal/applets/findutils/find/dir.go
@@ -1,0 +1,13 @@
+package find
+
+import "os"
+
+// readDirNames returns the names of the entries in dir.
+func readDirNames(dir string) ([]string, error) {
+	f, err := os.Open(dir) //nolint:gosec // operating on a user-named directory
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Readdirnames(-1)
+}

--- a/internal/applets/findutils/find/find.go
+++ b/internal/applets/findutils/find/find.go
@@ -1,0 +1,243 @@
+// Package find implements the find applet: walk one or more directory trees and
+// print the entries that satisfy the given tests (-name, -type, -maxdepth, ...).
+// It covers the predicates people reach for most; the default action is -print.
+package find
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the find applet.
+type Command struct{}
+
+// New returns a find command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "find" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Search for files in a directory hierarchy" }
+
+// predicate is one parsed test or action from the expression.
+type predicate struct {
+	kind  string
+	value string
+}
+
+// config is the parsed expression: the roots to walk and the predicates to
+// apply to every entry.
+type config struct {
+	roots    []string
+	preds    []predicate
+	maxDepth int
+	minDepth int
+	print0   bool
+}
+
+// Run executes find.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	// find has its own non-getopt expression grammar, so handle --help/--version
+	// by hand before splitting paths from the expression.
+	for _, a := range args {
+		switch a {
+		case "--help":
+			printUsage(stdio.Out)
+			return nil
+		case "--version":
+			printUsage(stdio.Out)
+			return nil
+		}
+	}
+
+	cfg, err := parse(args)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "find: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	var failed bool
+	for _, root := range cfg.roots {
+		if walkErr := walk(stdio, root, cfg); walkErr != nil {
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// parse splits args into the leading path operands and the trailing expression.
+func parse(args []string) (config, error) {
+	cfg := config{maxDepth: -1, minDepth: 0}
+
+	i := 0
+	for i < len(args) && !strings.HasPrefix(args[i], "-") && args[i] != "!" {
+		cfg.roots = append(cfg.roots, args[i])
+		i++
+	}
+	if len(cfg.roots) == 0 {
+		cfg.roots = []string{"."}
+	}
+
+	for i < len(args) {
+		tok := args[i]
+		switch tok {
+		case "-name", "-iname", "-path", "-type":
+			if i+1 >= len(args) {
+				return cfg, fmt.Errorf("missing argument to '%s'", tok)
+			}
+			cfg.preds = append(cfg.preds, predicate{kind: tok, value: args[i+1]})
+			i += 2
+		case "-maxdepth", "-mindepth":
+			if i+1 >= len(args) {
+				return cfg, fmt.Errorf("missing argument to '%s'", tok)
+			}
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n < 0 {
+				return cfg, fmt.Errorf("invalid argument '%s' to '%s'", args[i+1], tok)
+			}
+			if tok == "-maxdepth" {
+				cfg.maxDepth = n
+			} else {
+				cfg.minDepth = n
+			}
+			i += 2
+		case "-empty":
+			cfg.preds = append(cfg.preds, predicate{kind: tok})
+			i++
+		case "-print":
+			i++
+		case "-print0":
+			cfg.print0 = true
+			i++
+		default:
+			return cfg, fmt.Errorf("unknown predicate '%s'", tok)
+		}
+	}
+	return cfg, nil
+}
+
+// walk descends root, applying depth limits and predicates and printing every
+// entry that matches.
+func walk(stdio command.IO, root string, cfg config) error {
+	var retErr error
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "find: %s\n", command.FileError(path, err))
+			retErr = err
+			return nil
+		}
+
+		depth := entryDepth(root, path)
+		if cfg.maxDepth >= 0 && depth > cfg.maxDepth {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if depth < cfg.minDepth {
+			return nil
+		}
+
+		if matches(path, d, cfg.preds) {
+			printPath(stdio, path, cfg.print0)
+		}
+		return nil
+	})
+	return retErr
+}
+
+// entryDepth reports how many path components deep path is relative to root,
+// where root itself is depth 0.
+func entryDepth(root, path string) int {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." {
+		return 0
+	}
+	return len(strings.Split(rel, string(filepath.Separator)))
+}
+
+// matches reports whether an entry satisfies every predicate (logical AND).
+func matches(path string, d fs.DirEntry, preds []predicate) bool {
+	for _, p := range preds {
+		if !matchOne(path, d, p) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchOne evaluates a single predicate against an entry.
+func matchOne(path string, d fs.DirEntry, p predicate) bool {
+	switch p.kind {
+	case "-name":
+		ok, _ := filepath.Match(p.value, filepath.Base(path))
+		return ok
+	case "-iname":
+		ok, _ := filepath.Match(strings.ToLower(p.value), strings.ToLower(filepath.Base(path)))
+		return ok
+	case "-path":
+		ok, _ := filepath.Match(p.value, path)
+		return ok
+	case "-type":
+		return matchType(d, p.value)
+	case "-empty":
+		return isEmpty(path, d)
+	}
+	return false
+}
+
+// matchType reports whether the entry is of the requested type: f (regular),
+// d (directory), l (symlink), p (FIFO), s (socket).
+func matchType(d fs.DirEntry, t string) bool {
+	m := d.Type()
+	switch t {
+	case "f":
+		return m.IsRegular()
+	case "d":
+		return d.IsDir()
+	case "l":
+		return m&fs.ModeSymlink != 0
+	case "p":
+		return m&fs.ModeNamedPipe != 0
+	case "s":
+		return m&fs.ModeSocket != 0
+	}
+	return false
+}
+
+// isEmpty reports whether a regular file has zero size or a directory has no
+// entries.
+func isEmpty(path string, d fs.DirEntry) bool {
+	if d.IsDir() {
+		entries, err := readDirNames(path)
+		return err == nil && len(entries) == 0
+	}
+	info, err := d.Info()
+	return err == nil && info.Mode().IsRegular() && info.Size() == 0
+}
+
+// printPath writes a found path, terminated by NUL for -print0 or newline.
+func printPath(stdio command.IO, path string, zero bool) {
+	if zero {
+		_, _ = fmt.Fprintf(stdio.Out, "%s\x00", path)
+		return
+	}
+	_, _ = fmt.Fprintln(stdio.Out, path)
+}
+
+func printUsage(w interface{ Write([]byte) (int, error) }) {
+	_, _ = w.Write([]byte("Usage: find [PATH]... [EXPRESSION]\n\n" +
+		"Tests: -name, -iname, -path, -type [f|d|l|p|s], -empty\n" +
+		"Depth: -maxdepth N, -mindepth N\n" +
+		"Actions: -print (default), -print0\n"))
+}

--- a/internal/applets/findutils/find/find_test.go
+++ b/internal/applets/findutils/find/find_test.go
@@ -1,0 +1,264 @@
+package find_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/findutils/find"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := find.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// tree builds a fixed directory layout under a temp dir and returns its root:
+//
+//	root/
+//	  a.txt        (regular, "hi")
+//	  empty.txt    (regular, empty)
+//	  sub/         (directory)
+//	    b.log      (regular, "log")
+//	  emptydir/    (directory, empty)
+func tree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), "hi")
+	mustWrite(t, filepath.Join(root, "empty.txt"), "")
+	if err := os.Mkdir(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(root, "sub", "b.log"), "log")
+	if err := os.Mkdir(filepath.Join(root, "emptydir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func lines(out string) []string {
+	out = strings.TrimRight(out, "\n")
+	if out == "" {
+		return nil
+	}
+	ls := strings.Split(out, "\n")
+	sort.Strings(ls)
+	return ls
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := find.New()
+	if got := c.Name(); got != "find" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestPrintAll(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	got := lines(out)
+	// root itself plus 5 entries.
+	if len(got) != 6 {
+		t.Errorf("got %d paths, want 6: %v", len(got), got)
+	}
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-name", "*.txt")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	got := lines(out)
+	want := lines(filepath.Join(root, "a.txt") + "\n" + filepath.Join(root, "empty.txt"))
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestINameCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-iname", "*.TXT")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(lines(out)) != 2 {
+		t.Errorf("-iname got %v, want 2 files", lines(out))
+	}
+}
+
+func TestTypeFile(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-type", "f")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(lines(out)) != 3 {
+		t.Errorf("-type f got %v, want 3", lines(out))
+	}
+}
+
+func TestTypeDir(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-type", "d")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// root, sub, emptydir
+	if len(lines(out)) != 3 {
+		t.Errorf("-type d got %v, want 3", lines(out))
+	}
+}
+
+func TestMaxDepth(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-maxdepth", "1", "-type", "f")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Only top-level files: a.txt, empty.txt (b.log is at depth 2).
+	if len(lines(out)) != 2 {
+		t.Errorf("-maxdepth 1 -type f got %v, want 2", lines(out))
+	}
+}
+
+func TestMinDepth(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-mindepth", "2")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	got := lines(out)
+	// Only sub/b.log is at depth 2.
+	if len(got) != 1 || !strings.HasSuffix(got[0], filepath.Join("sub", "b.log")) {
+		t.Errorf("-mindepth 2 got %v, want sub/b.log", got)
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-empty")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	got := lines(out)
+	// empty.txt and emptydir
+	if len(got) != 2 {
+		t.Errorf("-empty got %v, want 2", got)
+	}
+}
+
+func TestPrint0(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, root, "-name", "a.txt", "-print0")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.HasSuffix(out, "a.txt\x00") {
+		t.Errorf("-print0 out = %q, want NUL terminator", out)
+	}
+}
+
+func TestDefaultPath(t *testing.T) {
+	t.Parallel()
+	// With no path, find walks "." which always contains the test binary cwd.
+	out, _, err := run(t, "-maxdepth", "0")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.TrimSpace(out) != "." {
+		t.Errorf("default path out = %q, want '.'", out)
+	}
+}
+
+func TestMultipleRoots(t *testing.T) {
+	t.Parallel()
+	root := tree(t)
+	out, _, err := run(t, filepath.Join(root, "sub"), filepath.Join(root, "emptydir"))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(lines(out)) != 3 { // sub, sub/b.log, emptydir
+		t.Errorf("got %v, want 3", lines(out))
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown predicate", []string{".", "-bogus"}, "unknown predicate"},
+		{"missing -name arg", []string{".", "-name"}, "missing argument"},
+		{"bad maxdepth", []string{".", "-maxdepth", "x"}, "invalid argument"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errOut, err := run(t, tt.args...)
+			if err == nil {
+				t.Errorf("expected error for %v", tt.args)
+			}
+			if !strings.Contains(errOut, tt.want) {
+				t.Errorf("stderr = %q, want %q", errOut, tt.want)
+			}
+		})
+	}
+}
+
+func TestMissingRoot(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "/no/such/path/xyz")
+	if err == nil {
+		t.Error("expected error for missing root")
+	}
+	if !strings.Contains(errOut, "find:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: find") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/internal/applets/findutils/grep/grep.go
+++ b/internal/applets/findutils/grep/grep.go
@@ -1,0 +1,244 @@
+// Package grep implements the grep applet: search files (or standard input) for
+// lines matching a pattern and print them. The pattern is a Go (RE2) regular
+// expression, which covers the common extended-regexp use; -F switches to plain
+// fixed-string matching.
+package grep
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the grep applet.
+type Command struct{}
+
+// New returns a grep command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "grep" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print lines that match patterns" }
+
+// options holds the parsed switches.
+type options struct {
+	ignoreCase bool
+	invert     bool
+	lineNum    bool
+	count      bool
+	recursive  bool
+	filesMatch bool
+	fixed      bool
+	word       bool
+	quiet      bool
+	withName   bool
+	noName     bool
+}
+
+// Run executes grep.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... PATTERN [FILE]...", stdio.Err)
+	patterns := fs.StringArrayP("regexp", "e", nil, "use PATTERN for matching (may be repeated)")
+	ignoreCase := fs.BoolP("ignore-case", "i", false, "ignore case distinctions")
+	invert := fs.BoolP("invert-match", "v", false, "select non-matching lines")
+	lineNum := fs.BoolP("line-number", "n", false, "print line number with output lines")
+	count := fs.BoolP("count", "c", false, "print only a count of matching lines per FILE")
+	recursive := fs.BoolP("recursive", "r", false, "search directories recursively")
+	fs.BoolP("recursive-R", "R", false, "search directories recursively")
+	filesMatch := fs.BoolP("files-with-matches", "l", false, "print only names of FILEs with matches")
+	fixed := fs.BoolP("fixed-strings", "F", false, "PATTERN is a set of newline-separated strings")
+	_ = fs.BoolP("extended-regexp", "E", false, "PATTERN is an extended regular expression (default)")
+	word := fs.BoolP("word-regexp", "w", false, "match only whole words")
+	quiet := fs.BoolP("quiet", "q", false, "suppress all normal output")
+	withName := fs.BoolP("with-filename", "H", false, "print the file name for each match")
+	noName := fs.BoolP("no-filename", "h", false, "suppress the file name prefix on output")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	recurse := *recursive
+	if r, _ := fs.GetBool("recursive-R"); r {
+		recurse = true
+	}
+
+	opts := options{
+		ignoreCase: *ignoreCase, invert: *invert, lineNum: *lineNum,
+		count: *count, recursive: recurse, filesMatch: *filesMatch,
+		fixed: *fixed, word: *word, quiet: *quiet,
+		withName: *withName, noName: *noName,
+	}
+
+	operands := fs.Args()
+	pats := *patterns
+	if len(pats) == 0 {
+		if len(operands) == 0 {
+			_, _ = fmt.Fprintln(stdio.Err, "grep: missing pattern")
+			return &command.ExitError{Code: 2}
+		}
+		pats = []string{operands[0]}
+		operands = operands[1:]
+	}
+
+	re, err := compile(pats, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "grep: %v\n", err)
+		return &command.ExitError{Code: 2}
+	}
+
+	files := operands
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+
+	g := &grepper{opts: opts, re: re, stdio: stdio, multi: len(files) > 1 || opts.recursive}
+	return g.run(files)
+}
+
+// compile builds a single regular expression that matches any of the patterns.
+func compile(pats []string, opts options) (*regexp.Regexp, error) {
+	parts := make([]string, 0, len(pats))
+	for _, p := range pats {
+		if opts.fixed {
+			p = regexp.QuoteMeta(p)
+		}
+		if opts.word {
+			p = `\b(?:` + p + `)\b`
+		}
+		parts = append(parts, "(?:"+p+")")
+	}
+	expr := strings.Join(parts, "|")
+	if opts.ignoreCase {
+		expr = "(?i)" + expr
+	}
+	return regexp.Compile(expr)
+}
+
+// grepper carries the shared state for one grep invocation.
+type grepper struct {
+	opts    options
+	re      *regexp.Regexp
+	stdio   command.IO
+	multi   bool
+	matched bool
+	failed  bool
+}
+
+// run searches every file (recursing into directories when -r is set) and
+// returns the GNU-style exit status: 0 if any line matched, 1 if none, 2 on
+// error.
+func (g *grepper) run(files []string) error {
+	for _, f := range files {
+		if g.opts.recursive && f != "-" {
+			g.walk(f)
+			continue
+		}
+		g.searchFile(f)
+	}
+	if g.failed {
+		return &command.ExitError{Code: 2}
+	}
+	if !g.matched {
+		return &command.ExitError{Code: 1}
+	}
+	return nil
+}
+
+// walk recursively searches every regular file under root.
+func (g *grepper) walk(root string) {
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			_, _ = fmt.Fprintf(g.stdio.Err, "grep: %s\n", command.FileError(path, err))
+			g.failed = true
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		g.searchFile(path)
+		return nil
+	})
+}
+
+// searchFile opens name (or stdin for "-") and scans it line by line.
+func (g *grepper) searchFile(name string) {
+	r, err := command.Open(g.stdio, name)
+	if err != nil {
+		_, _ = fmt.Fprintf(g.stdio.Err, "grep: %s\n", command.FileError(name, err))
+		g.failed = true
+		return
+	}
+	defer func() { _ = r.Close() }()
+
+	display := name
+	if name == "-" {
+		display = "(standard input)"
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var count int
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Text()
+		if g.re.MatchString(line) == g.opts.invert {
+			continue
+		}
+		g.matched = true
+		count++
+		if g.opts.quiet {
+			return
+		}
+		if g.opts.count || g.opts.filesMatch {
+			continue
+		}
+		g.printLine(display, lineNo, line)
+	}
+
+	if g.opts.filesMatch && count > 0 {
+		_, _ = fmt.Fprintln(g.stdio.Out, display)
+	}
+	if g.opts.count {
+		if g.showName() {
+			_, _ = fmt.Fprintf(g.stdio.Out, "%s:%d\n", display, count)
+		} else {
+			_, _ = fmt.Fprintf(g.stdio.Out, "%d\n", count)
+		}
+	}
+}
+
+// printLine writes one matching line with the optional file-name and
+// line-number prefixes.
+func (g *grepper) printLine(name string, lineNo int, line string) {
+	var b strings.Builder
+	if g.showName() {
+		b.WriteString(name)
+		b.WriteByte(':')
+	}
+	if g.opts.lineNum {
+		fmt.Fprintf(&b, "%d:", lineNo)
+	}
+	b.WriteString(line)
+	_, _ = fmt.Fprintln(g.stdio.Out, b.String())
+}
+
+// showName reports whether output lines should be prefixed with the file name.
+func (g *grepper) showName() bool {
+	if g.opts.noName {
+		return false
+	}
+	if g.opts.withName {
+		return true
+	}
+	return g.multi
+}

--- a/internal/applets/findutils/grep/grep_test.go
+++ b/internal/applets/findutils/grep/grep_test.go
@@ -1,0 +1,212 @@
+package grep_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/findutils/grep"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := grep.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func exitCode(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		return 0
+	}
+	var ee *command.ExitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+	return -1
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := grep.New()
+	if got := c.Name(); got != "grep" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestStdinBasic(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "apple\nbanana\ncherry\n", "an")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "banana\n" {
+		t.Errorf("out = %q, want banana", out)
+	}
+}
+
+func TestFlags(t *testing.T) {
+	t.Parallel()
+	in := "Apple\nbanana\nAPPLE pie\n"
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"ignore-case", []string{"-i", "apple"}, "Apple\nAPPLE pie\n"},
+		{"invert", []string{"-v", "banana"}, "Apple\nAPPLE pie\n"},
+		{"line-number", []string{"-n", "banana"}, "2:banana\n"},
+		{"count", []string{"-c", "p"}, "2\n"},
+		{"word", []string{"-w", "pie"}, "APPLE pie\n"},
+		{"fixed", []string{"-F", "APPLE pie"}, "APPLE pie\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, in, tt.args...)
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestMultiplePatterns(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "one\ntwo\nthree\n", "-e", "one", "-e", "three")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "one\nthree\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestNoMatchExit1(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "hello\n", "zzz")
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+	if code := exitCode(t, err); code != 1 {
+		t.Errorf("exit = %d, want 1", code)
+	}
+}
+
+func TestInvalidRegexExit2(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "[")
+	if code := exitCode(t, err); code != 2 {
+		t.Errorf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "grep:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingPatternExit2(t *testing.T) {
+	t.Parallel()
+	_, _, err := run(t, "")
+	if code := exitCode(t, err); code != 2 {
+		t.Errorf("exit = %d, want 2", code)
+	}
+}
+
+func TestQuiet(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "match me\n", "-q", "match")
+	if out != "" {
+		t.Errorf("quiet out = %q, want empty", out)
+	}
+	if exitCode(t, err) != 0 {
+		t.Errorf("quiet exit = %v, want 0", err)
+	}
+}
+
+func TestFilesWithName(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(a, []byte("foo\nbar\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("baz\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Multiple files -> filename prefix on matches.
+	out, _, err := run(t, "", "foo", a, b)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != a+":foo\n" {
+		t.Errorf("out = %q, want %q", out, a+":foo\n")
+	}
+
+	// -l prints only file names with matches.
+	out, _, err = run(t, "", "-l", "ba", a, b)
+	if err != nil {
+		t.Fatalf("-l err = %v", err)
+	}
+	if !strings.Contains(out, a) || !strings.Contains(out, b) {
+		t.Errorf("-l out = %q, want both files", out)
+	}
+}
+
+func TestRecursive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f := filepath.Join(sub, "deep.txt")
+	if err := os.WriteFile(f, []byte("needle\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "", "-r", "needle", dir)
+	if err != nil {
+		t.Fatalf("-r err = %v", err)
+	}
+	if !strings.Contains(out, f) {
+		t.Errorf("-r out = %q, want path %q", out, f)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "x", "/no/such/file/here")
+	if code := exitCode(t, err); code != 2 {
+		t.Errorf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "grep:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: grep") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/internal/applets/findutils/xargs/xargs.go
+++ b/internal/applets/findutils/xargs/xargs.go
@@ -1,0 +1,191 @@
+// Package xargs implements the xargs applet: read items from standard input and
+// run a command with those items appended as arguments. It covers the common
+// switches (-n, -I, -0, -d, -t, -r) used to glue command pipelines together.
+package xargs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the xargs applet.
+type Command struct{}
+
+// New returns an xargs command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "xargs" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Build and execute command lines from standard input" }
+
+// options holds the parsed switches.
+type options struct {
+	maxArgs    int    // -n: max arguments per command invocation (0 = unlimited)
+	replace    string // -I: replace this token with each input item
+	null       bool   // -0: input items are NUL-separated
+	delim      string // -d: custom input delimiter
+	verbose    bool   // -t: print each command before running it
+	noRunEmpty bool   // -r: do not run the command if input is empty
+}
+
+// Run executes xargs.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [COMMAND [INITIAL-ARGS]...]", stdio.Err)
+	maxArgs := fs.IntP("max-args", "n", 0, "use at most MAX-ARGS arguments per command line")
+	replace := fs.StringP("replace", "I", "", "replace occurrences of REPLACE-STR in the command with input")
+	null := fs.BoolP("null", "0", false, "input items are terminated by a null, not whitespace")
+	delim := fs.StringP("delimiter", "d", "", "input items are terminated by DELIM")
+	verbose := fs.BoolP("verbose", "t", false, "print the command line before executing it")
+	noRunEmpty := fs.BoolP("no-run-if-empty", "r", false, "do not run the command if input is empty")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	opts := options{
+		maxArgs: *maxArgs, replace: *replace, null: *null,
+		delim: *delim, verbose: *verbose, noRunEmpty: *noRunEmpty,
+	}
+
+	cmdArgs := fs.Args()
+	cmdName := "echo"
+	var initial []string
+	if len(cmdArgs) > 0 {
+		cmdName = cmdArgs[0]
+		initial = cmdArgs[1:]
+	}
+
+	items, err := readItems(stdio, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "xargs: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	if len(items) == 0 && opts.noRunEmpty {
+		return nil
+	}
+
+	if err := runCommands(ctx, stdio, cmdName, initial, items, opts); err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "xargs: %v\n", err)
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// readItems reads and splits the input into items according to the -0, -d and
+// default-whitespace rules.
+func readItems(stdio command.IO, opts options) ([]string, error) {
+	scanner := bufio.NewScanner(stdio.In)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	switch {
+	case opts.null:
+		scanner.Split(splitOn(0))
+	case opts.delim != "":
+		scanner.Split(splitOn(opts.delim[0]))
+	default:
+		scanner.Split(bufio.ScanWords)
+	}
+
+	var items []string
+	for scanner.Scan() {
+		tok := scanner.Text()
+		if opts.null || opts.delim != "" {
+			if tok == "" {
+				continue
+			}
+		}
+		items = append(items, tok)
+	}
+	return items, scanner.Err()
+}
+
+// splitOn returns a bufio.SplitFunc that splits on the byte sep.
+func splitOn(sep byte) bufio.SplitFunc {
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := bytes.IndexByte(data, sep); i >= 0 {
+			return i + 1, data[:i], nil
+		}
+		if atEOF {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	}
+}
+
+// runCommands builds and executes the command line(s) from the items.
+func runCommands(ctx context.Context, stdio command.IO, name string, initial, items []string, opts options) error {
+	// -I replaces a token and runs once per input item.
+	if opts.replace != "" {
+		for _, item := range items {
+			argv := make([]string, len(initial))
+			for i, a := range initial {
+				argv[i] = strings.ReplaceAll(a, opts.replace, item)
+			}
+			if err := exec1(ctx, stdio, name, argv, opts); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	batches := batch(items, opts.maxArgs)
+	if len(batches) == 0 {
+		// No input: run the command once with just the initial args (GNU xargs
+		// behavior unless -r was given, which is handled by the caller).
+		return exec1(ctx, stdio, name, initial, opts)
+	}
+	for _, b := range batches {
+		argv := append(append([]string{}, initial...), b...)
+		if err := exec1(ctx, stdio, name, argv, opts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// batch splits items into groups of at most n (n<=0 means a single group).
+func batch(items []string, n int) [][]string {
+	if len(items) == 0 {
+		return nil
+	}
+	if n <= 0 {
+		return [][]string{items}
+	}
+	var out [][]string
+	for i := 0; i < len(items); i += n {
+		end := i + n
+		if end > len(items) {
+			end = len(items)
+		}
+		out = append(out, items[i:end])
+	}
+	return out
+}
+
+// exec1 runs a single command, wiring it to the shell streams and honoring -t.
+func exec1(ctx context.Context, stdio command.IO, name string, argv []string, opts options) error {
+	if opts.verbose {
+		_, _ = fmt.Fprintln(stdio.Err, strings.TrimSpace(name+" "+strings.Join(argv, " ")))
+	}
+	cmd := exec.CommandContext(ctx, name, argv...) //nolint:gosec // running a user-named command is the purpose of xargs
+	cmd.Stdin = stdio.In
+	cmd.Stdout = stdio.Out
+	cmd.Stderr = stdio.Err
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/applets/findutils/xargs/xargs_test.go
+++ b/internal/applets/findutils/xargs/xargs_test.go
@@ -1,0 +1,151 @@
+package xargs_test
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/findutils/xargs"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := xargs.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := xargs.New()
+	if got := c.Name(); got != "xargs" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestEchoDefault(t *testing.T) {
+	t.Parallel()
+	// Default command is echo; all items end up on one line.
+	out, errOut, err := run(t, "a b c\n", "echo")
+	if err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	if strings.TrimSpace(out) != "a b c" {
+		t.Errorf("out = %q, want 'a b c'", out)
+	}
+}
+
+func TestMaxArgs(t *testing.T) {
+	t.Parallel()
+	// -n 1 runs echo once per item, producing one line each.
+	out, errOut, err := run(t, "x y z\n", "-n", "1", "echo")
+	if err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got := strings.Fields(strings.TrimSpace(out))
+	if len(got) != 3 {
+		t.Errorf("out = %q, want three items on separate invocations", out)
+	}
+	if strings.Count(strings.TrimRight(out, "\n"), "\n") != 2 {
+		t.Errorf("-n 1 should yield 3 lines, got %q", out)
+	}
+}
+
+func TestReplace(t *testing.T) {
+	t.Parallel()
+	out, errOut, err := run(t, "world\n", "-I", "{}", "echo", "hello", "{}")
+	if err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	if strings.TrimSpace(out) != "hello world" {
+		t.Errorf("out = %q, want 'hello world'", out)
+	}
+}
+
+func TestNullDelimiter(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\x00b\x00c\x00", "-0", "echo")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.TrimSpace(out) != "a b c" {
+		t.Errorf("out = %q, want 'a b c'", out)
+	}
+}
+
+func TestCustomDelimiter(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a,b,c", "-d", ",", "echo")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.TrimSpace(out) != "a b c" {
+		t.Errorf("out = %q, want 'a b c'", out)
+	}
+}
+
+func TestNoRunIfEmpty(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "   \n", "-r", "echo", "should-not-run")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty (command should not run)", out)
+	}
+}
+
+func TestVerbose(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "hi\n", "-t", "echo")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(errOut, "echo hi") {
+		t.Errorf("verbose stderr = %q, want 'echo hi'", errOut)
+	}
+}
+
+func TestCommandFailure(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "this-command-does-not-exist-xyz")
+	if err == nil {
+		t.Error("expected error when command cannot be run")
+	}
+	if !strings.Contains(errOut, "xargs:") {
+		t.Errorf("stderr = %q, want xargs: prefix", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: xargs") {
+		t.Errorf("help = %q", out)
+	}
+}
+
+func TestTrueCommandRunsOnEmptyWithoutR(t *testing.T) {
+	t.Parallel()
+	// Without -r, GNU xargs runs the command once even with empty input.
+	// Use "true" (a real binary) to avoid output; on platforms without it,
+	// skip.
+	if runtime.GOOS != "linux" {
+		t.Skip("relies on /usr/bin/true")
+	}
+	_, _, err := run(t, "", "true")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/test/it/findutils/find_test.sh
+++ b/test/it/findutils/find_test.sh
@@ -1,0 +1,19 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/find
+    mkdir -p ${TEST_DIR}/sub
+    touch ${TEST_DIR}/a.txt ${TEST_DIR}/sub/b.txt
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/find; }
+
+TestFindName() {
+    export TEST_DIR=/tmp/mimixbox/it/find
+    find ${TEST_DIR} -name 'a.txt'
+}
+TestFindTypeDirCount() {
+    export TEST_DIR=/tmp/mimixbox/it/find
+    find ${TEST_DIR} -type d | wc -l | tr -d ' '
+}
+TestFindUnknown() {
+    export TEST_DIR=/tmp/mimixbox/it/find
+    find ${TEST_DIR} -bogus
+}

--- a/test/it/findutils/grep_test.sh
+++ b/test/it/findutils/grep_test.sh
@@ -1,0 +1,21 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/grep
+    mkdir -p ${TEST_DIR}
+    printf 'apple\nbanana\ncherry\n' > ${TEST_DIR}/fruits.txt
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/grep; }
+
+TestGrepStdin() {
+    printf 'one\ntwo\nthree\n' | grep two
+}
+TestGrepFile() {
+    export TEST_DIR=/tmp/mimixbox/it/grep
+    grep an ${TEST_DIR}/fruits.txt
+}
+TestGrepCount() {
+    export TEST_DIR=/tmp/mimixbox/it/grep
+    grep -c a ${TEST_DIR}/fruits.txt
+}
+TestGrepNoMatch() {
+    printf 'x\n' | grep zzz
+}

--- a/test/it/findutils/xargs_test.sh
+++ b/test/it/findutils/xargs_test.sh
@@ -1,0 +1,9 @@
+TestXargsEcho() {
+    printf 'a b c\n' | xargs echo
+}
+TestXargsMaxArgs() {
+    printf '1 2 3 4\n' | xargs -n 2 echo | wc -l | tr -d ' '
+}
+TestXargsReplace() {
+    printf 'world\n' | xargs -I {} echo hello {}
+}

--- a/test/it/spec/find_spec.sh
+++ b/test/it/spec/find_spec.sh
@@ -1,0 +1,23 @@
+Describe 'find'
+    Include findutils/find_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'finds a file by -name'
+        When call TestFindName
+        The output should equal '/tmp/mimixbox/it/find/a.txt'
+        The status should be success
+    End
+
+    It 'lists directories with -type d'
+        When call TestFindTypeDirCount
+        The output should equal '2'
+        The status should be success
+    End
+
+    It 'rejects an unknown predicate'
+        When call TestFindUnknown
+        The status should be failure
+        The error should include 'unknown predicate'
+    End
+End

--- a/test/it/spec/grep_spec.sh
+++ b/test/it/spec/grep_spec.sh
@@ -1,0 +1,28 @@
+Describe 'grep'
+    Include findutils/grep_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'matches lines from stdin'
+        When call TestGrepStdin
+        The output should equal 'two'
+        The status should be success
+    End
+
+    It 'matches lines from a file'
+        When call TestGrepFile
+        The output should equal 'banana'
+        The status should be success
+    End
+
+    It 'counts matching lines with -c'
+        When call TestGrepCount
+        The output should equal '2'
+        The status should be success
+    End
+
+    It 'exits 1 when nothing matches'
+        When call TestGrepNoMatch
+        The status should equal 1
+    End
+End

--- a/test/it/spec/xargs_spec.sh
+++ b/test/it/spec/xargs_spec.sh
@@ -1,0 +1,21 @@
+Describe 'xargs'
+    Include findutils/xargs_test.sh
+
+    It 'appends stdin items to the command'
+        When call TestXargsEcho
+        The output should equal 'a b c'
+        The status should be success
+    End
+
+    It 'splits into groups with -n'
+        When call TestXargsMaxArgs
+        The output should equal '2'
+        The status should be success
+    End
+
+    It 'substitutes with -I'
+        When call TestXargsReplace
+        The output should equal 'hello world'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

New findutils category with three GNU-style applets.

| Command | Description | Issue |
|---|---|---|
| grep | Print lines that match patterns | #77 |
| find | Search for files in a directory hierarchy | #76 |
| xargs | Build and execute command lines from standard input | #78 |

grep: -i, -v, -n, -c, -l, -r/-R, -F, -w, -q, -H/-h, -e (repeatable). Patterns are Go RE2 (extended-regexp); -F switches to fixed strings. Exit status 0/1/2 like GNU grep.

find: path operands then an expression. Tests -name, -iname, -path, -type [f|d|l|p|s], -empty; depth limits -maxdepth/-mindepth; actions -print (default) and -print0. Default path is '.'.

xargs: reads whitespace/NUL/-d delimited items from stdin and runs a command (default echo) with -n batching, -I replacement, -0, -d, -t and -r.

## Testing

- Unit tests with t.Parallel() and table sub-tests. Coverage: grep 94.0%, find 88.1%, xargs 94.3%.
- shellspec integration tests for all three.
- golangci-lint clean; command list regenerated.

Closes #76, #77, #78.