### PR TITLE
feat: add 5 network/system ported applets (nc, ping, whris, log-collect, speaker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auditing; `pwscore` (#203) rates password strength; `http-status-code`
   (#206) explains HTTP status codes. New `netutils` and `securityutils`
   applet categories were introduced.
+- New network/system ported applets, with original MIT/BSD-3 attribution
+  preserved where applicable and no source copied verbatim: `nc` (#197,
+  netcat), `ping` (#198, raw-socket ICMP), `whris` (#199, domain IP/AS
+  lookup), `log-collect` (#200, gather log files), `speaker` (#196,
+  TTS via an installed engine).
 
 ## [0.34.0] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 145 commands. Run `mimixbox --list` to see them on the terminal.
+There are 150 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -85,6 +85,7 @@ There are 145 commands. Run `mimixbox --list` to see them on the terminal.
 | lifegame | Life game (Conway's Game of Life) |
 | link | Create a hard link to a file |
 | ln | Create hard or symbolic link |
+| log-collect | Gather system log files into one directory |
 | logname | Print the name of the current user |
 | mbsh | Mimix Box Shell |
 | md5sum | Calculate or Check md5sum message digest |
@@ -94,6 +95,7 @@ There are 145 commands. Run `mimixbox --list` to see them on the terminal.
 | mktemp | Create a temporary file or directory |
 | mountpoint | See if a directory is a mountpoint |
 | mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY |
+| nc | Read and write data across network connections |
 | nl | Write each FILE to standard output with line numbers added |
 | nohup | Run a command immune to hangups, with output to a non-tty |
 | nproc | Print the number of processing units available |
@@ -102,6 +104,7 @@ There are 145 commands. Run `mimixbox --list` to see them on the terminal.
 | paste | Merge lines of files |
 | patch | Apply a diff file to an original |
 | path | Manipulate filename path |
+| ping | Send ICMP ECHO_REQUEST to network hosts |
 | posixer | Report which POSIX utilities are installed |
 | poweroff | Power off the system |
 | printenv | Print environment variable |
@@ -132,6 +135,7 @@ There are 145 commands. Run `mimixbox --list` to see them on the terminal.
 | sl | Cure your bad habit of mistyping |
 | sleep | Pause for NUMBER seconds(minutes, hours, days) |
 | sort | Sort lines of text files |
+| speaker | Read text aloud using an installed TTS engine |
 | split | Split a file into pieces |
 | stat | Display file or file system status |
 | strings | Print printable character sequences in files |
@@ -164,6 +168,7 @@ There are 145 commands. Run `mimixbox --list` to see them on the terminal.
 | which | Returns the file path which would be executed in the current environment |
 | who | Show who is logged on |
 | whoami | Print login user name |
+| whris | Show management information for a domain's IP addresses |
 | xargs | Build and execute command lines from standard input |
 | xxd | Make a hex dump or do the reverse |
 | yes | Output a string repeatedly until killed |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -79,6 +79,9 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	"github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
 	"github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
+	"github.com/nao1215/mimixbox/internal/applets/netutils/nc"
+	"github.com/nao1215/mimixbox/internal/applets/netutils/ping"
+	"github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	"github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
 	"github.com/nao1215/mimixbox/internal/applets/securityutils/pwscore"
 	"github.com/nao1215/mimixbox/internal/applets/securityutils/unshadow"
@@ -112,6 +115,7 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/install"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/kill"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/killall"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/logcollect"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/logname"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/mknod"
@@ -129,6 +133,7 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/serial"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/sleep"
 	sortcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/sort"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/speaker"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/sync"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/tee"
 	testcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/test"
@@ -253,6 +258,7 @@ func init() {
 		"lifegame":         reg(lifegame.New()),
 		"link":             reg(link.New()),
 		"ln":               reg(ln.New()),
+		"log-collect":      reg(logcollect.New()),
 		"logname":          reg(logname.New()),
 		"mbsh":             reg(mbsh.New()),
 		"md5sum":           reg(md5sum.New()),
@@ -262,11 +268,13 @@ func init() {
 		"mktemp":           reg(mktemp.New()),
 		"mountpoint":       reg(mountpoint.New()),
 		"mv":               reg(mv.New()),
+		"nc":               reg(nc.New()),
 		"nl":               reg(nl.New()),
 		"nohup":            reg(nohup.New()),
 		"nproc":            reg(nproc.New()),
 		"nyancat":          reg(nyancat.New()),
 		"od":               reg(od.New()),
+		"ping":             reg(ping.New()),
 		"paste":            reg(paste.New()),
 		"patch":            reg(patch.New()),
 		"path":             reg(path.New()),
@@ -300,6 +308,7 @@ func init() {
 		"sl":               reg(sl.New()),
 		"sleep":            reg(sleep.New()),
 		"sort":             reg(sortcmd.New()),
+		"speaker":          reg(speaker.New()),
 		"split":            reg(split.New()),
 		"stat":             reg(statCmd.New()),
 		"strings":          reg(stringsCmd.New()),
@@ -335,6 +344,7 @@ func init() {
 		"zip":              reg(zipCmd.New()),
 		"who":              reg(who.New()),
 		"whoami":           reg(whoami.New()),
+		"whris":            reg(whris.New()),
 		"yes":              reg(yes.New()),
 	}
 }

--- a/internal/applets/netutils/nc/nc.go
+++ b/internal/applets/netutils/nc/nc.go
@@ -1,0 +1,160 @@
+// Package nc implements the nc (netcat) applet: read and write data across TCP
+// or UDP connections.
+//
+// This is a clean-room reimplementation. The original morrigan netcat was
+// forked from vfedoroff/go-netcat (MIT License, Copyright (c) 2016 Vasily
+// Fedoroff); the attribution is preserved here per the MIT terms even though no
+// source is copied verbatim.
+package nc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the nc applet.
+type Command struct{}
+
+// New returns an nc command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "nc" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Read and write data across network connections" }
+
+// Run executes nc.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-u] [-l] [-p PORT] [HOST] [PORT]", stdio.Err)
+	listen := fs.BoolP("listen", "l", false, "listen for an incoming connection")
+	udp := fs.BoolP("udp", "u", false, "use UDP instead of TCP")
+	port := fs.StringP("port", "p", "", "listen on (or source from) this port")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	network := "tcp"
+	if *udp {
+		network = "udp"
+	}
+
+	if *listen {
+		addr, err := listenAddr(*port, fs.Args())
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
+		return c.serve(stdio, network, addr)
+	}
+
+	host, p, err := dialAddr(*port, fs.Args())
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	return c.connect(stdio, network, net.JoinHostPort(host, p))
+}
+
+// listenAddr resolves the address to listen on from -p and the operands.
+func listenAddr(portFlag string, operands []string) (string, error) {
+	host, port := "", portFlag
+	switch len(operands) {
+	case 0:
+	case 1:
+		port = operands[0]
+	default:
+		host, port = operands[0], operands[1]
+	}
+	if port == "" {
+		return "", fmt.Errorf("a port is required to listen")
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+// dialAddr resolves the host and port to connect to from the operands.
+func dialAddr(portFlag string, operands []string) (string, string, error) {
+	switch len(operands) {
+	case 2:
+		return operands[0], operands[1], nil
+	case 1:
+		if portFlag != "" {
+			return operands[0], portFlag, nil
+		}
+		return "", "", fmt.Errorf("both HOST and PORT are required")
+	default:
+		return "", "", fmt.Errorf("both HOST and PORT are required")
+	}
+}
+
+// connect dials address and shuttles data between the connection and the
+// command's standard streams until either side closes.
+func (c *Command) connect(stdio command.IO, network, address string) error {
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	return shuttle(conn, stdio.In, stdio.Out)
+}
+
+// serve listens on address, accepts one connection and shuttles data over it.
+func (c *Command) serve(stdio command.IO, network, address string) error {
+	if network == "udp" {
+		return c.serveUDP(stdio, address)
+	}
+	ln, err := net.Listen(network, address)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	conn, err := ln.Accept()
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	return shuttle(conn, stdio.In, stdio.Out)
+}
+
+// serveUDP receives the first UDP payload and writes it to stdout.
+func (c *Command) serveUDP(stdio command.IO, address string) error {
+	pc, err := net.ListenPacket("udp", address)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	defer func() { _ = pc.Close() }()
+
+	buf := make([]byte, 64*1024)
+	n, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	if _, err := stdio.Out.Write(buf[:n]); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}
+
+// halfCloser is implemented by *net.TCPConn; closing the write half lets the
+// peer observe EOF once stdin is exhausted.
+type halfCloser interface{ CloseWrite() error }
+
+// shuttle copies in->conn and conn->out concurrently and returns when the
+// connection-to-output direction completes.
+func shuttle(conn net.Conn, in io.Reader, out io.Writer) error {
+	go func() {
+		_, _ = io.Copy(conn, in)
+		if cw, ok := conn.(halfCloser); ok {
+			_ = cw.CloseWrite()
+		}
+	}()
+	if _, err := io.Copy(out, conn); err != nil {
+		return command.Failure(err)
+	}
+	return nil
+}

--- a/internal/applets/netutils/nc/nc_test.go
+++ b/internal/applets/netutils/nc/nc_test.go
@@ -1,0 +1,204 @@
+package nc
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestConnectSendsAndReceives(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	done := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- ""
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 64)
+		n, _ := conn.Read(buf)
+		_, _ = conn.Write([]byte("pong"))
+		done <- string(buf[:n])
+	}()
+
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader("ping"), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"127.0.0.1", port}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+
+	select {
+	case got := <-done:
+		if got != "ping" {
+			t.Errorf("server received %q, want ping", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive data")
+	}
+	if out.String() != "pong" {
+		t.Errorf("client output = %q, want pong", out.String())
+	}
+}
+
+func TestListenAddr(t *testing.T) {
+	t.Parallel()
+	if got, err := listenAddr("8080", nil); err != nil || got != ":8080" {
+		t.Errorf("listenAddr(8080) = %q, %v", got, err)
+	}
+	if got, err := listenAddr("", []string{"9000"}); err != nil || got != ":9000" {
+		t.Errorf("listenAddr operand = %q, %v", got, err)
+	}
+	if got, err := listenAddr("", []string{"127.0.0.1", "9000"}); err != nil || got != "127.0.0.1:9000" {
+		t.Errorf("listenAddr host+port = %q, %v", got, err)
+	}
+	if _, err := listenAddr("", nil); err == nil {
+		t.Error("expected error with no port")
+	}
+}
+
+func TestDialAddr(t *testing.T) {
+	t.Parallel()
+	if h, p, err := dialAddr("", []string{"example.com", "80"}); err != nil || h != "example.com" || p != "80" {
+		t.Errorf("dialAddr = %q %q %v", h, p, err)
+	}
+	if h, p, err := dialAddr("443", []string{"host"}); err != nil || h != "host" || p != "443" {
+		t.Errorf("dialAddr with -p = %q %q %v", h, p, err)
+	}
+	if _, _, err := dialAddr("", []string{"only-host"}); err == nil {
+		t.Error("expected error with host but no port")
+	}
+	if _, _, err := dialAddr("", nil); err == nil {
+		t.Error("expected error with no operands")
+	}
+}
+
+func TestConnectRefused(t *testing.T) {
+	t.Parallel()
+	// Port 1 on loopback is virtually always closed.
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"127.0.0.1", "1"}); err == nil {
+		t.Fatal("expected a connection error")
+	}
+}
+
+func TestMissingOperands(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Fatal("expected error with no operands")
+	}
+}
+
+func TestUDPRoundTrip(t *testing.T) {
+	t.Parallel()
+	// Listen with the applet, send a datagram with a plain UDP socket.
+	out := &bytes.Buffer{}
+	errCh := make(chan error, 1)
+	ready := make(chan string, 1)
+
+	// Bind a UDP socket first to learn a free port, then hand it to the applet
+	// path via address reuse is awkward; instead listen directly here and feed
+	// serveUDP through Run using a fixed ephemeral port.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := pc.LocalAddr().String()
+	_ = pc.Close()
+
+	go func() {
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		_, port, _ := net.SplitHostPort(addr)
+		ready <- port
+		errCh <- New().Run(context.Background(), io, []string{"-u", "-l", "-p", port})
+	}()
+
+	port := <-ready
+	// Give the listener a moment to bind.
+	time.Sleep(200 * time.Millisecond)
+	conn, err := net.Dial("udp", net.JoinHostPort("127.0.0.1", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = conn.Write([]byte("hello-udp"))
+	_ = conn.Close()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("UDP listener did not return")
+	}
+	if out.String() != "hello-udp" {
+		t.Errorf("received %q, want hello-udp", out.String())
+	}
+}
+
+func TestListenTCP(t *testing.T) {
+	t.Parallel()
+	// Find a free TCP port, release it, then have the applet listen on it.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, _ := net.SplitHostPort(probe.Addr().String())
+	_ = probe.Close()
+
+	out := &bytes.Buffer{}
+	errCh := make(chan error, 1)
+	go func() {
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		errCh <- New().Run(context.Background(), io, []string{"-l", "-p", port})
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = conn.Write([]byte("from-client"))
+	if tc, ok := conn.(*net.TCPConn); ok {
+		_ = tc.CloseWrite()
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not return")
+	}
+	_ = conn.Close()
+	if out.String() != "from-client" {
+		t.Errorf("server received %q, want from-client", out.String())
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "nc" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/netutils/ping/ping.go
+++ b/internal/applets/netutils/ping/ping.go
@@ -1,0 +1,175 @@
+// Package ping implements the ping applet: send ICMP ECHO_REQUEST packets to a
+// network host and report the round-trip times.
+//
+// This is a clean-room reimplementation. The original morrigan ping was forked
+// from the u-root project (BSD-3-Clause, Copyright the u-root Authors); that
+// attribution is preserved here per the BSD-3 terms even though no source is
+// copied verbatim.
+//
+// Sending ICMP echo requests needs a raw socket (CAP_NET_RAW / root). When the
+// socket cannot be created the command reports the privilege requirement and
+// exits with an error rather than crashing.
+package ping
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the ping applet.
+type Command struct{}
+
+// New returns a ping command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ping" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Send ICMP ECHO_REQUEST to network hosts" }
+
+const (
+	icmpEchoRequest = 8
+	icmpEchoReply   = 0
+)
+
+// Run executes ping.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... HOST", stdio.Err)
+	count := fs.IntP("count", "c", 4, "stop after sending COUNT packets")
+	interval := fs.Float64P("interval", "i", 1.0, "seconds to wait between packets")
+	timeout := fs.Float64P("timeout", "W", 1.0, "seconds to wait for each reply")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	hosts := fs.Args()
+	if len(hosts) != 1 {
+		return command.Failuref("exactly one HOST is required")
+	}
+
+	addr, err := net.ResolveIPAddr("ip4", hosts[0])
+	if err != nil {
+		return command.Failuref("cannot resolve %q: %v", hosts[0], err)
+	}
+
+	return c.ping(stdio, addr, *count, time.Duration(*interval*float64(time.Second)), time.Duration(*timeout*float64(time.Second)))
+}
+
+// ping sends count echo requests to addr, printing each round-trip time.
+func (c *Command) ping(stdio command.IO, addr *net.IPAddr, count int, interval, timeout time.Duration) error {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_ICMP)
+	if err != nil {
+		return command.Failuref("cannot open raw ICMP socket (needs CAP_NET_RAW/root): %v", err)
+	}
+	defer func() { _ = unix.Close(fd) }()
+
+	id := os.Getpid() & 0xffff
+	var dst [4]byte
+	copy(dst[:], addr.IP.To4())
+	sa := &unix.SockaddrInet4{Addr: dst}
+
+	_, _ = fmt.Fprintf(stdio.Out, "PING %s (%s)\n", addr.IP, addr.IP)
+	received := 0
+	for seq := 0; seq < count; seq++ {
+		pkt := echoRequest(id, seq)
+		start := time.Now()
+		if err := unix.Sendto(fd, pkt, 0, sa); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "ping: send failed: %v\n", err)
+			continue
+		}
+		if rtt, ok := awaitReply(fd, id, seq, timeout, start); ok {
+			received++
+			_, _ = fmt.Fprintf(stdio.Out, "%d bytes from %s: icmp_seq=%d time=%.2f ms\n",
+				len(pkt), addr.IP, seq, float64(rtt.Microseconds())/1000)
+		} else {
+			_, _ = fmt.Fprintf(stdio.Out, "request timeout for icmp_seq=%d\n", seq)
+		}
+		if seq < count-1 {
+			time.Sleep(interval)
+		}
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "--- %s ping statistics ---\n%d packets transmitted, %d received\n",
+		addr.IP, count, received)
+	if received == 0 {
+		return &command.ExitError{Code: command.ExitFailure}
+	}
+	return nil
+}
+
+// awaitReply waits up to timeout for an echo reply matching id and seq.
+func awaitReply(fd, id, seq int, timeout time.Duration, start time.Time) (time.Duration, bool) {
+	tv := unix.NsecToTimeval(int64(timeout))
+	_ = unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv)
+
+	buf := make([]byte, 1500)
+	deadline := start.Add(timeout)
+	for time.Now().Before(deadline) {
+		n, _, err := unix.Recvfrom(fd, buf, 0)
+		if err != nil {
+			return 0, false
+		}
+		// Skip the IPv4 header to reach the ICMP message.
+		if rid, rseq, ok := parseReply(buf[:n]); ok && rid == id && rseq == seq {
+			return time.Since(start), true
+		}
+	}
+	return 0, false
+}
+
+// echoRequest builds an ICMP echo request packet with the given id and seq.
+func echoRequest(id, seq int) []byte {
+	body := make([]byte, 16) // payload
+	pkt := make([]byte, 8+len(body))
+	pkt[0] = icmpEchoRequest
+	pkt[1] = 0
+	binary.BigEndian.PutUint16(pkt[4:], uint16(id))
+	binary.BigEndian.PutUint16(pkt[6:], uint16(seq))
+	copy(pkt[8:], body)
+	cs := checksum(pkt)
+	binary.BigEndian.PutUint16(pkt[2:], cs)
+	return pkt
+}
+
+// parseReply extracts the id and seq from a received IPv4+ICMP echo reply.
+func parseReply(packet []byte) (id, seq int, ok bool) {
+	if len(packet) < 20 {
+		return 0, 0, false
+	}
+	ihl := int(packet[0]&0x0f) * 4
+	if len(packet) < ihl+8 {
+		return 0, 0, false
+	}
+	icmp := packet[ihl:]
+	if icmp[0] != icmpEchoReply {
+		return 0, 0, false
+	}
+	id = int(binary.BigEndian.Uint16(icmp[4:]))
+	seq = int(binary.BigEndian.Uint16(icmp[6:]))
+	return id, seq, true
+}
+
+// checksum computes the 16-bit one's-complement Internet checksum of data.
+func checksum(data []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(data); i += 2 {
+		sum += uint32(data[i])<<8 | uint32(data[i+1])
+	}
+	if len(data)%2 == 1 {
+		sum += uint32(data[len(data)-1]) << 8
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}

--- a/internal/applets/netutils/ping/ping_test.go
+++ b/internal/applets/netutils/ping/ping_test.go
@@ -1,0 +1,125 @@
+package ping
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestEchoRequestChecksumIsValid(t *testing.T) {
+	t.Parallel()
+	pkt := echoRequest(0x1234, 7)
+	if pkt[0] != icmpEchoRequest {
+		t.Errorf("type = %d, want %d", pkt[0], icmpEchoRequest)
+	}
+	// Recomputing the checksum over a packet that already carries it yields 0.
+	if got := checksum(pkt); got != 0 {
+		t.Errorf("verification checksum = %#x, want 0", got)
+	}
+	if id := binary.BigEndian.Uint16(pkt[4:]); id != 0x1234 {
+		t.Errorf("id = %#x, want 0x1234", id)
+	}
+	if seq := binary.BigEndian.Uint16(pkt[6:]); seq != 7 {
+		t.Errorf("seq = %d, want 7", seq)
+	}
+}
+
+func TestParseReply(t *testing.T) {
+	t.Parallel()
+	// Craft an IPv4 header (ihl=5 => 20 bytes) followed by an ICMP echo reply.
+	packet := make([]byte, 20+8)
+	packet[0] = 0x45 // version 4, ihl 5
+	icmp := packet[20:]
+	icmp[0] = icmpEchoReply
+	binary.BigEndian.PutUint16(icmp[4:], 0xabcd)
+	binary.BigEndian.PutUint16(icmp[6:], 42)
+
+	id, seq, ok := parseReply(packet)
+	if !ok || id != 0xabcd || seq != 42 {
+		t.Errorf("parseReply = %#x, %d, %v", id, seq, ok)
+	}
+}
+
+func TestParseReplyRejectsNonReply(t *testing.T) {
+	t.Parallel()
+	packet := make([]byte, 28)
+	packet[0] = 0x45
+	packet[20] = icmpEchoRequest // not a reply
+	if _, _, ok := parseReply(packet); ok {
+		t.Error("echo request should not parse as a reply")
+	}
+	if _, _, ok := parseReply([]byte{0x45}); ok {
+		t.Error("short packet should not parse")
+	}
+}
+
+func TestChecksumKnown(t *testing.T) {
+	t.Parallel()
+	// One's-complement sum of 0x0000 is 0xffff.
+	if got := checksum([]byte{0x00, 0x00}); got != 0xffff {
+		t.Errorf("checksum = %#x, want 0xffff", got)
+	}
+}
+
+func TestMissingHost(t *testing.T) {
+	t.Parallel()
+	_, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exactly one HOST") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestUnresolvableHost(t *testing.T) {
+	t.Parallel()
+	_, _, err := run(t, "no-such-host.invalid.")
+	if err == nil {
+		t.Fatal("expected resolve error")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestPingLoopback(t *testing.T) {
+	t.Parallel()
+	// Exercises ping(): as non-root the raw socket fails with a privilege
+	// error; as root it pings loopback and returns quickly. Either is fine.
+	out, _, err := run(t, "-c", "1", "-i", "0", "-W", "1", "127.0.0.1")
+	if err != nil {
+		if !strings.Contains(err.Error(), "raw ICMP socket") {
+			t.Errorf("unexpected error = %v", err)
+		}
+		return
+	}
+	// Ran as root: we should have printed the PING banner and statistics.
+	if !strings.Contains(out, "PING 127.0.0.1") || !strings.Contains(out, "statistics") {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "ping" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/netutils/whris/whris.go
+++ b/internal/applets/netutils/whris/whris.go
@@ -1,0 +1,130 @@
+// Package whris implements the whris applet: display management information
+// (owner / AS number) for the IP addresses a domain resolves to.
+//
+// This is a clean-room reimplementation. The original morrigan whris was forked
+// from harakeishi/whris (MIT License, Copyright (c) harakeishi); that
+// attribution is preserved here per the MIT terms even though no source is
+// copied verbatim.
+package whris
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the whris applet.
+type Command struct{}
+
+// New returns a whris command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "whris" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show management information for a domain's IP addresses" }
+
+// info holds the management information for one IP address.
+type info struct {
+	ip    string
+	asn   string
+	owner string
+}
+
+// resolver looks up the IP addresses of a host; tests replace it.
+var resolver = func(host string) ([]net.IP, error) {
+	return net.LookupIP(host)
+}
+
+// asnLookup returns the AS number and owner for an IP; tests replace it. The
+// default queries Team Cymru's WHOIS IP-to-ASN service.
+var asnLookup = cymruLookup
+
+// Run executes whris.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DOMAIN", stdio.Err)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	domains := fs.Args()
+	if len(domains) != 1 {
+		return command.Failuref("exactly one DOMAIN is required")
+	}
+
+	ips, err := resolver(domains[0])
+	if err != nil {
+		return command.Failuref("cannot resolve %q: %v", domains[0], err)
+	}
+
+	infos := collect(ips)
+	for _, in := range infos {
+		_, _ = fmt.Fprintf(stdio.Out, "%s\tAS%s\t%s\n", in.ip, in.asn, in.owner)
+	}
+	return nil
+}
+
+// collect gathers the management info for each IPv4 address, skipping lookups
+// that fail so one bad IP does not abort the whole report.
+func collect(ips []net.IP) []info {
+	var infos []info
+	for _, ip := range ips {
+		v4 := ip.To4()
+		if v4 == nil {
+			continue
+		}
+		asn, owner, err := asnLookup(v4.String())
+		if err != nil {
+			asn, owner = "?", "lookup failed"
+		}
+		infos = append(infos, info{ip: v4.String(), asn: asn, owner: owner})
+	}
+	return infos
+}
+
+// cymruServer is the Team Cymru WHOIS endpoint; tests point it at a local stub.
+var cymruServer = "whois.cymru.com:43"
+
+// cymruLookup queries whois.cymru.com for the AS number and owner of ip.
+func cymruLookup(ip string) (asn, owner string, err error) {
+	conn, err := net.DialTimeout("tcp", cymruServer, 5*time.Second)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, err := fmt.Fprintf(conn, " -v %s\n", ip); err != nil {
+		return "", "", err
+	}
+	return parseCymru(conn)
+}
+
+// parseCymru reads the Team Cymru "-v" response and returns the AS number and
+// owner from the data row (the second non-header line).
+func parseCymru(r interface{ Read([]byte) (int, error) }) (asn, owner string, err error) {
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "AS") && strings.Contains(line, "|") {
+			continue // header: "AS | IP | ..."
+		}
+		fields := strings.Split(line, "|")
+		if len(fields) < 7 {
+			continue
+		}
+		return strings.TrimSpace(fields[0]), strings.TrimSpace(fields[6]), nil
+	}
+	if err := sc.Err(); err != nil {
+		return "", "", err
+	}
+	return "", "", fmt.Errorf("no data in WHOIS response")
+}

--- a/internal/applets/netutils/whris/whris_test.go
+++ b/internal/applets/netutils/whris/whris_test.go
@@ -1,0 +1,163 @@
+package whris
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func stub(t *testing.T, ips []net.IP, asn, owner string, lookErr error) {
+	t.Helper()
+	origR, origA := resolver, asnLookup
+	resolver = func(string) ([]net.IP, error) { return ips, nil }
+	asnLookup = func(string) (string, string, error) { return asn, owner, lookErr }
+	t.Cleanup(func() { resolver, asnLookup = origR, origA })
+}
+
+func TestReportsInfo(t *testing.T) {
+	stub(t, []net.IP{net.ParseIP("93.184.216.34")}, "15133", "EDGECAST", nil)
+	out, _, err := run(t, "example.com")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "93.184.216.34\tAS15133\tEDGECAST") {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestLookupFailureIsTolerated(t *testing.T) {
+	stub(t, []net.IP{net.ParseIP("1.2.3.4")}, "", "", errors.New("boom"))
+	out, _, err := run(t, "example.com")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "1.2.3.4\tAS?\tlookup failed") {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestSkipsIPv6(t *testing.T) {
+	t.Parallel()
+	infos := collect([]net.IP{net.ParseIP("2606:2800:220:1:248:1893:25c8:1946")})
+	if len(infos) != 0 {
+		t.Errorf("IPv6 addresses should be skipped, got %v", infos)
+	}
+}
+
+func TestResolveFailure(t *testing.T) {
+	origR := resolver
+	resolver = func(string) ([]net.IP, error) { return nil, errors.New("nxdomain") }
+	t.Cleanup(func() { resolver = origR })
+
+	_, _, err := run(t, "example.com")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestMissingDomain(t *testing.T) {
+	t.Parallel()
+	_, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "exactly one DOMAIN") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestParseCymru(t *testing.T) {
+	t.Parallel()
+	resp := "AS      | IP               | BGP Prefix          | CC | Registry | Allocated  | AS Name\n" +
+		"15169   | 8.8.8.8          | 8.8.8.0/24          | US | arin     | 1992-12-01 | GOOGLE, US\n"
+	asn, owner, err := parseCymru(strings.NewReader(resp))
+	if err != nil {
+		t.Fatalf("parseCymru error = %v", err)
+	}
+	if asn != "15169" {
+		t.Errorf("asn = %q, want 15169", asn)
+	}
+	if owner != "GOOGLE, US" {
+		t.Errorf("owner = %q", owner)
+	}
+}
+
+func TestParseCymruNoData(t *testing.T) {
+	t.Parallel()
+	_, _, err := parseCymru(strings.NewReader("AS | IP | name\n"))
+	if err == nil {
+		t.Error("expected error for header-only response")
+	}
+}
+
+func TestCymruLookupAgainstLocalServer(t *testing.T) {
+	t.Parallel()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 128)
+		_, _ = conn.Read(buf)
+		_, _ = conn.Write([]byte(
+			"AS | IP | BGP Prefix | CC | Registry | Allocated | AS Name\n" +
+				"13335 | 1.1.1.1 | 1.1.1.0/24 | US | arin | 2010-07-14 | CLOUDFLARENET, US\n"))
+	}()
+
+	orig := cymruServer
+	cymruServer = ln.Addr().String()
+	t.Cleanup(func() { cymruServer = orig })
+
+	asn, owner, err := cymruLookup("1.1.1.1")
+	if err != nil {
+		t.Fatalf("cymruLookup error = %v", err)
+	}
+	if asn != "13335" || owner != "CLOUDFLARENET, US" {
+		t.Errorf("got AS%s %q", asn, owner)
+	}
+}
+
+func TestCymruLookupDialError(t *testing.T) {
+	t.Parallel()
+	orig := cymruServer
+	cymruServer = "127.0.0.1:1" // closed port
+	t.Cleanup(func() { cymruServer = orig })
+	if _, _, err := cymruLookup("8.8.8.8"); err == nil {
+		t.Error("expected a dial error")
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "whris" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/logcollect/logcollect.go
+++ b/internal/applets/shellutils/logcollect/logcollect.go
@@ -1,0 +1,110 @@
+// Package logcollect implements the log-collect applet: gather the log files
+// present on the system into one output directory for inspection. It is a
+// clean-room port of morrigan's log-collect.
+package logcollect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the log-collect applet.
+type Command struct{}
+
+// New returns a log-collect command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "log-collect" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Gather system log files into one directory" }
+
+// Run executes log-collect.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [SOURCE]", stdio.Err)
+	out := fs.StringP("output", "o", "collected-logs", "directory to copy the logs into")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	source := "/var/log"
+	if rest := fs.Args(); len(rest) > 0 {
+		source = rest[0]
+	}
+
+	copied, skipped, err := collect(source, *out)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "collected %d files into %s (%d skipped)\n", copied, *out, skipped)
+	return nil
+}
+
+// collect walks source and copies every readable regular file into dst,
+// recreating the directory layout. Unreadable files are skipped (root is
+// usually required to read everything under /var/log). It returns the number of
+// files copied and skipped.
+func collect(source, dst string) (copied, skipped int, err error) {
+	root, err := os.Stat(source)
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot read source %q: %v", source, err)
+	}
+	if !root.IsDir() {
+		return 0, 0, fmt.Errorf("source %q is not a directory", source)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil { //nolint:gosec // a collection directory is not sensitive
+		return 0, 0, fmt.Errorf("cannot create %q: %v", dst, err)
+	}
+
+	walkErr := filepath.Walk(source, func(path string, fi os.FileInfo, werr error) error {
+		if werr != nil || fi.IsDir() || !fi.Mode().IsRegular() {
+			if werr != nil {
+				skipped++
+			}
+			return nil //nolint:nilerr // keep walking past unreadable entries
+		}
+		rel, rerr := filepath.Rel(source, path)
+		if rerr != nil {
+			skipped++
+			return nil
+		}
+		if copyFile(path, filepath.Join(dst, rel)) != nil {
+			skipped++
+			return nil
+		}
+		copied++
+		return nil
+	})
+	return copied, skipped, walkErr
+}
+
+// copyFile copies src to dst, creating parent directories as needed.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src) //nolint:gosec // reading a discovered log file is the point
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil { //nolint:gosec // mirror layout
+		return err
+	}
+	out, err := os.Create(dst) //nolint:gosec // writing into the collection directory
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/internal/applets/shellutils/logcollect/logcollect_test.go
+++ b/internal/applets/shellutils/logcollect/logcollect_test.go
@@ -1,0 +1,155 @@
+package logcollect
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func makeTree(t *testing.T) string {
+	t.Helper()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "syslog"), []byte("line1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "nginx"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "nginx", "access.log"), []byte("GET /\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return src
+}
+
+func TestCollectCopiesTree(t *testing.T) {
+	t.Parallel()
+	src := makeTree(t)
+	dst := filepath.Join(t.TempDir(), "out")
+	out, _, err := run(t, "-o", dst, src)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "collected 2 files") {
+		t.Errorf("out = %q", out)
+	}
+	for _, rel := range []string{"syslog", "nginx/access.log"} {
+		if _, err := os.Stat(filepath.Join(dst, rel)); err != nil {
+			t.Errorf("expected %s to be copied: %v", rel, err)
+		}
+	}
+}
+
+func TestCollectPreservesContent(t *testing.T) {
+	t.Parallel()
+	src := makeTree(t)
+	dst := filepath.Join(t.TempDir(), "out")
+	if _, _, err := run(t, "-o", dst, src); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "syslog"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "line1\n" {
+		t.Errorf("content = %q", got)
+	}
+}
+
+func TestSourceMissing(t *testing.T) {
+	t.Parallel()
+	_, _, err := run(t, "-o", t.TempDir(), "/no/such/source")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot read source") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestSourceNotDir(t *testing.T) {
+	t.Parallel()
+	f := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := run(t, "-o", t.TempDir(), f)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestSkipsUnreadableFile(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "ok.log"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(src, "secret.log")
+	if err := os.WriteFile(secret, []byte("y"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o644) })
+
+	dst := filepath.Join(t.TempDir(), "out")
+	out, _, err := run(t, "-o", dst, src)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// As non-root the 0000 file cannot be opened, so it is skipped; as root it
+	// is readable and copied. Either way ok.log must be collected.
+	if _, err := os.Stat(filepath.Join(dst, "ok.log")); err != nil {
+		t.Errorf("ok.log should be collected: %v", err)
+	}
+	if !strings.Contains(out, "collected") {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestDefaultOutputAndSource(t *testing.T) {
+	t.Parallel()
+	// Use an explicit empty source dir but the default output directory, then
+	// clean it up. This exercises the default -o path.
+	src := t.TempDir()
+	wd, _ := os.Getwd()
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	out, _, err := run(t, src)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "collected-logs") {
+		t.Errorf("expected default output dir in %q", out)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "log-collect" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/internal/applets/shellutils/speaker/speaker.go
+++ b/internal/applets/shellutils/speaker/speaker.go
@@ -1,0 +1,97 @@
+// Package speaker implements the speaker applet: read text aloud using whatever
+// text-to-speech engine is installed. It is a clean-room port of
+// nao1215/speaker; because MimixBox builds with CGO disabled it shells out to an
+// installed engine (spd-say, espeak or say) rather than linking an audio
+// library, and degrades gracefully when none is present.
+package speaker
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the speaker applet.
+type Command struct{}
+
+// New returns a speaker command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "speaker" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Read text aloud using an installed TTS engine" }
+
+// engine describes a text-to-speech program and how to invoke it with text.
+type engine struct {
+	name string
+	args func(text, lang string) []string
+}
+
+// engines is the ordered list of TTS programs speaker will try.
+var engines = []engine{
+	{"spd-say", func(text, lang string) []string {
+		args := []string{"-w"}
+		if lang != "" {
+			args = append(args, "-l", lang)
+		}
+		return append(args, text)
+	}},
+	{"espeak", func(text, lang string) []string {
+		args := []string{}
+		if lang != "" {
+			args = append(args, "-v", lang)
+		}
+		return append(args, text)
+	}},
+	{"say", func(text, lang string) []string { return []string{text} }},
+}
+
+// lookPath resolves a program to its absolute path; tests replace it.
+var lookPath = exec.LookPath
+
+// runEngine runs the chosen engine with its arguments; tests replace it.
+var runEngine = func(name string, args []string) error {
+	return exec.Command(name, args...).Run() //nolint:gosec // invoking a known TTS engine
+}
+
+// Run executes speaker.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... TEXT...", stdio.Err)
+	lang := fs.StringP("language", "l", "", "language/voice to use (engine-specific)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	text := strings.Join(fs.Args(), " ")
+	if text == "" {
+		return command.Failuref("no text to speak")
+	}
+
+	eng, ok := selectEngine()
+	if !ok {
+		return command.Failuref("no text-to-speech engine found (install spd-say, espeak, or say)")
+	}
+
+	if err := runEngine(eng.name, eng.args(text, *lang)); err != nil {
+		return command.Failuref("%s failed: %v", eng.name, err)
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "spoke %d characters via %s\n", len(text), eng.name)
+	return nil
+}
+
+// selectEngine returns the first installed TTS engine.
+func selectEngine() (engine, bool) {
+	for _, e := range engines {
+		if _, err := lookPath(e.name); err == nil {
+			return e, true
+		}
+	}
+	return engine{}, false
+}

--- a/internal/applets/shellutils/speaker/speaker_test.go
+++ b/internal/applets/shellutils/speaker/speaker_test.go
@@ -1,0 +1,121 @@
+package speaker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func stub(t *testing.T, available string, runErr error) (calledName *string, calledArgs *[]string) {
+	t.Helper()
+	origLook, origRun := lookPath, runEngine
+	name := ""
+	var gotArgs []string
+	lookPath = func(n string) (string, error) {
+		if n == available {
+			return "/usr/bin/" + n, nil
+		}
+		return "", errors.New("not found")
+	}
+	runEngine = func(n string, a []string) error {
+		name, gotArgs = n, a
+		return runErr
+	}
+	t.Cleanup(func() { lookPath, runEngine = origLook, origRun })
+	return &name, &gotArgs
+}
+
+func TestSpeaksViaEngine(t *testing.T) {
+	name, args := stub(t, "espeak", nil)
+	out, _, err := run(t, "hello", "world")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if *name != "espeak" {
+		t.Errorf("engine = %q, want espeak", *name)
+	}
+	if got := *args; got[len(got)-1] != "hello world" {
+		t.Errorf("args = %v, want text last", got)
+	}
+	if !strings.Contains(out, "via espeak") {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestLanguageOption(t *testing.T) {
+	_, args := stub(t, "espeak", nil)
+	if _, _, err := run(t, "-l", "fr", "bonjour"); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	joined := strings.Join(*args, " ")
+	if !strings.Contains(joined, "-v fr") {
+		t.Errorf("args = %v, want -v fr", *args)
+	}
+}
+
+func TestPrefersFirstAvailable(t *testing.T) {
+	name, _ := stub(t, "spd-say", nil)
+	if _, _, err := run(t, "hi"); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if *name != "spd-say" {
+		t.Errorf("engine = %q, want spd-say", *name)
+	}
+}
+
+func TestNoEngine(t *testing.T) {
+	stub(t, "none-installed", nil)
+	_, _, err := run(t, "hi")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no text-to-speech engine") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestEngineFails(t *testing.T) {
+	stub(t, "espeak", errors.New("boom"))
+	_, _, err := run(t, "hi")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "espeak failed") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestNoText(t *testing.T) {
+	t.Parallel()
+	_, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no text to speak") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "speaker" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}

--- a/test/it/netutils/nc_test.sh
+++ b/test/it/netutils/nc_test.sh
@@ -1,0 +1,10 @@
+Setup() { export TEST_DIR=/tmp/mimixbox/it; mkdir -p ${TEST_DIR}; }
+CleanUp() { rm -rf /tmp/mimixbox/it; }
+TestNcLoopback() {
+    # Listener writes whatever the client sends into a file.
+    (nc -l -p 18642 > /tmp/mimixbox/it/nc_recv.txt) &
+    sleep 0.3
+    echo "from-client" | nc 127.0.0.1 18642 >/dev/null 2>&1
+    sleep 0.2
+    cat /tmp/mimixbox/it/nc_recv.txt
+}

--- a/test/it/netutils/ping_test.sh
+++ b/test/it/netutils/ping_test.sh
@@ -1,0 +1,5 @@
+TestPingUsage() {
+    # No HOST: usage error (does not need raw-socket privileges).
+    ping 2>&1
+    echo "rc:$?"
+}

--- a/test/it/netutils/whris_test.sh
+++ b/test/it/netutils/whris_test.sh
@@ -1,0 +1,4 @@
+TestWhrisUsage() {
+    whris 2>&1
+    echo "rc:$?"
+}

--- a/test/it/shellutils/logcollect_test.sh
+++ b/test/it/shellutils/logcollect_test.sh
@@ -1,0 +1,10 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    mkdir -p ${TEST_DIR}/src
+    printf 'log\n' > ${TEST_DIR}/src/a.log
+}
+CleanUp() { rm -rf /tmp/mimixbox/it; }
+TestLogCollect() {
+    log-collect -o /tmp/mimixbox/it/out /tmp/mimixbox/it/src >/dev/null
+    cat /tmp/mimixbox/it/out/a.log
+}

--- a/test/it/shellutils/speaker_test.sh
+++ b/test/it/shellutils/speaker_test.sh
@@ -1,0 +1,4 @@
+TestSpeakerNoText() {
+    speaker 2>&1
+    echo "rc:$?"
+}

--- a/test/it/spec/logcollect_spec.sh
+++ b/test/it/spec/logcollect_spec.sh
@@ -1,0 +1,10 @@
+Describe 'log-collect'
+    Include shellutils/logcollect_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+    It 'copies log files into the output directory'
+        When call TestLogCollect
+        The output should equal 'log'
+        The status should be success
+    End
+End

--- a/test/it/spec/nc_spec.sh
+++ b/test/it/spec/nc_spec.sh
@@ -1,0 +1,10 @@
+Describe 'nc loopback'
+    Include netutils/nc_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+    It 'transfers data over TCP'
+        When call TestNcLoopback
+        The output should equal 'from-client'
+        The status should be success
+    End
+End

--- a/test/it/spec/ping_spec.sh
+++ b/test/it/spec/ping_spec.sh
@@ -1,0 +1,8 @@
+Describe 'ping usage'
+    Include netutils/ping_test.sh
+    It 'reports an error when no host is given'
+        When call TestPingUsage
+        The output should include 'rc:1'
+        The status should be success
+    End
+End

--- a/test/it/spec/speaker_spec.sh
+++ b/test/it/spec/speaker_spec.sh
@@ -1,0 +1,8 @@
+Describe 'speaker'
+    Include shellutils/speaker_test.sh
+    It 'errors when no text is given'
+        When call TestSpeakerNoText
+        The output should include 'rc:1'
+        The status should be success
+    End
+End

--- a/test/it/spec/whris_spec.sh
+++ b/test/it/spec/whris_spec.sh
@@ -1,0 +1,8 @@
+Describe 'whris usage'
+    Include netutils/whris_test.sh
+    It 'reports an error when no domain is given'
+        When call TestWhrisUsage
+        The output should include 'rc:1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Ports five morrigan/maintainer tools requested in #196–#200 onto the `internal/command` framework. These are **clean-room** reimplementations; the original MIT (go-netcat, whris) and BSD-3 (u-root ping) attributions are preserved in the source headers, and no upstream source is copied verbatim. Each ships unit tests and a shellspec end-to-end test.

| Issue | Command | Category | Notes |
|------|---------|----------|-------|
| #197 | `nc` | netutils | TCP/UDP connect and `-l` listen, piping stdin/stdout |
| #198 | `ping` | netutils | raw-socket ICMP echo (`-c`/`-i`/`-W`); clean privilege error without CAP_NET_RAW |
| #199 | `whris` | netutils | resolve a domain, print AS/owner per IP via Team Cymru WHOIS |
| #200 | `log-collect` | shellutils | copy readable `/var/log` files into an output dir, skipping the rest |
| #196 | `speaker` | shellutils | TTS via an installed engine (spd-say/espeak/say), graceful when absent |

Network/privileged paths are kept thin; the testable logic (address parsing, packet build/checksum, WHOIS parsing, engine selection, file copy) is injected behind variables and unit-tested.

## Test

- `make test` green; new packages at 53% (`ping`, raw-socket loop is root-only, consistent with `sl`) to 93%.
- `golangci-lint run` on the new packages → `0 issues`.
- New shellspec specs pass: `5 examples, 0 failures` (network tools tested via loopback or usage paths so CI needs no internet/privileges).

Closes #196, closes #197, closes #198, closes #199, closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 5 new utilities: `nc` for TCP/UDP data transfer, `ping` for connectivity checks, `whris` for domain/IP ownership lookups, `log-collect` for gathering system logs, and `speaker` for text-to-speech conversion.
  * Command count increased from 145 to 150.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->