### PR TITLE
chore: drop Homebrew distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
@@ -37,11 +37,3 @@ nfpms:
       - deb
       - rpm
       - apk
-brews:
-  - name: mimixbox
-    description: MimixBox - mimic BusyBox on Linux
-    license: Apache-2.0 license
-    repository:
-      owner: nao1215
-      name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -149,12 +149,6 @@ $ go install github.com/nao1215/mimixbox/cmd/mimixbox@latest
 $ sudo mimixbox --install /usr/local/bin
 ```
 
-### Use homebrew
-
-```shell
-$ brew install nao1215/tap/mimixbox
-```
-
 ## Original commands
 
 MimixBox has its own commands that do not exist in packages like Coreutils.


### PR DESCRIPTION
## Summary

Homebrew distribution is no longer wanted, and its publish step was failing the release on an expired `TAP_GITHUB_TOKEN`.

- Remove the `brews` section from `.goreleaser.yml` (the homebrew-tap publish).
- Remove `TAP_GITHUB_TOKEN` from the release workflow env (no longer used).
- Remove the "Use homebrew" install section from the README.
- Update the deprecated `snapshot.name_template` to `snapshot.version_template`.

Linux packages (deb/rpm/apk) and the tarballs are unaffected; releases no longer depend on the tap token.