### PR TITLE
feat: add sed and diff commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 96 commands. Run `mimixbox --list` to see them on the terminal.
+There are 98 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -41,6 +41,7 @@ There are 96 commands. Run `mimixbox --list` to see them on the terminal.
 | date | Print or set the system date and time |
 | dd | Convert and copy a file |
 | df | Report file system disk space usage |
+| diff | Compare files line by line |
 | dirname | Print only directory path |
 | dos2unix | Change CRLF to LF |
 | du | Estimate file space usage |
@@ -87,6 +88,7 @@ There are 96 commands. Run `mimixbox --list` to see them on the terminal.
 | rm | Remove file(s) or directory(s) |
 | rmdir | Remove directory |
 | sddf | Search & Delete Duplicated File |
+| sed | Stream editor for filtering and transforming text |
 | seq | Print a column of numbers |
 | serial | Rename the file to the name with a serial number |
 | sha1sum | Calculate or Check secure hash 1 algorithm |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -40,6 +40,8 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
 	removeShell "github.com/nao1215/mimixbox/internal/applets/debianutils/remove-shell"
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/which"
+	"github.com/nao1215/mimixbox/internal/applets/editors/diff"
+	"github.com/nao1215/mimixbox/internal/applets/editors/sed"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/chgrp"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/chown"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/cp"
@@ -162,6 +164,7 @@ func init() {
 		"date":         reg(date.New()),
 		"dd":           reg(dd.New()),
 		"df":           reg(df.New()),
+		"diff":         reg(diff.New()),
 		"dirname":      reg(dirname.New()),
 		"du":           reg(du.New()),
 		"dos2unix":     reg(dos2unix.New()),
@@ -212,6 +215,7 @@ func init() {
 		"sha1sum":      reg(sha1sum.New()),
 		"sha256sum":    reg(sha256sum.New()),
 		"sha512sum":    reg(sha512sum.New()),
+		"sed":          reg(sed.New()),
 		"seq":          reg(seq.New()),
 		"sl":           reg(sl.New()),
 		"sleep":        reg(sleep.New()),

--- a/internal/applets/editors/diff/diff.go
+++ b/internal/applets/editors/diff/diff.go
@@ -13,6 +13,10 @@ import (
 	"github.com/nao1215/mimixbox/internal/command"
 )
 
+// maxDPCells caps the size of the LCS dynamic-programming table so that
+// comparing very large files cannot exhaust memory (~50M cells of int).
+const maxDPCells = 50_000_000
+
 // Command is the diff applet.
 type Command struct{}
 
@@ -38,8 +42,13 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 
 	names := fs.Args()
-	if len(names) != 2 {
+	if len(names) < 2 {
 		_, _ = fmt.Fprintln(stdio.Err, "diff: missing operand")
+		_, _ = fmt.Fprintln(stdio.Err, "diff: Try 'diff --help' for more information.")
+		return &command.ExitError{Code: 2}
+	}
+	if len(names) > 2 {
+		_, _ = fmt.Fprintf(stdio.Err, "diff: extra operand '%s'\n", names[2])
 		_, _ = fmt.Fprintln(stdio.Err, "diff: Try 'diff --help' for more information.")
 		return &command.ExitError{Code: 2}
 	}
@@ -52,6 +61,12 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	b, err := readLines(names[1])
 	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "diff: %s\n", command.FileError(names[1], err))
+		return &command.ExitError{Code: 2}
+	}
+
+	// Guard the O(n*m) LCS table against pathological memory use on huge files.
+	if len(a) > 0 && int64(len(a))*int64(len(b)) > maxDPCells {
+		_, _ = fmt.Fprintln(stdio.Err, "diff: files too large to compare")
 		return &command.ExitError{Code: 2}
 	}
 

--- a/internal/applets/editors/diff/diff.go
+++ b/internal/applets/editors/diff/diff.go
@@ -1,0 +1,167 @@
+// Package diff implements the diff applet: compare two text files line by line
+// and report how to change the first into the second. It produces the classic
+// "normal" diff output by default and unified output with -u, and uses the GNU
+// exit convention (0 identical, 1 different, 2 error).
+package diff
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the diff applet.
+type Command struct{}
+
+// New returns a diff command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "diff" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Compare files line by line" }
+
+// Run executes diff.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 FILE2", stdio.Err)
+	unified := fs.BoolP("unified", "u", false, "output NUM (default 3) lines of unified context")
+	brief := fs.BoolP("brief", "q", false, "report only when files differ")
+	ignoreCase := fs.BoolP("ignore-case", "i", false, "ignore case differences in file contents")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	names := fs.Args()
+	if len(names) != 2 {
+		_, _ = fmt.Fprintln(stdio.Err, "diff: missing operand")
+		_, _ = fmt.Fprintln(stdio.Err, "diff: Try 'diff --help' for more information.")
+		return &command.ExitError{Code: 2}
+	}
+
+	a, err := readLines(names[0])
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "diff: %s\n", command.FileError(names[0], err))
+		return &command.ExitError{Code: 2}
+	}
+	b, err := readLines(names[1])
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "diff: %s\n", command.FileError(names[1], err))
+		return &command.ExitError{Code: 2}
+	}
+
+	ops := diffLines(a, b, *ignoreCase)
+	if !hasChange(ops) {
+		return nil
+	}
+
+	if *brief {
+		_, _ = fmt.Fprintf(stdio.Out, "Files %s and %s differ\n", names[0], names[1])
+		return &command.ExitError{Code: 1}
+	}
+
+	if *unified {
+		writeUnified(stdio, names[0], names[1], a, b, ops)
+	} else {
+		writeNormal(stdio, a, b, ops)
+	}
+	return &command.ExitError{Code: 1}
+}
+
+// readLines reads a file into a slice of lines (without trailing newlines).
+func readLines(name string) ([]string, error) {
+	data, err := os.ReadFile(name) //nolint:gosec // user-named file
+	if err != nil {
+		return nil, err
+	}
+	s := string(data)
+	if s == "" {
+		return nil, nil
+	}
+	s = strings.TrimSuffix(s, "\n")
+	return strings.Split(s, "\n"), nil
+}
+
+// opKind is the type of an edit-script operation.
+type opKind int
+
+const (
+	opEqual opKind = iota
+	opDelete
+	opInsert
+)
+
+// op is one element of the edit script: ai/bi are 0-based indices into a and b.
+type op struct {
+	kind opKind
+	ai   int
+	bi   int
+}
+
+// hasChange reports whether the edit script contains any insert or delete.
+func hasChange(ops []op) bool {
+	for _, o := range ops {
+		if o.kind != opEqual {
+			return true
+		}
+	}
+	return false
+}
+
+// diffLines computes a line-level edit script from a to b using the
+// longest-common-subsequence dynamic program.
+func diffLines(a, b []string, ignoreCase bool) []op {
+	eq := func(x, y string) bool {
+		if ignoreCase {
+			return strings.EqualFold(x, y)
+		}
+		return x == y
+	}
+
+	n, m := len(a), len(b)
+	// lcs[i][j] = length of LCS of a[i:] and b[j:].
+	lcs := make([][]int, n+1)
+	for i := range lcs {
+		lcs[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if eq(a[i], b[j]) {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	var ops []op
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case eq(a[i], b[j]):
+			ops = append(ops, op{kind: opEqual, ai: i, bi: j})
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			ops = append(ops, op{kind: opDelete, ai: i, bi: j})
+			i++
+		default:
+			ops = append(ops, op{kind: opInsert, ai: i, bi: j})
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		ops = append(ops, op{kind: opDelete, ai: i, bi: j})
+	}
+	for ; j < m; j++ {
+		ops = append(ops, op{kind: opInsert, ai: i, bi: j})
+	}
+	return ops
+}

--- a/internal/applets/editors/diff/diff_test.go
+++ b/internal/applets/editors/diff/diff_test.go
@@ -1,0 +1,210 @@
+package diff_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/editors/diff"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := diff.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func exitCode(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		return 0
+	}
+	var ee *command.ExitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+	return -1
+}
+
+// files writes two temp files with the given contents and returns their paths.
+func files(t *testing.T, a, b string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	pa := filepath.Join(dir, "a")
+	pb := filepath.Join(dir, "b")
+	if err := os.WriteFile(pa, []byte(a), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pb, []byte(b), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return pa, pb
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := diff.New()
+	if got := c.Name(); got != "diff" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestIdenticalExit0(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "one\ntwo\n", "one\ntwo\n")
+	out, _, err := run(t, a, b)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+	if exitCode(t, err) != 0 {
+		t.Errorf("exit = %d, want 0", exitCode(t, err))
+	}
+}
+
+func TestChangeNormal(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "one\ntwo\nthree\n", "one\n2\nthree\n")
+	out, _, err := run(t, a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	want := "2c2\n< two\n---\n> 2\n"
+	if out != want {
+		t.Errorf("normal diff:\n got %q\nwant %q", out, want)
+	}
+}
+
+func TestDeletionNormal(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "one\ntwo\nthree\n", "one\nthree\n")
+	out, _, err := run(t, a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d", exitCode(t, err))
+	}
+	want := "2d1\n< two\n"
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestInsertionNormal(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "one\nthree\n", "one\ntwo\nthree\n")
+	out, _, err := run(t, a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d", exitCode(t, err))
+	}
+	want := "1a2\n> two\n"
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestUnified(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "one\ntwo\nthree\n", "one\n2\nthree\n")
+	out, _, err := run(t, "-u", a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d", exitCode(t, err))
+	}
+	if !strings.HasPrefix(out, "--- ") {
+		t.Errorf("missing --- header: %q", out)
+	}
+	if !strings.Contains(out, "@@ -") {
+		t.Errorf("missing @@ hunk: %q", out)
+	}
+	if !strings.Contains(out, "-two") || !strings.Contains(out, "+2") {
+		t.Errorf("unified body wrong: %q", out)
+	}
+	if !strings.Contains(out, " one") || !strings.Contains(out, " three") {
+		t.Errorf("unified context wrong: %q", out)
+	}
+}
+
+func TestBrief(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "x\n", "y\n")
+	out, _, err := run(t, "-q", a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d", exitCode(t, err))
+	}
+	if !strings.Contains(out, "differ") {
+		t.Errorf("brief out = %q", out)
+	}
+}
+
+func TestBriefIdentical(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "same\n", "same\n")
+	out, _, err := run(t, "-q", a, b)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+}
+
+func TestIgnoreCase(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "Hello\n", "hello\n")
+	out, _, err := run(t, "-i", a, b)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "" {
+		t.Errorf("with -i, out = %q, want empty", out)
+	}
+}
+
+func TestMissingOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "only-one")
+	if exitCode(t, err) != 2 {
+		t.Errorf("exit = %d, want 2", exitCode(t, err))
+	}
+	if !strings.Contains(errOut, "missing operand") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	if err := os.WriteFile(a, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, a, filepath.Join(dir, "nope"))
+	if exitCode(t, err) != 2 {
+		t.Errorf("exit = %d, want 2", exitCode(t, err))
+	}
+	if !strings.Contains(errOut, "diff:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: diff") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/internal/applets/editors/diff/diff_test.go
+++ b/internal/applets/editors/diff/diff_test.go
@@ -182,6 +182,17 @@ func TestMissingOperand(t *testing.T) {
 	}
 }
 
+func TestExtraOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "a", "b", "c")
+	if exitCode(t, err) != 2 {
+		t.Errorf("exit = %d, want 2", exitCode(t, err))
+	}
+	if !strings.Contains(errOut, "extra operand") {
+		t.Errorf("stderr = %q, want 'extra operand'", errOut)
+	}
+}
+
 func TestMissingFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/applets/editors/diff/format.go
+++ b/internal/applets/editors/diff/format.go
@@ -1,0 +1,186 @@
+package diff
+
+import (
+	"fmt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// contextLines is the number of unchanged lines shown around each change in
+// unified output.
+const contextLines = 3
+
+// hunk groups a consecutive run of deletes and inserts together with the file
+// positions they start at.
+type hunk struct {
+	aPos int   // 0-based count of a-lines before the hunk
+	bPos int   // 0-based count of b-lines before the hunk
+	dels []int // a indices deleted
+	ins  []int // b indices inserted
+}
+
+// collectHunks groups the edit script into change hunks, dropping the equal
+// runs between them.
+func collectHunks(ops []op) []hunk {
+	var hunks []hunk
+	i := 0
+	for i < len(ops) {
+		if ops[i].kind == opEqual {
+			i++
+			continue
+		}
+		h := hunk{aPos: ops[i].ai, bPos: ops[i].bi}
+		for i < len(ops) && ops[i].kind != opEqual {
+			if ops[i].kind == opDelete {
+				h.dels = append(h.dels, ops[i].ai)
+			} else {
+				h.ins = append(h.ins, ops[i].bi)
+			}
+			i++
+		}
+		hunks = append(hunks, h)
+	}
+	return hunks
+}
+
+// rangeStr formats a 1-based inclusive line range the way normal diff does:
+// a single number when start == end, otherwise "start,end".
+func rangeStr(start, end int) string {
+	if start == end {
+		return fmt.Sprintf("%d", start)
+	}
+	return fmt.Sprintf("%d,%d", start, end)
+}
+
+// writeNormal prints the classic (ed-style) diff output.
+func writeNormal(stdio command.IO, a, b []string, ops []op) {
+	for _, h := range collectHunks(ops) {
+		switch {
+		case len(h.ins) == 0: // deletion only
+			aRange := rangeStr(h.aPos+1, h.aPos+len(h.dels))
+			_, _ = fmt.Fprintf(stdio.Out, "%sd%d\n", aRange, h.bPos)
+			printLines(stdio, "< ", a, h.dels)
+		case len(h.dels) == 0: // insertion only
+			bRange := rangeStr(h.bPos+1, h.bPos+len(h.ins))
+			_, _ = fmt.Fprintf(stdio.Out, "%da%s\n", h.aPos, bRange)
+			printLines(stdio, "> ", b, h.ins)
+		default: // change
+			aRange := rangeStr(h.aPos+1, h.aPos+len(h.dels))
+			bRange := rangeStr(h.bPos+1, h.bPos+len(h.ins))
+			_, _ = fmt.Fprintf(stdio.Out, "%sc%s\n", aRange, bRange)
+			printLines(stdio, "< ", a, h.dels)
+			_, _ = fmt.Fprintln(stdio.Out, "---")
+			printLines(stdio, "> ", b, h.ins)
+		}
+	}
+}
+
+// printLines writes each indexed line of src with the given prefix.
+func printLines(stdio command.IO, prefix string, src []string, idx []int) {
+	for _, i := range idx {
+		_, _ = fmt.Fprintf(stdio.Out, "%s%s\n", prefix, src[i])
+	}
+}
+
+// writeUnified prints unified diff output with file headers and @@ hunks.
+func writeUnified(stdio command.IO, name1, name2 string, a, b []string, ops []op) {
+	groups := groupUnified(ops)
+	if len(groups) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "--- %s\n", name1)
+	_, _ = fmt.Fprintf(stdio.Out, "+++ %s\n", name2)
+
+	for _, g := range groups {
+		aStart, aLen, bStart, bLen := unifiedRange(g)
+		_, _ = fmt.Fprintf(stdio.Out, "@@ -%s +%s @@\n", countRange(aStart, aLen), countRange(bStart, bLen))
+		for _, o := range g {
+			switch o.kind {
+			case opEqual:
+				_, _ = fmt.Fprintf(stdio.Out, " %s\n", a[o.ai])
+			case opDelete:
+				_, _ = fmt.Fprintf(stdio.Out, "-%s\n", a[o.ai])
+			case opInsert:
+				_, _ = fmt.Fprintf(stdio.Out, "+%s\n", b[o.bi])
+			}
+		}
+	}
+}
+
+// groupUnified splits the edit script into hunks padded with up to `context`
+// unchanged lines, merging hunks whose context windows overlap.
+func groupUnified(ops []op) [][]op {
+	// Indices of changed ops.
+	var changed []int
+	for i, o := range ops {
+		if o.kind != opEqual {
+			changed = append(changed, i)
+		}
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+
+	var groups [][]op
+	start := max0(changed[0] - contextLines)
+	end := min(len(ops), changed[0]+1+contextLines)
+	for _, ci := range changed[1:] {
+		if ci-contextLines <= end {
+			end = min(len(ops), ci+1+contextLines)
+			continue
+		}
+		groups = append(groups, ops[start:end])
+		start = max0(ci - contextLines)
+		end = min(len(ops), ci+1+contextLines)
+	}
+	groups = append(groups, ops[start:end])
+	return groups
+}
+
+// unifiedRange returns the 1-based start lines and lengths in a and b for a hunk.
+func unifiedRange(g []op) (aStart, aLen, bStart, bLen int) {
+	aStart, bStart = -1, -1
+	for _, o := range g {
+		if o.kind != opInsert {
+			if aStart < 0 {
+				aStart = o.ai + 1
+			}
+			aLen++
+		}
+		if o.kind != opDelete {
+			if bStart < 0 {
+				bStart = o.bi + 1
+			}
+			bLen++
+		}
+	}
+	if aStart < 0 {
+		aStart = 0
+	}
+	if bStart < 0 {
+		bStart = 0
+	}
+	return aStart, aLen, bStart, bLen
+}
+
+// countRange formats the "start,len" portion of a unified @@ header.
+func countRange(start, length int) string {
+	if length == 1 {
+		return fmt.Sprintf("%d", start)
+	}
+	return fmt.Sprintf("%d,%d", start, length)
+}
+
+func max0(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/applets/editors/sed/exec.go
+++ b/internal/applets/editors/sed/exec.go
@@ -1,0 +1,432 @@
+package sed
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// addrKind classifies the three address forms sed understands.
+type addrKind int
+
+const (
+	addrNone addrKind = iota
+	addrLine
+	addrLast
+	addrRegex
+)
+
+// address is one address on a command (a line number, $ or /regexp/).
+type address struct {
+	kind addrKind
+	line int
+	re   *regexp.Regexp
+}
+
+// cmd is one parsed sed command with its optional one- or two-address selector.
+type cmd struct {
+	a1, a2 *address
+	active bool // range state for two-address commands
+
+	name byte // 's', 'p', 'd', 'q'
+
+	// substitute parameters (name == 's')
+	re         *regexp.Regexp
+	repl       string
+	global     bool
+	printSub   bool
+	occurrence int
+}
+
+// parse turns a script string into a list of commands. When extended is false,
+// patterns are treated as POSIX basic regular expressions (BRE) and translated
+// to the extended syntax Go's regexp engine expects.
+func parse(script string, extended bool) ([]cmd, error) {
+	p := &parser{s: script, extended: extended}
+	var cmds []cmd
+	for {
+		p.skipSeparators()
+		if p.eof() {
+			return cmds, nil
+		}
+		c, err := p.command()
+		if err != nil {
+			return nil, err
+		}
+		cmds = append(cmds, c)
+	}
+}
+
+// parser walks the script text one rune at a time.
+type parser struct {
+	s        string
+	i        int
+	extended bool
+}
+
+// compileRE compiles expr as a regexp, translating BRE to ERE first unless the
+// parser is in extended mode.
+func (p *parser) compileRE(expr string) (*regexp.Regexp, error) {
+	if !p.extended {
+		expr = bre2ere(expr)
+	}
+	return regexp.Compile(expr)
+}
+
+// bre2ere converts a POSIX basic regular expression to the equivalent extended
+// syntax Go's regexp engine uses: backslash-escaped \( \) \{ \} \+ \? \| become
+// the operators, while bare ( ) { } + ? | are literal in BRE and so are
+// escaped.
+func bre2ere(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch == '\\' && i+1 < len(s) {
+			next := s[i+1]
+			switch next {
+			case '(', ')', '{', '}', '+', '?', '|':
+				b.WriteByte(next) // promote to operator
+			default:
+				b.WriteByte('\\')
+				b.WriteByte(next)
+			}
+			i++
+			continue
+		}
+		switch ch {
+		case '(', ')', '{', '}', '+', '?', '|':
+			b.WriteByte('\\') // demote bare operator to literal
+			b.WriteByte(ch)
+		default:
+			b.WriteByte(ch)
+		}
+	}
+	return b.String()
+}
+
+func (p *parser) eof() bool { return p.i >= len(p.s) }
+
+// skipSeparators consumes whitespace, newlines and ';' between commands.
+func (p *parser) skipSeparators() {
+	for !p.eof() {
+		switch p.s[p.i] {
+		case ' ', '\t', '\n', ';':
+			p.i++
+		default:
+			return
+		}
+	}
+}
+
+// command parses one addressed command.
+func (p *parser) command() (cmd, error) {
+	var c cmd
+	a1 := p.address()
+	c.a1 = a1
+	if a1 != nil && !p.eof() && p.s[p.i] == ',' {
+		p.i++
+		c.a2 = p.address()
+		if c.a2 == nil {
+			return c, fmt.Errorf("expected address after ','")
+		}
+	}
+	p.skipSpaces()
+	if p.eof() {
+		return c, fmt.Errorf("missing command")
+	}
+
+	c.name = p.s[p.i]
+	p.i++
+	switch c.name {
+	case 's':
+		return p.substitute(c)
+	case 'p', 'd', 'q':
+		return c, nil
+	default:
+		return c, fmt.Errorf("unknown command: %q", string(c.name))
+	}
+}
+
+// address parses an optional address at the cursor, or returns nil.
+func (p *parser) address() *address {
+	p.skipSpaces()
+	if p.eof() {
+		return nil
+	}
+	switch ch := p.s[p.i]; {
+	case ch == '$':
+		p.i++
+		return &address{kind: addrLast}
+	case ch >= '0' && ch <= '9':
+		start := p.i
+		for !p.eof() && p.s[p.i] >= '0' && p.s[p.i] <= '9' {
+			p.i++
+		}
+		n, _ := strconvAtoi(p.s[start:p.i])
+		return &address{kind: addrLine, line: n}
+	case ch == '/':
+		p.i++
+		expr := p.until('/')
+		re, err := p.compileRE(expr)
+		if err != nil {
+			return &address{kind: addrRegex, re: regexp.MustCompile(regexp.QuoteMeta(expr))}
+		}
+		return &address{kind: addrRegex, re: re}
+	default:
+		return nil
+	}
+}
+
+// substitute parses the body of an s command: s<delim>re<delim>repl<delim>flags.
+func (p *parser) substitute(c cmd) (cmd, error) {
+	if p.eof() {
+		return c, fmt.Errorf("unterminated 's' command")
+	}
+	delim := p.s[p.i]
+	p.i++
+	pattern := p.until(delim)
+	repl := p.until(delim)
+	flags := p.flags()
+
+	caseInsensitive := strings.ContainsRune(flags, 'i') || strings.ContainsRune(flags, 'I')
+	expr := pattern
+	if !p.extended {
+		expr = bre2ere(expr)
+	}
+	if caseInsensitive {
+		expr = "(?i)" + expr
+	}
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return c, fmt.Errorf("invalid regex in 's' command: %v", err)
+	}
+	c.re = re
+	c.repl = translateRepl(repl)
+	c.global = strings.ContainsRune(flags, 'g')
+	c.printSub = strings.ContainsRune(flags, 'p')
+	for _, r := range flags {
+		if r >= '0' && r <= '9' {
+			c.occurrence = int(r - '0')
+		}
+	}
+	return c, nil
+}
+
+// until consumes runes up to (and consuming) the next unescaped delim, returning
+// the text in between with the escape of delim resolved.
+func (p *parser) until(delim byte) string {
+	var b strings.Builder
+	for !p.eof() {
+		ch := p.s[p.i]
+		if ch == '\\' && p.i+1 < len(p.s) {
+			next := p.s[p.i+1]
+			if next == delim {
+				b.WriteByte(delim)
+				p.i += 2
+				continue
+			}
+			b.WriteByte(ch)
+			b.WriteByte(next)
+			p.i += 2
+			continue
+		}
+		if ch == delim {
+			p.i++
+			return b.String()
+		}
+		b.WriteByte(ch)
+		p.i++
+	}
+	return b.String()
+}
+
+// flags reads the trailing flag characters of an s command.
+func (p *parser) flags() string {
+	start := p.i
+	for !p.eof() {
+		ch := p.s[p.i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+			p.i++
+			continue
+		}
+		break
+	}
+	return p.s[start:p.i]
+}
+
+func (p *parser) skipSpaces() {
+	for !p.eof() && (p.s[p.i] == ' ' || p.s[p.i] == '\t') {
+		p.i++
+	}
+}
+
+// translateRepl converts a sed replacement (& for whole match, \1..\9 for
+// groups) into the Go regexp template syntax ($0, $1, ...), escaping literal $.
+func translateRepl(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '&':
+			b.WriteString("${0}")
+		case '$':
+			b.WriteString("$$")
+		case '\\':
+			if i+1 < len(s) {
+				next := s[i+1]
+				switch {
+				case next >= '0' && next <= '9':
+					b.WriteString("${" + string(next) + "}")
+				case next == '&':
+					b.WriteByte('&')
+				case next == '\\':
+					b.WriteByte('\\')
+				case next == 'n':
+					b.WriteByte('\n')
+				case next == 't':
+					b.WriteByte('\t')
+				default:
+					b.WriteByte(next)
+				}
+				i++
+				continue
+			}
+			b.WriteByte('\\')
+		default:
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// editor applies a parsed program to a slice of lines.
+type editor struct {
+	program []cmd
+	quiet   bool
+	out     io.Writer
+}
+
+// run processes every line through the program, honoring auto-print.
+func (e *editor) run(lines []string) {
+	last := len(lines)
+	for idx := range lines {
+		lineNo := idx + 1
+		pattern := lines[idx]
+		deleted := false
+		quit := false
+
+		for ci := range e.program {
+			c := &e.program[ci]
+			if !e.selected(c, lineNo, last, pattern) {
+				continue
+			}
+			switch c.name {
+			case 's':
+				pattern = e.applySub(c, pattern)
+			case 'p':
+				_, _ = fmt.Fprintln(e.out, pattern)
+			case 'd':
+				deleted = true
+			case 'q':
+				quit = true
+			}
+			if deleted || quit {
+				break
+			}
+		}
+
+		if !deleted && !e.quiet {
+			_, _ = fmt.Fprintln(e.out, pattern)
+		}
+		if quit {
+			return
+		}
+	}
+}
+
+// applySub runs the substitute command on a line, honoring g, the Nth-occurrence
+// selector and the p flag.
+func (e *editor) applySub(c *cmd, line string) string {
+	var result string
+	switch {
+	case c.occurrence > 0:
+		result = replaceNth(c.re, line, c.repl, c.occurrence, c.global)
+	case c.global:
+		result = c.re.ReplaceAllString(line, c.repl)
+	default:
+		result = replaceNth(c.re, line, c.repl, 1, false)
+	}
+	if c.printSub && result != line {
+		_, _ = fmt.Fprintln(e.out, result)
+	}
+	return result
+}
+
+// replaceNth replaces the nth match (and, when global, every match after it).
+func replaceNth(re *regexp.Regexp, line, repl string, n int, global bool) string {
+	locs := re.FindAllStringSubmatchIndex(line, -1)
+	if len(locs) < n {
+		return line
+	}
+	var b strings.Builder
+	prev := 0
+	for i, loc := range locs {
+		if i+1 < n {
+			continue
+		}
+		if i+1 > n && !global {
+			break
+		}
+		b.WriteString(line[prev:loc[0]])
+		b.Write(re.ExpandString(nil, repl, line, loc))
+		prev = loc[1]
+		if !global {
+			break
+		}
+	}
+	b.WriteString(line[prev:])
+	return b.String()
+}
+
+// selected reports whether a command's address selects the current line,
+// maintaining range state for two-address commands.
+func (e *editor) selected(c *cmd, lineNo, last int, pattern string) bool {
+	if c.a1 == nil {
+		return true
+	}
+	if c.a2 == nil {
+		return matchAddr(c.a1, lineNo, last, pattern)
+	}
+	// Two-address range.
+	if !c.active {
+		if matchAddr(c.a1, lineNo, last, pattern) {
+			c.active = true
+			// A numeric end address on or before the current line ends the
+			// range immediately (single line).
+			if c.a2.kind == addrLine && c.a2.line <= lineNo {
+				c.active = false
+			}
+			return true
+		}
+		return false
+	}
+	// Already in range: this line is included; check whether it ends here.
+	if matchAddr(c.a2, lineNo, last, pattern) {
+		c.active = false
+	}
+	return true
+}
+
+// matchAddr reports whether a single address matches the current line.
+func matchAddr(a *address, lineNo, last int, pattern string) bool {
+	switch a.kind {
+	case addrLine:
+		return a.line == lineNo
+	case addrLast:
+		return lineNo == last
+	case addrRegex:
+		return a.re.MatchString(pattern)
+	default:
+		return false
+	}
+}

--- a/internal/applets/editors/sed/exec.go
+++ b/internal/applets/editors/sed/exec.go
@@ -122,14 +122,21 @@ func (p *parser) skipSeparators() {
 // command parses one addressed command.
 func (p *parser) command() (cmd, error) {
 	var c cmd
-	a1 := p.address()
+	a1, err := p.address()
+	if err != nil {
+		return c, err
+	}
 	c.a1 = a1
 	if a1 != nil && !p.eof() && p.s[p.i] == ',' {
 		p.i++
-		c.a2 = p.address()
-		if c.a2 == nil {
+		a2, err := p.address()
+		if err != nil {
+			return c, err
+		}
+		if a2 == nil {
 			return c, fmt.Errorf("expected address after ','")
 		}
+		c.a2 = a2
 	}
 	p.skipSpaces()
 	if p.eof() {
@@ -148,33 +155,37 @@ func (p *parser) command() (cmd, error) {
 	}
 }
 
-// address parses an optional address at the cursor, or returns nil.
-func (p *parser) address() *address {
+// address parses an optional address at the cursor. It returns (nil, nil) when
+// there is no address, and an error when a /regexp/ address fails to compile.
+func (p *parser) address() (*address, error) {
 	p.skipSpaces()
 	if p.eof() {
-		return nil
+		return nil, nil
 	}
 	switch ch := p.s[p.i]; {
 	case ch == '$':
 		p.i++
-		return &address{kind: addrLast}
+		return &address{kind: addrLast}, nil
 	case ch >= '0' && ch <= '9':
 		start := p.i
 		for !p.eof() && p.s[p.i] >= '0' && p.s[p.i] <= '9' {
 			p.i++
 		}
 		n, _ := strconvAtoi(p.s[start:p.i])
-		return &address{kind: addrLine, line: n}
+		return &address{kind: addrLine, line: n}, nil
 	case ch == '/':
 		p.i++
-		expr := p.until('/')
+		expr, found := p.until('/')
+		if !found {
+			return nil, fmt.Errorf("unterminated address regex")
+		}
 		re, err := p.compileRE(expr)
 		if err != nil {
-			return &address{kind: addrRegex, re: regexp.MustCompile(regexp.QuoteMeta(expr))}
+			return nil, fmt.Errorf("invalid address regex: %w", err)
 		}
-		return &address{kind: addrRegex, re: re}
+		return &address{kind: addrRegex, re: re}, nil
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
@@ -184,10 +195,19 @@ func (p *parser) substitute(c cmd) (cmd, error) {
 		return c, fmt.Errorf("unterminated 's' command")
 	}
 	delim := p.s[p.i]
+	if isValidDelim(delim) {
+		return c, fmt.Errorf("invalid delimiter for 's' command")
+	}
 	p.i++
-	pattern := p.until(delim)
-	repl := p.until(delim)
-	flags := p.flags()
+	pattern, ok1 := p.until(delim)
+	repl, ok2 := p.until(delim)
+	if !ok1 || !ok2 {
+		return c, fmt.Errorf("unterminated 's' command")
+	}
+	flags, err := p.flags()
+	if err != nil {
+		return c, err
+	}
 
 	caseInsensitive := strings.ContainsRune(flags, 'i') || strings.ContainsRune(flags, 'I')
 	expr := pattern
@@ -205,17 +225,51 @@ func (p *parser) substitute(c cmd) (cmd, error) {
 	c.repl = translateRepl(repl)
 	c.global = strings.ContainsRune(flags, 'g')
 	c.printSub = strings.ContainsRune(flags, 'p')
-	for _, r := range flags {
-		if r >= '0' && r <= '9' {
-			c.occurrence = int(r - '0')
-		}
+	if n, ok := flagNumber(flags); ok {
+		c.occurrence = n
 	}
 	return c, nil
 }
 
+// isValidDelim reports whether ch may not be used as the s-command delimiter.
+// GNU sed forbids a newline or backslash as the delimiter; alphanumerics are
+// reserved for flags and would make the command unparseable.
+func isValidDelim(ch byte) bool {
+	return ch == '\n' || ch == '\\' ||
+		(ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')
+}
+
+// flagNumber extracts the (possibly multi-digit) occurrence number from the s
+// flags, e.g. "10" in "s/x/y/10".
+func flagNumber(flags string) (int, bool) {
+	start := -1
+	for i, r := range flags {
+		if r >= '0' && r <= '9' {
+			if start < 0 {
+				start = i
+			}
+		} else if start >= 0 {
+			break
+		}
+	}
+	if start < 0 {
+		return 0, false
+	}
+	end := start
+	for end < len(flags) && flags[end] >= '0' && flags[end] <= '9' {
+		end++
+	}
+	n, err := strconvAtoi(flags[start:end])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 // until consumes runes up to (and consuming) the next unescaped delim, returning
-// the text in between with the escape of delim resolved.
-func (p *parser) until(delim byte) string {
+// the text in between with the escape of delim resolved. found reports whether
+// the closing delimiter was actually seen.
+func (p *parser) until(delim byte) (text string, found bool) {
 	var b strings.Builder
 	for !p.eof() {
 		ch := p.s[p.i]
@@ -233,26 +287,30 @@ func (p *parser) until(delim byte) string {
 		}
 		if ch == delim {
 			p.i++
-			return b.String()
+			return b.String(), true
 		}
 		b.WriteByte(ch)
 		p.i++
 	}
-	return b.String()
+	return b.String(), false
 }
 
-// flags reads the trailing flag characters of an s command.
-func (p *parser) flags() string {
+// flags reads the trailing flag characters of an s command, rejecting any flag
+// that is not one of g, p, i, I or a digit.
+func (p *parser) flags() (string, error) {
 	start := p.i
 	for !p.eof() {
 		ch := p.s[p.i]
-		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+		switch {
+		case ch == 'g' || ch == 'p' || ch == 'i' || ch == 'I' || (ch >= '0' && ch <= '9'):
 			p.i++
-			continue
+		case ch == ';' || ch == '\n' || ch == ' ' || ch == '\t':
+			return p.s[start:p.i], nil
+		default:
+			return "", fmt.Errorf("unknown option to 's' command: %q", string(ch))
 		}
-		break
 	}
-	return p.s[start:p.i]
+	return p.s[start:p.i], nil
 }
 
 func (p *parser) skipSpaces() {
@@ -345,18 +403,24 @@ func (e *editor) run(lines []string) {
 }
 
 // applySub runs the substitute command on a line, honoring g, the Nth-occurrence
-// selector and the p flag.
+// selector and the p flag. The p flag prints whenever a substitution was made,
+// even if the replacement text is identical to what it replaced.
 func (e *editor) applySub(c *cmd, line string) string {
+	matches := c.re.FindAllStringIndex(line, -1)
 	var result string
+	var substituted bool
 	switch {
 	case c.occurrence > 0:
 		result = replaceNth(c.re, line, c.repl, c.occurrence, c.global)
+		substituted = len(matches) >= c.occurrence
 	case c.global:
 		result = c.re.ReplaceAllString(line, c.repl)
+		substituted = len(matches) > 0
 	default:
 		result = replaceNth(c.re, line, c.repl, 1, false)
+		substituted = len(matches) > 0
 	}
-	if c.printSub && result != line {
+	if c.printSub && substituted {
 		_, _ = fmt.Fprintln(e.out, result)
 	}
 	return result

--- a/internal/applets/editors/sed/sed.go
+++ b/internal/applets/editors/sed/sed.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -115,7 +116,9 @@ func runStreaming(stdio command.IO, program []cmd, files []string, quiet bool) e
 	return nil
 }
 
-// runInPlace rewrites each file with the result of applying the program.
+// runInPlace rewrites each file with the result of applying the program. Each
+// file gets a fresh copy of the program so that range (two-address) state from
+// one file does not leak into the next.
 func runInPlace(stdio command.IO, program []cmd, files []string, quiet bool) error {
 	var failed bool
 	for _, f := range files {
@@ -126,15 +129,62 @@ func runInPlace(stdio command.IO, program []cmd, files []string, quiet bool) err
 			continue
 		}
 		var b strings.Builder
-		ed := &editor{program: program, quiet: quiet, out: &b}
+		ed := &editor{program: cloneProgram(program), quiet: quiet, out: &b}
 		ed.run(lines)
-		if err := os.WriteFile(f, []byte(b.String()), 0o644); err != nil { //nolint:gosec // preserve simple default mode
+		if err := writeFilePreservingMode(f, b.String()); err != nil {
 			_, _ = fmt.Fprintf(stdio.Err, "sed: %v\n", err)
 			failed = true
 		}
 	}
 	if failed {
 		return command.SilentFailure()
+	}
+	return nil
+}
+
+// cloneProgram returns a copy of the program with all range state reset, so a
+// fresh run starts with no command mid-range.
+func cloneProgram(program []cmd) []cmd {
+	out := make([]cmd, len(program))
+	copy(out, program)
+	for i := range out {
+		out[i].active = false
+	}
+	return out
+}
+
+// writeFilePreservingMode writes content to name atomically (via a temp file in
+// the same directory and a rename) while preserving the file's original
+// permission bits.
+func writeFilePreservingMode(name, content string) error {
+	info, err := os.Stat(name)
+	mode := os.FileMode(0o644)
+	if err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	dir := filepath.Dir(name)
+	tmp, err := os.CreateTemp(dir, ".sed-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, name); err != nil {
+		_ = os.Remove(tmpName)
+		return err
 	}
 	return nil
 }

--- a/internal/applets/editors/sed/sed.go
+++ b/internal/applets/editors/sed/sed.go
@@ -1,0 +1,161 @@
+// Package sed implements the sed applet: a stream editor that applies a small
+// but practical subset of GNU sed scripts to its input. It supports the
+// substitute command (s/re/repl/flags), p (print), d (delete) and q (quit),
+// each with an optional line-number, $ or /regexp/ address (single or range).
+package sed
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the sed applet.
+type Command struct{}
+
+// New returns a sed command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "sed" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Stream editor for filtering and transforming text" }
+
+// Run executes sed.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... {SCRIPT} [FILE]...", stdio.Err)
+	scripts := fs.StringArrayP("expression", "e", nil, "add the script to the commands to be executed")
+	scriptFile := fs.StringP("file", "f", "", "add the contents of FILE to the commands")
+	quiet := fs.BoolP("quiet", "n", false, "suppress automatic printing of pattern space")
+	extended := fs.BoolP("regexp-extended", "E", false, "use extended regular expressions")
+	fs.BoolP("regexp-extended-r", "r", false, "use extended regular expressions (alias of -E)")
+	inplace := fs.BoolP("in-place", "i", false, "edit files in place")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	// -E and -r are aliases that select extended regular expressions.
+	useExtended := *extended
+	if r, _ := fs.GetBool("regexp-extended-r"); r {
+		useExtended = true
+	}
+
+	operands := fs.Args()
+	scriptText, files, err := gatherScript(*scripts, *scriptFile, operands)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "sed: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	program, err := parse(scriptText, useExtended)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "sed: -e expression: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	if *inplace {
+		if len(files) == 0 {
+			_, _ = fmt.Fprintln(stdio.Err, "sed: no input files for in-place editing")
+			return command.SilentFailure()
+		}
+		return runInPlace(stdio, program, files, *quiet)
+	}
+
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+	return runStreaming(stdio, program, files, *quiet)
+}
+
+// gatherScript resolves the script text from -e, -f or the first operand, and
+// returns the remaining operands as the file list.
+func gatherScript(exprs []string, file string, operands []string) (string, []string, error) {
+	var parts []string
+	parts = append(parts, exprs...)
+	if file != "" {
+		data, err := os.ReadFile(file) //nolint:gosec // user-named script file
+		if err != nil {
+			return "", nil, err
+		}
+		parts = append(parts, string(data))
+	}
+
+	files := operands
+	if len(parts) == 0 {
+		if len(operands) == 0 {
+			return "", nil, fmt.Errorf("no script specified")
+		}
+		parts = append(parts, operands[0])
+		files = operands[1:]
+	}
+	return strings.Join(parts, "\n"), files, nil
+}
+
+// runStreaming applies the program to the concatenation of files, writing to
+// stdout.
+func runStreaming(stdio command.IO, program []cmd, files []string, quiet bool) error {
+	ed := &editor{program: program, quiet: quiet, out: stdio.Out}
+	var lines []string
+	for _, f := range files {
+		ls, err := readLines(stdio, f)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sed: %s\n", command.FileError(f, err))
+			return command.SilentFailure()
+		}
+		lines = append(lines, ls...)
+	}
+	ed.run(lines)
+	return nil
+}
+
+// runInPlace rewrites each file with the result of applying the program.
+func runInPlace(stdio command.IO, program []cmd, files []string, quiet bool) error {
+	var failed bool
+	for _, f := range files {
+		lines, err := readLines(stdio, f)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sed: %s\n", command.FileError(f, err))
+			failed = true
+			continue
+		}
+		var b strings.Builder
+		ed := &editor{program: program, quiet: quiet, out: &b}
+		ed.run(lines)
+		if err := os.WriteFile(f, []byte(b.String()), 0o644); err != nil { //nolint:gosec // preserve simple default mode
+			_, _ = fmt.Fprintf(stdio.Err, "sed: %v\n", err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// readLines reads name (or stdin for "-") into a slice of lines without the
+// trailing newline.
+func readLines(stdio command.IO, name string) ([]string, error) {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}
+
+// strconvAtoi is a thin wrapper so callers read clearly.
+func strconvAtoi(s string) (int, error) { return strconv.Atoi(s) }

--- a/internal/applets/editors/sed/sed_test.go
+++ b/internal/applets/editors/sed/sed_test.go
@@ -226,6 +226,10 @@ func TestErrors(t *testing.T) {
 		{"no script", nil, "no script"},
 		{"unknown command", []string{"Z"}, "unknown command"},
 		{"missing file", []string{"s/a/b/", "/no/such/file/x"}, "sed:"},
+		{"invalid s flag", []string{"s/a/b/z"}, "unknown option"},
+		{"invalid delimiter", []string{"saXa"}, "invalid delimiter"},
+		{"unterminated s", []string{"s/a/b"}, "unterminated"},
+		{"invalid address regex", []string{"/[/d"}, "invalid address regex"},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/applets/editors/sed/sed_test.go
+++ b/internal/applets/editors/sed/sed_test.go
@@ -1,0 +1,254 @@
+package sed_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/editors/sed"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := sed.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := sed.New()
+	if got := c.Name(); got != "sed" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestSubstitute(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		script string
+		in     string
+		want   string
+	}{
+		{"basic", "s/a/X/", "aaa\n", "Xaa\n"},
+		{"global", "s/a/X/g", "aaa\n", "XXX\n"},
+		{"nth", "s/a/X/2", "aaa\n", "aXa\n"},
+		{"nth-global", "s/a/X/2g", "aaaa\n", "aXXX\n"},
+		{"ignore-case", "s/a/X/gi", "aAa\n", "XXX\n"},
+		{"whole-match-amp", "s/bc/[&]/", "abcd\n", "a[bc]d\n"},
+		{"backref", `s/\(a\)\(b\)/\2\1/`, "ab\n", "ba\n"},
+		{"alt-delim", "s|/usr|/opt|", "/usr/bin\n", "/opt/bin\n"},
+		{"no-match", "s/zzz/Q/", "abc\n", "abc\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, errOut, err := run(t, tt.in, tt.script)
+			if err != nil {
+				t.Fatalf("err = %v (stderr=%q)", err, errOut)
+			}
+			if out != tt.want {
+				t.Errorf("script %q: out = %q, want %q", tt.script, out, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintWithN(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "one\ntwo\nthree\n", "-n", "2p")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "two\n" {
+		t.Errorf("out = %q, want two", out)
+	}
+}
+
+func TestDeleteLine(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\nc\n", "2d")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "a\nc\n" {
+		t.Errorf("out = %q, want a\\nc", out)
+	}
+}
+
+func TestDeleteRegex(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "keep\ndrop me\nkeep\n", "/drop/d")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "keep\nkeep\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestRangeDelete(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "1\n2\n3\n4\n5\n", "2,4d")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "1\n5\n" {
+		t.Errorf("out = %q, want 1\\n5", out)
+	}
+}
+
+func TestLastLineAddress(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\nc\n", "-n", "$p")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "c\n" {
+		t.Errorf("out = %q, want c", out)
+	}
+}
+
+func TestPrintFlagOnSub(t *testing.T) {
+	t.Parallel()
+	// -n with s///p prints only substituted lines.
+	out, _, err := run(t, "cat\ndog\n", "-n", "s/cat/CAT/p")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "CAT\n" {
+		t.Errorf("out = %q, want CAT", out)
+	}
+}
+
+func TestQuit(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "1\n2\n3\n", "2q")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "1\n2\n" {
+		t.Errorf("out = %q, want 1\\n2", out)
+	}
+}
+
+func TestMultipleExpressions(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "abc\n", "-e", "s/a/X/", "-e", "s/c/Z/")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "XbZ\n" {
+		t.Errorf("out = %q, want XbZ", out)
+	}
+}
+
+func TestSemicolonSeparatedCommands(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\n", "s/a/X/;s/b/Y/")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "X\nY\n" {
+		t.Errorf("out = %q, want X\\nY", out)
+	}
+}
+
+func TestScriptFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "prog.sed")
+	if err := os.WriteFile(script, []byte("s/foo/bar/g\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "foo foo\n", "-f", script)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "bar bar\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestInPlace(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(f, []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, errOut, err := run(t, "", "-i", "s/world/earth/", f); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello\nearth\n" {
+		t.Errorf("file = %q", got)
+	}
+}
+
+func TestFileOperand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(f, []byte("aaa\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "", "s/a/b/g", f)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "bbb\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no script", nil, "no script"},
+		{"unknown command", []string{"Z"}, "unknown command"},
+		{"missing file", []string{"s/a/b/", "/no/such/file/x"}, "sed:"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errOut, err := run(t, "", tt.args...)
+			if err == nil {
+				t.Errorf("expected error for %v", tt.args)
+			}
+			if !strings.Contains(errOut, tt.want) {
+				t.Errorf("stderr = %q, want %q", errOut, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: sed") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/test/it/editors/diff_test.sh
+++ b/test/it/editors/diff_test.sh
@@ -1,0 +1,21 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/diff
+    mkdir -p ${TEST_DIR}
+    printf 'one\ntwo\nthree\n' > ${TEST_DIR}/a
+    printf 'one\n2\nthree\n'   > ${TEST_DIR}/b
+    printf 'one\ntwo\nthree\n' > ${TEST_DIR}/c
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/diff; }
+
+TestDiffNormal() {
+    export TEST_DIR=/tmp/mimixbox/it/diff
+    diff ${TEST_DIR}/a ${TEST_DIR}/b
+}
+TestDiffSame() {
+    export TEST_DIR=/tmp/mimixbox/it/diff
+    diff ${TEST_DIR}/a ${TEST_DIR}/c
+}
+TestDiffBrief() {
+    export TEST_DIR=/tmp/mimixbox/it/diff
+    diff -q ${TEST_DIR}/a ${TEST_DIR}/b
+}

--- a/test/it/editors/sed_test.sh
+++ b/test/it/editors/sed_test.sh
@@ -1,0 +1,12 @@
+TestSedSubstitute() {
+    printf 'hello world\n' | sed 's/world/sed/'
+}
+TestSedGlobal() {
+    printf 'a a a\n' | sed 's/a/b/g'
+}
+TestSedDelete() {
+    printf '1\n2\n3\n' | sed '2d'
+}
+TestSedPrintN() {
+    printf 'x\ny\nz\n' | sed -n '2p'
+}

--- a/test/it/spec/diff_spec.sh
+++ b/test/it/spec/diff_spec.sh
@@ -1,0 +1,21 @@
+Describe 'diff'
+    Include editors/diff_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'reports a change in normal format'
+        When call TestDiffNormal
+        The line 1 of output should equal '2c2'
+        The status should equal 1
+    End
+    It 'is silent and succeeds for identical files'
+        When call TestDiffSame
+        The output should equal ''
+        The status should be success
+    End
+    It 'reports briefly with -q'
+        When call TestDiffBrief
+        The output should include 'differ'
+        The status should equal 1
+    End
+End

--- a/test/it/spec/sed_spec.sh
+++ b/test/it/spec/sed_spec.sh
@@ -1,0 +1,25 @@
+Describe 'sed'
+    Include editors/sed_test.sh
+
+    It 'substitutes the first match'
+        When call TestSedSubstitute
+        The output should equal 'hello sed'
+        The status should be success
+    End
+    It 'substitutes globally'
+        When call TestSedGlobal
+        The output should equal 'b b b'
+        The status should be success
+    End
+    It 'deletes a line by number'
+        When call TestSedDelete
+        The line 1 of output should equal '1'
+        The line 2 of output should equal '3'
+        The status should be success
+    End
+    It 'prints a single line with -n'
+        When call TestSedPrintN
+        The output should equal 'y'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

New editors category with two GNU-style applets.

| Command | Description | Issue |
|---|---|---|
| sed | Stream editor for filtering and transforming text | #72 |
| diff | Compare files line by line | #73 |

sed: the substitute command s/re/repl/flags (flags g, p, i/I, Nth occurrence), plus p, d and q. Each command takes an optional address: a line number, $ (last line) or /regexp/, as a single address or an addr1,addr2 range. Options: -n (suppress auto-print), -e SCRIPT (repeatable), -f FILE, -E/-r (extended regexp), -i (in-place). Patterns are POSIX basic regexps by default (translated to Go RE2) and extended with -E. Replacements support & and \1..\9.

diff: line-by-line comparison via an LCS edit script. Normal (ed-style) output by default, -u for unified output with 3 lines of context, -q for brief, -i to ignore case. Exit status 0 (identical), 1 (different), 2 (error).

## Testing

- Unit tests with t.Parallel() and table sub-tests. Coverage: sed 88.0%, diff 90.9%.
- shellspec integration tests for both.
- golangci-lint clean; command list regenerated.

Closes #72, #73.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `diff` command for file comparison, supporting normal and unified diff output formats, brief mode for existence-only checks, and case-insensitive comparison
  * Added `sed` command as a stream editor, featuring text substitution, line deletion, selective printing, in-place file editing, and extended regular expression support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->