### PR TITLE
fix: build MimixBox from local source in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang as builder
+FROM golang AS builder
 ENV ROOT=/go/app
 ENV IT_SHELL=/home/mimixbox/do_integration_test.sh
 WORKDIR ${ROOT}
@@ -9,22 +9,25 @@ WORKDIR ${ROOT}
 RUN echo 'root:password' | chpasswd
 RUN useradd mimixbox -m -s /bin/bash &&\
     echo 'mimixbox:password' |chpasswd
-RUN apt-get update && apt-get upgrade && apt-get -y install sudo file
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get -y install sudo file libpam0g-dev
 
-# Copy ShellSpec installer
-COPY ./test/it /home/mimixbox/integration_tests
-RUN  git clone https://github.com/shellspec/shellspec.git && \
+# Install ShellSpec for the integration tests.
+RUN git clone https://github.com/shellspec/shellspec.git && \
     cd shellspec && make install
 
+# Build MimixBox from the local source tree (not a remote clone) so the image
+# always reflects the working copy, with cgo enabled in the toolchain image.
+COPY . ${ROOT}/mimixbox
+RUN cd ${ROOT}/mimixbox && make build && sudo make full-install
+
+# Make the integration tests available to the mimixbox user.
+COPY ./test/it /home/mimixbox/integration_tests
 RUN echo "#!/bin/bash" > ${IT_SHELL} && \
-    echo "cd /home/mimixbox/integration_tests && shellspec\n" >> ${IT_SHELL} && \
+    echo "cd /home/mimixbox/integration_tests && shellspec" >> ${IT_SHELL} && \
     chmod a+x ${IT_SHELL} && \
     chown -R mimixbox:mimixbox /home/mimixbox/.
 
-RUN git clone https://github.com/nao1215/mimixbox.git && cd mimixbox && \
-    make build
-RUN cd ${ROOT}/mimixbox && sudo make full-install
-
-# If you want to administrator privileges, you become the root user.
+# If you want administrator privileges, become the root user.
 # RUN echo "mimixbox    ALL=(ALL)       ALL" >> /etc/sudoers
 CMD ["su", "-", "mimixbox"]


### PR DESCRIPTION
## Summary

Addresses #4: `make docker` cloned the published repository and built that, so local changes were never exercised in the container and contributors hit a "no matching versions for query latest" style mismatch when trying to build local source.

The Dockerfile now copies the local source tree into the builder stage and builds it there (cgo enabled by the golang toolchain image), and installs libpam0g-dev so PAM-linked builds work. The ShellSpec setup and the mimixbox user are unchanged.

## Note

I could not run a Docker build in my environment (no Docker daemon available here), so this change is reasoned from the existing Dockerfile rather than verified by an actual build. Please confirm with `make docker`. The change only swaps the remote `git clone` for `COPY . ...` and adds the PAM dev package, mirroring the existing build/install steps, so the risk is low.

Refs #4.