### PR TITLE
feat: add a minimal vi editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The GIF above is generated from [assets/demo.tape](./assets/demo.tape) with [vhs
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 100 commands. Run `mimixbox --list` to see them on the terminal.
+There are 101 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -118,6 +118,7 @@ There are 100 commands. Run `mimixbox --list` to see them on the terminal.
 | unzip | Extract files from a ZIP archive |
 | uuidgen | Print UUID (Universal Unique IDentifier |
 | valid-shell | Verify if /etc/shells is valid |
+| vi | A minimal vi-style screen text editor |
 | wc | Print newline, word, and byte counts for each file |
 | wget | The non-interactive network downloader |
 | which | Returns the file path which would be executed in the current environment |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -44,6 +44,7 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/editors/diff"
 	"github.com/nao1215/mimixbox/internal/applets/editors/patch"
 	"github.com/nao1215/mimixbox/internal/applets/editors/sed"
+	"github.com/nao1215/mimixbox/internal/applets/editors/vi"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/chgrp"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/chown"
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/cp"
@@ -237,6 +238,7 @@ func init() {
 		"uniq":         reg(uniq.New()),
 		"unix2dos":     reg(unix2dos.New()),
 		"unzip":        reg(unzip.New()),
+		"vi":           reg(vi.New()),
 		"uuidgen":      reg(uuidgen.New()),
 		"valid-shell":  reg(validShell.New()),
 		"wc":           reg(wc.New()),

--- a/internal/applets/editors/vi/editor.go
+++ b/internal/applets/editors/vi/editor.go
@@ -1,0 +1,303 @@
+package vi
+
+import "strings"
+
+// mode is the editor's current input mode.
+type mode int
+
+const (
+	modeNormal mode = iota
+	modeInsert
+	modeCommand // typing a ":" ex command
+)
+
+// editor is the in-memory editing state. It is deliberately decoupled from any
+// terminal so the whole command model can be unit-tested by feeding it bytes.
+type editor struct {
+	lines    []string
+	cx, cy   int // cursor column and row (0-based)
+	mode     mode
+	pending  byte   // first key of a two-key command (d, g, Z)
+	cmdline  string // accumulates the ":" command
+	filename string
+	dirty    bool
+	quit     bool   // set when the editor should stop
+	save     bool   // set when the buffer should be written on quit
+	message  string // status message (e.g. for :q with unsaved changes)
+}
+
+// newEditor builds an editor over the given file contents.
+func newEditor(filename, content string) *editor {
+	lines := []string{""}
+	if content != "" {
+		lines = strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+	}
+	return &editor{lines: lines, filename: filename, mode: modeNormal}
+}
+
+// content returns the buffer as a string with a trailing newline.
+func (e *editor) content() string {
+	return strings.Join(e.lines, "\n") + "\n"
+}
+
+// feed processes one input byte according to the current mode.
+func (e *editor) feed(b byte) {
+	switch e.mode {
+	case modeInsert:
+		e.feedInsert(b)
+	case modeCommand:
+		e.feedCommand(b)
+	default:
+		e.feedNormal(b)
+	}
+}
+
+// feedString feeds every byte of s in order (handy for tests and batch mode).
+func (e *editor) feedString(s string) {
+	for i := 0; i < len(s) && !e.quit; i++ {
+		e.feed(s[i])
+	}
+}
+
+const esc = 0x1b
+
+// feedNormal handles a key in normal mode.
+func (e *editor) feedNormal(b byte) {
+	// Resolve a pending two-key command first.
+	if e.pending != 0 {
+		first := e.pending
+		e.pending = 0
+		switch {
+		case first == 'd' && b == 'd':
+			e.deleteLine()
+		case first == 'g' && b == 'g':
+			e.cy, e.cx = 0, 0
+		case first == 'Z' && b == 'Z':
+			e.save = true
+			e.quit = true
+		}
+		return
+	}
+
+	switch b {
+	case 'h':
+		e.moveLeft()
+	case 'l':
+		e.moveRight()
+	case 'j':
+		e.moveDown()
+	case 'k':
+		e.moveUp()
+	case '0':
+		e.cx = 0
+	case '$':
+		e.cx = lastCol(e.lines[e.cy])
+	case 'G':
+		e.cy = len(e.lines) - 1
+		e.clampX()
+	case 'x':
+		e.deleteRune()
+	case 'i':
+		e.mode = modeInsert
+	case 'a':
+		if len(e.lines[e.cy]) > 0 {
+			e.cx++
+		}
+		e.mode = modeInsert
+	case 'A':
+		e.cx = len(e.lines[e.cy])
+		e.mode = modeInsert
+	case 'o':
+		e.openBelow()
+	case 'O':
+		e.openAbove()
+	case 'd', 'g', 'Z':
+		e.pending = b
+	case ':':
+		e.mode = modeCommand
+		e.cmdline = ""
+	}
+}
+
+// feedInsert handles a key in insert mode.
+func (e *editor) feedInsert(b byte) {
+	switch b {
+	case esc:
+		e.mode = modeNormal
+		if e.cx > 0 {
+			e.cx--
+		}
+	case '\r', '\n':
+		e.splitLine()
+	case 0x7f, 0x08: // DEL / backspace
+		e.backspace()
+	default:
+		e.insertRune(b)
+	}
+}
+
+// feedCommand accumulates and then runs a ":" command on Enter.
+func (e *editor) feedCommand(b byte) {
+	switch b {
+	case '\r', '\n':
+		e.runExCommand(e.cmdline)
+		e.mode = modeNormal
+		e.cmdline = ""
+	case esc:
+		e.mode = modeNormal
+		e.cmdline = ""
+	case 0x7f, 0x08:
+		if len(e.cmdline) > 0 {
+			e.cmdline = e.cmdline[:len(e.cmdline)-1]
+		}
+	default:
+		e.cmdline += string(b)
+	}
+}
+
+// runExCommand interprets the small set of ":" commands.
+func (e *editor) runExCommand(cmd string) {
+	switch cmd {
+	case "w":
+		e.save = true
+	case "wq", "x":
+		e.save = true
+		e.quit = true
+	case "q":
+		if e.dirty {
+			e.message = "E37: No write since last change (add ! to override)"
+			return
+		}
+		e.quit = true
+	case "q!":
+		e.quit = true
+	}
+}
+
+// --- buffer operations ---
+
+func (e *editor) moveLeft() {
+	if e.cx > 0 {
+		e.cx--
+	}
+}
+
+func (e *editor) moveRight() {
+	if e.cx < lastCol(e.lines[e.cy]) {
+		e.cx++
+	}
+}
+
+func (e *editor) moveDown() {
+	if e.cy < len(e.lines)-1 {
+		e.cy++
+		e.clampX()
+	}
+}
+
+func (e *editor) moveUp() {
+	if e.cy > 0 {
+		e.cy--
+		e.clampX()
+	}
+}
+
+func (e *editor) clampX() {
+	if m := lastCol(e.lines[e.cy]); e.cx > m {
+		e.cx = m
+	}
+}
+
+func (e *editor) deleteRune() {
+	line := e.lines[e.cy]
+	if e.cx < len(line) {
+		e.lines[e.cy] = line[:e.cx] + line[e.cx+1:]
+		e.dirty = true
+		e.clampX()
+	}
+}
+
+func (e *editor) deleteLine() {
+	if len(e.lines) == 1 {
+		e.lines[0] = ""
+	} else {
+		e.lines = append(e.lines[:e.cy], e.lines[e.cy+1:]...)
+		if e.cy >= len(e.lines) {
+			e.cy = len(e.lines) - 1
+		}
+	}
+	e.cx = 0
+	e.dirty = true
+}
+
+func (e *editor) openBelow() {
+	e.lines = insertAt(e.lines, e.cy+1, "")
+	e.cy++
+	e.cx = 0
+	e.mode = modeInsert
+	e.dirty = true
+}
+
+func (e *editor) openAbove() {
+	e.lines = insertAt(e.lines, e.cy, "")
+	e.cx = 0
+	e.mode = modeInsert
+	e.dirty = true
+}
+
+func (e *editor) insertRune(b byte) {
+	line := e.lines[e.cy]
+	if e.cx > len(line) {
+		e.cx = len(line)
+	}
+	e.lines[e.cy] = line[:e.cx] + string(b) + line[e.cx:]
+	e.cx++
+	e.dirty = true
+}
+
+func (e *editor) splitLine() {
+	line := e.lines[e.cy]
+	if e.cx > len(line) {
+		e.cx = len(line)
+	}
+	head, tail := line[:e.cx], line[e.cx:]
+	e.lines[e.cy] = head
+	e.lines = insertAt(e.lines, e.cy+1, tail)
+	e.cy++
+	e.cx = 0
+	e.dirty = true
+}
+
+func (e *editor) backspace() {
+	if e.cx > 0 {
+		line := e.lines[e.cy]
+		e.lines[e.cy] = line[:e.cx-1] + line[e.cx:]
+		e.cx--
+		e.dirty = true
+		return
+	}
+	if e.cy > 0 {
+		prev := e.lines[e.cy-1]
+		e.cx = len(prev)
+		e.lines[e.cy-1] = prev + e.lines[e.cy]
+		e.lines = append(e.lines[:e.cy], e.lines[e.cy+1:]...)
+		e.cy--
+		e.dirty = true
+	}
+}
+
+// lastCol is the rightmost column the cursor may rest on in normal mode.
+func lastCol(line string) int {
+	if len(line) == 0 {
+		return 0
+	}
+	return len(line) - 1
+}
+
+// insertAt inserts v into s at index i.
+func insertAt(s []string, i int, v string) []string {
+	s = append(s, "")
+	copy(s[i+1:], s[i:])
+	s[i] = v
+	return s
+}

--- a/internal/applets/editors/vi/editor_test.go
+++ b/internal/applets/editors/vi/editor_test.go
@@ -1,0 +1,313 @@
+package vi
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// drive builds an editor over content and feeds it the keystroke script.
+func drive(content, keys string) *editor {
+	e := newEditor("test.txt", content)
+	e.feedString(keys)
+	return e
+}
+
+func TestNewEditor(t *testing.T) {
+	t.Parallel()
+	e := newEditor("f", "")
+	if len(e.lines) != 1 || e.lines[0] != "" {
+		t.Errorf("empty file should yield one empty line, got %v", e.lines)
+	}
+	e = newEditor("f", "a\nb\n")
+	if len(e.lines) != 2 || e.lines[0] != "a" || e.lines[1] != "b" {
+		t.Errorf("lines = %v, want [a b]", e.lines)
+	}
+}
+
+func TestContent(t *testing.T) {
+	t.Parallel()
+	e := newEditor("f", "x\ny")
+	if e.content() != "x\ny\n" {
+		t.Errorf("content = %q", e.content())
+	}
+}
+
+func TestInsertText(t *testing.T) {
+	t.Parallel()
+	// i, type "hi", ESC.
+	e := drive("", "ihi\x1b")
+	if e.lines[0] != "hi" {
+		t.Errorf("lines[0] = %q, want hi", e.lines[0])
+	}
+	if e.mode != modeNormal {
+		t.Errorf("ESC should return to normal mode")
+	}
+	if !e.dirty {
+		t.Error("buffer should be dirty after insert")
+	}
+}
+
+func TestAppend(t *testing.T) {
+	t.Parallel()
+	// On "ab", 'a' inserts after the cursor (col 0 -> after 'a').
+	e := drive("ab", "aX\x1b")
+	if e.lines[0] != "aXb" {
+		t.Errorf("lines[0] = %q, want aXb", e.lines[0])
+	}
+}
+
+func TestAppendEndOfLine(t *testing.T) {
+	t.Parallel()
+	e := drive("ab", "A!\x1b")
+	if e.lines[0] != "ab!" {
+		t.Errorf("lines[0] = %q, want ab!", e.lines[0])
+	}
+}
+
+func TestDeleteRune(t *testing.T) {
+	t.Parallel()
+	e := drive("abc", "x")
+	if e.lines[0] != "bc" {
+		t.Errorf("lines[0] = %q, want bc", e.lines[0])
+	}
+}
+
+func TestDeleteLine(t *testing.T) {
+	t.Parallel()
+	e := drive("one\ntwo\nthree", "jdd") // move to line 2, delete it
+	if len(e.lines) != 2 || e.lines[0] != "one" || e.lines[1] != "three" {
+		t.Errorf("lines = %v, want [one three]", e.lines)
+	}
+}
+
+func TestDeleteOnlyLine(t *testing.T) {
+	t.Parallel()
+	e := drive("solo", "dd")
+	if len(e.lines) != 1 || e.lines[0] != "" {
+		t.Errorf("lines = %v, want one empty line", e.lines)
+	}
+}
+
+func TestOpenBelow(t *testing.T) {
+	t.Parallel()
+	e := drive("top", "oNEW\x1b")
+	if len(e.lines) != 2 || e.lines[1] != "NEW" {
+		t.Errorf("lines = %v, want [top NEW]", e.lines)
+	}
+}
+
+func TestOpenAbove(t *testing.T) {
+	t.Parallel()
+	e := drive("bottom", "ONEW\x1b")
+	if len(e.lines) != 2 || e.lines[0] != "NEW" || e.lines[1] != "bottom" {
+		t.Errorf("lines = %v, want [NEW bottom]", e.lines)
+	}
+}
+
+func TestMotions(t *testing.T) {
+	t.Parallel()
+	e := newEditor("f", "abcde\nfghij")
+	e.feedString("ll") // cx -> 2
+	if e.cx != 2 {
+		t.Errorf("cx = %d, want 2", e.cx)
+	}
+	e.feedString("$")
+	if e.cx != 4 {
+		t.Errorf("$ -> cx = %d, want 4", e.cx)
+	}
+	e.feedString("0")
+	if e.cx != 0 {
+		t.Errorf("0 -> cx = %d, want 0", e.cx)
+	}
+	e.feedString("j")
+	if e.cy != 1 {
+		t.Errorf("j -> cy = %d, want 1", e.cy)
+	}
+	e.feedString("G")
+	if e.cy != 1 {
+		t.Errorf("G -> cy = %d, want last line 1", e.cy)
+	}
+	e.feedString("gg")
+	if e.cy != 0 {
+		t.Errorf("gg -> cy = %d, want 0", e.cy)
+	}
+}
+
+func TestSplitAndBackspace(t *testing.T) {
+	t.Parallel()
+	// Insert at start, press Enter to split "abc" -> "" and "abc".
+	e := drive("abc", "i\r\x1b")
+	if len(e.lines) != 2 || e.lines[0] != "" || e.lines[1] != "abc" {
+		t.Errorf("after split lines = %v", e.lines)
+	}
+
+	// Backspace joining: on line 2 col 0, insert-mode backspace joins lines.
+	e2 := newEditor("f", "ab\ncd")
+	e2.feedString("j")  // line 2
+	e2.feedString("i")  // insert at col 0
+	e2.feedString("\x7f") // backspace -> join
+	if len(e2.lines) != 1 || e2.lines[0] != "abcd" {
+		t.Errorf("after join lines = %v, want [abcd]", e2.lines)
+	}
+}
+
+func TestExWriteQuit(t *testing.T) {
+	t.Parallel()
+	e := drive("data", ":wq\r")
+	if !e.save || !e.quit {
+		t.Errorf("save=%v quit=%v, want both true", e.save, e.quit)
+	}
+}
+
+func TestExWriteThenQuit(t *testing.T) {
+	t.Parallel()
+	e := drive("x", "iY\x1b:w\r")
+	if !e.save {
+		t.Error(":w should set save")
+	}
+	if e.quit {
+		t.Error(":w alone should not quit")
+	}
+}
+
+func TestExQuitDirtyBlocked(t *testing.T) {
+	t.Parallel()
+	e := drive("x", "iY\x1b:q\r")
+	if e.quit {
+		t.Error(":q with unsaved changes should not quit")
+	}
+	if e.message == "" {
+		t.Error("expected a warning message")
+	}
+}
+
+func TestExQuitForce(t *testing.T) {
+	t.Parallel()
+	e := drive("x", "iY\x1b:q!\r")
+	if !e.quit {
+		t.Error(":q! should quit")
+	}
+	if e.save {
+		t.Error(":q! should not save")
+	}
+}
+
+func TestZZ(t *testing.T) {
+	t.Parallel()
+	e := drive("x", "ZZ")
+	if !e.save || !e.quit {
+		t.Errorf("ZZ save=%v quit=%v, want both true", e.save, e.quit)
+	}
+}
+
+func TestCommandModeEscapeAndBackspace(t *testing.T) {
+	t.Parallel()
+	// ":" then type "wX", backspace removes X, ESC cancels -> no save.
+	e := drive("x", ":wX\x7f\x1b")
+	if e.save || e.quit {
+		t.Errorf("ESC should cancel the command, save=%v quit=%v", e.save, e.quit)
+	}
+	if e.mode != modeNormal {
+		t.Error("ESC should return to normal mode")
+	}
+}
+
+func TestRedraw(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		keys string
+		want string
+	}{
+		{"normal status", "", "NORMAL"},
+		{"insert status", "i", "INSERT"},
+		{"command line", ":w", ":w"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := drive("alpha\nbeta", tt.keys)
+			var b bytes.Buffer
+			redraw(&b, e)
+			out := b.String()
+			if !strings.Contains(out, "alpha") || !strings.Contains(out, "beta") {
+				t.Errorf("redraw missing buffer text: %q", out)
+			}
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("redraw = %q, want it to contain %q", out, tt.want)
+			}
+			if !strings.Contains(out, "\x1b[2J") {
+				t.Errorf("redraw should clear the screen: %q", out)
+			}
+		})
+	}
+}
+
+func TestRedrawDirtyAndMessage(t *testing.T) {
+	t.Parallel()
+	// Dirty marker after an edit.
+	e := drive("x", "iY\x1b")
+	var b bytes.Buffer
+	redraw(&b, e)
+	if !strings.Contains(b.String(), "[+]") {
+		t.Errorf("redraw should show dirty marker: %q", b.String())
+	}
+
+	// A status message (e.g. from :q on a dirty buffer) is shown verbatim.
+	e2 := drive("x", "iY\x1b:q\r")
+	var b2 bytes.Buffer
+	redraw(&b2, e2)
+	if !strings.Contains(b2.String(), "No write since last change") {
+		t.Errorf("redraw should show the message: %q", b2.String())
+	}
+}
+
+func TestIsTerminalNonFile(t *testing.T) {
+	t.Parallel()
+	if isTerminal(strings.NewReader("x")) {
+		t.Error("a strings.Reader is not a terminal")
+	}
+}
+
+func TestIsTerminalPipeIsNotTTY(t *testing.T) {
+	t.Parallel()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close(); _ = w.Close() }()
+	if isTerminal(r) {
+		t.Error("an os.Pipe read end is not a terminal")
+	}
+}
+
+// TestRunInteractiveFallsBackOnPipe verifies that runInteractive degrades to
+// batch processing when its input is an *os.File that is not a real terminal
+// (the TCGETS ioctl fails on a pipe).
+func TestRunInteractiveFallsBackOnPipe(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, werr := w.WriteString("x:wq\r"); werr != nil {
+		t.Fatal(werr)
+	}
+	_ = w.Close()
+	defer func() { _ = r.Close() }()
+
+	e := newEditor("f", "abc")
+	out := &bytes.Buffer{}
+	runInteractive(command.IO{In: r, Out: out, Err: &bytes.Buffer{}}, e)
+
+	if e.lines[0] != "bc" {
+		t.Errorf("batch fallback should have applied 'x': lines[0] = %q", e.lines[0])
+	}
+	if !e.save || !e.quit {
+		t.Errorf("batch fallback should have run :wq (save=%v quit=%v)", e.save, e.quit)
+	}
+}

--- a/internal/applets/editors/vi/vi.go
+++ b/internal/applets/editors/vi/vi.go
@@ -1,0 +1,168 @@
+// Package vi implements a small vi-style modal text editor. It is intentionally
+// minimal: it supports the everyday motions (h/j/k/l, 0, $, gg, G), edits
+// (x, dd, i, a, A, o, O) and the ex commands :w, :q, :q!, :wq and ZZ.
+//
+// When standard input is a terminal it runs interactively with a redrawn
+// screen; when input is a pipe or file (as in tests) it consumes the input as a
+// keystroke script and writes the file on :w/:wq/ZZ, which keeps the whole
+// editor automatically testable.
+package vi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the vi applet.
+type Command struct{}
+
+// New returns a vi command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "vi" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "A minimal vi-style screen text editor" }
+
+// Run executes vi.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err)
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	filename := ""
+	if rest := fs.Args(); len(rest) > 0 {
+		filename = rest[0]
+	}
+
+	content := ""
+	if filename != "" {
+		if data, rerr := os.ReadFile(filename); rerr == nil { //nolint:gosec // user-named file
+			content = string(data)
+		} else if !os.IsNotExist(rerr) {
+			_, _ = fmt.Fprintf(stdio.Err, "vi: %s\n", command.FileError(filename, rerr))
+			return command.SilentFailure()
+		}
+	}
+
+	ed := newEditor(filename, content)
+
+	if isTerminal(stdio.In) {
+		runInteractive(stdio, ed)
+	} else {
+		runBatch(stdio, ed)
+	}
+
+	if ed.save {
+		if filename == "" {
+			_, _ = fmt.Fprintln(stdio.Err, "vi: no file name")
+			return command.SilentFailure()
+		}
+		if err := os.WriteFile(filename, []byte(ed.content()), 0o644); err != nil { //nolint:gosec // simple default mode
+			_, _ = fmt.Fprintf(stdio.Err, "vi: %v\n", err)
+			return command.SilentFailure()
+		}
+	}
+	return nil
+}
+
+// runBatch feeds all input bytes to the editor as a keystroke script.
+func runBatch(stdio command.IO, ed *editor) {
+	data, _ := io.ReadAll(stdio.In)
+	ed.feedString(string(data))
+}
+
+// isTerminal reports whether r is a character device (a real terminal).
+func isTerminal(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// runInteractive drives the editor in raw mode, redrawing the screen after each
+// keystroke until the editor asks to quit.
+func runInteractive(stdio command.IO, ed *editor) {
+	f, ok := stdio.In.(*os.File)
+	if !ok {
+		runBatch(stdio, ed)
+		return
+	}
+	fd := int(f.Fd())
+	old, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		runBatch(stdio, ed)
+		return
+	}
+	raw := *old
+	raw.Lflag &^= unix.ECHO | unix.ICANON | unix.ISIG | unix.IEXTEN
+	raw.Iflag &^= unix.IXON | unix.ICRNL | unix.BRKINT | unix.INPCK | unix.ISTRIP
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &raw); err != nil {
+		runBatch(stdio, ed)
+		return
+	}
+	defer func() { _ = unix.IoctlSetTermios(fd, unix.TCSETS, old) }()
+
+	buf := make([]byte, 1)
+	for !ed.quit {
+		redraw(stdio.Out, ed)
+		n, err := f.Read(buf)
+		if err != nil || n == 0 {
+			return
+		}
+		ed.feed(buf[0])
+	}
+	redraw(stdio.Out, ed)
+}
+
+// redraw clears the screen and paints the buffer, a status line and the cursor.
+func redraw(w io.Writer, ed *editor) {
+	var b []byte
+	b = append(b, "\x1b[2J\x1b[H"...) // clear, home
+	for _, line := range ed.lines {
+		b = append(b, line...)
+		b = append(b, "\r\n"...)
+	}
+	status := fmt.Sprintf("\x1b[7m %s%s mode=%s \x1b[0m", ed.filename, dirtyMark(ed), modeName(ed.mode))
+	if ed.mode == modeCommand {
+		status = ":" + ed.cmdline
+	}
+	if ed.message != "" {
+		status = ed.message
+	}
+	b = append(b, status...)
+	// Position the cursor (1-based).
+	b = append(b, fmt.Sprintf("\x1b[%d;%dH", ed.cy+1, ed.cx+1)...)
+	_, _ = w.Write(b)
+}
+
+func dirtyMark(ed *editor) string {
+	if ed.dirty {
+		return " [+]"
+	}
+	return ""
+}
+
+func modeName(m mode) string {
+	switch m {
+	case modeInsert:
+		return "INSERT"
+	case modeCommand:
+		return "COMMAND"
+	default:
+		return "NORMAL"
+	}
+}

--- a/internal/applets/editors/vi/vi_test.go
+++ b/internal/applets/editors/vi/vi_test.go
@@ -1,0 +1,129 @@
+package vi_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/editors/vi"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	// A bytes.Reader is not an *os.File, so vi runs in batch (non-terminal) mode.
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := vi.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := vi.New()
+	if got := c.Name(); got != "vi" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestEditAndSave(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "doc.txt")
+	if err := os.WriteFile(f, []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the first character of line 1, then write & quit.
+	if _, errOut, err := run(t, "x:wq\r", f); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ello\nworld\n" {
+		t.Errorf("file = %q, want %q", got, "ello\nworld\n")
+	}
+}
+
+func TestInsertAndSave(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "doc.txt")
+	if err := os.WriteFile(f, []byte("bar\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Insert "foo" before the buffer, ESC, write & quit.
+	if _, errOut, err := run(t, "ifoo\x1b:wq\r", f); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != "foobar\n" {
+		t.Errorf("file = %q, want foobar", got)
+	}
+}
+
+func TestNoWriteWithoutSave(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "doc.txt")
+	if err := os.WriteFile(f, []byte("keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Edit but quit with :q! (no save) -> file unchanged.
+	if _, _, err := run(t, "x:q!\r", f); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != "keep\n" {
+		t.Errorf("file = %q, want unchanged 'keep'", got)
+	}
+}
+
+func TestCreateNewFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "new.txt")
+	// File does not exist yet; create content and save.
+	if _, errOut, err := run(t, "inew content\x1b:wq\r", f); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("expected file created: %v", err)
+	}
+	if string(got) != "new content\n" {
+		t.Errorf("file = %q", got)
+	}
+}
+
+func TestSaveWithoutFilename(t *testing.T) {
+	t.Parallel()
+	// No filename operand, but the script asks to write -> error.
+	_, errOut, err := run(t, "ihi\x1b:wq\r")
+	if err == nil {
+		t.Error("expected error saving with no file name")
+	}
+	if !strings.Contains(errOut, "no file name") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: vi") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/test/it/editors/vi_test.sh
+++ b/test/it/editors/vi_test.sh
@@ -1,0 +1,25 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    mkdir -p ${TEST_DIR}
+    printf 'hello\nworld\n' > ${TEST_DIR}/a.txt
+    printf 'bar\n' > ${TEST_DIR}/b.txt
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/vi; }
+
+TestViDeleteChar() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    printf 'x:wq\r' | vi ${TEST_DIR}/a.txt
+    printf '%s' "$(< ${TEST_DIR}/a.txt)"
+}
+
+TestViInsert() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    printf 'ifoo\033:wq\r' | vi ${TEST_DIR}/b.txt
+    printf '%s' "$(< ${TEST_DIR}/b.txt)"
+}
+
+TestViNewFile() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    printf 'icreated\033:wq\r' | vi ${TEST_DIR}/new.txt
+    printf '%s' "$(< ${TEST_DIR}/new.txt)"
+}

--- a/test/it/spec/vi_spec.sh
+++ b/test/it/spec/vi_spec.sh
@@ -1,0 +1,22 @@
+Describe 'vi'
+    Include editors/vi_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'deletes a character and writes the file'
+        When call TestViDeleteChar
+        The output should equal 'ello
+world'
+        The status should be success
+    End
+    It 'inserts text and writes the file'
+        When call TestViInsert
+        The output should equal 'foobar'
+        The status should be success
+    End
+    It 'creates a new file'
+        When call TestViNewFile
+        The output should equal 'created'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

A small vi-style modal text editor.

| Command | Description | Issue |
|---|---|---|
| vi | A minimal vi-style screen text editor | #75 |

Supported:
- motions: h/j/k/l, 0, $, gg, G
- edits: x (delete char), dd (delete line), i/a/A (insert), o/O (open line); insert mode with ESC to return to normal
- ex commands: :w, :q, :q!, :wq, ZZ — and :q refuses to quit a buffer with unsaved changes

Design: when standard input is a terminal, vi runs interactively in raw mode with a redrawn screen. When input is a pipe or file (tests, scripts), it consumes the input as a keystroke script and writes the file on :w/:wq/ZZ. This keeps the whole editor automatically testable without a pseudo-terminal.

## Out of scope

Visual mode, registers, undo, search (/), counts, and most ex commands. This is an MVP to get the command in place.

## Testing

- Unit tests for the editing core (motions, edits, insert/command modes, ex commands) and the redraw output. Coverage 80.6%. The raw-mode interactive loop itself needs a real TTY and is exercised only through its non-terminal fallback.
- shellspec tests drive keystroke scripts (delete, insert, create new file) end to end.
- golangci-lint clean; command list regenerated.

Closes #75.