### PR TITLE
chore: release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-06-08
+
 ### Added
+
+- Many new applets, each with GNU-style options, unit tests and shellspec
+  integration tests: `cal`, `chmod`, `dd`, `df`, `du`, `od` (#144); `install`,
+  `mknod` (#146); `resize` (#147); `find`, `grep`, `xargs` (#148); `tar`,
+  `gunzip`, `bunzip2`, `zip`, `unzip` (#149); `ar`, `cpio` (#150); `sed`,
+  `diff` (#151); `awk`, `patch` (#152); `vi` (#155); `compress`, `uncompress`
+  (#156); `rpm2cpio`, `rpm` (#157).
+- `mbsh` grew into a minimally usable interactive shell: `cd` to `$HOME` and
+  `cd -`, a cwd-aware prompt, comment lines, `$?` expansion, `exit`/`quit`, and
+  a fallback that runs MimixBox applets when a command is not on `PATH` (#153).
+- `compress`/`uncompress` share a from-scratch Unix LZW (.Z) codec that is
+  byte-compatible with the system `compress` and `gzip -d`.
+- `rpm`/`rpm2cpio` share an internal RPM parser (lead, headers, gzip/bzip2
+  payloads).
 
 - `internal/command`: a small framework every applet can be built on. An applet
   is now a `Command` that receives its I/O streams and arguments as values, so

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import (
 
 // Version is the MimixBox version. It is over_written at build time with
 // -ldflags "-X github.com/nao1215/mimixbox/internal/version.Version=x.y.z".
-var Version = "0.33.3"
+var Version = "0.34.0"
 
 // Print writes the "--version" line for a single command to w, following the
 // GNU coreutils convention, e.g. "cat (mimixbox) 0.33.3".


### PR DESCRIPTION
## Summary

Prepare the v0.34.0 release: bump `internal/version.Version` to `0.34.0` and add the CHANGELOG entry.

This release bundles this development cycle's work:
- ~25 new applets (cal, chmod, dd, df, du, od, install, mknod, resize, find, grep, xargs, tar, gunzip, bunzip2, zip, unzip, ar, cpio, sed, diff, awk, patch, vi, compress, uncompress, rpm2cpio, rpm), each with GNU-style options, unit tests and shellspec integration tests.
- mbsh turned into a minimal interactive shell.
- Documentation consolidated into a single English README with a vhs demo GIF.

After this merges, tag `v0.34.0` will be pushed to trigger the GoReleaser release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 0.34.0 with new applets featuring enhanced option handling and comprehensive test coverage
  * Expanded interactive shell functionality and capabilities
  * Added Unix LZW compression codec implementation
  * Implemented shared RPM parser for improved package management support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->