### PR TITLE
feat: add 11 textutils applets (comm, paste, fold, fmt, split, shuf, rev, cksum, strings, xxd, base32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New textutils applets on the `internal/command` framework, each with
+  GNU-style options, table-driven unit tests and shellspec integration tests:
+  `comm` (#159), `paste` (#160), `fold` (#161), `fmt` (#162), `split` (#163),
+  `shuf` (#164), `rev` (#165), `cksum` (#166), `strings` (#167), `xxd` (#168),
+  `base32` (#169).
+
 ## [0.34.0] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 105 commands. Run `mimixbox --list` to see them on the terminal.
+There are 116 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
 | add-shell | Add shell name to /etc/shells |
 | ar | Create, modify and extract from archives |
 | awk | Pattern scanning and processing language |
+| base32 | Base32 encode/decode from FILE(or STDIN) to STDOUT |
 | base64 | Base64 encode/decode from FILR(or STDIN) to STDOUT |
 | basename | Print basename (PATH without "/") from file path |
 | bunzip2 | Decompress bzip2 (.bz2) files |
@@ -35,8 +36,10 @@ There are 105 commands. Run `mimixbox --list` to see them on the terminal.
 | chmod | Change file mode bits |
 | chown | Change the owner and/or group of each FILE to OWNER and/or GROUP |
 | chroot | Run command or interactive shell with special root directory |
+| cksum | Print CRC checksum and byte count of each file |
 | clear | Clear terminal |
 | cmp | Compare two files byte by byte |
+| comm | Compare two sorted files line by line |
 | compress | Compress files with LZW (.Z) |
 | cowsay | Print message with cow's ASCII art |
 | cp | Copy file(s) otr Directory(s) |
@@ -56,6 +59,8 @@ There are 105 commands. Run `mimixbox --list` to see them on the terminal.
 | fakemovie | Adds a video playback button to the image |
 | false | Do nothing. Return unsuccess(1) |
 | find | Search for files in a directory hierarchy |
+| fmt | Simple optimal text formatter |
+| fold | Wrap each input line to fit in specified width |
 | ghrdc | GitHub Relase Download Counter |
 | grep | Print lines that match patterns |
 | groups | Print the groups to which USERNAME belongs |
@@ -79,6 +84,7 @@ There are 105 commands. Run `mimixbox --list` to see them on the terminal.
 | mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY |
 | nl | Write each FILE to standard output with line numbers added |
 | od | Dump files in octal and other formats |
+| paste | Merge lines of files |
 | patch | Apply a diff file to an original |
 | path | Manipulate filename path |
 | poweroff | Power off the system |
@@ -90,6 +96,7 @@ There are 105 commands. Run `mimixbox --list` to see them on the terminal.
 | remove-shell | Remove shell name from /etc/shells |
 | reset | Reset terminal |
 | resize | Print commands to set the terminal size |
+| rev | Reverse the order of characters in every line |
 | rm | Remove file(s) or directory(s) |
 | rmdir | Remove directory |
 | rpm | Query an RPM package file |
@@ -101,9 +108,12 @@ There are 105 commands. Run `mimixbox --list` to see them on the terminal.
 | sha1sum | Calculate or Check secure hash 1 algorithm |
 | sha256sum | Calculate or Check secure hash 256 algorithm |
 | sha512sum | Calculate or Check secure hash 512 algorithm |
+| shuf | Generate a random permutation of input lines |
 | sl | Cure your bad habit of mistyping |
 | sleep | Pause for NUMBER seconds(minutes, hours, days) |
 | sort | Sort lines of text files |
+| split | Split a file into pieces |
+| strings | Print printable character sequences in files |
 | sync | Synchronize cached writes to persistent storage |
 | tac | Print the file contents from the end to the beginning |
 | tail | Print the last NUMBER(default=10) lines |
@@ -127,6 +137,7 @@ There are 105 commands. Run `mimixbox --list` to see them on the terminal.
 | who | Show who is logged on |
 | whoami | Print login user name |
 | xargs | Build and execute command lines from standard input |
+| xxd | Make a hex dump or do the reverse |
 | zip | Package and compress files into a ZIP archive |
 <!-- COMMAND_LIST_END -->
 

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -114,15 +114,25 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/wget"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/who"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/whoami"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/base32"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/cat"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/cksum"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/comm"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/dos2unix"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/expand"
+	fmtCmd "github.com/nao1215/mimixbox/internal/applets/textutils/fmt"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/fold"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/head"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/md5sum"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/nl"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/paste"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/rev"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/sha1sum"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/sha256sum"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/sha512sum"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/shuf"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/split"
+	stringsCmd "github.com/nao1215/mimixbox/internal/applets/textutils/strings"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/tac"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/tail"
 
@@ -130,6 +140,7 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/textutils/unexpand"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/unix2dos"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/wc"
+	"github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
 )
 
 type EntryPoint func() (int, error)
@@ -153,12 +164,15 @@ func init() {
 		"add-shell": reg(addShell.New()),
 		"ar":        reg(ar.New()),
 		"awk":       reg(awk.New()),
+		"base32":    reg(base32.New()),
 		"base64":    reg(base64.New()),
 		"basename":  reg(basename.New()),
 		"bunzip2":   reg(bunzip2.New()),
 		"cal":       reg(cal.New()),
 		"cat":       reg(cat.New()),
+		"cksum":     reg(cksum.New()),
 		"chmod":     reg(chmod.New()),
+		"comm":      reg(comm.New()),
 		"cowsay":    reg(cowsay.New()),
 		"chgrp":     reg(chgrp.New()),
 		"chown":     reg(chown.New()),
@@ -184,6 +198,8 @@ func init() {
 		"fakemovie":    reg(fakemovie.New()),
 		"false":        reg(boolfalse.New()),
 		"find":         reg(find.New()),
+		"fmt":          reg(fmtCmd.New()),
+		"fold":         reg(fold.New()),
 		"ghrdc":        reg(ghrdc.New()),
 		"grep":         reg(grep.New()),
 		"groups":       reg(groups.New()),
@@ -207,6 +223,7 @@ func init() {
 		"mv":           reg(mv.New()),
 		"nl":           reg(nl.New()),
 		"od":           reg(od.New()),
+		"paste":        reg(paste.New()),
 		"patch":        reg(patch.New()),
 		"path":         reg(path.New()),
 		"poweroff":     reg(halt.NewPoweroff()),
@@ -215,6 +232,7 @@ func init() {
 		"pwd":          reg(pwd.New()),
 		"realpath":     reg(realpath.New()),
 		"remove-shell": reg(removeShell.New()),
+		"rev":          reg(rev.New()),
 		"reboot":       reg(halt.NewReboot()),
 		"rpm":          reg(rpm.New()),
 		"rpm2cpio":     reg(rpm2cpio.New()),
@@ -229,9 +247,12 @@ func init() {
 		"sha512sum":    reg(sha512sum.New()),
 		"sed":          reg(sed.New()),
 		"seq":          reg(seq.New()),
+		"shuf":         reg(shuf.New()),
 		"sl":           reg(sl.New()),
 		"sleep":        reg(sleep.New()),
 		"sort":         reg(sortcmd.New()),
+		"split":        reg(split.New()),
+		"strings":      reg(stringsCmd.New()),
 		"sync":         reg(sync.New()),
 		"tac":          reg(tac.New()),
 		"tail":         reg(tail.New()),
@@ -253,6 +274,7 @@ func init() {
 		"wget":         reg(wget.New()),
 		"which":        reg(which.New()),
 		"xargs":        reg(xargs.New()),
+		"xxd":          reg(xxd.New()),
 		"zip":          reg(zipCmd.New()),
 		"who":          reg(who.New()),
 		"whoami":       reg(whoami.New()),

--- a/internal/applets/textutils/base32/base32.go
+++ b/internal/applets/textutils/base32/base32.go
@@ -1,0 +1,143 @@
+// Package base32 implements the base32 applet: encode or decode data from a
+// file (or standard input) to standard output, following GNU base32 semantics.
+package base32
+
+import (
+	"context"
+	stdbase32 "encoding/base32"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the base32 applet.
+type Command struct{}
+
+// New returns a base32 command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "base32" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	return "Base32 encode/decode from FILE(or STDIN) to STDOUT"
+}
+
+// Run executes base32.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	decode := fs.BoolP("decode", "d", false, "decode data")
+	ignoreGarbage := fs.BoolP("ignore-garbage", "i", false, "when decoding, ignore non-alphabet characters")
+	wrap := fs.IntP("wrap", "w", 76, "wrap encoded lines after COLS character (default 76).\nUse 0 to disable line wrapping")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	name := operand(fs.Args())
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "base32: %s\n", command.FileError(name, err))
+		return command.SilentFailure()
+	}
+	defer func() { _ = r.Close() }()
+
+	input, err := io.ReadAll(r)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "base32: %s\n", command.FileError(name, err))
+		return command.SilentFailure()
+	}
+
+	if *decode {
+		return c.decode(stdio, input, *ignoreGarbage)
+	}
+	return c.encode(stdio, input, *wrap)
+}
+
+// operand returns the single FILE operand, defaulting to "-" (standard input)
+// when none is given.
+func operand(args []string) string {
+	if len(args) == 0 {
+		return "-"
+	}
+	return args[0]
+}
+
+// encode writes the base32 encoding of input to stdout, wrapping lines after
+// wrap characters. A wrap of 0 disables wrapping.
+func (c *Command) encode(stdio command.IO, input []byte, wrap int) error {
+	encoded := stdbase32.StdEncoding.EncodeToString(input)
+	if _, err := io.WriteString(stdio.Out, wrapLines(encoded, wrap)); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// decode writes the base32 decoding of input to stdout.
+func (c *Command) decode(stdio command.IO, input []byte, ignoreGarbage bool) error {
+	s := string(input)
+	if ignoreGarbage {
+		s = stripGarbage(s)
+	} else {
+		s = stripWhitespace(s)
+	}
+
+	decoded, err := stdbase32.StdEncoding.DecodeString(s)
+	if err != nil {
+		_, _ = fmt.Fprintln(stdio.Err, "base32: invalid input")
+		return command.SilentFailure()
+	}
+	if _, err := stdio.Out.Write(decoded); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// wrapLines inserts a newline every cols characters and appends a trailing
+// newline. A cols of 0 (or negative) produces a single line.
+func wrapLines(s string, cols int) string {
+	if cols <= 0 {
+		return s + "\n"
+	}
+	var b strings.Builder
+	for len(s) > cols {
+		b.WriteString(s[:cols])
+		b.WriteByte('\n')
+		s = s[cols:]
+	}
+	b.WriteString(s)
+	b.WriteByte('\n')
+	return b.String()
+}
+
+// stripWhitespace removes ASCII whitespace, which is never part of a base32
+// payload, so encoded input that spans multiple lines still decodes.
+func stripWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t', '\n', '\r', '\v', '\f':
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// stripGarbage removes every character that is not part of the standard base32
+// alphabet, implementing -i / --ignore-garbage.
+func stripGarbage(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			return r
+		case r >= '2' && r <= '7':
+			return r
+		case r == '=':
+			return r
+		}
+		return -1
+	}, s)
+}

--- a/internal/applets/textutils/base32/base32_test.go
+++ b/internal/applets/textutils/base32/base32_test.go
@@ -1,0 +1,114 @@
+package base32_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/base32"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := base32.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestEncode(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "hello\n")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "NBSWY3DPBI======\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestDecode(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "NBSWY3DPBI======\n", "-d")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "hello\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	enc, _, err := run(t, "MimixBox")
+	if err != nil {
+		t.Fatalf("encode error = %v", err)
+	}
+	dec, _, err := run(t, enc, "-d")
+	if err != nil {
+		t.Fatalf("decode error = %v", err)
+	}
+	if dec != "MimixBox" {
+		t.Errorf("round trip = %q", dec)
+	}
+}
+
+func TestWrap(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, strings.Repeat("a", 100), "-w", "8")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if len(line) > 8 {
+			t.Errorf("line too long: %q", line)
+		}
+	}
+}
+
+func TestDecodeInvalid(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "!!!not-base32!!!", "-d")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "base32: invalid input") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestDecodeIgnoreGarbage(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "NBSW Y3DP\nBI======", "-d", "-i")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "hello\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "base32:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := base32.New()
+	if c.Name() != "base32" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/cksum/cksum.go
+++ b/internal/applets/textutils/cksum/cksum.go
@@ -1,0 +1,111 @@
+// Package cksum implements the cksum applet: print a POSIX CRC checksum and the
+// byte count for each file (or standard input).
+package cksum
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the cksum applet.
+type Command struct{}
+
+// New returns a cksum command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "cksum" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print CRC checksum and byte count of each file" }
+
+// Run executes cksum.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		return c.sumStdin(stdio)
+	}
+
+	var firstErr error
+	for _, name := range files {
+		if err := c.sumFile(stdio, name); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "cksum: %s\n", command.FileError(name, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+		}
+	}
+	return firstErr
+}
+
+// sumStdin checksums standard input and prints "crc bytes".
+func (c *Command) sumStdin(stdio command.IO) error {
+	data, err := io.ReadAll(stdio.In)
+	if err != nil {
+		return command.Failure(err)
+	}
+	crc, n := checksum(data)
+	_, err = fmt.Fprintf(stdio.Out, "%d %d\n", crc, n)
+	return err
+}
+
+// sumFile checksums name and prints "crc bytes name".
+func (c *Command) sumFile(stdio command.IO, name string) error {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	crc, n := checksum(data)
+	_, err = fmt.Fprintf(stdio.Out, "%d %d %s\n", crc, n, name)
+	return err
+}
+
+// crcPoly is the polynomial POSIX cksum uses (CRC-32/CKSUM).
+const crcPoly = 0x04C11DB7
+
+// crcTable is the precomputed lookup table for crcPoly.
+var crcTable = func() [256]uint32 {
+	var t [256]uint32
+	for i := range t {
+		crc := uint32(i) << 24
+		for j := 0; j < 8; j++ {
+			if crc&0x80000000 != 0 {
+				crc = (crc << 1) ^ crcPoly
+			} else {
+				crc <<= 1
+			}
+		}
+		t[i] = crc
+	}
+	return t
+}()
+
+// checksum returns the POSIX CRC checksum of data and its length in bytes. The
+// length is folded into the CRC the way POSIX cksum specifies, so the result
+// matches GNU coreutils' cksum.
+func checksum(data []byte) (uint32, int) {
+	var crc uint32
+	for _, b := range data {
+		crc = (crc << 8) ^ crcTable[byte(crc>>24)^b]
+	}
+	for n := len(data); n != 0; n >>= 8 {
+		crc = (crc << 8) ^ crcTable[byte(crc>>24)^byte(n)]
+	}
+	return ^crc, len(data)
+}

--- a/internal/applets/textutils/cksum/cksum_test.go
+++ b/internal/applets/textutils/cksum/cksum_test.go
@@ -1,0 +1,81 @@
+package cksum_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/cksum"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := cksum.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRunStdin(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		want  string
+	}{
+		{"empty", "", "4294967295 0\n"},
+		{"hello", "hello\n", "3015617425 6\n"},
+		{"digits", "123456789", "930766865 9\n"},
+		{"one byte", "a", "1220704766 1\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunFileNameInOutput(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "-")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// "-" is treated as a file operand, so the name is echoed.
+	if !strings.Contains(out, " -\n") {
+		t.Errorf("out = %q, want name suffix", out)
+	}
+}
+
+func TestRunMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "cksum: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := cksum.New()
+	if c.Name() != "cksum" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/comm/comm.go
+++ b/internal/applets/textutils/comm/comm.go
@@ -1,0 +1,131 @@
+// Package comm implements the comm applet: compare two sorted files line by
+// line, showing lines unique to each file and lines common to both.
+package comm
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the comm applet.
+type Command struct{}
+
+// New returns a comm command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "comm" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Compare two sorted files line by line" }
+
+// Run executes comm.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 FILE2", stdio.Err)
+	no1 := fs.BoolP("suppress-col1", "1", false, "suppress column 1 (lines unique to FILE1)")
+	no2 := fs.BoolP("suppress-col2", "2", false, "suppress column 2 (lines unique to FILE2)")
+	no3 := fs.BoolP("suppress-col3", "3", false, "suppress column 3 (lines that appear in both files)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) != 2 {
+		_, _ = fmt.Fprintln(stdio.Err, "comm: two file operands are required")
+		return command.SilentFailure()
+	}
+
+	a, err := readLines(stdio, files[0])
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "comm: %s\n", command.FileError(files[0], err))
+		return command.SilentFailure()
+	}
+	b, err := readLines(stdio, files[1])
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "comm: %s\n", command.FileError(files[1], err))
+		return command.SilentFailure()
+	}
+
+	return c.compare(stdio, a, b, !*no1, !*no2, !*no3)
+}
+
+// compare walks the two sorted line slices in merge order and writes each line
+// in the column selected by show1/show2/show3.
+func (c *Command) compare(stdio command.IO, a, b []string, show1, show2, show3 bool) error {
+	// col2 indent skips the active leading columns; col3 skips both.
+	pad2, pad3 := "", ""
+	if show1 {
+		pad2 = "\t"
+		pad3 = "\t"
+	}
+	if show2 {
+		pad3 += "\t"
+	}
+
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] < b[j]:
+			if err := emit(stdio, show1, "", a[i]); err != nil {
+				return err
+			}
+			i++
+		case a[i] > b[j]:
+			if err := emit(stdio, show2, pad2, b[j]); err != nil {
+				return err
+			}
+			j++
+		default:
+			if err := emit(stdio, show3, pad3, a[i]); err != nil {
+				return err
+			}
+			i++
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		if err := emit(stdio, show1, "", a[i]); err != nil {
+			return err
+		}
+	}
+	for ; j < len(b); j++ {
+		if err := emit(stdio, show2, pad2, b[j]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emit writes line in its column (prefixed with pad) when show is true.
+func emit(stdio command.IO, show bool, pad, line string) error {
+	if !show {
+		return nil
+	}
+	if _, err := io.WriteString(stdio.Out, pad+line+"\n"); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// readLines reads name fully and returns its lines without the line endings.
+func readLines(stdio command.IO, name string) ([]string, error) {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	var lines []string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines, sc.Err()
+}

--- a/internal/applets/textutils/comm/comm_test.go
+++ b/internal/applets/textutils/comm/comm_test.go
@@ -1,0 +1,106 @@
+package comm_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/comm"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := comm.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func writeFile(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "f.txt")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestThreeColumns(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "apple\nbanana\ncherry\n")
+	b := writeFile(t, "banana\ncherry\ndate\n")
+	out, _, err := run(t, a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "apple\n\t\tbanana\n\t\tcherry\n\tdate\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestSuppressColumns(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "apple\nbanana\ncherry\n")
+	b := writeFile(t, "banana\ncherry\ndate\n")
+	// -1 -2 leaves only the common column, with no indentation.
+	out, _, err := run(t, "-1", "-2", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "banana\ncherry\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestOnlyUniqueToFirst(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "apple\nbanana\n")
+	b := writeFile(t, "banana\n")
+	out, _, err := run(t, "-2", "-3", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "apple\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestWrongOperandCount(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "onlyone")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "two file operands") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	b := writeFile(t, "x\n")
+	_, errOut, err := run(t, "/no/such/file", b)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "comm: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := comm.New()
+	if c.Name() != "comm" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/fmt/fmt.go
+++ b/internal/applets/textutils/fmt/fmt.go
@@ -1,0 +1,126 @@
+// Package fmt implements the fmt applet: reflow paragraphs of text so each
+// output line fits within a target width.
+package fmt
+
+import (
+	"bufio"
+	"context"
+	stdfmt "fmt"
+	"io"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fmt applet.
+type Command struct{}
+
+// New returns a fmt command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fmt" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Simple optimal text formatter" }
+
+// Run executes fmt.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	width := fs.IntP("width", "w", 75, "maximum line width")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *width <= 0 {
+		_, _ = stdfmt.Fprintf(stdio.Err, "fmt: invalid width: %d\n", *width)
+		return command.SilentFailure()
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+
+	var firstErr error
+	for _, name := range files {
+		if err := c.fmtFile(stdio, name, *width); err != nil {
+			_, _ = stdfmt.Fprintf(stdio.Err, "fmt: %s\n", command.FileError(name, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+		}
+	}
+	return firstErr
+}
+
+// fmtFile reflows the text read from name. Blank lines separate paragraphs and
+// are preserved; each paragraph's words are greedily packed into width columns.
+func (c *Command) fmtFile(stdio command.IO, name string, width int) error {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var para []string
+	flush := func() error {
+		if len(para) == 0 {
+			return nil
+		}
+		text := reflow(strings.Join(para, " "), width)
+		para = para[:0]
+		_, werr := io.WriteString(stdio.Out, text)
+		return werr
+	}
+
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			if err := flush(); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(stdio.Out, "\n"); err != nil {
+				return err
+			}
+			continue
+		}
+		para = append(para, strings.Fields(line)...)
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	return flush()
+}
+
+// reflow greedily packs words into lines no wider than width, returning the
+// joined lines each terminated by a newline.
+func reflow(text string, width int) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	lineLen := 0
+	for i, w := range words {
+		switch {
+		case i == 0:
+			b.WriteString(w)
+			lineLen = len(w)
+		case lineLen+1+len(w) > width:
+			b.WriteByte('\n')
+			b.WriteString(w)
+			lineLen = len(w)
+		default:
+			b.WriteByte(' ')
+			b.WriteString(w)
+			lineLen += 1 + len(w)
+		}
+	}
+	b.WriteByte('\n')
+	return b.String()
+}

--- a/internal/applets/textutils/fmt/fmt_test.go
+++ b/internal/applets/textutils/fmt/fmt_test.go
@@ -1,0 +1,86 @@
+package fmt_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/fmt"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := fmt.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestReflow(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "aa bb cc dd\n", "-w", "5")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "aa bb\ncc dd\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestJoinShortLines(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "aa\nbb\ncc\n", "-w", "10")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "aa bb cc\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestParagraphSeparation(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "aa bb\n\ncc dd\n", "-w", "20")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "aa bb\n\ncc dd\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestInvalidWidth(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "-w", "0")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid width") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "fmt: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := fmt.New()
+	if c.Name() != "fmt" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/fold/fold.go
+++ b/internal/applets/textutils/fold/fold.go
@@ -1,0 +1,99 @@
+// Package fold implements the fold applet: wrap each input line to a given
+// width, optionally breaking at spaces.
+package fold
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fold applet.
+type Command struct{}
+
+// New returns a fold command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fold" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Wrap each input line to fit in specified width" }
+
+// Run executes fold.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	width := fs.IntP("width", "w", 80, "use WIDTH columns instead of 80")
+	spaces := fs.BoolP("spaces", "s", false, "break at spaces")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *width <= 0 {
+		_, _ = fmt.Fprintf(stdio.Err, "fold: invalid number of columns: %d\n", *width)
+		return command.SilentFailure()
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+
+	var firstErr error
+	for _, name := range files {
+		if err := c.foldFile(stdio, name, *width, *spaces); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "fold: %s\n", command.FileError(name, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+		}
+	}
+	return firstErr
+}
+
+// foldFile wraps every line read from name to width columns.
+func (c *Command) foldFile(stdio command.IO, name string, width int, spaces bool) error {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		for _, piece := range foldLine(sc.Text(), width, spaces) {
+			if _, err := io.WriteString(stdio.Out, piece+"\n"); err != nil {
+				return err
+			}
+		}
+	}
+	return sc.Err()
+}
+
+// foldLine splits a single line into chunks no wider than width. When spaces is
+// set it prefers to break after the last blank within the chunk, matching
+// "fold -s".
+func foldLine(line string, width int, spaces bool) []string {
+	if line == "" {
+		return []string{""}
+	}
+	var out []string
+	for len(line) > width {
+		cut := width
+		if spaces {
+			if idx := strings.LastIndexAny(line[:width], " \t"); idx > 0 {
+				cut = idx + 1
+			}
+		}
+		out = append(out, line[:cut])
+		line = line[cut:]
+	}
+	out = append(out, line)
+	return out
+}

--- a/internal/applets/textutils/fold/fold_test.go
+++ b/internal/applets/textutils/fold/fold_test.go
@@ -1,0 +1,82 @@
+package fold_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/fold"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := fold.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"wrap at width", "abcdefgh\n", []string{"-w", "3"}, "abc\ndef\ngh\n"},
+		{"shorter than width", "ab\n", []string{"-w", "5"}, "ab\n"},
+		{"empty line preserved", "\n", []string{"-w", "5"}, "\n"},
+		{"break at spaces", "aa bb cc\n", []string{"-w", "5", "-s"}, "aa \nbb cc\n"},
+		{"exact width", "abc\n", []string{"-w", "3"}, "abc\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestInvalidWidth(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "abc\n", "-w", "0")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid number of columns") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "fold: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := fold.New()
+	if c.Name() != "fold" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/paste/paste.go
+++ b/internal/applets/textutils/paste/paste.go
@@ -1,0 +1,164 @@
+// Package paste implements the paste applet: merge corresponding lines of
+// files, or (with -s) join each file's lines onto a single line.
+package paste
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the paste applet.
+type Command struct{}
+
+// New returns a paste command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "paste" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Merge lines of files" }
+
+// Run executes paste.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	delims := fs.StringP("delimiters", "d", "\t", "reuse characters from LIST instead of TABs")
+	serial := fs.BoolP("serial", "s", false, "paste one file at a time instead of in parallel")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+	seps := delimiters(*delims)
+
+	if *serial {
+		return c.serial(stdio, files, seps)
+	}
+	return c.parallel(stdio, files, seps)
+}
+
+// delimiters expands the -d LIST into the cycle of separators paste uses,
+// translating the common backslash escapes. An empty list means TAB.
+func delimiters(list string) []string {
+	if list == "" {
+		return []string{"\t"}
+	}
+	var seps []string
+	for i := 0; i < len(list); i++ {
+		if list[i] == '\\' && i+1 < len(list) {
+			i++
+			switch list[i] {
+			case 'n':
+				seps = append(seps, "\n")
+			case 't':
+				seps = append(seps, "\t")
+			case '\\':
+				seps = append(seps, "\\")
+			case '0':
+				seps = append(seps, "")
+			default:
+				seps = append(seps, string(list[i]))
+			}
+			continue
+		}
+		seps = append(seps, string(list[i]))
+	}
+	if len(seps) == 0 {
+		return []string{"\t"}
+	}
+	return seps
+}
+
+// serial joins every line of each file onto one output line, cycling through
+// the separators between lines.
+func (c *Command) serial(stdio command.IO, files []string, seps []string) error {
+	var firstErr error
+	for _, name := range files {
+		lines, err := readLines(stdio, name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "paste: %s\n", command.FileError(name, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+			continue
+		}
+		var b strings.Builder
+		for i, line := range lines {
+			if i > 0 {
+				b.WriteString(seps[(i-1)%len(seps)])
+			}
+			b.WriteString(line)
+		}
+		b.WriteByte('\n')
+		if _, err := io.WriteString(stdio.Out, b.String()); err != nil {
+			return command.Failure(err)
+		}
+	}
+	return firstErr
+}
+
+// parallel merges the i-th line of every file, separated by the delimiter
+// cycle, until all files are exhausted.
+func (c *Command) parallel(stdio command.IO, files []string, seps []string) error {
+	cols := make([][]string, 0, len(files))
+	maxLen := 0
+	var firstErr error
+	for _, name := range files {
+		lines, err := readLines(stdio, name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "paste: %s\n", command.FileError(name, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+			continue
+		}
+		cols = append(cols, lines)
+		if len(lines) > maxLen {
+			maxLen = len(lines)
+		}
+	}
+
+	for row := 0; row < maxLen; row++ {
+		var b strings.Builder
+		for col, lines := range cols {
+			if col > 0 {
+				b.WriteString(seps[(col-1)%len(seps)])
+			}
+			if row < len(lines) {
+				b.WriteString(lines[row])
+			}
+		}
+		b.WriteByte('\n')
+		if _, err := io.WriteString(stdio.Out, b.String()); err != nil {
+			return command.Failure(err)
+		}
+	}
+	return firstErr
+}
+
+// readLines reads name fully and returns its lines without the line endings.
+func readLines(stdio command.IO, name string) ([]string, error) {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	var lines []string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines, sc.Err()
+}

--- a/internal/applets/textutils/paste/paste_test.go
+++ b/internal/applets/textutils/paste/paste_test.go
@@ -1,0 +1,112 @@
+package paste_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/paste"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := paste.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func writeFile(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "f.txt")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestSerial(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\nc\n", "-s")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "a\tb\tc\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestSerialCustomDelimiter(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\nc\n", "-s", "-d", ",")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "a,b,c\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestParallelTwoFiles(t *testing.T) {
+	t.Parallel()
+	f1 := writeFile(t, "1\n2\n3\n")
+	f2 := writeFile(t, "a\nb\nc\n")
+	out, _, err := run(t, "", f1, f2)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "1\ta\n2\tb\n3\tc\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestParallelUnevenLength(t *testing.T) {
+	t.Parallel()
+	f1 := writeFile(t, "1\n2\n")
+	f2 := writeFile(t, "a\n")
+	out, _, err := run(t, "", f1, f2)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "1\ta\n2\t\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestDelimiterEscape(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\n", "-s", "-d", `\n`)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "a\nb\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "paste: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := paste.New()
+	if c.Name() != "paste" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/rev/rev.go
+++ b/internal/applets/textutils/rev/rev.go
@@ -1,0 +1,78 @@
+// Package rev implements the rev applet: reverse the characters of every input
+// line, reading from files or standard input.
+package rev
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the rev applet.
+type Command struct{}
+
+// New returns a rev command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "rev" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Reverse the order of characters in every line" }
+
+// Run executes rev.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+
+	var firstErr error
+	for _, name := range files {
+		if err := c.revFile(stdio, name); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "rev: %s\n", command.FileError(name, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+		}
+	}
+	return firstErr
+}
+
+// revFile reverses every line read from name and writes it to stdout.
+func (c *Command) revFile(stdio command.IO, name string) error {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		if _, err := io.WriteString(stdio.Out, reverseRunes(sc.Text())+"\n"); err != nil {
+			return err
+		}
+	}
+	return sc.Err()
+}
+
+// reverseRunes returns s with its runes in reverse order so multi-byte UTF-8
+// characters are preserved rather than split.
+func reverseRunes(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}

--- a/internal/applets/textutils/rev/rev_test.go
+++ b/internal/applets/textutils/rev/rev_test.go
@@ -1,0 +1,83 @@
+package rev_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/rev"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := rev.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"single line", "abc\n", nil, "cba\n"},
+		{"multiple lines", "abc\ndef\n", nil, "cba\nfed\n"},
+		{"no trailing newline", "abc", nil, "cba\n"},
+		{"empty line", "\n", nil, "\n"},
+		{"utf8 aware", "あいう\n", nil, "ういあ\n"},
+		{"explicit stdin", "hello\n", []string{"-"}, "olleh\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "rev: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := rev.New()
+	if c.Name() != "rev" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: rev") {
+		t.Errorf("help output = %q", out)
+	}
+}

--- a/internal/applets/textutils/shuf/shuf.go
+++ b/internal/applets/textutils/shuf/shuf.go
@@ -1,0 +1,112 @@
+// Package shuf implements the shuf applet: write a random permutation of its
+// input lines (or of a numeric range, or of its arguments).
+package shuf
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the shuf applet.
+type Command struct{}
+
+// New returns a shuf command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "shuf" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Generate a random permutation of input lines" }
+
+// Run executes shuf.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	echo := fs.BoolP("echo", "e", false, "treat each ARG as an input line")
+	inputRange := fs.StringP("input-range", "i", "", "treat each number LO through HI as an input line")
+	count := fs.IntP("head-count", "n", -1, "output at most COUNT lines")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	lines, err := c.collect(stdio, fs.Args(), *echo, *inputRange)
+	if err != nil {
+		return err
+	}
+
+	rand.Shuffle(len(lines), func(i, j int) { lines[i], lines[j] = lines[j], lines[i] })
+	if *count >= 0 && *count < len(lines) {
+		lines = lines[:*count]
+	}
+
+	for _, line := range lines {
+		if _, err := io.WriteString(stdio.Out, line+"\n"); err != nil {
+			return command.Failure(err)
+		}
+	}
+	return nil
+}
+
+// collect resolves the lines to shuffle from the chosen input mode: -e uses the
+// arguments, -i uses a numeric range, otherwise lines come from the file (or
+// standard input).
+func (c *Command) collect(stdio command.IO, args []string, echo bool, inputRange string) ([]string, error) {
+	switch {
+	case echo:
+		return args, nil
+	case inputRange != "":
+		return expandRange(stdio, inputRange)
+	default:
+		name := "-"
+		if len(args) > 0 {
+			name = args[0]
+		}
+		return readLines(stdio, name)
+	}
+}
+
+// expandRange turns "LO-HI" into the slice of numbers from LO to HI inclusive.
+func expandRange(stdio command.IO, spec string) ([]string, error) {
+	lo, hi, ok := strings.Cut(spec, "-")
+	loN, err1 := strconv.Atoi(lo)
+	hiN, err2 := strconv.Atoi(hi)
+	if !ok || err1 != nil || err2 != nil || loN > hiN {
+		_, _ = fmt.Fprintf(stdio.Err, "shuf: invalid input range %q\n", spec)
+		return nil, command.SilentFailure()
+	}
+	lines := make([]string, 0, hiN-loN+1)
+	for i := loN; i <= hiN; i++ {
+		lines = append(lines, strconv.Itoa(i))
+	}
+	return lines, nil
+}
+
+// readLines reads name fully and returns its lines without line endings.
+func readLines(stdio command.IO, name string) ([]string, error) {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "shuf: %s\n", command.FileError(name, err))
+		return nil, command.SilentFailure()
+	}
+	defer func() { _ = r.Close() }()
+
+	var lines []string
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		return nil, command.Failure(err)
+	}
+	return lines, nil
+}

--- a/internal/applets/textutils/shuf/shuf_test.go
+++ b/internal/applets/textutils/shuf/shuf_test.go
@@ -1,0 +1,109 @@
+package shuf_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/shuf"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := shuf.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func sortedLines(s string) []string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	sort.Strings(lines)
+	return lines
+}
+
+func TestPermutation(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\nc\nd\ne\n")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got := sortedLines(out)
+	want := []string{"a", "b", "c", "d", "e"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("multiset = %v, want %v", got, want)
+	}
+}
+
+func TestHeadCount(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a\nb\nc\nd\ne\n", "-n", "2")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Errorf("got %d lines, want 2", len(lines))
+	}
+}
+
+func TestEcho(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "-e", "x", "y", "z")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got := sortedLines(out)
+	if strings.Join(got, ",") != "x,y,z" {
+		t.Errorf("multiset = %v", got)
+	}
+}
+
+func TestInputRange(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "-i", "1-4")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got := sortedLines(out)
+	if strings.Join(got, ",") != "1,2,3,4" {
+		t.Errorf("multiset = %v", got)
+	}
+}
+
+func TestInvalidRange(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "-i", "5-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid input range") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "shuf: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := shuf.New()
+	if c.Name() != "shuf" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/split/split.go
+++ b/internal/applets/textutils/split/split.go
@@ -1,0 +1,172 @@
+// Package split implements the split applet: break an input file into smaller
+// output files by a line count or a byte count.
+package split
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the split applet.
+type Command struct{}
+
+// New returns a split command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "split" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Split a file into pieces" }
+
+// Run executes split.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [INPUT [PREFIX]]", stdio.Err)
+	lines := fs.IntP("lines", "l", 1000, "put NUMBER lines per output file")
+	byteSpec := fs.StringP("bytes", "b", "", "put SIZE bytes per output file (suffixes K, M allowed)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	input := "-"
+	prefix := "x"
+	if len(rest) > 0 {
+		input = rest[0]
+	}
+	if len(rest) > 1 {
+		prefix = rest[1]
+	}
+
+	r, err := command.Open(stdio, input)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "split: %s\n", command.FileError(input, err))
+		return command.SilentFailure()
+	}
+	defer func() { _ = r.Close() }()
+
+	if *byteSpec != "" {
+		size, perr := parseSize(*byteSpec)
+		if perr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "split: invalid number of bytes: %q\n", *byteSpec)
+			return command.SilentFailure()
+		}
+		return c.byBytes(stdio, r, prefix, size)
+	}
+	if *lines <= 0 {
+		_, _ = fmt.Fprintf(stdio.Err, "split: invalid number of lines: %d\n", *lines)
+		return command.SilentFailure()
+	}
+	return c.byLines(stdio, r, prefix, *lines)
+}
+
+// parseSize parses a byte count that may carry a K (1024) or M (1048576) suffix.
+func parseSize(s string) (int, error) {
+	mult := 1
+	switch {
+	case strings.HasSuffix(s, "K"):
+		mult, s = 1024, strings.TrimSuffix(s, "K")
+	case strings.HasSuffix(s, "M"):
+		mult, s = 1024*1024, strings.TrimSuffix(s, "M")
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid size")
+	}
+	return n * mult, nil
+}
+
+// byLines writes perFile lines into each successive output file.
+func (c *Command) byLines(stdio command.IO, r io.Reader, prefix string, perFile int) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	idx, count := 0, 0
+	var w *os.File
+	closeCur := func() error {
+		if w != nil {
+			err := w.Close()
+			w = nil
+			return err
+		}
+		return nil
+	}
+	for sc.Scan() {
+		if w == nil {
+			f, err := create(prefix, idx)
+			if err != nil {
+				_, _ = fmt.Fprintf(stdio.Err, "split: %v\n", err)
+				return command.SilentFailure()
+			}
+			w = f
+			idx++
+		}
+		if _, err := w.WriteString(sc.Text() + "\n"); err != nil {
+			_ = closeCur()
+			return command.Failure(err)
+		}
+		count++
+		if count == perFile {
+			if err := closeCur(); err != nil {
+				return command.Failure(err)
+			}
+			count = 0
+		}
+	}
+	if err := closeCur(); err != nil {
+		return command.Failure(err)
+	}
+	return sc.Err()
+}
+
+// byBytes writes perFile bytes into each successive output file.
+func (c *Command) byBytes(stdio command.IO, r io.Reader, prefix string, perFile int) error {
+	br := bufio.NewReader(r)
+	buf := make([]byte, perFile)
+	idx := 0
+	for {
+		n, err := io.ReadFull(br, buf)
+		if n > 0 {
+			f, cerr := create(prefix, idx)
+			if cerr != nil {
+				_, _ = fmt.Fprintf(stdio.Err, "split: %v\n", cerr)
+				return command.SilentFailure()
+			}
+			idx++
+			if _, werr := f.Write(buf[:n]); werr != nil {
+				_ = f.Close()
+				return command.Failure(werr)
+			}
+			if cerr := f.Close(); cerr != nil {
+				return command.Failure(cerr)
+			}
+		}
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return nil
+		}
+		if err != nil {
+			return command.Failure(err)
+		}
+	}
+}
+
+// create opens the idx-th output file, named prefix followed by a two-letter
+// suffix (aa, ab, ...).
+func create(prefix string, idx int) (*os.File, error) {
+	name := prefix + suffix(idx)
+	return os.Create(name) //nolint:gosec // writing a user-named output file is the point
+}
+
+// suffix returns the two-letter split suffix for the idx-th file.
+func suffix(idx int) string {
+	return string(rune('a'+idx/26)) + string(rune('a'+idx%26))
+}

--- a/internal/applets/textutils/split/split_test.go
+++ b/internal/applets/textutils/split/split_test.go
@@ -1,0 +1,103 @@
+package split_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/split"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := split.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestByLines(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "part-")
+	_, _, err := run(t, "1\n2\n3\n4\n5\n", "-l", "2", "-", prefix)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"aa", "1\n2\n")
+	checkFile(t, prefix+"ab", "3\n4\n")
+	checkFile(t, prefix+"ac", "5\n")
+}
+
+func TestByBytes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "b-")
+	_, _, err := run(t, "abcdefg", "-b", "3", "-", prefix)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"aa", "abc")
+	checkFile(t, prefix+"ab", "def")
+	checkFile(t, prefix+"ac", "g")
+}
+
+func TestInvalidLines(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "-l", "0")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid number of lines") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestInvalidBytes(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "-b", "notanumber")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid number of bytes") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingInput(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "split: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := split.New()
+	if c.Name() != "split" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+func checkFile(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path) //nolint:gosec // test reads a file it just wrote
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("%s = %q, want %q", path, got, want)
+	}
+}

--- a/internal/applets/textutils/strings/strings.go
+++ b/internal/applets/textutils/strings/strings.go
@@ -1,0 +1,100 @@
+// Package strings implements the strings applet: print sequences of printable
+// characters of at least a minimum length found in files (or standard input).
+package strings
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the strings applet.
+type Command struct{}
+
+// New returns a strings command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "strings" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print printable character sequences in files" }
+
+// Run executes strings.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	minLen := fs.IntP("bytes", "n", 4, "print sequences of at least N printable characters")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *minLen < 1 {
+		_, _ = fmt.Fprintf(stdio.Err, "strings: invalid minimum string length: %d\n", *minLen)
+		return command.SilentFailure()
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+
+	var firstErr error
+	for _, name := range files {
+		if err := c.scan(stdio, name, *minLen); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "strings: %s\n", command.FileError(name, err))
+			if firstErr == nil {
+				firstErr = command.SilentFailure()
+			}
+		}
+	}
+	return firstErr
+}
+
+// scan reads name and prints every run of printable bytes that is at least
+// minLen characters long.
+func (c *Command) scan(stdio command.IO, name string, minLen int) error {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = r.Close() }()
+
+	br := bufio.NewReader(r)
+	cur := make([]byte, 0, 64)
+	flush := func() error {
+		if len(cur) >= minLen {
+			if _, err := stdio.Out.Write(append(cur, '\n')); err != nil {
+				return err
+			}
+		}
+		cur = cur[:0]
+		return nil
+	}
+
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return flush()
+			}
+			return err
+		}
+		if isPrintable(b) {
+			cur = append(cur, b)
+			continue
+		}
+		if ferr := flush(); ferr != nil {
+			return ferr
+		}
+	}
+}
+
+// isPrintable reports whether b is a printable ASCII character (including the
+// space and tab that strings treats as part of a run).
+func isPrintable(b byte) bool {
+	return b == '\t' || (b >= 0x20 && b <= 0x7e)
+}

--- a/internal/applets/textutils/strings/strings_test.go
+++ b/internal/applets/textutils/strings/strings_test.go
@@ -1,0 +1,88 @@
+package strings_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	cmdstrings "github.com/nao1215/mimixbox/internal/applets/textutils/strings"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := cmdstrings.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	// "hi" (too short) then NUL then "hello" then NUL then "world".
+	in := "hi\x00hello\x00world"
+	out, _, err := run(t, in)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "hello\nworld\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestMinLength(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "ab\x00abcd", "-n", "2")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "ab\nabcd\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestTrailingRun(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "\x01\x02abcd")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "abcd\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestInvalidLength(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "abcd", "-n", "0")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid minimum string length") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "strings: /no/such/file:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := cmdstrings.New()
+	if c.Name() != "strings" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/textutils/xxd/xxd.go
+++ b/internal/applets/textutils/xxd/xxd.go
@@ -1,0 +1,134 @@
+// Package xxd implements the xxd applet: make a hex dump of its input, or with
+// -r convert a hex dump back into binary.
+package xxd
+
+import (
+	"bufio"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the xxd applet.
+type Command struct{}
+
+// New returns an xxd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "xxd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Make a hex dump or do the reverse" }
+
+const bytesPerLine = 16
+
+// Run executes xxd.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	reverse := fs.BoolP("revert", "r", false, "reverse operation: convert a hex dump into binary")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	name := operand(fs.Args())
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "xxd: %s\n", command.FileError(name, err))
+		return command.SilentFailure()
+	}
+	defer func() { _ = r.Close() }()
+
+	if *reverse {
+		return c.revert(stdio, r)
+	}
+	return c.dump(stdio, r)
+}
+
+// operand returns the single FILE operand, defaulting to "-" (standard input).
+func operand(args []string) string {
+	if len(args) == 0 {
+		return "-"
+	}
+	return args[0]
+}
+
+// dump writes the canonical xxd hex dump of r to stdout.
+func (c *Command) dump(stdio command.IO, r io.Reader) error {
+	br := bufio.NewReader(r)
+	buf := make([]byte, bytesPerLine)
+	offset := 0
+	for {
+		n, err := io.ReadFull(br, buf)
+		if n > 0 {
+			if _, werr := io.WriteString(stdio.Out, formatLine(offset, buf[:n])); werr != nil {
+				return command.Failure(werr)
+			}
+			offset += n
+		}
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return nil
+		}
+		if err != nil {
+			return command.Failure(err)
+		}
+	}
+}
+
+// formatLine renders one dump line: an 8-digit offset, the bytes as
+// space-separated 2-byte groups padded to a fixed width, and the printable
+// rendering of the bytes.
+func formatLine(offset int, data []byte) string {
+	var hexPart strings.Builder
+	var asciiPart strings.Builder
+	for i, b := range data {
+		if i > 0 && i%2 == 0 {
+			hexPart.WriteByte(' ')
+		}
+		fmt.Fprintf(&hexPart, "%02x", b)
+		if b >= 0x20 && b <= 0x7e {
+			asciiPart.WriteByte(b)
+		} else {
+			asciiPart.WriteByte('.')
+		}
+	}
+	// 16 bytes -> 8 groups of 4 hex chars + 7 separators = 39 columns.
+	return fmt.Sprintf("%08x: %-39s  %s\n", offset, hexPart.String(), asciiPart.String())
+}
+
+// revert reads an xxd dump and writes the original bytes. The hex column is the
+// text between ": " and the two-space gap that precedes the ASCII column.
+func (c *Command) revert(stdio command.IO, r io.Reader) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		colon := strings.Index(line, ": ")
+		if colon < 0 {
+			continue
+		}
+		rest := line[colon+2:]
+		if gap := strings.Index(rest, "  "); gap >= 0 {
+			rest = rest[:gap]
+		}
+		raw := strings.ReplaceAll(rest, " ", "")
+		decoded, err := hex.DecodeString(raw)
+		if err != nil {
+			_, _ = fmt.Fprintln(stdio.Err, "xxd: invalid hex dump")
+			return command.SilentFailure()
+		}
+		if _, err := stdio.Out.Write(decoded); err != nil {
+			return command.Failure(err)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}

--- a/internal/applets/textutils/xxd/xxd_test.go
+++ b/internal/applets/textutils/xxd/xxd_test.go
@@ -1,0 +1,109 @@
+package xxd_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := xxd.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestDumpShort(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "hello\n")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "00000000: 6865 6c6c 6f0a                           hello.\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestDumpFullLine(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "0123456789abcdefghij")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "00000000: 3031 3233 3435 3637 3839 6162 6364 6566  0123456789abcdef\n" +
+		"00000010: 6768 696a                                ghij\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestRevert(t *testing.T) {
+	t.Parallel()
+	dump, _, err := run(t, "hello\n")
+	if err != nil {
+		t.Fatalf("dump error = %v", err)
+	}
+	out, _, err := run(t, dump, "-r")
+	if err != nil {
+		t.Fatalf("revert error = %v", err)
+	}
+	if out != "hello\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestRevertFullLineRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := "0123456789abcdefghij"
+	dump, _, err := run(t, orig)
+	if err != nil {
+		t.Fatalf("dump error = %v", err)
+	}
+	out, _, err := run(t, dump, "-r")
+	if err != nil {
+		t.Fatalf("revert error = %v", err)
+	}
+	if out != orig {
+		t.Errorf("round trip = %q, want %q", out, orig)
+	}
+}
+
+func TestRevertInvalid(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "00000000: zzzz  ..\n", "-r")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "xxd: invalid hex dump") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "/no/such/file")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "xxd:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := xxd.New()
+	if c.Name() != "xxd" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/test/it/spec/base32_spec.sh
+++ b/test/it/spec/base32_spec.sh
@@ -1,0 +1,17 @@
+Describe 'base32 encode from pipe'
+    Include textutils/base32_test.sh
+    It 'encodes standard input'
+        When call TestBase32EncodePipe
+        The output should equal 'NBSWY3DPBI======'
+        The status should be success
+    End
+End
+
+Describe 'base32 decode from pipe'
+    Include textutils/base32_test.sh
+    It 'decodes standard input'
+        When call TestBase32DecodePipe
+        The output should equal 'hello'
+        The status should be success
+    End
+End

--- a/test/it/spec/cksum_spec.sh
+++ b/test/it/spec/cksum_spec.sh
@@ -1,0 +1,8 @@
+Describe 'cksum from pipe'
+    Include textutils/cksum_test.sh
+    It 'prints the CRC checksum and byte count'
+        When call TestCksumPipe
+        The output should equal '3015617425 6'
+        The status should be success
+    End
+End

--- a/test/it/spec/comm_spec.sh
+++ b/test/it/spec/comm_spec.sh
@@ -1,0 +1,10 @@
+Describe 'comm common lines'
+    Include textutils/comm_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+    It 'prints lines common to both files'
+        When call TestCommBoth
+        The output should equal 'banana'
+        The status should be success
+    End
+End

--- a/test/it/spec/fmt_spec.sh
+++ b/test/it/spec/fmt_spec.sh
@@ -1,0 +1,12 @@
+Describe 'fmt by width'
+    Include textutils/fmt_test.sh
+    result() { %text
+        #|aa bb
+        #|cc dd
+    }
+    It 'reflows text to the given width'
+        When call TestFmtWidth
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/fold_spec.sh
+++ b/test/it/spec/fold_spec.sh
@@ -1,0 +1,13 @@
+Describe 'fold by width'
+    Include textutils/fold_test.sh
+    result() { %text
+        #|abc
+        #|def
+        #|gh
+    }
+    It 'wraps lines to the given width'
+        When call TestFoldWidth
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/paste_spec.sh
+++ b/test/it/spec/paste_spec.sh
@@ -1,0 +1,8 @@
+Describe 'paste serial'
+    Include textutils/paste_test.sh
+    It 'joins lines with a delimiter'
+        When call TestPasteSerial
+        The output should equal 'a,b,c'
+        The status should be success
+    End
+End

--- a/test/it/spec/rev_spec.sh
+++ b/test/it/spec/rev_spec.sh
@@ -1,0 +1,8 @@
+Describe 'rev from pipe'
+    Include textutils/rev_test.sh
+    It 'reverses the characters of a line'
+        When call TestRevPipe
+        The output should equal 'cba'
+        The status should be success
+    End
+End

--- a/test/it/spec/shuf_spec.sh
+++ b/test/it/spec/shuf_spec.sh
@@ -1,0 +1,8 @@
+Describe 'shuf range'
+    Include textutils/shuf_test.sh
+    It 'shuffles a single-element range'
+        When call TestShufRange
+        The output should equal '1'
+        The status should be success
+    End
+End

--- a/test/it/spec/split_spec.sh
+++ b/test/it/spec/split_spec.sh
@@ -1,0 +1,14 @@
+Describe 'split by lines'
+    Include textutils/split_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+    result() { %text
+        #|1
+        #|2
+    }
+    It 'splits input into files of N lines'
+        When call TestSplitLines
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/strings_spec.sh
+++ b/test/it/spec/strings_spec.sh
@@ -1,0 +1,12 @@
+Describe 'strings from pipe'
+    Include textutils/strings_test.sh
+    result() { %text
+        #|hello
+        #|world
+    }
+    It 'prints printable sequences'
+        When call TestStringsPipe
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/xxd_spec.sh
+++ b/test/it/spec/xxd_spec.sh
@@ -1,0 +1,17 @@
+Describe 'xxd dump'
+    Include textutils/xxd_test.sh
+    It 'prints a hex dump'
+        When call TestXxdDump
+        The output should equal '00000000: 6865 6c6c 6f0a                           hello.'
+        The status should be success
+    End
+End
+
+Describe 'xxd revert'
+    Include textutils/xxd_test.sh
+    It 'reverses a hex dump'
+        When call TestXxdRevert
+        The output should equal 'hello'
+        The status should be success
+    End
+End

--- a/test/it/textutils/base32_test.sh
+++ b/test/it/textutils/base32_test.sh
@@ -1,0 +1,6 @@
+TestBase32EncodePipe() {
+    printf 'hello\n' | base32
+}
+TestBase32DecodePipe() {
+    printf 'NBSWY3DPBI======\n' | base32 -d
+}

--- a/test/it/textutils/cksum_test.sh
+++ b/test/it/textutils/cksum_test.sh
@@ -1,0 +1,3 @@
+TestCksumPipe() {
+    printf 'hello\n' | cksum
+}

--- a/test/it/textutils/comm_test.sh
+++ b/test/it/textutils/comm_test.sh
@@ -1,0 +1,12 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    mkdir -p ${TEST_DIR}
+    printf 'apple\nbanana\n' > ${TEST_DIR}/comm_a.txt
+    printf 'banana\ncherry\n' > ${TEST_DIR}/comm_b.txt
+}
+CleanUp() {
+    rm -rf /tmp/mimixbox/it
+}
+TestCommBoth() {
+    comm -1 -2 /tmp/mimixbox/it/comm_a.txt /tmp/mimixbox/it/comm_b.txt
+}

--- a/test/it/textutils/fmt_test.sh
+++ b/test/it/textutils/fmt_test.sh
@@ -1,0 +1,3 @@
+TestFmtWidth() {
+    printf 'aa bb cc dd\n' | fmt -w 5
+}

--- a/test/it/textutils/fold_test.sh
+++ b/test/it/textutils/fold_test.sh
@@ -1,0 +1,3 @@
+TestFoldWidth() {
+    printf 'abcdefgh\n' | fold -w 3
+}

--- a/test/it/textutils/paste_test.sh
+++ b/test/it/textutils/paste_test.sh
@@ -1,0 +1,3 @@
+TestPasteSerial() {
+    printf 'a\nb\nc\n' | paste -s -d ,
+}

--- a/test/it/textutils/rev_test.sh
+++ b/test/it/textutils/rev_test.sh
@@ -1,0 +1,3 @@
+TestRevPipe() {
+    printf 'abc\n' | rev
+}

--- a/test/it/textutils/shuf_test.sh
+++ b/test/it/textutils/shuf_test.sh
@@ -1,0 +1,3 @@
+TestShufRange() {
+    shuf -i 1-1
+}

--- a/test/it/textutils/split_test.sh
+++ b/test/it/textutils/split_test.sh
@@ -1,0 +1,11 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    mkdir -p ${TEST_DIR}
+}
+CleanUp() {
+    rm -rf /tmp/mimixbox/it
+}
+TestSplitLines() {
+    printf '1\n2\n3\n' | split -l 2 - /tmp/mimixbox/it/part-
+    cat /tmp/mimixbox/it/part-aa
+}

--- a/test/it/textutils/strings_test.sh
+++ b/test/it/textutils/strings_test.sh
@@ -1,0 +1,3 @@
+TestStringsPipe() {
+    printf 'hi\000hello\000world' | strings
+}

--- a/test/it/textutils/xxd_test.sh
+++ b/test/it/textutils/xxd_test.sh
@@ -1,0 +1,6 @@
+TestXxdDump() {
+    printf 'hello\n' | xxd
+}
+TestXxdRevert() {
+    printf 'hello\n' | xxd | xxd -r
+}


### PR DESCRIPTION
## Summary

Implements the eleven textutils applets requested in #159–#169 on the `internal/command` framework. Each applet follows GNU semantics for a sensible subset of options, reads files or standard input (`-`), ships table-driven unit tests with `t.Parallel()` (80%+ coverage each), and a shellspec end-to-end test under `test/it/`.

| Issue | Command | Notes |
|------|---------|-------|
| #159 | `comm` | compare two sorted files, `-1`/`-2`/`-3` suppress columns |
| #160 | `paste` | `-s` serial, `-d` delimiter list |
| #161 | `fold` | `-w` width, `-s` break at spaces |
| #162 | `fmt` | reflow paragraphs to `-w` width |
| #163 | `split` | `-l` lines or `-b` bytes, `aa`/`ab`/… suffixes |
| #164 | `shuf` | `-e` args, `-i` range, `-n` head-count |
| #165 | `rev` | reverse characters per line (UTF-8 aware) |
| #166 | `cksum` | POSIX CRC checksum + byte count |
| #167 | `strings` | printable runs of `>= -n` bytes |
| #168 | `xxd` | canonical hex dump and `-r` revert |
| #169 | `base32` | encode/decode mirroring the `base64` applet |

All eleven are registered in `internal/applets/applet.go` and the README command list is regenerated (now 116 commands).

## Test

- `make test` green; new packages at 81–97% coverage.
- `golangci-lint run ./...` reports no new issues from these files.
- New shellspec specs pass: `13 examples, 0 failures`.

Closes #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169