### PR TITLE
chore: release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-06-08
+
 ### Added
 
 - New textutils applets on the `internal/command` framework, each with

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,7 +1,0 @@
-|      NAME       |                       EMAIL                       | +(APPEND) | -(DELETE) |
-|-----------------|---------------------------------------------------|-----------|-----------|
-| Nao1215         | n.chika156@gmail.com                              |     20781 |      3306 |
-| polynomialspace | github@polynomial.space                           |       310 |       293 |
-| Kavya Shukla    | kavyuushukla59@gmail.com                          |        72 |         0 |
-| nao1215         | nao1215@users.noreply.github.com                  |         5 |         0 |
-| dependabot[bot] | 49699333+dependabot[bot]@users.noreply.github.com |         0 |         0 |

--- a/README.md
+++ b/README.md
@@ -244,14 +244,6 @@ $ serial -n photo .             # photo0, photo1, ... in the current directory
 $ serial -d -n photo .          # dry run: print the renames without applying them
 ```
 
-## Roadmap
-
-- Step 1. Implement many common Unix commands (〜Version 0.x.x).
-- Step 2. Increase the options for each command (〜Version 1.x.x).
-- Step 3. Move commands toward modern specifications (〜Version 2.x.x).
-
-MimixBox does not yet have enough commands, so the first priority is increasing their number until the project can be dogfooded. Next, command options are brought closer to Coreutils and other packages. MimixBox does not aim to copy Coreutils, but it does aim to provide the options Linux users expect. The final phase makes MimixBox unique by extending commands toward higher functionality, like [bat](https://github.com/sharkdp/bat) and [lsd](https://github.com/Peltoche/lsd), which are reimplementations of cat and ls.
-
 ## Development
 
 ### Tools & Libraries

--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -54,7 +54,7 @@ type options struct {
 
 var osExit = os.Exit
 
-const version = "0.33.3"
+const version = "0.35.0"
 
 func main() {
 	var opts options

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,10 +9,10 @@ import (
 
 // Version is the MimixBox version. It is over_written at build time with
 // -ldflags "-X github.com/nao1215/mimixbox/internal/version.Version=x.y.z".
-var Version = "0.34.0"
+var Version = "0.35.0"
 
 // Print writes the "--version" line for a single command to w, following the
-// GNU coreutils convention, e.g. "cat (mimixbox) 0.33.3".
+// GNU coreutils convention, e.g. "cat (mimixbox) 0.35.0".
 func Print(w io.Writer, command string) {
 	_, _ = fmt.Fprintf(w, "%s (mimixbox) %s\n", command, Version)
 }


### PR DESCRIPTION
## Summary

Release **v0.35.0**. Bumps the version string (in both `internal/version` and the `mimixbox` multiplexer, which was still `0.33.3`) and records the release in `CHANGELOG.md`.

This release closes every open issue:

- **38 new applets** across `textutils` (comm, paste, fold, fmt, split, shuf, rev, cksum, strings, xxd, base32), `fileutils` (stat, truncate, readlink, link, unlink, shred, mountpoint), `shellutils` (yes, uname, arch, nproc, hostname, logname, tty, nohup, timeout, watch, free, pidof, killall, posixer, log-collect, speaker), `jokeutils` (fortune, banner, cowthink, nyancat, cmatrix), and the new `netutils` (http-status-code, nc, ping, whris) and `securityutils` (pwgen, pwscore, unshadow, pwcrack, zip-pwcrack) categories. MimixBox now ships **152 commands**.
- **`internal/auth`**: cross-platform basic authentication (#34) — shadow/crypt by default, PAM behind `-tags pam`.
- **Coverage**: raised above the 80% octocov target.
- **Docker** (#4): the image build is now validated in CI.

## Housekeeping (per request)

- Delete `Contributors.md`.
- Remove the `Roadmap` section from the README.

## Test

`make test` green (total coverage 80.3%); `go build ./...` clean; `mimixbox --version` now prints `0.35.0`.