### PR TITLE
ci: build the Docker image in CI to keep "build in Docker" working (#4)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Builds the Docker image from the local source tree to guarantee that
+# "build mimixbox in Docker" keeps working (GitHub issue #4). The image's
+# Dockerfile compiles MimixBox inside the golang toolchain image, so a broken
+# go.mod or build step fails this job.
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the Docker image from local source
+        run: docker image build -t mimixbox/ci:${{ github.sha }} .
+
+      - name: Verify the in-image binary runs
+        run: |
+          docker container run --rm mimixbox/ci:${{ github.sha }} mimixbox --version
+          docker container run --rm mimixbox/ci:${{ github.sha }} mimixbox --list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auditing; `pwscore` (#203) rates password strength; `http-status-code`
   (#206) explains HTTP status codes. New `netutils` and `securityutils`
   applet categories were introduced.
+- A `Docker` CI workflow that builds the image from the local source tree
+  and verifies the in-image `mimixbox` binary runs, so building MimixBox in
+  Docker stays working (#4).
 
 ## [0.34.0] - 2026-06-08
 


### PR DESCRIPTION
## Summary

Resolves the long-standing #4 ("Build mimixbox in Docker"). The original problem — building the local source failed with `no matching versions for query "latest"` — was fixed when the Dockerfile switched to compiling from the copied source tree inside the golang toolchain image (#158). This PR makes that guarantee continuous: a new `Docker` workflow runs `docker image build` from the local source on every push/PR and then verifies the in-image binary runs (`mimixbox --version` and `mimixbox --list`).

A broken `go.mod` or build step now fails CI, so building MimixBox in Docker stays working.

Closes #4