### PR TITLE
feat: add awk and patch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 98 commands. Run `mimixbox --list` to see them on the terminal.
+There are 100 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
 | add-shell | Add shell name to /etc/shells |
 | ar | Create, modify and extract from archives |
+| awk | Pattern scanning and processing language |
 | base64 | Base64 encode/decode from FILR(or STDIN) to STDOUT |
 | basename | Print basename (PATH without "/") from file path |
 | bunzip2 | Decompress bzip2 (.bz2) files |
@@ -75,6 +76,7 @@ There are 98 commands. Run `mimixbox --list` to see them on the terminal.
 | mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY |
 | nl | Write each FILE to standard output with line numbers added |
 | od | Dump files in octal and other formats |
+| patch | Apply a diff file to an original |
 | path | Manipulate filename path |
 | poweroff | Power off the system |
 | printenv | Print environment variable |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -40,7 +40,9 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
 	removeShell "github.com/nao1215/mimixbox/internal/applets/debianutils/remove-shell"
 	"github.com/nao1215/mimixbox/internal/applets/debianutils/which"
+	"github.com/nao1215/mimixbox/internal/applets/editors/awk"
 	"github.com/nao1215/mimixbox/internal/applets/editors/diff"
+	"github.com/nao1215/mimixbox/internal/applets/editors/patch"
 	"github.com/nao1215/mimixbox/internal/applets/editors/sed"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/chgrp"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/chown"
@@ -145,6 +147,7 @@ func init() {
 	Applets = map[string]Applet{
 		"add-shell": reg(addShell.New()),
 		"ar":        reg(ar.New()),
+		"awk":       reg(awk.New()),
 		"base64":    reg(base64.New()),
 		"basename":  reg(basename.New()),
 		"bunzip2":   reg(bunzip2.New()),
@@ -198,6 +201,7 @@ func init() {
 		"mv":           reg(mv.New()),
 		"nl":           reg(nl.New()),
 		"od":           reg(od.New()),
+		"patch":        reg(patch.New()),
 		"path":         reg(path.New()),
 		"poweroff":     reg(halt.NewPoweroff()),
 		"printenv":     reg(printenv.New()),

--- a/internal/applets/editors/awk/awk.go
+++ b/internal/applets/editors/awk/awk.go
@@ -1,0 +1,126 @@
+// Package awk implements the awk applet: a deliberately small subset of the awk
+// language that covers the everyday one-liners. It supports BEGIN/END blocks,
+// /regexp/ and comparison patterns, field variables ($0, $1..$NF, NR, NF) and
+// the print statement with -F to choose the field separator and -v to preset
+// variables.
+package awk
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the awk applet.
+type Command struct{}
+
+// New returns an awk command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "awk" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Pattern scanning and processing language" }
+
+// Run executes awk.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-F sep] [-v var=val]... 'program' [FILE]...", stdio.Err)
+	sep := fs.StringP("field-separator", "F", "", "use sep as the input field separator")
+	assigns := fs.StringArrayP("assign", "v", nil, "assign var=value before execution")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	operands := fs.Args()
+	if len(operands) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "awk: no program text")
+		return command.SilentFailure()
+	}
+	programText := operands[0]
+	files := operands[1:]
+
+	rules, err := parseProgram(programText)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "awk: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	st := &state{
+		out:  stdio.Out,
+		fs:   *sep,
+		ofs:  " ",
+		vars: map[string]string{},
+	}
+	for _, a := range *assigns {
+		if k, v, ok := strings.Cut(a, "="); ok {
+			st.vars[k] = v
+		}
+	}
+
+	// BEGIN blocks run before any input.
+	for _, r := range rules {
+		if r.kind == ruleBegin {
+			st.exec(r)
+		}
+	}
+
+	if hasMainOrEnd(rules) {
+		if err := st.process(stdio, files, rules); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "awk: %v\n", err)
+			return command.SilentFailure()
+		}
+	}
+
+	for _, r := range rules {
+		if r.kind == ruleEnd {
+			st.exec(r)
+		}
+	}
+	return nil
+}
+
+// hasMainOrEnd reports whether any rule needs the input to be read.
+func hasMainOrEnd(rules []rule) bool {
+	for _, r := range rules {
+		if r.kind != ruleBegin {
+			return true
+		}
+	}
+	return false
+}
+
+// process reads each input file (or stdin) line by line and applies the
+// non-BEGIN rules.
+func (st *state) process(stdio command.IO, files []string, rules []rule) error {
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+	for _, f := range files {
+		r, err := command.Open(stdio, f)
+		if err != nil {
+			return fmt.Errorf("%s", command.FileError(f, err))
+		}
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			st.nr++
+			st.setLine(scanner.Text())
+			for _, rl := range rules {
+				if rl.kind == ruleMain && st.match(rl.pattern) {
+					st.exec(rl)
+				}
+			}
+		}
+		_ = r.Close()
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/applets/editors/awk/awk_test.go
+++ b/internal/applets/editors/awk/awk_test.go
@@ -1,0 +1,251 @@
+package awk_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/editors/awk"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := awk.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := awk.New()
+	if got := c.Name(); got != "awk" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestPrintWholeLine(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a b\nc d\n", "{print}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "a b\nc d\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestPrintField(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "one two three\n", "{print $2}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "two\n" {
+		t.Errorf("out = %q, want two", out)
+	}
+}
+
+func TestPrintMultipleFields(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a b c\n", "{print $1, $3}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "a c\n" {
+		t.Errorf("out = %q, want 'a c'", out)
+	}
+}
+
+func TestFieldSeparator(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "root:x:0:0\n", "-F", ":", "{print $1}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "root\n" {
+		t.Errorf("out = %q, want root", out)
+	}
+}
+
+func TestRegexPattern(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "apple\nbanana\ncherry\n", "/an/{print}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "banana\n" {
+		t.Errorf("out = %q, want banana", out)
+	}
+}
+
+func TestRegexDefaultAction(t *testing.T) {
+	t.Parallel()
+	// A bare /regex/ pattern prints matching lines.
+	out, _, err := run(t, "yes\nno\nyes\n", "/yes/")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "yes\nyes\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestNRComparison(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "l1\nl2\nl3\n", "NR==2")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "l2\n" {
+		t.Errorf("out = %q, want l2", out)
+	}
+}
+
+func TestFieldComparison(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "alice 30\nbob 25\n", "$2 > 27 {print $1}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "alice\n" {
+		t.Errorf("out = %q, want alice", out)
+	}
+}
+
+func TestStringComparison(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "cat\ndog\ncat\n", `$1 == "cat"`)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "cat\ncat\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestNF(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a b c\n", "{print NF}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "3\n" {
+		t.Errorf("out = %q, want 3", out)
+	}
+}
+
+func TestLastField(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a b c d\n", "{print $NF}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "d\n" {
+		t.Errorf("out = %q, want d", out)
+	}
+}
+
+func TestBeginEnd(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "x\ny\nz\n", "BEGIN{print \"start\"} END{print NR}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "start\n3\n" {
+		t.Errorf("out = %q, want start\\n3", out)
+	}
+}
+
+func TestVarAssign(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "x\n", "-v", "name=world", "{print name}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "world\n" {
+		t.Errorf("out = %q, want world", out)
+	}
+}
+
+func TestStringLiteral(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\n", `{print "hello", $1}`)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "hello a\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestPrintf(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "bob\n", `{printf "name=%s\n", $1}`)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "name=bob\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestFileOperand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(f, []byte("p q\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "", "{print $2}", f)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "q\n" {
+		t.Errorf("out = %q, want q", out)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no program", nil, "no program"},
+		{"missing file", []string{"{print}", "/no/such/file/zz"}, "awk:"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errOut, err := run(t, "", tt.args...)
+			if err == nil {
+				t.Errorf("expected error for %v", tt.args)
+			}
+			if !strings.Contains(errOut, tt.want) {
+				t.Errorf("stderr = %q, want %q", errOut, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: awk") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/internal/applets/editors/awk/eval.go
+++ b/internal/applets/editors/awk/eval.go
@@ -1,0 +1,328 @@
+package awk
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ruleKind distinguishes BEGIN, END and ordinary (main) rules.
+type ruleKind int
+
+const (
+	ruleMain ruleKind = iota
+	ruleBegin
+	ruleEnd
+)
+
+// rule is one "pattern { action }" entry from the program.
+type rule struct {
+	kind    ruleKind
+	pattern string // raw pattern text ("" means always)
+	action  string // raw action text ("" means default: print $0)
+}
+
+// parseProgram splits a program into rules. Rules are separated by newlines (or
+// by the boundaries of brace blocks); each rule is "pattern { action }",
+// "pattern" or "{ action }".
+func parseProgram(text string) ([]rule, error) {
+	var rules []rule
+	i := 0
+	for i < len(text) {
+		// Skip separators.
+		for i < len(text) && (text[i] == ' ' || text[i] == '\t' || text[i] == '\n' || text[i] == ';') {
+			i++
+		}
+		if i >= len(text) {
+			break
+		}
+		// Read the pattern up to '{' or a rule separator.
+		start := i
+		for i < len(text) && text[i] != '{' && text[i] != '\n' {
+			i++
+		}
+		pattern := strings.TrimSpace(text[start:i])
+		action := ""
+		if i < len(text) && text[i] == '{' {
+			depth := 0
+			as := i
+			for i < len(text) {
+				if text[i] == '{' {
+					depth++
+				} else if text[i] == '}' {
+					depth--
+					if depth == 0 {
+						i++
+						break
+					}
+				}
+				i++
+			}
+			if depth != 0 {
+				return nil, fmt.Errorf("syntax error: unbalanced braces")
+			}
+			inner := text[as+1 : i-1]
+			action = strings.TrimSpace(inner)
+		}
+
+		r := rule{kind: ruleMain, pattern: pattern, action: action}
+		switch pattern {
+		case "BEGIN":
+			r.kind, r.pattern = ruleBegin, ""
+		case "END":
+			r.kind, r.pattern = ruleEnd, ""
+		}
+		rules = append(rules, r)
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("empty program")
+	}
+	return rules, nil
+}
+
+// state is the runtime context shared across rules.
+type state struct {
+	out    io.Writer
+	fs     string
+	ofs    string
+	vars   map[string]string
+	fields []string // fields[0] == $0
+	nf     int
+	nr     int
+}
+
+// setLine splits a new input record into fields.
+func (st *state) setLine(line string) {
+	st.fields = []string{line}
+	var parts []string
+	switch {
+	case st.fs == "" || st.fs == " ":
+		parts = strings.Fields(line)
+	case len(st.fs) == 1:
+		parts = strings.Split(line, st.fs)
+	default:
+		re, err := regexp.Compile(st.fs)
+		if err != nil {
+			parts = strings.Split(line, st.fs)
+		} else {
+			parts = re.Split(line, -1)
+		}
+	}
+	st.fields = append(st.fields, parts...)
+	st.nf = len(parts)
+}
+
+// field returns the i-th field ($0 is the whole record).
+func (st *state) field(i int) string {
+	if i == 0 {
+		if len(st.fields) > 0 {
+			return st.fields[0]
+		}
+		return ""
+	}
+	if i >= 1 && i < len(st.fields) {
+		return st.fields[i]
+	}
+	return ""
+}
+
+// match evaluates a rule pattern against the current record.
+func (st *state) match(pattern string) bool {
+	if pattern == "" {
+		return true
+	}
+	if strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/") && len(pattern) >= 2 {
+		re, err := regexp.Compile(pattern[1 : len(pattern)-1])
+		if err != nil {
+			return false
+		}
+		return re.MatchString(st.field(0))
+	}
+	return st.evalCondition(pattern)
+}
+
+// comparisonOps are the relational operators understood in patterns, longest
+// first so "<=" is matched before "<".
+var comparisonOps = []string{"==", "!=", "<=", ">=", "<", ">"}
+
+// evalCondition evaluates a simple comparison pattern such as NR==2 or $1=="x".
+// A bare value is true when it is a non-zero number or a non-empty string.
+func (st *state) evalCondition(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	for _, op := range comparisonOps {
+		if idx := strings.Index(expr, op); idx >= 0 {
+			lhs := st.evalPrimary(strings.TrimSpace(expr[:idx]))
+			rhs := st.evalPrimary(strings.TrimSpace(expr[idx+len(op):]))
+			return compare(lhs, rhs, op)
+		}
+	}
+	v := st.evalPrimary(expr)
+	if n, err := strconv.ParseFloat(v, 64); err == nil {
+		return n != 0
+	}
+	return v != ""
+}
+
+// compare applies a relational operator, numerically when both sides parse as
+// numbers and lexically otherwise.
+func compare(lhs, rhs, op string) bool {
+	ln, lerr := strconv.ParseFloat(lhs, 64)
+	rn, rerr := strconv.ParseFloat(rhs, 64)
+	if lerr == nil && rerr == nil {
+		switch op {
+		case "==":
+			return ln == rn
+		case "!=":
+			return ln != rn
+		case "<":
+			return ln < rn
+		case "<=":
+			return ln <= rn
+		case ">":
+			return ln > rn
+		case ">=":
+			return ln >= rn
+		}
+	}
+	switch op {
+	case "==":
+		return lhs == rhs
+	case "!=":
+		return lhs != rhs
+	case "<":
+		return lhs < rhs
+	case "<=":
+		return lhs <= rhs
+	case ">":
+		return lhs > rhs
+	case ">=":
+		return lhs >= rhs
+	}
+	return false
+}
+
+// evalPrimary resolves a single value: $n, NR, NF, a "string" literal, a named
+// -v variable, or a numeric/!bare token.
+func (st *state) evalPrimary(tok string) string {
+	tok = strings.TrimSpace(tok)
+	switch {
+	case tok == "":
+		return ""
+	case tok == "NR":
+		return strconv.Itoa(st.nr)
+	case tok == "NF":
+		return strconv.Itoa(st.nf)
+	case tok == "$0":
+		return st.field(0)
+	case strings.HasPrefix(tok, "$"):
+		idxTok := tok[1:]
+		switch idxTok {
+		case "NF":
+			return st.field(st.nf)
+		case "NR":
+			return st.field(st.nr)
+		}
+		if n, err := strconv.Atoi(idxTok); err == nil {
+			return st.field(n)
+		}
+		return ""
+	case len(tok) >= 2 && tok[0] == '"' && tok[len(tok)-1] == '"':
+		return tok[1 : len(tok)-1]
+	}
+	if v, ok := st.vars[tok]; ok {
+		return v
+	}
+	return tok
+}
+
+// exec runs a rule's action (default: print $0).
+func (st *state) exec(r rule) {
+	action := r.action
+	if action == "" {
+		_, _ = fmt.Fprintln(st.out, st.field(0))
+		return
+	}
+	for _, stmt := range splitStatements(action) {
+		st.execStatement(strings.TrimSpace(stmt))
+	}
+}
+
+// splitStatements splits an action body on top-level ';' and newlines.
+func splitStatements(action string) []string {
+	fields := strings.FieldsFunc(action, func(r rune) bool {
+		return r == ';' || r == '\n'
+	})
+	return fields
+}
+
+// execStatement runs one statement; only print/printf are supported.
+func (st *state) execStatement(stmt string) {
+	switch {
+	case stmt == "print" || stmt == "":
+		_, _ = fmt.Fprintln(st.out, st.field(0))
+	case strings.HasPrefix(stmt, "printf"):
+		args := strings.TrimSpace(strings.TrimPrefix(stmt, "printf"))
+		st.doPrintf(args)
+	case strings.HasPrefix(stmt, "print"):
+		args := strings.TrimSpace(strings.TrimPrefix(stmt, "print"))
+		st.doPrint(args)
+	}
+}
+
+// doPrint prints comma-separated values joined by OFS.
+func (st *state) doPrint(args string) {
+	if args == "" {
+		_, _ = fmt.Fprintln(st.out, st.field(0))
+		return
+	}
+	parts := splitTopComma(args)
+	vals := make([]string, 0, len(parts))
+	for _, p := range parts {
+		vals = append(vals, st.evalPrimary(strings.TrimSpace(p)))
+	}
+	_, _ = fmt.Fprintln(st.out, strings.Join(vals, st.ofs))
+}
+
+// doPrintf implements a minimal printf: the first argument is a "format" string
+// and %s/%d are filled from the remaining values.
+func (st *state) doPrintf(args string) {
+	parts := splitTopComma(args)
+	if len(parts) == 0 {
+		return
+	}
+	format := st.evalPrimary(strings.TrimSpace(parts[0]))
+	var vals []any
+	for _, p := range parts[1:] {
+		vals = append(vals, st.evalPrimary(strings.TrimSpace(p)))
+	}
+	_, _ = fmt.Fprintf(st.out, unescape(format), vals...)
+}
+
+// splitTopComma splits on commas that are not inside a double-quoted string.
+func splitTopComma(s string) []string {
+	var parts []string
+	var b strings.Builder
+	inQuote := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch == '"' {
+			inQuote = !inQuote
+		}
+		if ch == ',' && !inQuote {
+			parts = append(parts, b.String())
+			b.Reset()
+			continue
+		}
+		b.WriteByte(ch)
+	}
+	parts = append(parts, b.String())
+	return parts
+}
+
+// unescape resolves the common backslash escapes in a printf format string.
+func unescape(s string) string {
+	r := strings.NewReplacer(`\n`, "\n", `\t`, "\t", `\\`, "\\")
+	return r.Replace(s)
+}

--- a/internal/applets/editors/patch/parse.go
+++ b/internal/applets/editors/patch/parse.go
@@ -1,0 +1,188 @@
+package patch
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// hunk is one @@ block of a unified diff.
+type hunk struct {
+	oldStart int
+	oldLen   int
+	newStart int
+	newLen   int
+	lines    []string // each begins with ' ', '-' or '+'
+}
+
+// filePatch is the set of hunks for one file, with its --- and +++ names.
+type filePatch struct {
+	oldName string
+	newName string
+	hunks   []hunk
+}
+
+// parseUnified parses unified-diff text into per-file patches.
+func parseUnified(text string) ([]filePatch, error) {
+	lines := strings.Split(text, "\n")
+	var patches []filePatch
+	var cur *filePatch
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		switch {
+		case strings.HasPrefix(line, "--- "):
+			if i+1 >= len(lines) || !strings.HasPrefix(lines[i+1], "+++ ") {
+				return nil, fmt.Errorf("malformed header near line %d", i+1)
+			}
+			patches = append(patches, filePatch{
+				oldName: strings.TrimSpace(strings.TrimPrefix(line, "--- ")),
+				newName: strings.TrimSpace(strings.TrimPrefix(lines[i+1], "+++ ")),
+			})
+			cur = &patches[len(patches)-1]
+			i += 2
+		case strings.HasPrefix(line, "@@"):
+			if cur == nil {
+				return nil, fmt.Errorf("hunk before file header")
+			}
+			h, next, err := parseHunk(lines, i)
+			if err != nil {
+				return nil, err
+			}
+			cur.hunks = append(cur.hunks, h)
+			i = next
+		default:
+			i++
+		}
+	}
+	return patches, nil
+}
+
+// parseHunk parses one @@ header and its body starting at index start.
+func parseHunk(lines []string, start int) (hunk, int, error) {
+	var h hunk
+	header := lines[start]
+	os1, ol, ns, nl, err := parseHunkHeader(header)
+	if err != nil {
+		return h, start, err
+	}
+	h.oldStart, h.oldLen, h.newStart, h.newLen = os1, ol, ns, nl
+
+	i := start + 1
+	for i < len(lines) {
+		l := lines[i]
+		if l == "" && i == len(lines)-1 {
+			break
+		}
+		if strings.HasPrefix(l, "@@") || strings.HasPrefix(l, "--- ") {
+			break
+		}
+		if len(l) == 0 {
+			// A truly empty line counts as a context line containing "".
+			h.lines = append(h.lines, " ")
+			i++
+			continue
+		}
+		switch l[0] {
+		case ' ', '-', '+':
+			h.lines = append(h.lines, l)
+			i++
+		case '\\':
+			// "\ No newline at end of file" - ignore.
+			i++
+		default:
+			// End of hunk body.
+			return h, i, nil
+		}
+	}
+	return h, i, nil
+}
+
+// parseHunkHeader parses "@@ -l,s +l,s @@".
+func parseHunkHeader(s string) (oldStart, oldLen, newStart, newLen int, err error) {
+	fields := strings.Fields(s)
+	if len(fields) < 3 || fields[0] != "@@" {
+		return 0, 0, 0, 0, fmt.Errorf("bad hunk header: %q", s)
+	}
+	oldStart, oldLen, err = parseRange(strings.TrimPrefix(fields[1], "-"))
+	if err != nil {
+		return
+	}
+	newStart, newLen, err = parseRange(strings.TrimPrefix(fields[2], "+"))
+	return
+}
+
+// parseRange parses "start,len" or "start" (len defaults to 1).
+func parseRange(s string) (start, length int, err error) {
+	length = 1
+	if idx := strings.IndexByte(s, ','); idx >= 0 {
+		length, err = strconv.Atoi(s[idx+1:])
+		if err != nil {
+			return
+		}
+		s = s[:idx]
+	}
+	start, err = strconv.Atoi(s)
+	return
+}
+
+// reverseHunks swaps the add/remove sense of every hunk so a patch can be
+// un-applied.
+func reverseHunks(fp *filePatch) {
+	for hi := range fp.hunks {
+		h := &fp.hunks[hi]
+		h.oldStart, h.newStart = h.newStart, h.oldStart
+		h.oldLen, h.newLen = h.newLen, h.oldLen
+		for li, l := range h.lines {
+			if l == "" {
+				continue
+			}
+			switch l[0] {
+			case '-':
+				h.lines[li] = "+" + l[1:]
+			case '+':
+				h.lines[li] = "-" + l[1:]
+			}
+		}
+	}
+}
+
+// applyHunks applies every hunk to orig and returns the patched lines.
+func applyHunks(orig []string, hunks []hunk) ([]string, error) {
+	var out []string
+	pos := 0 // 0-based index into orig
+	for _, h := range hunks {
+		target := h.oldStart - 1
+		if target < 0 {
+			target = 0
+		}
+		if target > len(orig) {
+			return nil, fmt.Errorf("hunk start %d beyond end of file", h.oldStart)
+		}
+		// Copy unchanged lines before the hunk.
+		out = append(out, orig[pos:target]...)
+		pos = target
+
+		for _, l := range h.lines {
+			tag, text := l[0], l[1:]
+			switch tag {
+			case ' ':
+				if pos >= len(orig) || orig[pos] != text {
+					return nil, fmt.Errorf("context mismatch at line %d", pos+1)
+				}
+				out = append(out, orig[pos])
+				pos++
+			case '-':
+				if pos >= len(orig) || orig[pos] != text {
+					return nil, fmt.Errorf("delete mismatch at line %d", pos+1)
+				}
+				pos++
+			case '+':
+				out = append(out, text)
+			}
+		}
+	}
+	// Copy whatever remains after the last hunk.
+	out = append(out, orig[pos:]...)
+	return out, nil
+}

--- a/internal/applets/editors/patch/patch.go
+++ b/internal/applets/editors/patch/patch.go
@@ -1,0 +1,159 @@
+// Package patch implements the patch applet: apply a unified diff (as produced
+// by "diff -u") to the target files. It reads the patch from a file given with
+// -i or from standard input, supports -pN path stripping, -R reverse
+// application and --dry-run.
+package patch
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the patch applet.
+type Command struct{}
+
+// New returns a patch command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "patch" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Apply a diff file to an original" }
+
+// Run executes patch.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [ORIGFILE]", stdio.Err)
+	strip := fs.IntP("strip", "p", 0, "strip NUM leading components from file names")
+	input := fs.StringP("input", "i", "", "read patch from FILE instead of stdin")
+	reverse := fs.BoolP("reverse", "R", false, "assume patches were created with old and new swapped")
+	dryRun := fs.Bool("dry-run", false, "print the results without changing any files")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	var patchText string
+	if *input != "" {
+		data, err := os.ReadFile(*input) //nolint:gosec // user-named patch file
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "patch: %s\n", command.FileError(*input, err))
+			return command.SilentFailure()
+		}
+		patchText = string(data)
+	} else {
+		var b strings.Builder
+		sc := bufio.NewScanner(stdio.In)
+		sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+		for sc.Scan() {
+			b.WriteString(sc.Text())
+			b.WriteByte('\n')
+		}
+		patchText = b.String()
+	}
+
+	patches, err := parseUnified(patchText)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "patch: %v\n", err)
+		return command.SilentFailure()
+	}
+	if len(patches) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "patch: no valid patches in input")
+		return command.SilentFailure()
+	}
+
+	// An explicit ORIGFILE operand overrides the file name in the patch (used
+	// for single-file patches).
+	override := ""
+	if rest := fs.Args(); len(rest) > 0 {
+		override = rest[0]
+	}
+
+	var failed bool
+	for i := range patches {
+		fp := &patches[i]
+		if *reverse {
+			reverseHunks(fp)
+		}
+		target := override
+		if target == "" {
+			target = pickName(fp, *strip, *reverse)
+		}
+		if err := applyFile(stdio, target, fp, *dryRun); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "patch: %v\n", err)
+			failed = true
+			continue
+		}
+		if !*dryRun {
+			_, _ = fmt.Fprintf(stdio.Out, "patching file %s\n", target)
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// pickName chooses the target file name from the patch headers, applying -p
+// stripping. For reverse patches the old name is the target.
+func pickName(fp *filePatch, strip int, reverse bool) string {
+	name := fp.newName
+	if reverse {
+		name = fp.oldName
+	}
+	return stripComponents(name, strip)
+}
+
+// stripComponents removes the first n path components from a patch file name.
+func stripComponents(name string, n int) string {
+	name = strings.TrimSpace(name)
+	// Drop a trailing tab-separated timestamp if present.
+	if i := strings.IndexByte(name, '\t'); i >= 0 {
+		name = name[:i]
+	}
+	for i := 0; i < n; i++ {
+		if idx := strings.IndexByte(name, '/'); idx >= 0 {
+			name = name[idx+1:]
+		}
+	}
+	return name
+}
+
+// applyFile applies a file patch to its target on disk.
+func applyFile(stdio command.IO, target string, fp *filePatch, dryRun bool) error {
+	data, err := os.ReadFile(target) //nolint:gosec // user-named target file
+	if err != nil {
+		return fmt.Errorf("cannot open %s", command.FileError(target, err))
+	}
+	orig := splitLinesKeep(string(data))
+
+	result, err := applyHunks(orig, fp.hunks)
+	if err != nil {
+		return fmt.Errorf("%s: %v", target, err)
+	}
+
+	out := strings.Join(result, "\n")
+	if len(result) > 0 {
+		out += "\n"
+	}
+	if dryRun {
+		_, _ = fmt.Fprintf(stdio.Out, "checking file %s\n", target)
+		return nil
+	}
+	return os.WriteFile(target, []byte(out), 0o644) //nolint:gosec // preserve simple default mode
+}
+
+// splitLinesKeep splits text into lines, dropping a single trailing newline.
+func splitLinesKeep(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.TrimSuffix(s, "\n")
+	return strings.Split(s, "\n")
+}

--- a/internal/applets/editors/patch/patch_test.go
+++ b/internal/applets/editors/patch/patch_test.go
@@ -1,0 +1,209 @@
+package patch_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/editors/patch"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := patch.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := patch.New()
+	if got := c.Name(); got != "patch" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+// unifiedPatch returns a unified diff that turns "one\ntwo\nthree\n" into
+// "one\n2\nthree\n" for the file named target.
+func unifiedPatch(target string) string {
+	return "--- " + target + "\n" +
+		"+++ " + target + "\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		" one\n" +
+		"-two\n" +
+		"+2\n" +
+		" three\n"
+}
+
+func TestApplyUnified(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, errOut, err := run(t, unifiedPatch(target)); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "one\n2\nthree\n" {
+		t.Errorf("patched = %q", got)
+	}
+}
+
+func TestApplyFromInputFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	patchFile := filepath.Join(dir, "p.diff")
+	if err := os.WriteFile(patchFile, []byte(unifiedPatch(target)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, errOut, err := run(t, "", "-i", patchFile); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "one\n2\nthree\n" {
+		t.Errorf("patched = %q", got)
+	}
+}
+
+func TestReverse(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	// Already-patched file; -R should undo it back to the original.
+	if err := os.WriteFile(target, []byte("one\n2\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, errOut, err := run(t, unifiedPatch(target), "-R"); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "one\ntwo\nthree\n" {
+		t.Errorf("reversed = %q", got)
+	}
+}
+
+func TestStrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Patch names the file as a/<target> and b/<target>; -p1 strips the prefix.
+	diff := "--- a/" + target + "\n" +
+		"+++ b/" + target + "\n" +
+		"@@ -1,3 +1,3 @@\n one\n-two\n+2\n three\n"
+	if _, errOut, err := run(t, diff, "-p1"); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "one\n2\nthree\n" {
+		t.Errorf("patched = %q", got)
+	}
+}
+
+func TestDryRun(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	orig := "one\ntwo\nthree\n"
+	if err := os.WriteFile(target, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, unifiedPatch(target), "--dry-run"); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != orig {
+		t.Errorf("--dry-run modified the file: %q", got)
+	}
+}
+
+func TestAddAndDelete(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Delete b, add X after c.
+	diff := "--- " + target + "\n+++ " + target + "\n" +
+		"@@ -1,3 +1,3 @@\n a\n-b\n c\n+X\n"
+	if _, errOut, err := run(t, diff); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "a\nc\nX\n" {
+		t.Errorf("patched = %q, want a\\nc\\nX", got)
+	}
+}
+
+func TestContextMismatch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("totally\ndifferent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, unifiedPatch(target))
+	if err == nil {
+		t.Error("expected error on context mismatch")
+	}
+	if !strings.Contains(errOut, "patch:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+		_, errOut, err := run(t, "")
+		if err == nil {
+			t.Error("expected error for empty patch")
+		}
+		if !strings.Contains(errOut, "no valid patches") {
+			t.Errorf("stderr = %q", errOut)
+		}
+	})
+	t.Run("missing input file", func(t *testing.T) {
+		t.Parallel()
+		_, errOut, err := run(t, "", "-i", "/no/such/patch/file")
+		if err == nil {
+			t.Error("expected error for missing -i file")
+		}
+		if !strings.Contains(errOut, "patch:") {
+			t.Errorf("stderr = %q", errOut)
+		}
+	})
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: patch") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/test/it/editors/awk_test.sh
+++ b/test/it/editors/awk_test.sh
@@ -1,0 +1,12 @@
+TestAwkField() {
+    printf 'one two three\n' | awk '{print $2}'
+}
+TestAwkFS() {
+    printf 'root:x:0\n' | awk -F: '{print $1}'
+}
+TestAwkNR() {
+    printf 'a\nb\nc\n' | awk 'NR==2'
+}
+TestAwkEnd() {
+    printf 'a\nb\nc\n' | awk 'END{print NR}'
+}

--- a/test/it/editors/patch_test.sh
+++ b/test/it/editors/patch_test.sh
@@ -1,0 +1,17 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/patch
+    mkdir -p ${TEST_DIR}
+    printf 'one\ntwo\nthree\n' > ${TEST_DIR}/f.txt
+    {
+        printf -- '--- %s\n' "${TEST_DIR}/f.txt"
+        printf -- '+++ %s\n' "${TEST_DIR}/f.txt"
+        printf '@@ -1,3 +1,3 @@\n one\n-two\n+2\n three\n'
+    } > ${TEST_DIR}/p.diff
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/patch; }
+
+TestPatchApply() {
+    export TEST_DIR=/tmp/mimixbox/it/patch
+    patch -i ${TEST_DIR}/p.diff >/dev/null
+    printf '%s' "$(< ${TEST_DIR}/f.txt)"
+}

--- a/test/it/spec/awk_spec.sh
+++ b/test/it/spec/awk_spec.sh
@@ -1,0 +1,24 @@
+Describe 'awk'
+    Include editors/awk_test.sh
+
+    It 'prints a field'
+        When call TestAwkField
+        The output should equal 'two'
+        The status should be success
+    End
+    It 'honors -F'
+        When call TestAwkFS
+        The output should equal 'root'
+        The status should be success
+    End
+    It 'selects a record with NR'
+        When call TestAwkNR
+        The output should equal 'b'
+        The status should be success
+    End
+    It 'counts records in END'
+        When call TestAwkEnd
+        The output should equal '3'
+        The status should be success
+    End
+End

--- a/test/it/spec/patch_spec.sh
+++ b/test/it/spec/patch_spec.sh
@@ -1,0 +1,13 @@
+Describe 'patch'
+    Include editors/patch_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'applies a unified diff'
+        When call TestPatchApply
+        The output should equal 'one
+2
+three'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Two more editors-category applets.

| Command | Description | Issue |
|---|---|---|
| awk | Pattern scanning and processing language | #71 |
| patch | Apply a diff file to an original | #74 |

awk implements a practical subset: BEGIN/END blocks; patterns that are empty (always), /regexp/, or a comparison (NR==2, $1=="x", $2>27, NF); field variables $0, $1..$NF, NR, NF; the print statement (comma-separated values joined by OFS) and a minimal printf; options -F (field separator) and -v var=value.

patch applies a unified diff (as produced by diff -u) to its target files. It reads the patch from -i FILE or stdin, supports -pN path stripping, -R reverse application and --dry-run. Context and deletion lines are verified before a hunk is applied.

## Testing

- Unit tests with t.Parallel() and sub-tests. Coverage: awk 83.3%, patch 86.8%.
- shellspec integration tests for both.
- golangci-lint clean; command list regenerated.

Closes #71, #74.