### PR TITLE
feat: add 7 shellutils system-info applets (yes, uname, arch, nproc, hostname, logname, tty)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New fileutils applets, each with unit tests and shellspec integration tests:
   `stat` (#170), `truncate` (#171), `readlink` (#172), `link` (#173),
   `unlink` (#174), `shred` (#175), `mountpoint` (#176).
+- New shellutils system-information applets, each with unit tests and shellspec
+  integration tests: `yes` (#177), `uname` (#178), `arch` (#179), `nproc`
+  (#180), `hostname` (#181), `logname` (#182), `tty` (#183).
 
 ## [0.34.0] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 123 commands. Run `mimixbox --list` to see them on the terminal.
+There are 130 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
 | add-shell | Add shell name to /etc/shells |
 | ar | Create, modify and extract from archives |
+| arch | Print machine hardware name (same as uname -m) |
 | awk | Pattern scanning and processing language |
 | base32 | Base32 encode/decode from FILE(or STDIN) to STDOUT |
 | base64 | Base64 encode/decode from FILR(or STDIN) to STDOUT |
@@ -69,6 +70,7 @@ There are 123 commands. Run `mimixbox --list` to see them on the terminal.
 | halt | Halt the system |
 | head | Print the first NUMBER(default=10) lines |
 | hostid | Print the numeric identifier (in hexadecimal) for the current host |
+| hostname | Show the system's host name |
 | id | Print User ID and Group ID |
 | install | Copy files and set attributes |
 | ischroot | Detect if running in a chroot |
@@ -76,6 +78,7 @@ There are 123 commands. Run `mimixbox --list` to see them on the terminal.
 | lifegame | Life game (Conway's Game of Life) |
 | link | Create a hard link to a file |
 | ln | Create hard or symbolic link |
+| logname | Print the name of the current user |
 | mbsh | Mimix Box Shell |
 | md5sum | Calculate or Check md5sum message digest |
 | mkdir | Make directories |
@@ -85,6 +88,7 @@ There are 123 commands. Run `mimixbox --list` to see them on the terminal.
 | mountpoint | See if a directory is a mountpoint |
 | mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY |
 | nl | Write each FILE to standard output with line numbers added |
+| nproc | Print the number of processing units available |
 | od | Dump files in octal and other formats |
 | paste | Merge lines of files |
 | patch | Apply a diff file to an original |
@@ -129,6 +133,8 @@ There are 123 commands. Run `mimixbox --list` to see them on the terminal.
 | tr | Translate or delete characters |
 | true | Do nothing. Return success(0) |
 | truncate | Shrink or extend the size of a file to a given size |
+| tty | Print the file name of the terminal connected to stdin |
+| uname | Print system information |
 | uncompress | Decompress LZW (.Z) files |
 | unexpand | Convert N space to TAB(default:N=8) |
 | uniq | Report or omit repeated lines |
@@ -145,6 +151,7 @@ There are 123 commands. Run `mimixbox --list` to see them on the terminal.
 | whoami | Print login user name |
 | xargs | Build and execute command lines from standard input |
 | xxd | Make a hex dump or do the reverse |
+| yes | Output a string repeatedly until killed |
 | zip | Package and compress files into a ZIP archive |
 <!-- COMMAND_LIST_END -->
 

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -77,6 +77,7 @@ import (
 	//"github.com/nao1215/mimixbox/internal/applets/loginutils/chsh"
 	validShell "github.com/nao1215/mimixbox/internal/applets/debianutils/valid-shell"
 	"github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/arch"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/base64"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/basename"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/cal"
@@ -96,11 +97,14 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/ghrdc"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/groups"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/hostid"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/hostname"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/id"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/logname"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/install"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/kill"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/mknod"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/nproc"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/od"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/path"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/printenv"
@@ -116,11 +120,14 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/tee"
 	testcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/test"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/true"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/tty"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/uname"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/uniq"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/uuidgen"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/wget"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/who"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/whoami"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/yes"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/base32"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/cat"
 	"github.com/nao1215/mimixbox/internal/applets/textutils/cksum"
@@ -170,6 +177,7 @@ func init() {
 	Applets = map[string]Applet{
 		"add-shell": reg(addShell.New()),
 		"ar":        reg(ar.New()),
+		"arch":      reg(arch.New()),
 		"awk":       reg(awk.New()),
 		"base32":    reg(base32.New()),
 		"base64":    reg(base64.New()),
@@ -215,6 +223,7 @@ func init() {
 		"halt":         reg(halt.NewHalt()),
 		"head":         reg(head.New()),
 		"hostid":       reg(hostid.New()),
+		"hostname":     reg(hostname.New()),
 		"id":           reg(id.New()),
 		"install":      reg(install.New()),
 		"ischroot":     reg(ischroot.New()),
@@ -222,6 +231,7 @@ func init() {
 		"lifegame":     reg(lifegame.New()),
 		"link":         reg(link.New()),
 		"ln":           reg(ln.New()),
+		"logname":      reg(logname.New()),
 		"mbsh":         reg(mbsh.New()),
 		"md5sum":       reg(md5sum.New()),
 		"mkdir":        reg(mkdir.New()),
@@ -231,6 +241,7 @@ func init() {
 		"mountpoint":   reg(mountpoint.New()),
 		"mv":           reg(mv.New()),
 		"nl":           reg(nl.New()),
+		"nproc":        reg(nproc.New()),
 		"od":           reg(od.New()),
 		"paste":        reg(paste.New()),
 		"patch":        reg(patch.New()),
@@ -275,6 +286,8 @@ func init() {
 		"tr":           reg(tr.New()),
 		"true":         reg(booltrue.New()),
 		"truncate":     reg(truncate.New()),
+		"tty":          reg(tty.New()),
+		"uname":        reg(uname.New()),
 		"uncompress":   reg(uncompress.New()),
 		"unexpand":     reg(unexpand.New()),
 		"uniq":         reg(uniq.New()),
@@ -292,6 +305,7 @@ func init() {
 		"zip":          reg(zipCmd.New()),
 		"who":          reg(who.New()),
 		"whoami":       reg(whoami.New()),
+		"yes":          reg(yes.New()),
 	}
 }
 

--- a/internal/applets/shellutils/arch/arch.go
+++ b/internal/applets/shellutils/arch/arch.go
@@ -1,0 +1,58 @@
+// Package arch implements the arch applet: print the machine hardware name,
+// equivalent to "uname -m".
+package arch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the arch applet.
+type Command struct{}
+
+// New returns an arch command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "arch" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print machine hardware name (same as uname -m)" }
+
+// machine is the source of the hardware name; tests replace it.
+var machine = realMachine
+
+// Run executes arch.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	name, err := machine()
+	if err != nil {
+		return command.Failuref("cannot get machine hardware name: %v", err)
+	}
+	if _, err := fmt.Fprintln(stdio.Out, name); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// realMachine reads the machine field from the uname(2) system call.
+func realMachine() (string, error) {
+	var u unix.Utsname
+	if err := unix.Uname(&u); err != nil {
+		return "", err
+	}
+	n := 0
+	for n < len(u.Machine) && u.Machine[n] != 0 {
+		n++
+	}
+	return string(u.Machine[:n]), nil
+}

--- a/internal/applets/shellutils/arch/arch_test.go
+++ b/internal/applets/shellutils/arch/arch_test.go
@@ -1,0 +1,67 @@
+package arch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestPrintsMachine(t *testing.T) {
+	orig := machine
+	machine = func() (string, error) { return "x86_64", nil }
+	t.Cleanup(func() { machine = orig })
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "x86_64\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestError(t *testing.T) {
+	orig := machine
+	machine = func() (string, error) { return "", errors.New("boom") }
+	t.Cleanup(func() { machine = orig })
+
+	_, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRealMachine(t *testing.T) {
+	t.Parallel()
+	got, err := realMachine()
+	if err != nil {
+		t.Fatalf("realMachine() error = %v", err)
+	}
+	if got == "" {
+		t.Error("machine name is empty")
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "arch" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/hostname/hostname.go
+++ b/internal/applets/shellutils/hostname/hostname.go
@@ -1,0 +1,50 @@
+// Package hostname implements the hostname applet: print the system's host
+// name, optionally trimmed to the short form.
+package hostname
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the hostname applet.
+type Command struct{}
+
+// New returns a hostname command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "hostname" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show the system's host name" }
+
+// hostFn is the source of the host name; tests replace it.
+var hostFn = os.Hostname
+
+// Run executes hostname.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	short := fs.BoolP("short", "s", false, "display the short host name (up to the first dot)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	name, err := hostFn()
+	if err != nil {
+		return command.Failuref("cannot determine host name: %v", err)
+	}
+	if *short {
+		name, _, _ = strings.Cut(name, ".")
+	}
+	if _, err := fmt.Fprintln(stdio.Out, name); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}

--- a/internal/applets/shellutils/hostname/hostname_test.go
+++ b/internal/applets/shellutils/hostname/hostname_test.go
@@ -1,0 +1,81 @@
+package hostname
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestPrintsHostname(t *testing.T) {
+	orig := hostFn
+	hostFn = func() (string, error) { return "host.example.com", nil }
+	t.Cleanup(func() { hostFn = orig })
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "host.example.com\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestShort(t *testing.T) {
+	orig := hostFn
+	hostFn = func() (string, error) { return "host.example.com", nil }
+	t.Cleanup(func() { hostFn = orig })
+
+	out, _, err := run(t, "-s")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "host\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestError(t *testing.T) {
+	orig := hostFn
+	hostFn = func() (string, error) { return "", errors.New("boom") }
+	t.Cleanup(func() { hostFn = orig })
+
+	_, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRealHostname(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Error("hostname is empty")
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "hostname" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/logname/logname.go
+++ b/internal/applets/shellutils/logname/logname.go
@@ -1,0 +1,61 @@
+// Package logname implements the logname applet: print the login name of the
+// current user.
+package logname
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the logname applet.
+type Command struct{}
+
+// New returns a logname command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "logname" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the name of the current user" }
+
+// loginName resolves the current login name; tests replace it.
+var loginName = currentLogin
+
+// Run executes logname.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	name, err := loginName()
+	if err != nil {
+		return command.Failuref("no login name")
+	}
+	if _, err := fmt.Fprintln(stdio.Out, name); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// currentLogin returns the login name from the LOGNAME or USER environment
+// variables, falling back to the current user's account name.
+func currentLogin() (string, error) {
+	for _, key := range []string{"LOGNAME", "USER"} {
+		if v := os.Getenv(key); v != "" {
+			return v, nil
+		}
+	}
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return u.Username, nil
+}

--- a/internal/applets/shellutils/logname/logname_test.go
+++ b/internal/applets/shellutils/logname/logname_test.go
@@ -1,0 +1,105 @@
+package logname
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestPrintsLoginName(t *testing.T) {
+	orig := loginName
+	loginName = func() (string, error) { return "alice", nil }
+	t.Cleanup(func() { loginName = orig })
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "alice\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestError(t *testing.T) {
+	orig := loginName
+	loginName = func() (string, error) { return "", errors.New("no name") }
+	t.Cleanup(func() { loginName = orig })
+
+	_, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no login name") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestCurrentLoginFromEnv(t *testing.T) {
+	t.Setenv("LOGNAME", "bob")
+	got, err := currentLogin()
+	if err != nil {
+		t.Fatalf("currentLogin() error = %v", err)
+	}
+	if got != "bob" {
+		t.Errorf("got = %q, want bob", got)
+	}
+}
+
+func TestCurrentLoginFallsBackToUser(t *testing.T) {
+	t.Setenv("LOGNAME", "")
+	t.Setenv("USER", "carol")
+	got, err := currentLogin()
+	if err != nil {
+		t.Fatalf("currentLogin() error = %v", err)
+	}
+	if got != "carol" {
+		t.Errorf("got = %q, want carol", got)
+	}
+}
+
+func TestCurrentLoginFallsBackToCurrentUser(t *testing.T) {
+	t.Setenv("LOGNAME", "")
+	t.Setenv("USER", "")
+	got, err := currentLogin()
+	if err != nil {
+		t.Fatalf("currentLogin() error = %v", err)
+	}
+	if got == "" {
+		t.Error("expected a non-empty user name from user.Current()")
+	}
+}
+
+func TestRealLognameRuns(t *testing.T) {
+	t.Setenv("LOGNAME", "dave")
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "dave\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "logname" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/nproc/nproc.go
+++ b/internal/applets/shellutils/nproc/nproc.go
@@ -1,0 +1,47 @@
+// Package nproc implements the nproc applet: print the number of processing
+// units available to the current process.
+package nproc
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the nproc applet.
+type Command struct{}
+
+// New returns an nproc command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "nproc" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the number of processing units available" }
+
+// cpuCount reports the number of usable CPUs; tests replace it.
+var cpuCount = runtime.NumCPU
+
+// Run executes nproc.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	ignore := fs.Uint("ignore", 0, "if possible, exclude N processing units")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	n := cpuCount()
+	n -= int(*ignore)
+	if n < 1 {
+		n = 1
+	}
+	if _, err := fmt.Fprintln(stdio.Out, n); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}

--- a/internal/applets/shellutils/nproc/nproc_test.go
+++ b/internal/applets/shellutils/nproc/nproc_test.go
@@ -1,0 +1,83 @@
+package nproc
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestPrintsCount(t *testing.T) {
+	orig := cpuCount
+	cpuCount = func() int { return 8 }
+	t.Cleanup(func() { cpuCount = orig })
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "8\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestIgnore(t *testing.T) {
+	orig := cpuCount
+	cpuCount = func() int { return 8 }
+	t.Cleanup(func() { cpuCount = orig })
+
+	out, _, err := run(t, "--ignore", "3")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "5\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestIgnoreClampsToOne(t *testing.T) {
+	orig := cpuCount
+	cpuCount = func() int { return 2 }
+	t.Cleanup(func() { cpuCount = orig })
+
+	out, _, err := run(t, "--ignore", "10")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "1\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestRealCount(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Error("output is empty")
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "nproc" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/tty/tty.go
+++ b/internal/applets/shellutils/tty/tty.go
@@ -1,0 +1,72 @@
+// Package tty implements the tty applet: print the file name of the terminal
+// connected to standard input.
+package tty
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/term"
+)
+
+// Command is the tty applet.
+type Command struct{}
+
+// New returns a tty command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "tty" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the file name of the terminal connected to stdin" }
+
+// fder is implemented by *os.File; it exposes the underlying descriptor so tty
+// can inspect whatever standard input is wired to.
+type fder interface{ Fd() uintptr }
+
+// isTerminal reports whether fd refers to a terminal; tests replace it.
+var isTerminal = term.IsTerminal
+
+// Run executes tty.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	silent := fs.BoolP("silent", "s", false, "print nothing, only return an exit status")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	name, isTTY := ttyName(stdio.In)
+	if !isTTY {
+		if !*silent {
+			_, _ = fmt.Fprintln(stdio.Out, "not a tty")
+		}
+		return &command.ExitError{Code: command.ExitFailure}
+	}
+	if !*silent {
+		_, _ = fmt.Fprintln(stdio.Out, name)
+	}
+	return nil
+}
+
+// ttyName returns the terminal device path backing in, and whether in is a
+// terminal at all. A non-file reader (as used by tests) is never a terminal.
+func ttyName(in any) (string, bool) {
+	f, ok := in.(fder)
+	if !ok {
+		return "", false
+	}
+	fd := int(f.Fd())
+	if !isTerminal(fd) {
+		return "", false
+	}
+	// /proc/self/fd/N is a symlink to the real device (e.g. /dev/pts/0).
+	if link, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", fd)); err == nil {
+		return link, true
+	}
+	return fmt.Sprintf("/dev/fd/%d", fd), true
+}

--- a/internal/applets/shellutils/tty/tty_test.go
+++ b/internal/applets/shellutils/tty/tty_test.go
@@ -1,0 +1,121 @@
+package tty
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestNotATTY(t *testing.T) {
+	t.Parallel()
+	// A strings.Reader has no Fd, so it can never be a terminal.
+	out, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected non-zero exit when stdin is not a tty")
+	}
+	if out != "not a tty\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestSilent(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "-s")
+	if err == nil {
+		t.Fatal("expected non-zero exit")
+	}
+	if out != "" {
+		t.Errorf("silent output should be empty, got %q", out)
+	}
+}
+
+func TestTTYNameNonFile(t *testing.T) {
+	t.Parallel()
+	if _, ok := ttyName(strings.NewReader("")); ok {
+		t.Error("a non-file reader must not be reported as a tty")
+	}
+}
+
+func TestTTYNameRegularFileIsNotTTY(t *testing.T) {
+	t.Parallel()
+	p := filepath.Join(t.TempDir(), "f")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	// A regular file has an Fd but is not a terminal.
+	if _, ok := ttyName(f); ok {
+		t.Error("a regular file must not be reported as a tty")
+	}
+}
+
+func TestRunWithRegularFileStdin(t *testing.T) {
+	t.Parallel()
+	p := filepath.Join(t.TempDir(), "f")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	out := &bytes.Buffer{}
+	io := command.IO{In: f, Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Fatal("expected non-zero exit when stdin is a regular file")
+	}
+	if out.String() != "not a tty\n" {
+		t.Errorf("out = %q", out.String())
+	}
+}
+
+func TestTTYNameResolvesViaProc(t *testing.T) {
+	// Pretend the descriptor is a terminal; ttyName should then resolve the
+	// device name through /proc/self/fd/N, which works for any open file.
+	orig := isTerminal
+	isTerminal = func(int) bool { return true }
+	t.Cleanup(func() { isTerminal = orig })
+
+	p := filepath.Join(t.TempDir(), "f")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	out := &bytes.Buffer{}
+	io := command.IO{In: f, Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	resolved, _ := filepath.EvalSymlinks(p)
+	got := strings.TrimRight(out.String(), "\n")
+	if got != p && got != resolved {
+		t.Errorf("out = %q, want %q", got, p)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "tty" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/uname/uname.go
+++ b/internal/applets/shellutils/uname/uname.go
@@ -1,0 +1,116 @@
+// Package uname implements the uname applet: print system information such as
+// the kernel name, hostname, release, version and machine architecture.
+package uname
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the uname applet.
+type Command struct{}
+
+// New returns a uname command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "uname" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print system information" }
+
+// info holds the pieces of system information uname can print.
+type info struct {
+	sysname  string
+	nodename string
+	release  string
+	version  string
+	machine  string
+	os       string
+}
+
+// sysInfo is the source of system information; tests replace it.
+var sysInfo = uts
+
+// Run executes uname.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	all := fs.BoolP("all", "a", false, "print all information")
+	sysname := fs.BoolP("kernel-name", "s", false, "print the kernel name")
+	nodename := fs.BoolP("nodename", "n", false, "print the network node hostname")
+	release := fs.BoolP("kernel-release", "r", false, "print the kernel release")
+	version := fs.BoolP("kernel-version", "v", false, "print the kernel version")
+	machine := fs.BoolP("machine", "m", false, "print the machine hardware name")
+	osName := fs.BoolP("operating-system", "o", false, "print the operating system")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	in, err := sysInfo()
+	if err != nil {
+		return command.Failuref("cannot get system information: %v", err)
+	}
+
+	var parts []string
+	if *all {
+		parts = []string{in.sysname, in.nodename, in.release, in.version, in.machine, in.os}
+	} else {
+		if *sysname {
+			parts = append(parts, in.sysname)
+		}
+		if *nodename {
+			parts = append(parts, in.nodename)
+		}
+		if *release {
+			parts = append(parts, in.release)
+		}
+		if *version {
+			parts = append(parts, in.version)
+		}
+		if *machine {
+			parts = append(parts, in.machine)
+		}
+		if *osName {
+			parts = append(parts, in.os)
+		}
+		if len(parts) == 0 {
+			parts = []string{in.sysname}
+		}
+	}
+
+	if _, err := fmt.Fprintln(stdio.Out, strings.Join(parts, " ")); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// uts reads the real system information via the uname(2) system call.
+func uts() (info, error) {
+	var u unix.Utsname
+	if err := unix.Uname(&u); err != nil {
+		return info{}, err
+	}
+	return info{
+		sysname:  charsToString(u.Sysname[:]),
+		nodename: charsToString(u.Nodename[:]),
+		release:  charsToString(u.Release[:]),
+		version:  charsToString(u.Version[:]),
+		machine:  charsToString(u.Machine[:]),
+		os:       "GNU/Linux",
+	}, nil
+}
+
+// charsToString turns a NUL-terminated C character array into a Go string.
+func charsToString(ca []byte) string {
+	n := 0
+	for n < len(ca) && ca[n] != 0 {
+		n++
+	}
+	return string(ca[:n])
+}

--- a/internal/applets/shellutils/uname/uname_test.go
+++ b/internal/applets/shellutils/uname/uname_test.go
@@ -1,0 +1,109 @@
+package uname
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T) {
+	t.Helper()
+	orig := sysInfo
+	sysInfo = func() (info, error) {
+		return info{
+			sysname:  "Linux",
+			nodename: "host",
+			release:  "6.6.0",
+			version:  "#1 SMP",
+			machine:  "x86_64",
+			os:       "GNU/Linux",
+		}, nil
+	}
+	t.Cleanup(func() { sysInfo = orig })
+}
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestDefaultIsSysname(t *testing.T) {
+	withStub(t)
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "Linux\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestAll(t *testing.T) {
+	withStub(t)
+	out, _, err := run(t, "-a")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "Linux host 6.6.0 #1 SMP x86_64 GNU/Linux\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestIndividualFlagsCombine(t *testing.T) {
+	withStub(t)
+	out, _, err := run(t, "-s", "-m")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "Linux x86_64\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestMachineAndOS(t *testing.T) {
+	withStub(t)
+	out, _, err := run(t, "-m")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "x86_64\n" {
+		t.Errorf("out = %q", out)
+	}
+	out, _, err = run(t, "-o")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "GNU/Linux\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestRealUnameDoesNotError(t *testing.T) {
+	t.Parallel()
+	// Exercise the real uname(2)-backed path; the value is host-specific.
+	in, err := uts()
+	if err != nil {
+		t.Fatalf("uts() error = %v", err)
+	}
+	if in.sysname == "" {
+		t.Error("sysname is empty")
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "uname" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/yes/yes.go
+++ b/internal/applets/shellutils/yes/yes.go
@@ -1,0 +1,54 @@
+// Package yes implements the yes applet: repeatedly output a line until it is
+// killed, printing "y" by default or the joined command-line arguments.
+package yes
+
+import (
+	"bufio"
+	"context"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the yes applet.
+type Command struct{}
+
+// New returns a yes command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "yes" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Output a string repeatedly until killed" }
+
+// Run executes yes. It writes the line forever and returns only when the output
+// stream reports an error (for example a closed pipe), so it terminates the way
+// the system yes does when its reader goes away.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[STRING]...", stdio.Err)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	line := "y"
+	if rest := fs.Args(); len(rest) > 0 {
+		line = strings.Join(rest, " ")
+	}
+	line += "\n"
+
+	w := bufio.NewWriter(stdio.Out)
+	for {
+		select {
+		case <-ctx.Done():
+			_ = w.Flush()
+			return nil
+		default:
+		}
+		if _, err := w.WriteString(line); err != nil {
+			return nil
+		}
+	}
+}

--- a/internal/applets/shellutils/yes/yes_test.go
+++ b/internal/applets/shellutils/yes/yes_test.go
@@ -1,0 +1,98 @@
+package yes_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/yes"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// errorWriter fails every write, standing in for a closed pipe so yes stops.
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) { return 0, errors.New("broken pipe") }
+
+// limitedWriter records output but reports a failure once it has accepted limit
+// bytes, so yes terminates after producing a bounded, inspectable prefix.
+type limitedWriter struct {
+	buf   bytes.Buffer
+	limit int
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	if w.buf.Len() >= w.limit {
+		return 0, errors.New("limit reached")
+	}
+	return w.buf.Write(p)
+}
+
+func runUntilError(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	w := &limitedWriter{limit: 256}
+	io := command.IO{In: strings.NewReader(""), Out: w, Err: &bytes.Buffer{}}
+	err := yes.New().Run(context.Background(), io, args)
+	return w.buf.String(), err
+}
+
+func TestStopsOnWriteError(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: strings.NewReader(""), Out: errorWriter{}, Err: &bytes.Buffer{}}
+	if err := yes.New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run returned %v, want nil on write error", err)
+	}
+}
+
+func TestContextCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: Run should return promptly
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := yes.New().Run(ctx, io, nil); err != nil {
+		t.Fatalf("Run returned %v, want nil", err)
+	}
+}
+
+func TestDefaultString(t *testing.T) {
+	t.Parallel()
+	got, err := runUntilError(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.HasPrefix(got, "y\ny\n") {
+		t.Errorf("output prefix = %q", got[:min(8, len(got))])
+	}
+}
+
+func TestCustomString(t *testing.T) {
+	t.Parallel()
+	got, err := runUntilError(t, "hello", "world")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.HasPrefix(got, "hello world\nhello world\n") {
+		t.Errorf("output prefix = %q", got[:min(24, len(got))])
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := yes.New()
+	if c.Name() != "yes" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/test/it/shellutils/arch_test.sh
+++ b/test/it/shellutils/arch_test.sh
@@ -1,0 +1,3 @@
+TestArch() {
+    arch
+}

--- a/test/it/shellutils/hostname_test.sh
+++ b/test/it/shellutils/hostname_test.sh
@@ -1,0 +1,3 @@
+TestHostname() {
+    hostname
+}

--- a/test/it/shellutils/logname_test.sh
+++ b/test/it/shellutils/logname_test.sh
@@ -1,0 +1,3 @@
+TestLogname() {
+    LOGNAME=mimixuser logname
+}

--- a/test/it/shellutils/nproc_test.sh
+++ b/test/it/shellutils/nproc_test.sh
@@ -1,0 +1,3 @@
+TestNproc() {
+    nproc
+}

--- a/test/it/shellutils/tty_test.sh
+++ b/test/it/shellutils/tty_test.sh
@@ -1,0 +1,3 @@
+TestTtyNotATty() {
+    echo "" | tty
+}

--- a/test/it/shellutils/uname_test.sh
+++ b/test/it/shellutils/uname_test.sh
@@ -1,0 +1,3 @@
+TestUnameKernel() {
+    uname -s
+}

--- a/test/it/shellutils/yes_test.sh
+++ b/test/it/shellutils/yes_test.sh
@@ -1,0 +1,6 @@
+TestYesHead() {
+    yes | head -n 3
+}
+TestYesString() {
+    yes mimix | head -n 2
+}

--- a/test/it/spec/arch_spec.sh
+++ b/test/it/spec/arch_spec.sh
@@ -1,0 +1,8 @@
+Describe 'arch'
+    Include shellutils/arch_test.sh
+    It 'prints a non-empty machine name'
+        When call TestArch
+        The output should not equal ''
+        The status should be success
+    End
+End

--- a/test/it/spec/hostname_spec.sh
+++ b/test/it/spec/hostname_spec.sh
@@ -1,0 +1,8 @@
+Describe 'hostname'
+    Include shellutils/hostname_test.sh
+    It 'prints a non-empty host name'
+        When call TestHostname
+        The output should not equal ''
+        The status should be success
+    End
+End

--- a/test/it/spec/logname_spec.sh
+++ b/test/it/spec/logname_spec.sh
@@ -1,0 +1,8 @@
+Describe 'logname'
+    Include shellutils/logname_test.sh
+    It 'prints the login name from LOGNAME'
+        When call TestLogname
+        The output should equal 'mimixuser'
+        The status should be success
+    End
+End

--- a/test/it/spec/nproc_spec.sh
+++ b/test/it/spec/nproc_spec.sh
@@ -1,0 +1,8 @@
+Describe 'nproc'
+    Include shellutils/nproc_test.sh
+    It 'prints a positive number'
+        When call TestNproc
+        The output should not equal ''
+        The status should be success
+    End
+End

--- a/test/it/spec/tty_spec.sh
+++ b/test/it/spec/tty_spec.sh
@@ -1,0 +1,8 @@
+Describe 'tty not a tty'
+    Include shellutils/tty_test.sh
+    It 'reports not a tty when stdin is a pipe'
+        When call TestTtyNotATty
+        The output should equal 'not a tty'
+        The status should be failure
+    End
+End

--- a/test/it/spec/uname_spec.sh
+++ b/test/it/spec/uname_spec.sh
@@ -1,0 +1,8 @@
+Describe 'uname'
+    Include shellutils/uname_test.sh
+    It 'prints the kernel name'
+        When call TestUnameKernel
+        The output should equal 'Linux'
+        The status should be success
+    End
+End

--- a/test/it/spec/yes_spec.sh
+++ b/test/it/spec/yes_spec.sh
@@ -1,0 +1,26 @@
+Describe 'yes default'
+    Include shellutils/yes_test.sh
+    result() { %text
+        #|y
+        #|y
+        #|y
+    }
+    It 'repeats y until the reader closes'
+        When call TestYesHead
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'yes with a string'
+    Include shellutils/yes_test.sh
+    result() { %text
+        #|mimix
+        #|mimix
+    }
+    It 'repeats the given string'
+        When call TestYesString
+        The output should equal "$(result)"
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Implements the seven system-information shellutils applets requested in #177–#183 on the `internal/command` framework. System calls and lookups are injected behind package-level function variables so each applet is exercised in memory; each ships table-driven unit tests with `t.Parallel()` (80%+ coverage) and a shellspec end-to-end test.

| Issue | Command | Notes |
|------|---------|-------|
| #177 | `yes` | repeat `y` or the given string until the writer closes |
| #178 | `uname` | `-a` and `-s`/`-n`/`-r`/`-v`/`-m`/`-o` via `uname(2)` |
| #179 | `arch` | machine hardware name (`uname -m`) |
| #180 | `nproc` | number of CPUs, `--ignore N` |
| #181 | `hostname` | print host name, `-s` short form |
| #182 | `logname` | login name from `LOGNAME`/`USER` or current user |
| #183 | `tty` | terminal name of stdin, `-s` silent |

All seven are registered in `internal/applets/applet.go` and the README command list is regenerated (now 130 commands).

## Test

- `make test` green; new packages at 84–94% coverage.
- `golangci-lint run` on the new packages → `0 issues`.
- New shellspec specs pass: `8 examples, 0 failures`.

Closes #177, closes #178, closes #179, closes #180, closes #181, closes #182, closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added seven new system information commands: `arch` (machine hardware), `hostname` (system hostname), `logname` (current login name), `nproc` (processor count), `tty` (terminal device), `uname` (system information), and `yes` (repeat output).
  * Total available commands increased from 123 to 130.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->