### PR TITLE
feat: add compress and uncompress commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The GIF above is generated from [assets/demo.tape](./assets/demo.tape) with [vhs
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 101 commands. Run `mimixbox --list` to see them on the terminal.
+There are 103 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -39,6 +39,7 @@ There are 101 commands. Run `mimixbox --list` to see them on the terminal.
 | chroot | Run command or interactive shell with special root directory |
 | clear | Clear terminal |
 | cmp | Compare two files byte by byte |
+| compress | Compress files with LZW (.Z) |
 | cowsay | Print message with cow's ASCII art |
 | cp | Copy file(s) otr Directory(s) |
 | cpio | Copy files to and from archives |
@@ -112,6 +113,7 @@ There are 101 commands. Run `mimixbox --list` to see them on the terminal.
 | touch | Update the access and modification times of each FILE to the current time |
 | tr | Translate or delete characters |
 | true | Do nothing. Return success(0) |
+| uncompress | Decompress LZW (.Z) files |
 | unexpand | Convert N space to TAB(default:N=8) |
 | uniq | Report or omit repeated lines |
 | unix2dos | Change LF to CRLF |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -26,10 +26,12 @@ import (
 
 	"github.com/nao1215/mimixbox/internal/applets/archival/ar"
 	"github.com/nao1215/mimixbox/internal/applets/archival/bunzip2"
+	compressCmd "github.com/nao1215/mimixbox/internal/applets/archival/compress"
 	"github.com/nao1215/mimixbox/internal/applets/archival/cpio"
 	"github.com/nao1215/mimixbox/internal/applets/archival/gunzip"
 	gzipCmd "github.com/nao1215/mimixbox/internal/applets/archival/gzip"
 	tarCmd "github.com/nao1215/mimixbox/internal/applets/archival/tar"
+	"github.com/nao1215/mimixbox/internal/applets/archival/uncompress"
 	"github.com/nao1215/mimixbox/internal/applets/archival/unzip"
 	zipCmd "github.com/nao1215/mimixbox/internal/applets/archival/zip"
 	"github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
@@ -162,6 +164,7 @@ func init() {
 		//"chsh":         {chsh.Run, "Cqhange login shell"},
 		"clear":        reg(clear.New()),
 		"cmp":          reg(cmp.New()),
+		"compress":     reg(compressCmd.New()),
 		"cp":           reg(cp.New()),
 		"cpio":         reg(cpio.New()),
 		"cut":          reg(cut.New()),
@@ -234,6 +237,7 @@ func init() {
 		"touch":        reg(touch.New()),
 		"tr":           reg(tr.New()),
 		"true":         reg(booltrue.New()),
+		"uncompress":   reg(uncompress.New()),
 		"unexpand":     reg(unexpand.New()),
 		"uniq":         reg(uniq.New()),
 		"unix2dos":     reg(unix2dos.New()),

--- a/internal/applets/archival/compress/compress.go
+++ b/internal/applets/archival/compress/compress.go
@@ -1,0 +1,107 @@
+// Package compress implements the compress applet: compress files with the
+// classic Unix LZW algorithm, producing .Z files that the system
+// compress/uncompress and gzip can read. Each FILE becomes FILE.Z; with -c the
+// result is written to standard output and the input is left in place.
+package compress
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/applets/archival/lzw"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the compress applet.
+type Command struct{}
+
+// New returns a compress command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "compress" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Compress files with LZW (.Z)" }
+
+type options struct {
+	stdout bool
+	keep   bool
+	force  bool
+}
+
+// Run executes compress.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	stdout := fs.BoolP("stdout", "c", false, "write on standard output, keep original files unchanged")
+	keep := fs.BoolP("keep", "k", false, "keep (don't delete) input files")
+	force := fs.BoolP("force", "f", false, "force overwrite of output file")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	opts := options{stdout: *stdout, keep: *keep, force: *force}
+
+	files := fs.Args()
+	if len(files) == 0 || (len(files) == 1 && files[0] == "-") {
+		if err := lzw.Compress(stdio.In, stdio.Out); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "compress: %v\n", err)
+			return command.SilentFailure()
+		}
+		return nil
+	}
+
+	var failed bool
+	for _, f := range files {
+		if err := c.processFile(stdio, f, opts); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "compress: %v\n", err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// processFile compresses one file to FILE.Z (or to stdout with -c).
+func (c *Command) processFile(stdio command.IO, name string, opts options) error {
+	in, err := os.Open(name) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	if opts.stdout {
+		return lzw.Compress(in, stdio.Out)
+	}
+
+	if strings.HasSuffix(name, ".Z") {
+		return fmt.Errorf("%s already has .Z suffix -- unchanged", name)
+	}
+	out := name + ".Z"
+	if !opts.force {
+		if _, statErr := os.Stat(out); statErr == nil {
+			return fmt.Errorf("%s already exists; use -f to overwrite", out)
+		}
+	}
+
+	w, err := os.Create(out) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	if err := lzw.Compress(in, w); err != nil {
+		_ = w.Close()
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	if !opts.keep {
+		return os.Remove(name)
+	}
+	return nil
+}

--- a/internal/applets/archival/compress/compress_test.go
+++ b/internal/applets/archival/compress/compress_test.go
@@ -1,0 +1,181 @@
+package compress_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/archival/compress"
+	"github.com/nao1215/mimixbox/internal/applets/archival/lzw"
+	"github.com/nao1215/mimixbox/internal/applets/archival/uncompress"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin []byte, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: bytes.NewReader(stdin), Out: out, Err: errBuf}
+	err := compress.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := compress.New()
+	if got := c.Name(); got != "compress" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestStdinStdout(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, []byte("hello compress hello compress"))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Round-trip back through the decoder.
+	var dec bytes.Buffer
+	if derr := lzw.Decompress(strings.NewReader(out), &dec); derr != nil {
+		t.Fatalf("decompress err = %v", derr)
+	}
+	if dec.String() != "hello compress hello compress" {
+		t.Errorf("round trip = %q", dec.String())
+	}
+}
+
+func TestFileToZ(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "data.txt")
+	content := strings.Repeat("compress me ", 100)
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, errOut, err := run(t, nil, f); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	// FILE becomes FILE.Z and the original is removed.
+	if _, statErr := os.Stat(f); statErr == nil {
+		t.Error("original should be removed without -k")
+	}
+	zf := f + ".Z"
+	zdata, err := os.ReadFile(zf)
+	if err != nil {
+		t.Fatalf("expected %s: %v", zf, err)
+	}
+	var dec bytes.Buffer
+	if derr := lzw.Decompress(bytes.NewReader(zdata), &dec); derr != nil {
+		t.Fatalf("decompress err = %v", derr)
+	}
+	if dec.String() != content {
+		t.Error("decompressed content mismatch")
+	}
+}
+
+func TestKeep(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "k.txt")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, nil, "-k", f); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if _, statErr := os.Stat(f); statErr != nil {
+		t.Errorf("-k should keep input: %v", statErr)
+	}
+}
+
+func TestStdoutFlag(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "c.txt")
+	if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, nil, "-c", f)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.HasPrefix(out, "\x1f\x9d") {
+		t.Error("-c should write a .Z stream to stdout")
+	}
+	if _, statErr := os.Stat(f); statErr != nil {
+		t.Error("-c should keep the input")
+	}
+}
+
+func TestAppletRoundTripWithUncompress(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "rt.txt")
+	content := strings.Repeat("round trip ", 50)
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, nil, f); err != nil {
+		t.Fatalf("compress err = %v", err)
+	}
+	// Now decompress with the uncompress applet.
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := uncompress.New().Run(context.Background(), io, []string{f + ".Z"}); err != nil {
+		t.Fatalf("uncompress err = %v", err)
+	}
+	got, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("expected restored file: %v", err)
+	}
+	if string(got) != content {
+		t.Error("applet round trip mismatch")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		_, errOut, err := run(t, nil, filepath.Join(dir, "nope"))
+		if err == nil {
+			t.Error("expected error for missing file")
+		}
+		if !strings.Contains(errOut, "compress:") {
+			t.Errorf("stderr = %q", errOut)
+		}
+	})
+	t.Run("already .Z", func(t *testing.T) {
+		t.Parallel()
+		zf := filepath.Join(dir, "already.Z")
+		if err := os.WriteFile(zf, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, errOut, err := run(t, nil, zf)
+		if err == nil {
+			t.Error("expected error for .Z input")
+		}
+		if !strings.Contains(errOut, ".Z suffix") {
+			t.Errorf("stderr = %q", errOut)
+		}
+	})
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, nil, "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: compress") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/internal/applets/archival/lzw/lzw.go
+++ b/internal/applets/archival/lzw/lzw.go
@@ -1,0 +1,334 @@
+// Package lzw implements the Unix "compress" (.Z) variant of LZW, compatible
+// with the system compress/uncompress and with gzip -d. It is shared by the
+// compress and uncompress applets.
+//
+// The format: a 3-byte header (0x1F, 0x9D, max_bits|0x80 for block mode)
+// followed by variable-width LZW codes packed least-significant-bit first, in
+// "blocks" of eight codes so that the bit width can grow from 9 up to max_bits.
+// Code 256 is the CLEAR code (block mode) and codes are assigned from 257.
+package lzw
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+)
+
+const (
+	magic1    = 0x1f
+	magic2    = 0x9d
+	blockMode = 0x80
+	initBits  = 9
+	maxBits   = 16
+	clearCode = 256
+	firstCode = 257 // first dictionary entry in block mode
+)
+
+// Compress reads r and writes the .Z-compressed stream to w.
+func Compress(r io.Reader, w io.Writer) error {
+	br := bufio.NewReader(r)
+	bw := bufio.NewWriter(w)
+
+	if _, err := bw.Write([]byte{magic1, magic2, byte(maxBits | blockMode)}); err != nil {
+		return err
+	}
+
+	e := &encoder{bw: bw, nBits: initBits, maxCode: (1 << initBits) - 1, free: firstCode}
+	e.resetDict()
+
+	first, err := br.ReadByte()
+	if err == io.EOF {
+		return e.finish()
+	}
+	if err != nil {
+		return err
+	}
+	ent := int(first)
+
+	for {
+		b, err := br.ReadByte()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		c := int(b)
+		key := (c << maxBits) | ent
+		if next, ok := e.dict[key]; ok {
+			ent = next
+			continue
+		}
+		if err := e.output(ent); err != nil {
+			return err
+		}
+		if e.free < (1 << maxBits) {
+			e.dict[key] = e.free
+			e.free++
+		} else {
+			if err := e.output(clearCode); err != nil {
+				return err
+			}
+			e.resetDict()
+		}
+		ent = c
+	}
+	if err := e.output(ent); err != nil {
+		return err
+	}
+	return e.finish()
+}
+
+// encoder holds the LZW compression state.
+type encoder struct {
+	bw      *bufio.Writer
+	dict    map[int]int
+	nBits   uint
+	maxCode int
+	free    int
+
+	buf    [maxBits]byte // accumulates one block of nBits codes
+	offset uint          // bit offset within buf
+	nCodes int           // codes accumulated since the last width change
+}
+
+// resetDict clears the dictionary and resets the code width, as a CLEAR does.
+func (e *encoder) resetDict() {
+	e.dict = make(map[int]int, 1<<maxBits)
+	e.nBits = initBits
+	e.maxCode = (1 << initBits) - 1
+	e.free = firstCode
+	e.nCodes = 0
+}
+
+// output writes one code using the current width, growing the width on block
+// boundaries the way ncompress does.
+func (e *encoder) output(code int) error {
+	// Pack code at the current bit offset, LSB first (may span up to 3 bytes).
+	r := e.offset
+	for i := uint(0); i < e.nBits; i++ {
+		if code&(1<<i) != 0 {
+			e.buf[(r+i)>>3] |= 1 << ((r + i) & 7)
+		}
+	}
+	e.offset += e.nBits
+	e.nCodes++
+
+	if e.offset == e.nBits<<3 { // a full block of 8 codes
+		if _, err := e.bw.Write(e.buf[:e.nBits]); err != nil {
+			return err
+		}
+		e.clearBuf()
+	}
+
+	// After CLEAR, the width resets to initBits (handled by resetDict, but the
+	// block must be flushed first).
+	if code == clearCode {
+		return e.flushBlock()
+	}
+
+	// Grow the width when the dictionary has filled the current code space.
+	if e.free > e.maxCode && e.nBits < maxBits {
+		if err := e.flushBlock(); err != nil {
+			return err
+		}
+		e.nBits++
+		e.maxCode = (1 << e.nBits) - 1
+	}
+	return nil
+}
+
+// flushBlock writes any partial block and resets the block counters, which is
+// what ncompress does at every width change and clear.
+func (e *encoder) flushBlock() error {
+	if e.offset > 0 {
+		n := (e.offset + 7) >> 3
+		if _, err := e.bw.Write(e.buf[:n]); err != nil {
+			return err
+		}
+		e.clearBuf()
+	}
+	e.nCodes = 0
+	return nil
+}
+
+func (e *encoder) clearBuf() {
+	for i := range e.buf {
+		e.buf[i] = 0
+	}
+	e.offset = 0
+}
+
+// finish flushes the last partial block and the writer.
+func (e *encoder) finish() error {
+	if e.offset > 0 {
+		n := (e.offset + 7) >> 3
+		if _, err := e.bw.Write(e.buf[:n]); err != nil {
+			return err
+		}
+	}
+	return e.bw.Flush()
+}
+
+// Decompress reads a .Z stream from r and writes the original bytes to w.
+func Decompress(r io.Reader, w io.Writer) error {
+	br := bufio.NewReader(r)
+	bw := bufio.NewWriter(w)
+
+	hdr := make([]byte, 3)
+	if _, err := io.ReadFull(br, hdr); err != nil {
+		return fmt.Errorf("not a .Z file")
+	}
+	if hdr[0] != magic1 || hdr[1] != magic2 {
+		return fmt.Errorf("not a .Z file")
+	}
+	mb := int(hdr[2] & 0x1f)
+	block := hdr[2]&blockMode != 0
+	if mb < initBits || mb > maxBits {
+		return fmt.Errorf("unsupported max bits %d", mb)
+	}
+
+	d := &decoder{br: br, bw: bw, maxBits: mb, block: block}
+	if err := d.run(); err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+// decoder holds the LZW decompression state.
+type decoder struct {
+	br      *bufio.Reader
+	bw      *bufio.Writer
+	maxBits int
+	block   bool
+
+	prefix [1 << maxBits]int
+	suffix [1 << maxBits]byte
+	stack  []byte
+}
+
+// run performs the decompression loop, mirroring the encoder's blocked,
+// growing-width packing.
+func (d *decoder) run() error {
+	nBits := uint(initBits)
+	maxCode := func(n uint) int { return (1 << n) - 1 }
+	free := firstCode
+	if !d.block {
+		free = clearCode
+	}
+
+	// Block-aligned bit reader state.
+	var buf [maxBits]byte
+	var size int // bits available in buf
+	var bitPos int
+
+	readCode := func() (int, bool, error) {
+		if bitPos >= size || free > maxCode(nBits) {
+			// Width change or buffer exhausted: refill on a block boundary.
+			if free > maxCode(nBits) && nBits < uint(d.maxBits) {
+				nBits++
+			}
+			n, err := io.ReadFull(d.br, buf[:nBits])
+			if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
+				return 0, false, nil
+			}
+			if err != nil && err != io.ErrUnexpectedEOF {
+				return 0, false, err
+			}
+			size = n << 3
+			bitPos = 0
+			if size == 0 {
+				return 0, false, nil
+			}
+		}
+		if bitPos+int(nBits) > size {
+			return 0, false, nil
+		}
+		code := 0
+		for i := uint(0); i < nBits; i++ {
+			if buf[(bitPos+int(i))>>3]&(1<<uint((bitPos+int(i))&7)) != 0 {
+				code |= 1 << i
+			}
+		}
+		bitPos += int(nBits)
+		return code, true, nil
+	}
+
+	// Initialize single-byte entries.
+	for i := 0; i < 256; i++ {
+		d.suffix[i] = byte(i)
+	}
+
+	resetWidth := func() {
+		nBits = initBits
+		free = firstCode
+		size = 0
+		bitPos = 0
+	}
+
+	first, ok, err := readCode()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	prevCode := first
+	if err := d.bw.WriteByte(byte(first)); err != nil {
+		return err
+	}
+	finChar := byte(first)
+
+	for {
+		code, ok, err := readCode()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+		if d.block && code == clearCode {
+			free = firstCode
+			resetWidth()
+			c, ok, err := readCode()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+			prevCode = c
+			finChar = byte(c)
+			if err := d.bw.WriteByte(finChar); err != nil {
+				return err
+			}
+			continue
+		}
+
+		cur := code
+		d.stack = d.stack[:0]
+		if code >= free {
+			// KwKwK case: emit prevCode's string + its first char.
+			d.stack = append(d.stack, finChar)
+			cur = prevCode
+		}
+		for cur >= 256 {
+			d.stack = append(d.stack, d.suffix[cur])
+			cur = d.prefix[cur]
+		}
+		finChar = byte(cur)
+		d.stack = append(d.stack, finChar)
+		for i := len(d.stack) - 1; i >= 0; i-- {
+			if err := d.bw.WriteByte(d.stack[i]); err != nil {
+				return err
+			}
+		}
+
+		if free < (1 << d.maxBits) {
+			d.prefix[free] = prevCode
+			d.suffix[free] = finChar
+			free++
+		}
+		prevCode = code
+	}
+}

--- a/internal/applets/archival/lzw/lzw_test.go
+++ b/internal/applets/archival/lzw/lzw_test.go
@@ -1,0 +1,152 @@
+package lzw_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/archival/lzw"
+)
+
+func roundTrip(t *testing.T, data []byte) {
+	t.Helper()
+	var z bytes.Buffer
+	if err := lzw.Compress(bytes.NewReader(data), &z); err != nil {
+		t.Fatalf("Compress error = %v", err)
+	}
+	// The stream must start with the .Z magic and block-mode max-bits byte.
+	b := z.Bytes()
+	if len(b) < 3 || b[0] != 0x1f || b[1] != 0x9d {
+		t.Fatalf("missing .Z magic: % x", b[:min(3, len(b))])
+	}
+	var out bytes.Buffer
+	if err := lzw.Decompress(bytes.NewReader(b), &out); err != nil {
+		t.Fatalf("Decompress error = %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), data) {
+		t.Errorf("round trip mismatch: got %d bytes, want %d", out.Len(), len(data))
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", []byte{}},
+		{"single", []byte("a")},
+		{"repeated", []byte(strings.Repeat("ab", 1000))},
+		{"text", []byte("the quick brown fox jumps over the lazy dog\n")},
+		{"all bytes", func() []byte {
+			b := make([]byte, 1024)
+			for i := range b {
+				b[i] = byte(i % 256)
+			}
+			return b
+		}()},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			roundTrip(t, tt.data)
+		})
+	}
+}
+
+func TestLargeInputGrowsWidth(t *testing.T) {
+	t.Parallel()
+	// A large, varied input forces the code width to grow past 9 bits and
+	// eventually issue CLEAR codes, exercising the block-alignment logic.
+	var b bytes.Buffer
+	for i := 0; i < 20000; i++ {
+		b.WriteString("line ")
+		b.WriteByte(byte('a' + i%26))
+		b.WriteByte('\n')
+	}
+	roundTrip(t, b.Bytes())
+}
+
+// failWriter returns an error after allowing n bytes through, to exercise the
+// codec's write-error branches.
+type failWriter struct {
+	n int
+}
+
+func (f *failWriter) Write(p []byte) (int, error) {
+	if f.n <= 0 {
+		return 0, errFail
+	}
+	if len(p) > f.n {
+		w := f.n
+		f.n = 0
+		return w, errFail
+	}
+	f.n -= len(p)
+	return len(p), nil
+}
+
+type fixedErr struct{}
+
+func (fixedErr) Error() string { return "boom" }
+
+var errFail = fixedErr{}
+
+func TestCompressWriteErrors(t *testing.T) {
+	t.Parallel()
+	// A large, varied input compresses to well over bufio's 4 KiB buffer, so a
+	// limited writer surfaces errors at the inner block writes, not just at the
+	// final flush.
+	var buf bytes.Buffer
+	for i := 0; i < 60000; i++ {
+		buf.WriteString("entry ")
+		buf.WriteByte(byte('a' + i%26))
+		buf.WriteByte(byte('0' + i%10))
+		buf.WriteByte('\n')
+	}
+	data := buf.Bytes()
+	for _, budget := range []int{0, 8, 5000, 9000} {
+		budget := budget
+		t.Run("budget", func(t *testing.T) {
+			t.Parallel()
+			if err := lzw.Compress(bytes.NewReader(data), &failWriter{n: budget}); err == nil {
+				t.Errorf("expected a write error at budget %d", budget)
+			}
+		})
+	}
+}
+
+func TestDecompressWriteError(t *testing.T) {
+	t.Parallel()
+	var z bytes.Buffer
+	if err := lzw.Compress(strings.NewReader(strings.Repeat("abc", 500)), &z); err != nil {
+		t.Fatal(err)
+	}
+	if err := lzw.Decompress(bytes.NewReader(z.Bytes()), &failWriter{n: 4}); err == nil {
+		t.Error("expected a write error during decompression")
+	}
+}
+
+func TestDecompressRejectsNonZ(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if err := lzw.Decompress(strings.NewReader("not compressed"), &out); err == nil {
+		t.Error("expected error for non-.Z input")
+	}
+}
+
+func TestDecompressShortHeader(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if err := lzw.Decompress(strings.NewReader("\x1f"), &out); err == nil {
+		t.Error("expected error for truncated header")
+	}
+}

--- a/internal/applets/archival/uncompress/uncompress.go
+++ b/internal/applets/archival/uncompress/uncompress.go
@@ -1,0 +1,106 @@
+// Package uncompress implements the uncompress applet: decompress .Z files
+// produced by the classic Unix compress (or gzip). Each FILE.Z becomes FILE;
+// with -c the result is written to standard output.
+package uncompress
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/applets/archival/lzw"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the uncompress applet.
+type Command struct{}
+
+// New returns an uncompress command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "uncompress" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Decompress LZW (.Z) files" }
+
+type options struct {
+	stdout bool
+	keep   bool
+	force  bool
+}
+
+// Run executes uncompress.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	stdout := fs.BoolP("stdout", "c", false, "write on standard output, keep original files unchanged")
+	keep := fs.BoolP("keep", "k", false, "keep (don't delete) input files")
+	force := fs.BoolP("force", "f", false, "force overwrite of output file")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	opts := options{stdout: *stdout, keep: *keep, force: *force}
+
+	files := fs.Args()
+	if len(files) == 0 || (len(files) == 1 && files[0] == "-") {
+		if err := lzw.Decompress(stdio.In, stdio.Out); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "uncompress: %v\n", err)
+			return command.SilentFailure()
+		}
+		return nil
+	}
+
+	var failed bool
+	for _, f := range files {
+		if err := c.processFile(stdio, f, opts); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "uncompress: %v\n", err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// processFile decompresses one .Z file to FILE (or to stdout with -c).
+func (c *Command) processFile(stdio command.IO, name string, opts options) error {
+	in, err := os.Open(name) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	if opts.stdout {
+		return lzw.Decompress(in, stdio.Out)
+	}
+
+	if !strings.HasSuffix(name, ".Z") {
+		return fmt.Errorf("%s: unknown suffix -- ignored", name)
+	}
+	out := strings.TrimSuffix(name, ".Z")
+	if !opts.force {
+		if _, statErr := os.Stat(out); statErr == nil {
+			return fmt.Errorf("%s already exists; use -f to overwrite", out)
+		}
+	}
+
+	w, err := os.Create(out) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	if err := lzw.Decompress(in, w); err != nil {
+		_ = w.Close()
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	if !opts.keep {
+		return os.Remove(name)
+	}
+	return nil
+}

--- a/internal/applets/archival/uncompress/uncompress_test.go
+++ b/internal/applets/archival/uncompress/uncompress_test.go
@@ -1,0 +1,134 @@
+package uncompress_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/archival/lzw"
+	"github.com/nao1215/mimixbox/internal/applets/archival/uncompress"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin []byte, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: bytes.NewReader(stdin), Out: out, Err: errBuf}
+	err := uncompress.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// zbytes returns the .Z-compressed form of s.
+func zbytes(t *testing.T, s string) []byte {
+	t.Helper()
+	var z bytes.Buffer
+	if err := lzw.Compress(strings.NewReader(s), &z); err != nil {
+		t.Fatal(err)
+	}
+	return z.Bytes()
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := uncompress.New()
+	if got := c.Name(); got != "uncompress" {
+		t.Errorf("Name() = %q", got)
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis empty")
+	}
+}
+
+func TestStdin(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, zbytes(t, "hello there"))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "hello there" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	zf := filepath.Join(dir, "doc.Z")
+	if err := os.WriteFile(zf, zbytes(t, "the content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, errOut, err := run(t, nil, zf); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "doc"))
+	if err != nil {
+		t.Fatalf("expected decompressed file: %v", err)
+	}
+	if string(got) != "the content" {
+		t.Errorf("decompressed = %q", got)
+	}
+	if _, statErr := os.Stat(zf); statErr == nil {
+		t.Error(".Z input should be removed without -k")
+	}
+}
+
+func TestStdoutFlag(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	zf := filepath.Join(dir, "s.Z")
+	if err := os.WriteFile(zf, zbytes(t, "stdout please"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, nil, "-c", zf)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "stdout please" {
+		t.Errorf("out = %q", out)
+	}
+	if _, statErr := os.Stat(zf); statErr != nil {
+		t.Error("-c should keep the input")
+	}
+}
+
+func TestUnknownSuffix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "noext")
+	if err := os.WriteFile(f, zbytes(t, "x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, nil, f)
+	if err == nil {
+		t.Error("expected error for unknown suffix")
+	}
+	if !strings.Contains(errOut, "unknown suffix") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestBadStream(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, []byte("not a .Z stream"))
+	if err == nil {
+		t.Error("expected error for invalid stream")
+	}
+	if !strings.Contains(errOut, "uncompress:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, nil, "--help")
+	if err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	if !strings.Contains(out, "Usage: uncompress") {
+		t.Errorf("help = %q", out)
+	}
+}

--- a/test/it/archival/compress_test.sh
+++ b/test/it/archival/compress_test.sh
@@ -1,0 +1,14 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/compress
+    mkdir -p ${TEST_DIR}
+    printf 'compress me compress me compress me\n' > ${TEST_DIR}/data.txt
+}
+CleanUp() { rm -rf /tmp/mimixbox/it/compress; }
+
+TestCompressRoundTrip() {
+    export TEST_DIR=/tmp/mimixbox/it/compress
+    cp ${TEST_DIR}/data.txt ${TEST_DIR}/rt.txt
+    compress ${TEST_DIR}/rt.txt
+    uncompress ${TEST_DIR}/rt.txt.Z
+    printf '%s' "$(< ${TEST_DIR}/rt.txt)"
+}

--- a/test/it/spec/compress_spec.sh
+++ b/test/it/spec/compress_spec.sh
@@ -1,0 +1,11 @@
+Describe 'compress and uncompress'
+    Include archival/compress_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'round-trips a file through compress and uncompress'
+        When call TestCompressRoundTrip
+        The output should equal 'compress me compress me compress me'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

The classic Unix LZW (.Z) compressor and decompressor.

| Command | Description | Issue |
|---|---|---|
| compress | Compress files with LZW (.Z) | #46 |
| uncompress | Decompress LZW (.Z) files | #47 |

compress turns FILE into FILE.Z (or writes to stdout with -c); -k keeps the input, -f overwrites. uncompress reverses it (FILE.Z -> FILE, or stdout with -c).

Both share a new internal package, internal/applets/archival/lzw, a from-scratch implementation of the compress LZW variant: the 3-byte header (1F 9D, max-bits | block-mode), variable-width 9..16-bit codes packed least-significant-bit first in eight-code blocks, and the CLEAR code handling. The output is byte-for-byte identical to the system `compress` and is read correctly by `gzip -d` / `uncompress` (verified manually against /usr/bin/compress).

## Testing

- The codec has round-trip tests over empty, single-byte, repeated, text and all-byte-values inputs, plus a large input that forces the code width to grow and CLEAR codes to be emitted, and write-error paths. Applet coverage: compress 85.7%, uncompress 85.7%.
- shellspec round-trips a file through `compress` then `uncompress`. (A system-tool interop test is intentionally omitted because the CI installs MimixBox symlinks ahead of the system tools on PATH, which would make such a test circular.)
- golangci-lint clean; command list regenerated.

Closes #46, #47.