### PR TITLE
feat: add ar and cpio commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 94 commands. Run `mimixbox --list` to see them on the terminal.
+There are 96 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
 | add-shell | Add shell name to /etc/shells |
+| ar | Create, modify and extract from archives |
 | base64 | Base64 encode/decode from FILR(or STDIN) to STDOUT |
 | basename | Print basename (PATH without "/") from file path |
 | bunzip2 | Decompress bzip2 (.bz2) files |
@@ -35,6 +36,7 @@ There are 94 commands. Run `mimixbox --list` to see them on the terminal.
 | cmp | Compare two files byte by byte |
 | cowsay | Print message with cow's ASCII art |
 | cp | Copy file(s) otr Directory(s) |
+| cpio | Copy files to and from archives |
 | cut | Remove sections from each line of files |
 | date | Print or set the system date and time |
 | dd | Convert and copy a file |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -24,7 +24,9 @@ import (
 
 	"github.com/nao1215/mimixbox/internal/command"
 
+	"github.com/nao1215/mimixbox/internal/applets/archival/ar"
 	"github.com/nao1215/mimixbox/internal/applets/archival/bunzip2"
+	"github.com/nao1215/mimixbox/internal/applets/archival/cpio"
 	"github.com/nao1215/mimixbox/internal/applets/archival/gunzip"
 	gzipCmd "github.com/nao1215/mimixbox/internal/applets/archival/gzip"
 	tarCmd "github.com/nao1215/mimixbox/internal/applets/archival/tar"
@@ -140,6 +142,7 @@ func reg(c command.Command) Applet {
 func init() {
 	Applets = map[string]Applet{
 		"add-shell": reg(addShell.New()),
+		"ar":        reg(ar.New()),
 		"base64":    reg(base64.New()),
 		"basename":  reg(basename.New()),
 		"bunzip2":   reg(bunzip2.New()),
@@ -154,6 +157,7 @@ func init() {
 		"clear":        reg(clear.New()),
 		"cmp":          reg(cmp.New()),
 		"cp":           reg(cp.New()),
+		"cpio":         reg(cpio.New()),
 		"cut":          reg(cut.New()),
 		"date":         reg(date.New()),
 		"dd":           reg(dd.New()),

--- a/internal/applets/archival/ar/ar.go
+++ b/internal/applets/archival/ar/ar.go
@@ -1,0 +1,230 @@
+// Package ar implements the ar applet: create, list and extract Unix "common"
+// (System V/GNU) ar archives, the format used by .a static libraries and Debian
+// .deb packages. It supports the everyday operations: r (replace/create), t
+// (list) and x (extract).
+package ar
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// magic is the ar archive global header.
+const magic = "!<arch>\n"
+
+// headerSize is the fixed size of each per-member header.
+const headerSize = 60
+
+// Command is the ar applet.
+type Command struct{}
+
+// New returns an ar command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ar" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Create, modify and extract from archives" }
+
+// Run executes ar. The first operand is a key letter (r, t or x) optionally
+// preceded by a dash, matching ar's traditional calling convention.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "{rtx}[v] ARCHIVE [MEMBER]...", stdio.Err)
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		_, _ = fmt.Fprintln(stdio.Err, "ar: usage: ar {rtx}[v] ARCHIVE [MEMBER]...")
+		return command.SilentFailure()
+	}
+
+	key := strings.TrimPrefix(rest[0], "-")
+	archive := rest[1]
+	members := rest[2:]
+	verbose := strings.ContainsRune(key, 'v')
+
+	var runErr error
+	switch {
+	case strings.ContainsRune(key, 'r'):
+		runErr = create(archive, members, verbose, stdio)
+	case strings.ContainsRune(key, 't'):
+		runErr = list(archive, stdio)
+	case strings.ContainsRune(key, 'x'):
+		runErr = extract(archive, members, verbose, stdio)
+	default:
+		_, _ = fmt.Fprintf(stdio.Err, "ar: invalid operation key '%s' (use r, t or x)\n", key)
+		return command.SilentFailure()
+	}
+	if runErr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "ar: %v\n", runErr)
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// member is one entry parsed from an archive.
+type member struct {
+	name string
+	mode int64
+	data []byte
+}
+
+// create writes an archive containing the named files.
+func create(archive string, files []string, verbose bool, stdio command.IO) error {
+	if len(files) == 0 {
+		return fmt.Errorf("no members specified")
+	}
+	out, err := os.Create(archive) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.WriteString(out, magic); err != nil {
+		return err
+	}
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(f) //nolint:gosec // archiving a user-named file
+		if err != nil {
+			return err
+		}
+		if err := writeMember(out, filepath.Base(f), int64(info.Mode().Perm()), info.ModTime().Unix(), data); err != nil {
+			return err
+		}
+		if verbose {
+			_, _ = fmt.Fprintf(stdio.Out, "a - %s\n", filepath.Base(f))
+		}
+	}
+	return nil
+}
+
+// writeMember writes one member header and its (even-padded) data.
+func writeMember(w io.Writer, name string, mode, mtime int64, data []byte) error {
+	hdr := fmt.Sprintf("%-16s%-12d%-6d%-6d%-8o%-10d`\n",
+		name+"/", mtime, 0, 0, mode, len(data))
+	if len(hdr) != headerSize {
+		hdr = fmt.Sprintf("%-16s%-12d%-6d%-6d%-8o%-10d`\n", trunc(name+"/", 16), mtime, 0, 0, mode, len(data))
+	}
+	if _, err := io.WriteString(w, hdr); err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	if len(data)%2 == 1 {
+		if _, err := io.WriteString(w, "\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// trunc shortens s to at most n bytes.
+func trunc(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+// readArchive parses every member of an archive.
+func readArchive(archive string) ([]member, error) {
+	f, err := os.Open(archive) //nolint:gosec // user-named file
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	hdr := make([]byte, len(magic))
+	if _, err := io.ReadFull(f, hdr); err != nil {
+		return nil, fmt.Errorf("not an ar archive")
+	}
+	if string(hdr) != magic {
+		return nil, fmt.Errorf("not an ar archive")
+	}
+
+	var members []member
+	for {
+		h := make([]byte, headerSize)
+		_, err := io.ReadFull(f, h)
+		if err == io.EOF {
+			return members, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		name := strings.TrimRight(string(h[0:16]), " ")
+		name = strings.TrimSuffix(name, "/")
+		mode, _ := strconv.ParseInt(strings.TrimSpace(string(h[40:48])), 8, 64)
+		size, err := strconv.ParseInt(strings.TrimSpace(string(h[48:58])), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("corrupt member header")
+		}
+		data := make([]byte, size)
+		if _, err := io.ReadFull(f, data); err != nil {
+			return nil, err
+		}
+		if size%2 == 1 {
+			if _, err := f.Seek(1, io.SeekCurrent); err != nil {
+				return nil, err
+			}
+		}
+		members = append(members, member{name: name, mode: mode, data: data})
+	}
+}
+
+// list prints the member names in the archive.
+func list(archive string, stdio command.IO) error {
+	members, err := readArchive(archive)
+	if err != nil {
+		return err
+	}
+	for _, m := range members {
+		_, _ = fmt.Fprintln(stdio.Out, m.name)
+	}
+	return nil
+}
+
+// extract writes the requested members (or all of them) to the current
+// directory.
+func extract(archive string, want []string, verbose bool, stdio command.IO) error {
+	members, err := readArchive(archive)
+	if err != nil {
+		return err
+	}
+	wanted := map[string]bool{}
+	for _, w := range want {
+		wanted[w] = true
+	}
+	for _, m := range members {
+		if len(want) > 0 && !wanted[m.name] {
+			continue
+		}
+		mode := os.FileMode(m.mode)
+		if mode == 0 {
+			mode = 0o644
+		}
+		if err := os.WriteFile(m.name, m.data, mode); err != nil { //nolint:gosec // archive-defined mode
+			return err
+		}
+		if verbose {
+			_, _ = fmt.Fprintf(stdio.Out, "x - %s\n", m.name)
+		}
+	}
+	return nil
+}

--- a/internal/applets/archival/ar/ar_test.go
+++ b/internal/applets/archival/ar/ar_test.go
@@ -1,0 +1,192 @@
+package ar_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/archival/ar"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := ar.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := ar.New()
+	if got := c.Name(); got != "ar" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestCreateListExtract(t *testing.T) {
+	// Uses t.Chdir, so it cannot be parallel.
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	write(t, a, "alpha")
+	write(t, b, "beta-odd") // 8 bytes (even); use odd below too
+	archive := filepath.Join(dir, "lib.a")
+
+	if _, errOut, err := run(t, "rc", archive, a, b); err != nil {
+		t.Fatalf("create err = %v (stderr=%q)", err, errOut)
+	}
+
+	out, _, err := run(t, "t", archive)
+	if err != nil {
+		t.Fatalf("list err = %v", err)
+	}
+	if !strings.Contains(out, "a.txt") || !strings.Contains(out, "b.txt") {
+		t.Errorf("list = %q, want both members", out)
+	}
+
+	// Extract into a fresh dir (extract writes to the current directory).
+	extractDir := filepath.Join(dir, "out")
+	if err := os.Mkdir(extractDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(extractDir)
+	if _, errOut, err := run(t, "x", archive); err != nil {
+		t.Fatalf("extract err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(filepath.Join(extractDir, "a.txt"))
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if string(got) != "alpha" {
+		t.Errorf("extracted a.txt = %q", got)
+	}
+}
+
+func TestOddSizePadding(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "odd.txt")
+	write(t, a, "abc") // 3 bytes -> needs padding
+	archive := filepath.Join(dir, "o.a")
+	if _, _, err := run(t, "r", archive, a); err != nil {
+		t.Fatalf("create err = %v", err)
+	}
+	out, _, err := run(t, "t", archive)
+	if err != nil {
+		t.Fatalf("list err = %v", err)
+	}
+	if strings.TrimSpace(out) != "odd.txt" {
+		t.Errorf("list = %q", out)
+	}
+}
+
+func TestExtractSpecificMember(t *testing.T) {
+	// Uses t.Chdir, so it cannot be parallel.
+	dir := t.TempDir()
+	a := filepath.Join(dir, "one.txt")
+	b := filepath.Join(dir, "two.txt")
+	write(t, a, "1")
+	write(t, b, "2")
+	archive := filepath.Join(dir, "m.a")
+	if _, _, err := run(t, "r", archive, a, b); err != nil {
+		t.Fatalf("create err = %v", err)
+	}
+	extractDir := filepath.Join(dir, "ex")
+	if err := os.Mkdir(extractDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(extractDir)
+	if _, _, err := run(t, "x", archive, "two.txt"); err != nil {
+		t.Fatalf("extract err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, "two.txt")); err != nil {
+		t.Errorf("expected two.txt extracted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, "one.txt")); err == nil {
+		t.Error("one.txt should not have been extracted")
+	}
+}
+
+func TestVerbose(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "v.txt")
+	write(t, a, "x")
+	archive := filepath.Join(dir, "v.a")
+	out, _, err := run(t, "rv", archive, a)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(out, "v.txt") {
+		t.Errorf("verbose out = %q", out)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"too few args", []string{"t"}, "usage"},
+		{"bad key", []string{"q", filepath.Join(dir, "x.a")}, "invalid operation key"},
+		{"create no members", []string{"r", filepath.Join(dir, "y.a")}, "no members"},
+		{"list missing archive", []string{"t", filepath.Join(dir, "nope.a")}, "ar:"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errOut, err := run(t, tt.args...)
+			if err == nil {
+				t.Errorf("expected error for %v", tt.args)
+			}
+			if !strings.Contains(errOut, tt.want) {
+				t.Errorf("stderr = %q, want %q", errOut, tt.want)
+			}
+		})
+	}
+}
+
+func TestNotAnArchive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.a")
+	write(t, bad, "garbage")
+	_, errOut, err := run(t, "t", bad)
+	if err == nil {
+		t.Error("expected error for non-archive")
+	}
+	if !strings.Contains(errOut, "not an ar archive") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: ar") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/internal/applets/archival/cpio/cpio.go
+++ b/internal/applets/archival/cpio/cpio.go
@@ -1,0 +1,239 @@
+// Package cpio implements the cpio applet: copy files into and out of a cpio
+// archive in the portable "new ASCII" (newc, magic 070701) format. It supports
+// the three classic modes: -o (copy-out, read names from stdin and write an
+// archive), -i (copy-in, extract an archive) and -t (list, with -i).
+package cpio
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+const (
+	newcMagic = "070701"
+	trailer   = "TRAILER!!!"
+)
+
+// Command is the cpio applet.
+type Command struct{}
+
+// New returns a cpio command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "cpio" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Copy files to and from archives" }
+
+type options struct {
+	create  bool
+	extract bool
+	list    bool
+	verbose bool
+}
+
+// Run executes cpio.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "{-o|-i|-t} [-v] [-H newc]", stdio.Err)
+	create := fs.BoolP("create", "o", false, "copy-out: read file names from stdin, write archive to stdout")
+	extract := fs.BoolP("extract", "i", false, "copy-in: read archive from stdin and extract")
+	list := fs.BoolP("list", "t", false, "list the contents of the archive (with -i)")
+	verbose := fs.BoolP("verbose", "v", false, "list files processed")
+	format := fs.StringP("format", "H", "newc", "archive format (only 'newc' is supported)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *format != "newc" {
+		_, _ = fmt.Fprintf(stdio.Err, "cpio: unsupported format '%s' (only newc)\n", *format)
+		return command.SilentFailure()
+	}
+
+	opts := options{create: *create, extract: *extract, list: *list, verbose: *verbose}
+
+	var runErr error
+	switch {
+	case opts.create:
+		runErr = copyOut(stdio, opts)
+	case opts.list:
+		runErr = copyIn(stdio, opts, true)
+	case opts.extract:
+		runErr = copyIn(stdio, opts, false)
+	default:
+		_, _ = fmt.Fprintln(stdio.Err, "cpio: you must specify one of -o, -i or -t")
+		return command.SilentFailure()
+	}
+	if runErr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "cpio: %v\n", runErr)
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// copyOut reads newline-separated file names from stdin and writes a newc
+// archive to stdout.
+func copyOut(stdio command.IO, opts options) error {
+	scanner := bufio.NewScanner(stdio.In)
+	ino := 1
+	for scanner.Scan() {
+		name := strings.TrimSpace(scanner.Text())
+		if name == "" {
+			continue
+		}
+		info, err := os.Stat(name)
+		if err != nil {
+			return err
+		}
+		var data []byte
+		if info.Mode().IsRegular() {
+			data, err = os.ReadFile(name) //nolint:gosec // archiving a user-named file
+			if err != nil {
+				return err
+			}
+		}
+		if err := writeEntry(stdio.Out, ino, uint32(info.Mode()), info.ModTime().Unix(), name, data); err != nil {
+			return err
+		}
+		if opts.verbose {
+			_, _ = fmt.Fprintln(stdio.Err, name)
+		}
+		ino++
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return writeEntry(stdio.Out, ino, 0, 0, trailer, nil)
+}
+
+// writeEntry writes one newc header, the NUL-terminated name and the file data,
+// each padded to a 4-byte boundary.
+func writeEntry(w io.Writer, ino int, mode uint32, mtime int64, name string, data []byte) error {
+	nameBytes := append([]byte(name), 0)
+	fields := []uint32{
+		uint32(ino), mode, 0, 0, 1, uint32(mtime), uint32(len(data)),
+		0, 0, 0, 0, uint32(len(nameBytes)), 0,
+	}
+	var b strings.Builder
+	b.WriteString(newcMagic)
+	for _, f := range fields {
+		fmt.Fprintf(&b, "%08X", f)
+	}
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return err
+	}
+	if _, err := w.Write(nameBytes); err != nil {
+		return err
+	}
+	// Header (110) + name padded to 4 bytes.
+	if err := pad(w, 110+len(nameBytes)); err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	return pad(w, len(data))
+}
+
+// pad writes NUL bytes so that n becomes a multiple of 4.
+func pad(w io.Writer, n int) error {
+	if r := n % 4; r != 0 {
+		_, err := w.Write(make([]byte, 4-r))
+		return err
+	}
+	return nil
+}
+
+// copyIn reads a newc archive from stdin and either lists (listOnly) or
+// extracts every entry.
+func copyIn(stdio command.IO, opts options, listOnly bool) error {
+	r := bufio.NewReader(stdio.In)
+	for {
+		hdr := make([]byte, 110)
+		if _, err := io.ReadFull(r, hdr); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if string(hdr[0:6]) != newcMagic {
+			return fmt.Errorf("not a newc cpio archive")
+		}
+		nameSize := int(hexField(hdr, 94))
+		fileSize := int(hexField(hdr, 54))
+		mode := hexField(hdr, 14)
+
+		nameBuf := make([]byte, nameSize)
+		if _, err := io.ReadFull(r, nameBuf); err != nil {
+			return err
+		}
+		name := strings.TrimRight(string(nameBuf), "\x00")
+		if err := skip(r, (110 + nameSize)); err != nil {
+			return err
+		}
+
+		if name == trailer {
+			return nil
+		}
+
+		data := make([]byte, fileSize)
+		if _, err := io.ReadFull(r, data); err != nil {
+			return err
+		}
+		if err := skip(r, fileSize); err != nil {
+			return err
+		}
+
+		if listOnly {
+			_, _ = fmt.Fprintln(stdio.Out, name)
+			continue
+		}
+		if err := extractEntry(name, os.FileMode(mode), data); err != nil {
+			return err
+		}
+		if opts.verbose {
+			_, _ = fmt.Fprintln(stdio.Err, name)
+		}
+	}
+}
+
+// hexField parses the 8-char hex newc field at offset off in hdr.
+func hexField(hdr []byte, off int) uint64 {
+	v, _ := strconv.ParseUint(string(hdr[off:off+8]), 16, 64)
+	return v
+}
+
+// skip discards the padding bytes that align n to a 4-byte boundary.
+func skip(r *bufio.Reader, n int) error {
+	if rem := n % 4; rem != 0 {
+		_, err := io.CopyN(io.Discard, r, int64(4-rem))
+		return err
+	}
+	return nil
+}
+
+// extractEntry writes one extracted entry (directory or regular file) to disk.
+func extractEntry(name string, mode os.FileMode, data []byte) error {
+	if mode.IsDir() {
+		return os.MkdirAll(name, mode.Perm()|0o700)
+	}
+	if dir := filepath.Dir(name); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	perm := mode.Perm()
+	if perm == 0 {
+		perm = 0o644
+	}
+	return os.WriteFile(name, data, perm) //nolint:gosec // archive-defined mode
+}

--- a/internal/applets/archival/cpio/cpio_test.go
+++ b/internal/applets/archival/cpio/cpio_test.go
@@ -1,0 +1,154 @@
+package cpio_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/archival/cpio"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin []byte, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: bytes.NewReader(stdin), Out: out, Err: errBuf}
+	err := cpio.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := cpio.New()
+	if got := c.Name(); got != "cpio" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+// archiveOf builds a newc archive from the named files by driving copy-out, and
+// returns the raw archive bytes.
+func archiveOf(t *testing.T, names ...string) []byte {
+	t.Helper()
+	out, errOut, err := run(t, []byte(strings.Join(names, "\n")+"\n"), "-o")
+	if err != nil {
+		t.Fatalf("copy-out err = %v (stderr=%q)", err, errOut)
+	}
+	return []byte(out)
+}
+
+func TestRoundTrip(t *testing.T) {
+	// Uses t.Chdir for extraction; cannot be parallel.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("a.txt", []byte("alpha"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll("sub", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("sub", "b.txt"), []byte("beta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	archive := archiveOf(t, "a.txt", "sub/b.txt")
+
+	// List.
+	out, _, err := run(t, archive, "-i", "-t")
+	if err != nil {
+		t.Fatalf("list err = %v", err)
+	}
+	if !strings.Contains(out, "a.txt") || !strings.Contains(out, "sub/b.txt") {
+		t.Errorf("list = %q", out)
+	}
+
+	// Extract into a fresh directory.
+	extractDir := filepath.Join(dir, "out")
+	if err := os.Mkdir(extractDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(extractDir)
+	if _, errOut, err := run(t, archive, "-i"); err != nil {
+		t.Fatalf("extract err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(filepath.Join(extractDir, "a.txt"))
+	if err != nil {
+		t.Fatalf("read a.txt: %v", err)
+	}
+	if string(got) != "alpha" {
+		t.Errorf("a.txt = %q", got)
+	}
+	got, err = os.ReadFile(filepath.Join(extractDir, "sub", "b.txt"))
+	if err != nil {
+		t.Fatalf("read sub/b.txt: %v", err)
+	}
+	if string(got) != "beta" {
+		t.Errorf("sub/b.txt = %q", got)
+	}
+}
+
+func TestVerbose(t *testing.T) {
+	// Uses t.Chdir; cannot be parallel.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("v.txt", []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, []byte("v.txt\n"), "-o", "-v")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(errOut, "v.txt") {
+		t.Errorf("verbose stderr = %q", errOut)
+	}
+}
+
+func TestNoModeError(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, nil, "-v")
+	if err == nil {
+		t.Error("expected error when no mode is given")
+	}
+	if !strings.Contains(errOut, "one of -o, -i or -t") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestUnsupportedFormat(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, nil, "-o", "-H", "odc")
+	if err == nil {
+		t.Error("expected error for unsupported format")
+	}
+	if !strings.Contains(errOut, "unsupported format") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestBadArchive(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, []byte("this is not cpio at all!!!"), "-i", "-t")
+	if err == nil {
+		t.Error("expected error for invalid archive")
+	}
+	if !strings.Contains(errOut, "cpio:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, nil, "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: cpio") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/test/it/archival/ar_test.sh
+++ b/test/it/archival/ar_test.sh
@@ -1,0 +1,20 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/ar
+    mkdir -p ${TEST_DIR}
+    printf 'alpha' > ${TEST_DIR}/a.txt
+    printf 'beta'  > ${TEST_DIR}/b.txt
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/ar; }
+
+TestArList() {
+    export TEST_DIR=/tmp/mimixbox/it/ar
+    ar rc ${TEST_DIR}/lib.a ${TEST_DIR}/a.txt ${TEST_DIR}/b.txt
+    ar t ${TEST_DIR}/lib.a
+}
+TestArExtract() {
+    export TEST_DIR=/tmp/mimixbox/it/ar
+    ar rc ${TEST_DIR}/lib2.a ${TEST_DIR}/a.txt
+    mkdir -p ${TEST_DIR}/out && cd ${TEST_DIR}/out
+    ar x ${TEST_DIR}/lib2.a
+    printf '%s' "$(< ${TEST_DIR}/out/a.txt)"
+}

--- a/test/it/archival/cpio_test.sh
+++ b/test/it/archival/cpio_test.sh
@@ -1,0 +1,21 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/cpio
+    mkdir -p ${TEST_DIR}/in
+    printf 'payload' > ${TEST_DIR}/in/file.txt
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/cpio; }
+
+TestCpioRoundTrip() {
+    export TEST_DIR=/tmp/mimixbox/it/cpio
+    cd ${TEST_DIR}/in
+    printf 'file.txt\n' | cpio -o > ${TEST_DIR}/arch.cpio
+    mkdir -p ${TEST_DIR}/out && cd ${TEST_DIR}/out
+    cpio -i < ${TEST_DIR}/arch.cpio
+    printf '%s' "$(< ${TEST_DIR}/out/file.txt)"
+}
+TestCpioList() {
+    export TEST_DIR=/tmp/mimixbox/it/cpio
+    cd ${TEST_DIR}/in
+    printf 'file.txt\n' | cpio -o > ${TEST_DIR}/arch2.cpio
+    cpio -i -t < ${TEST_DIR}/arch2.cpio
+}

--- a/test/it/spec/ar_spec.sh
+++ b/test/it/spec/ar_spec.sh
@@ -1,0 +1,18 @@
+Describe 'ar'
+    Include archival/ar_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'lists members'
+        When call TestArList
+        The line 1 of output should equal 'a.txt'
+        The line 2 of output should equal 'b.txt'
+        The status should be success
+    End
+
+    It 'extracts a member'
+        When call TestArExtract
+        The output should equal 'alpha'
+        The status should be success
+    End
+End

--- a/test/it/spec/cpio_spec.sh
+++ b/test/it/spec/cpio_spec.sh
@@ -1,0 +1,17 @@
+Describe 'cpio'
+    Include archival/cpio_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'round-trips a file through -o and -i'
+        When call TestCpioRoundTrip
+        The output should equal 'payload'
+        The status should be success
+    End
+
+    It 'lists archive contents with -i -t'
+        When call TestCpioList
+        The output should equal 'file.txt'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Two archive applets that read and write classic Unix archive formats directly (no external dependencies).

| Command | Description | Issue |
|---|---|---|
| ar | Create, list and extract ar archives | #38 |
| cpio | Copy files to and from cpio archives | #40 |

ar: key letters r (replace/create), t (list), x (extract), with optional v for verbose. Implements the System V / GNU "common" ar format ("!<arch>", 60-byte member headers, even-byte padding) used by .a static libraries and .deb packages.

cpio: -o copy-out (read file names from stdin, write archive to stdout), -i copy-in (extract), -t list (with -i), -v verbose. Uses the portable new ASCII format (newc, magic 070701) with 4-byte alignment and a TRAILER!!! sentinel. -H accepts only newc.

## Testing

- Unit tests with sub-tests; round-trip create/list/extract. Coverage: ar 81.7%, cpio 82.6%. (Tests that chdir to extract are non-parallel; the rest use t.Parallel().)
- shellspec round-trip integration tests for both.
- golangci-lint clean; command list regenerated.

Closes #38, #40.