### PR TITLE
fix: cp/mv/dos2unix/watch correctness & safety; stream cat/nl; self-contained lib tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `cp` now copies files and directories with the **source's** permission
+  bits instead of a hardcoded 0644/0755, so the execute bit on scripts is
+  kept and private directory trees are not widened. `cp -f` now actually
+  removes and replaces a destination that cannot be opened.
+- `mv` across filesystems (the `EXDEV` copy+remove fallback) preserves mode
+  and timestamps and moves directories recursively, instead of dropping
+  metadata and failing on directories.
+- `dos2unix`, `unix2dos` and `internal/lib.ListToFile` rewrite files
+  atomically (write a temp file, then rename) and preserve the original
+  mode, so an interrupted write or full disk no longer truncates the
+  original file.
+- `watch` runs the child command with the context, so cancelling watch
+  (Ctrl-C) interrupts a hung child instead of blocking on it.
+
+### Changed
+
+- `cat` and `nl` stream their input line by line instead of reading whole
+  files into memory, so they work in constant space on large files and
+  pipes; `internal/textproc.Numberer` streams likewise.
+- `internal/lib` file tests build their fixtures with `t.TempDir()` instead
+  of a shared `/tmp/mimixbox/ut` tree, so `go test ./...` passes on a clean
+  checkout and the suite is parallel-safe.
+
 ## [0.35.0] - 2026-06-08
 
 ### Added

--- a/internal/applets/fileutils/cp/cp.go
+++ b/internal/applets/fileutils/cp/cp.go
@@ -177,12 +177,15 @@ func cpDir(stdio command.IO, src, dest string, opts options) error {
 		target := filepath.Join(root, rel)
 
 		if info.IsDir() {
-			mode := os.FileMode(0755)
-			if opts.preserve {
-				mode = info.Mode().Perm()
-			}
-			if err := os.MkdirAll(target, mode); err != nil {
+			// Use the source directory's mode (GNU cp does this even without
+			// -p); a hardcoded 0755 would widen a private tree such as 0700.
+			if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
 				return err
+			}
+			// MkdirAll is a no-op when target already exists, and umask may have
+			// masked the mode on creation; with -p, set the exact source mode.
+			if opts.preserve {
+				_ = os.Chmod(target, info.Mode().Perm())
 			}
 			return nil
 		}
@@ -219,14 +222,24 @@ func copyFileContents(src, dst string, info os.FileInfo, opts options) error {
 	}
 	defer func() { _ = in.Close() }()
 
-	mode := os.FileMode(0644)
-	if opts.preserve {
-		mode = info.Mode().Perm()
-	}
+	// Create the destination with the source file's mode (GNU cp does this even
+	// without -p); a hardcoded 0644 would strip the execute bit from scripts and
+	// binaries. The mode only takes effect when the file is created, so an
+	// existing destination keeps its own permissions.
+	mode := info.Mode().Perm()
 
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode) //nolint:gosec // user-named destination
 	if err != nil {
-		return err
+		// cp -f: if an existing destination cannot be opened (for example it is
+		// read-only), remove it and try once more.
+		if opts.force && os.IsPermission(err) {
+			if rmErr := os.Remove(dst); rmErr == nil {
+				out, err = os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode) //nolint:gosec // user-named destination
+			}
+		}
+		if err != nil {
+			return err
+		}
 	}
 
 	if _, err := io.Copy(out, in); err != nil {

--- a/internal/applets/fileutils/cp/cp_test.go
+++ b/internal/applets/fileutils/cp/cp_test.go
@@ -218,3 +218,72 @@ func TestRunCopyFileOntoItselfViaDirectory(t *testing.T) {
 		t.Errorf("source was modified: content=%q err=%v", got, readErr)
 	}
 }
+
+func TestRunPreservesFileMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "script.sh")
+	dst := filepath.Join(dir, "copy.sh")
+	if err := os.WriteFile(src, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, src, dst); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("dst mode = %o, want 755 (execute bit must not be stripped)", info.Mode().Perm())
+	}
+}
+
+func TestRunPreservesDirMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "private")
+	if err := os.Mkdir(src, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "f.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "private_copy")
+	if _, _, err := run(t, "-r", src, dst); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Errorf("dst dir mode = %o, want 700 (a private tree must not be widened)", info.Mode().Perm())
+	}
+}
+
+func TestRunForceOverwritesReadOnly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old\n"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without -f, a read-only destination cannot be opened for writing.
+	if _, _, err := run(t, src, dst); err == nil {
+		t.Skip("environment allows writing a read-only file (likely running as root); skipping")
+	}
+
+	if _, _, err := run(t, "-f", src, dst); err != nil {
+		t.Fatalf("cp -f error = %v", err)
+	}
+	got, _ := os.ReadFile(dst) //nolint:gosec // test-written file
+	if string(got) != "new\n" {
+		t.Errorf("dst content = %q, want new", got)
+	}
+}

--- a/internal/applets/fileutils/mv/mv.go
+++ b/internal/applets/fileutils/mv/mv.go
@@ -185,19 +185,22 @@ func (c *Command) report(stdio command.IO, src, dest string, opts options) {
 }
 
 // rename moves src to dest, falling back to copy+remove when the rename crosses
-// a device boundary (os.Rename fails with EXDEV in that case).
+// a device boundary (os.Rename fails with EXDEV in that case). The fallback
+// preserves mode and timestamps and handles directories recursively, so a
+// cross-filesystem move behaves like an in-filesystem one.
+// osRename is os.Rename, indirected so tests can force the cross-device
+// fallback path that real filesystems only take across mount points.
+var osRename = os.Rename
+
 func rename(src, dest string) error {
-	if err := os.Rename(src, dest); err != nil {
+	if err := osRename(src, dest); err != nil {
 		if !isCrossDevice(err) {
 			return err
 		}
-		if mb.IsDir(src) {
-			return err
-		}
-		if cerr := mb.Copy(src, dest); cerr != nil {
+		if cerr := mb.CopyTree(src, dest); cerr != nil {
 			return cerr
 		}
-		return os.Remove(src)
+		return os.RemoveAll(src)
 	}
 	return nil
 }

--- a/internal/applets/fileutils/mv/mv_internal_test.go
+++ b/internal/applets/fileutils/mv/mv_internal_test.go
@@ -1,0 +1,107 @@
+// mimixbox/internal/applets/fileutils/mv/mv_internal_test.go
+//
+// Copyright 2021 Naohiro CHIKAMATSU
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mv
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestCrossDeviceFallbackMovesDirectory forces os.Rename to report a
+// cross-device error (EXDEV) so rename() takes its copy+remove fallback, and
+// checks that a directory tree is moved with its modes preserved. Before the
+// fix the fallback bailed out on directories and dropped file modes.
+func TestCrossDeviceFallbackMovesDirectory(t *testing.T) {
+	orig := osRename
+	osRename = func(_, _ string) error {
+		return &os.LinkError{Op: "rename", Err: syscall.EXDEV}
+	}
+	t.Cleanup(func() { osRename = orig })
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub", "note.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(dir, "moved")
+	if err := rename(src, dest); err != nil {
+		t.Fatalf("rename across devices error = %v", err)
+	}
+
+	// Source must be gone.
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Errorf("source still exists after move: %v", err)
+	}
+	// Destination tree must exist with preserved modes and content.
+	checks := map[string]os.FileMode{
+		"sub":          0o700,
+		"run.sh":       0o755,
+		"sub/note.txt": 0o600,
+	}
+	for rel, want := range checks {
+		info, err := os.Stat(filepath.Join(dest, rel))
+		if err != nil {
+			t.Errorf("missing %s: %v", rel, err)
+			continue
+		}
+		if info.Mode().Perm() != want {
+			t.Errorf("%s mode = %o, want %o", rel, info.Mode().Perm(), want)
+		}
+	}
+	got, _ := os.ReadFile(filepath.Join(dest, "sub", "note.txt")) //nolint:gosec // test-written file
+	if string(got) != "hi" {
+		t.Errorf("moved content = %q", got)
+	}
+}
+
+// TestCrossDeviceFallbackMovesFile checks the single-file cross-device path
+// preserves the file's mode (the execute bit in particular).
+func TestCrossDeviceFallbackMovesFile(t *testing.T) {
+	orig := osRename
+	osRename = func(_, _ string) error {
+		return &os.LinkError{Op: "rename", Err: syscall.EXDEV}
+	}
+	t.Cleanup(func() { osRename = orig })
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "script.sh")
+	dest := filepath.Join(dir, "dest.sh")
+	if err := os.WriteFile(src, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := rename(src, dest); err != nil {
+		t.Fatalf("rename error = %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Errorf("source still exists: %v", err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("dest mode = %o, want 755", info.Mode().Perm())
+	}
+}

--- a/internal/applets/shellutils/watch/watch.go
+++ b/internal/applets/shellutils/watch/watch.go
@@ -52,7 +52,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		return command.Failuref("interval must be positive")
 	}
 
-	render := func() error { return c.renderOnce(stdio, *interval, *noTitle, rest) }
+	render := func() error { return c.renderOnce(ctx, stdio, *interval, *noTitle, rest) }
 	if err := render(); err != nil {
 		return err
 	}
@@ -73,13 +73,13 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 
 // renderOnce clears the screen, writes the optional header and then the output
 // of one run of the command.
-func (c *Command) renderOnce(stdio command.IO, interval float64, noTitle bool, argv []string) error {
+func (c *Command) renderOnce(ctx context.Context, stdio command.IO, interval float64, noTitle bool, argv []string) error {
 	var b bytes.Buffer
 	b.WriteString(clearScreen)
 	if !noTitle {
 		b.WriteString(header(interval, argv))
 	}
-	b.WriteString(runCommand(argv))
+	b.WriteString(runCommand(ctx, argv))
 	if _, err := io.Copy(stdio.Out, &b); err != nil {
 		return command.Failure(err)
 	}
@@ -92,9 +92,11 @@ func header(interval float64, argv []string) string {
 }
 
 // runCommand executes argv once and returns its combined output, or the error
-// text when it cannot run, so something is always shown on screen.
-func runCommand(argv []string) string {
-	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // running a user-named command is the point
+// text when it cannot run, so something is always shown on screen. The context
+// is honored, so a cancelled watch (Ctrl-C) terminates a still-running child
+// instead of hanging on it.
+func runCommand(ctx context.Context, argv []string) string {
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec // running a user-named command is the point
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return string(out) + fmt.Sprintf("watch: %v\n", err)

--- a/internal/applets/shellutils/watch/watch_test.go
+++ b/internal/applets/shellutils/watch/watch_test.go
@@ -5,25 +5,28 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
 
-func runCancelled(t *testing.T, args ...string) (string, string, error) {
+// runBounded runs watch with a context that cancels after a short delay, so the
+// refresh loop renders a few times and then returns (watch otherwise loops
+// forever). It returns the collected stdout and the run error.
+func runBounded(t *testing.T, timeout time.Duration, args ...string) (string, string, error) {
 	t.Helper()
 	out := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
-	// An already-cancelled context makes Run render exactly once and return.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	err := New().Run(ctx, io, args)
 	return out.String(), errBuf.String(), err
 }
 
-func TestRendersOnceWithoutTitle(t *testing.T) {
+func TestRendersWithoutTitle(t *testing.T) {
 	t.Parallel()
-	out, _, err := runCancelled(t, "-t", "echo", "hello")
+	out, _, err := runBounded(t, 150*time.Millisecond, "-t", "-n", "0.05", "echo", "hello")
 	if err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
@@ -40,18 +43,18 @@ func TestRendersOnceWithoutTitle(t *testing.T) {
 
 func TestRendersHeader(t *testing.T) {
 	t.Parallel()
-	out, _, err := runCancelled(t, "-n", "1", "echo", "hi")
+	out, _, err := runBounded(t, 150*time.Millisecond, "-n", "0.05", "echo", "hi")
 	if err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	if !strings.Contains(out, "Every 1s: echo hi") {
+	if !strings.Contains(out, "Every 0.05s: echo hi") {
 		t.Errorf("missing header in %q", out)
 	}
 }
 
 func TestCommandError(t *testing.T) {
 	t.Parallel()
-	out, _, err := runCancelled(t, "-t", "false")
+	out, _, err := runBounded(t, 150*time.Millisecond, "-t", "-n", "0.05", "false")
 	if err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
@@ -60,9 +63,24 @@ func TestCommandError(t *testing.T) {
 	}
 }
 
+func TestCancelInterruptsHungChild(t *testing.T) {
+	t.Parallel()
+	// The first render runs "sleep 30"; cancelling the context must kill that
+	// child (via exec.CommandContext) so Run returns promptly instead of
+	// blocking for the full sleep.
+	start := time.Now()
+	_, _, err := runBounded(t, 200*time.Millisecond, "-t", "sleep", "30")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Run took %v; a hung child was not interrupted by cancellation", elapsed)
+	}
+}
+
 func TestMissingCommand(t *testing.T) {
 	t.Parallel()
-	_, _, err := runCancelled(t)
+	_, _, err := runBounded(t, 100*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -73,7 +91,7 @@ func TestMissingCommand(t *testing.T) {
 
 func TestInvalidInterval(t *testing.T) {
 	t.Parallel()
-	_, _, err := runCancelled(t, "-n", "0", "echo", "x")
+	_, _, err := runBounded(t, 100*time.Millisecond, "-n", "0", "echo", "x")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/applets/textutils/cat/cat.go
+++ b/internal/applets/textutils/cat/cat.go
@@ -3,6 +3,7 @@
 package cat
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -54,22 +55,16 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		showTabs:       *showTabs,
 	}
 
-	text, readErr := concat(stdio, fs.Args())
-	if err := write(stdio.Out, render(text, opts), opts); err != nil {
-		return command.Failure(err)
-	}
-	return readErr
-}
-
-// concat reads every operand (defaulting to standard input when there are none)
-// and returns the joined text. A failed open or read is reported on stderr but
-// does not stop the remaining files; the returned error only sets the exit
-// code, because its message was already printed.
-func concat(stdio command.IO, files []string) (string, error) {
+	files := fs.Args()
 	if len(files) == 0 {
 		files = []string{"-"}
 	}
-	var b strings.Builder
+
+	// Open every operand up front and stream the concatenation, so cat works in
+	// constant memory on large files and pipes instead of reading everything in.
+	// A failed open is reported and skipped; the others are still printed.
+	var readers []io.Reader
+	var closers []io.Closer
 	var firstErr error
 	for _, name := range files {
 		r, err := command.Open(stdio, name)
@@ -78,42 +73,76 @@ func concat(stdio command.IO, files []string) (string, error) {
 			firstErr = keep(firstErr)
 			continue
 		}
-		_, err = io.Copy(&b, r)
-		_ = r.Close()
+		readers = append(readers, r)
+		closers = append(closers, r)
+	}
+	defer func() {
+		for _, c := range closers {
+			_ = c.Close()
+		}
+	}()
+
+	src := io.Reader(io.MultiReader(readers...))
+
+	// Apply -s/-T/-E as a streaming filter before numbering, so the line counter
+	// still sees the squeezed lines (matching the previous behavior).
+	if opts.squeeze || opts.showTabs || opts.showEnds {
+		raw := src // capture before reassigning src, or the goroutine would read the pipe itself
+		pr, pw := io.Pipe()
+		go func() { _ = pw.CloseWithError(renderStream(pw, raw, opts)) }()
+		src = pr
+	}
+
+	if err := writeStream(stdio.Out, src, opts); err != nil {
+		return command.Failure(err)
+	}
+	return firstErr
+}
+
+// renderStream copies r to w line by line, applying the display
+// transformations (-s squeeze blank lines, -T show tabs, -E show line ends).
+func renderStream(w io.Writer, r io.Reader, opts options) error {
+	br := bufio.NewReader(r)
+	prevBlank := false
+	for {
+		chunk, err := br.ReadString('\n')
+		if chunk != "" {
+			body, nl := chunk, ""
+			if strings.HasSuffix(chunk, "\n") {
+				body, nl = chunk[:len(chunk)-1], "\n"
+			}
+			emit := true
+			if opts.squeeze {
+				blank := body == ""
+				if blank && prevBlank {
+					emit = false
+				}
+				prevBlank = blank
+			}
+			if emit {
+				if opts.showTabs {
+					body = strings.ReplaceAll(body, "\t", "^I")
+				}
+				if opts.showEnds {
+					body += "$"
+				}
+				if _, werr := io.WriteString(w, body+nl); werr != nil {
+					return werr
+				}
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
 		if err != nil {
-			_, _ = fmt.Fprintf(stdio.Err, "cat: %s\n", command.FileError(name, err))
-			firstErr = keep(firstErr)
+			return err
 		}
 	}
-	return b.String(), firstErr
 }
 
-// render applies the display transformations (-s, -T, -E) and returns new text.
-// Numbering is applied later by write so its counter sees the squeezed lines.
-func render(text string, opts options) string {
-	if !opts.squeeze && !opts.showTabs && !opts.showEnds {
-		return text
-	}
-	lines := splitKeepNewline(text)
-	if opts.squeeze {
-		lines = squeezeBlank(lines)
-	}
-	var b strings.Builder
-	for _, l := range lines {
-		body := l.body
-		if opts.showTabs {
-			body = strings.ReplaceAll(body, "\t", "^I")
-		}
-		if opts.showEnds {
-			body += "$"
-		}
-		b.WriteString(body)
-		b.WriteString(l.newline)
-	}
-	return b.String()
-}
-
-func write(w io.Writer, text string, opts options) error {
+// writeStream writes src to w, numbering lines when -n/-b is set (streaming via
+// the Numberer) or copying through otherwise.
+func writeStream(w io.Writer, src io.Reader, opts options) error {
 	if opts.number || opts.numberNonBlank {
 		n := textproc.Numberer{
 			Style:     numberStyle(opts.numberNonBlank),
@@ -122,9 +151,9 @@ func write(w io.Writer, text string, opts options) error {
 			Width:     6,
 			Separator: "\t",
 		}
-		return n.WriteTo(w, strings.NewReader(text))
+		return n.WriteTo(w, src)
 	}
-	_, err := io.WriteString(w, text)
+	_, err := io.Copy(w, src)
 	return err
 }
 
@@ -133,39 +162,6 @@ func numberStyle(nonBlank bool) textproc.NumberStyle {
 		return textproc.NumberNonBlank
 	}
 	return textproc.NumberAll
-}
-
-type line struct {
-	body    string
-	newline string
-}
-
-func splitKeepNewline(s string) []line {
-	var lines []line
-	for s != "" {
-		i := strings.IndexByte(s, '\n')
-		if i < 0 {
-			lines = append(lines, line{body: s})
-			break
-		}
-		lines = append(lines, line{body: s[:i], newline: "\n"})
-		s = s[i+1:]
-	}
-	return lines
-}
-
-func squeezeBlank(lines []line) []line {
-	out := make([]line, 0, len(lines))
-	prevBlank := false
-	for _, l := range lines {
-		blank := l.body == ""
-		if blank && prevBlank {
-			continue
-		}
-		prevBlank = blank
-		out = append(out, l)
-	}
-	return out
 }
 
 func keep(existing error) error {

--- a/internal/applets/textutils/dos2unix/dos2unix_test.go
+++ b/internal/applets/textutils/dos2unix/dos2unix_test.go
@@ -157,3 +157,26 @@ func TestRunMixedFilesAndDirectory(t *testing.T) {
 		t.Errorf("f3 content = %q, want %q", string(got3), "c\n")
 	}
 }
+
+func TestRunPreservesFileMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "m.txt")
+	if err := os.WriteFile(file, []byte("a\r\nb\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, file); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %o, want 600 (in-place conversion must keep the mode)", info.Mode().Perm())
+	}
+	got, _ := os.ReadFile(file) //nolint:gosec // test-written file
+	if string(got) != "a\nb\n" {
+		t.Errorf("content = %q", got)
+	}
+}

--- a/internal/applets/textutils/nl/nl.go
+++ b/internal/applets/textutils/nl/nl.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
 	"github.com/nao1215/mimixbox/internal/textproc"
@@ -67,7 +66,11 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		files = []string{"-"}
 	}
 
-	var b strings.Builder
+	// Open every operand and number the concatenation as a single stream, so
+	// the line counter spans file boundaries (as nl does) without ever holding
+	// the whole input in memory.
+	var readers []io.Reader
+	var closers []io.Closer
 	var firstErr error
 	for _, name := range files {
 		r, err := command.Open(stdio, name)
@@ -76,15 +79,16 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			firstErr = keep(firstErr)
 			continue
 		}
-		_, err = io.Copy(&b, r)
-		_ = r.Close()
-		if err != nil {
-			_, _ = fmt.Fprintf(stdio.Err, "nl: %s\n", command.FileError(name, err))
-			firstErr = keep(firstErr)
-		}
+		readers = append(readers, r)
+		closers = append(closers, r)
 	}
+	defer func() {
+		for _, c := range closers {
+			_ = c.Close()
+		}
+	}()
 
-	if err := numberer.WriteTo(stdio.Out, strings.NewReader(b.String())); err != nil {
+	if err := numberer.WriteTo(stdio.Out, io.MultiReader(readers...)); err != nil {
 		return command.Failure(err)
 	}
 	return firstErr

--- a/internal/applets/textutils/tac/tac.go
+++ b/internal/applets/textutils/tac/tac.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
-	"github.com/nao1215/mimixbox/internal/textproc"
 )
 
 // Command is the tac applet.
@@ -43,6 +42,11 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		files = []string{"-"}
 	}
 
+	// tac has to read all of its input before it can emit anything (the first
+	// line it prints is the input's last record), so unlike a forward filter it
+	// is inherently non-streaming. Read each operand in turn into one buffer and
+	// then write the records out in reverse, separator-by-separator, straight to
+	// the output rather than materializing a second reversed copy of the data.
 	var b strings.Builder
 	var firstErr error
 	for _, name := range files {
@@ -60,10 +64,35 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		}
 	}
 
-	if _, err := io.WriteString(stdio.Out, textproc.Reverse(b.String(), sep)); err != nil {
+	if err := writeReversed(stdio.Out, b.String(), sep); err != nil {
 		return command.Failure(err)
 	}
 	return firstErr
+}
+
+// writeReversed splits text into records terminated by sep and writes them to w
+// in reverse order, so it never builds a second full-size copy of the input the
+// way returning a reversed string would.
+func writeReversed(w io.Writer, text, sep string) error {
+	if text == "" {
+		return nil
+	}
+	var records []string
+	for text != "" {
+		i := strings.Index(text, sep)
+		if i < 0 {
+			records = append(records, text)
+			break
+		}
+		records = append(records, text[:i+len(sep)])
+		text = text[i+len(sep):]
+	}
+	for i := len(records) - 1; i >= 0; i-- {
+		if _, err := io.WriteString(w, records[i]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func firstNonNil(existing error) error {

--- a/internal/applets/textutils/unix2dos/unix2dos.go
+++ b/internal/applets/textutils/unix2dos/unix2dos.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
+	mb "github.com/nao1215/mimixbox/internal/lib"
 )
 
 // Command is the unix2dos applet.
@@ -53,7 +54,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			continue
 		}
 		_, _ = fmt.Fprintln(stdio.Out, c.Name()+": converting file "+target+" to DOS format...")
-		if writeErr := listToFile(target, toCRLF(lines)); writeErr != nil {
+		if writeErr := mb.ListToFile(target, toCRLF(lines)); writeErr != nil {
 			_, _ = fmt.Fprintln(stdio.Err, writeErr)
 			firstErr = keep(firstErr)
 			continue
@@ -104,28 +105,6 @@ func readFileToStrList(path string) ([]string, error) {
 		strList = append(strList, line)
 	}
 	return strList, nil
-}
-
-// listToFile writes lines to path, truncating any existing content. A failed
-// Close is reported (it can mean the written data was not flushed to disk).
-func listToFile(path string, lines []string) (err error) {
-	fp, err := os.Create(path) //nolint:gosec // operating on a user-named file is the whole point
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cerr := fp.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	w := bufio.NewWriter(fp)
-	for _, line := range lines {
-		if _, werr := w.WriteString(line); werr != nil {
-			return werr
-		}
-	}
-	return w.Flush()
 }
 
 // keep returns the first error seen, creating a silent failure when none exists

--- a/internal/applets/textutils/unix2dos/unix2dos_test.go
+++ b/internal/applets/textutils/unix2dos/unix2dos_test.go
@@ -137,3 +137,26 @@ func TestRunFileAndDirectory(t *testing.T) {
 		t.Errorf("file = %q, want CRLF", string(got))
 	}
 }
+
+func TestRunPreservesFileMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "m.txt")
+	if err := os.WriteFile(file, []byte("a\nb\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, file); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %o, want 600 (in-place conversion must keep the mode)", info.Mode().Perm())
+	}
+	got, _ := os.ReadFile(file) //nolint:gosec // test-written file
+	if string(got) != "a\r\nb\r\n" {
+		t.Errorf("content = %q", got)
+	}
+}

--- a/internal/lib/file.go
+++ b/internal/lib/file.go
@@ -141,24 +141,68 @@ func IsSameFileName(src string, dest string) bool {
 	return filepath.Base(src) == filepath.Base(dest)
 }
 
-// Copy file(src) to dest
+// Copy copies the regular file src to dest, preserving the source's permission
+// bits and modification time. Preserving the mode matters for callers such as
+// mv's cross-filesystem fallback, where a plain os.Create would otherwise drop
+// the execute bit and reset timestamps.
 func Copy(src string, dest string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+
 	s, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
-	d, err := os.Create(dest)
+	d, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}
-	defer d.Close()
 
-	_, err = io.Copy(d, s)
+	if _, err := io.Copy(d, s); err != nil {
+		_ = d.Close()
+		return err
+	}
+	if err := d.Close(); err != nil {
+		return err
+	}
+
+	// Restore the exact mode (umask may have masked it on creation) and mtime.
+	_ = os.Chmod(dest, info.Mode().Perm())
+	_ = os.Chtimes(dest, info.ModTime(), info.ModTime())
+	return nil
+}
+
+// CopyTree recursively copies the file or directory tree rooted at src to dest,
+// preserving each entry's permission bits and modification times. It is used by
+// mv when a rename crosses a filesystem boundary (os.Rename returns EXDEV), a
+// case a single-file Copy cannot handle.
+func CopyTree(src string, dest string) error {
+	info, err := os.Lstat(src)
 	if err != nil {
 		return err
 	}
+	if !info.IsDir() {
+		return Copy(src, dest)
+	}
+
+	if err := os.MkdirAll(dest, info.Mode().Perm()); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if err := CopyTree(filepath.Join(src, e.Name()), filepath.Join(dest, e.Name())); err != nil {
+			return err
+		}
+	}
+	_ = os.Chmod(dest, info.Mode().Perm())
+	_ = os.Chtimes(dest, info.ModTime(), info.ModTime())
 	return nil
 }
 
@@ -225,7 +269,7 @@ func ReadFileToStrList(path string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	r := bufio.NewReader(f)
 	for {
@@ -241,18 +285,48 @@ func ReadFileToStrList(path string) ([]string, error) {
 	return strList, nil
 }
 
-func ListToFile(filepath string, lines []string) error {
-	fp, err := os.Create(filepath)
+// ListToFile writes lines to path atomically: it writes a temporary file in the
+// same directory and renames it over path on success. This way an interrupted
+// write or a full disk leaves the original file intact instead of a truncated
+// one (the danger of a plain os.Create on the target). When path already exists
+// its permission bits are preserved.
+func ListToFile(path string, lines []string) error {
+	mode := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
 		return err
 	}
-	defer fp.Close()
+	tmpName := tmp.Name()
+	// Clean up the temp file if anything below fails before the rename.
+	defer func() { _ = os.Remove(tmpName) }()
 
-	writer := bufio.NewWriter(fp)
+	writer := bufio.NewWriter(tmp)
 	for _, line := range lines {
-		writer.WriteString(line)
+		if _, err := writer.WriteString(line); err != nil {
+			_ = tmp.Close()
+			return err
+		}
 	}
-	return writer.Flush()
+	if err := writer.Flush(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // Return file size(Byte)

--- a/internal/lib/file_more_test.go
+++ b/internal/lib/file_more_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCopyAndSize(t *testing.T) {
@@ -146,5 +147,108 @@ func TestIsNamedPipe(t *testing.T) {
 	}
 	if IsNamedPipe(p) {
 		t.Error("a regular file is not a named pipe")
+	}
+}
+
+func TestCopyPreservesModeAndMtime(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Unix(1000000000, 0)
+	if err := os.Chtimes(src, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Copy(src, dst); err != nil {
+		t.Fatalf("Copy error = %v", err)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("dst mode = %o, want 755 (execute bit must survive)", info.Mode().Perm())
+	}
+	if !info.ModTime().Equal(mtime) {
+		t.Errorf("dst mtime = %v, want %v", info.ModTime(), mtime)
+	}
+	got, _ := os.ReadFile(dst) //nolint:gosec // reading a file the test wrote
+	if string(got) != "data" {
+		t.Errorf("dst content = %q", got)
+	}
+}
+
+func TestCopyTreeRecursivePreservesModes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub", "note.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(dir, "copy")
+	if err := CopyTree(src, dst); err != nil {
+		t.Fatalf("CopyTree error = %v", err)
+	}
+
+	checks := map[string]os.FileMode{
+		"sub":          0o700,
+		"run.sh":       0o755,
+		"sub/note.txt": 0o600,
+	}
+	for rel, want := range checks {
+		info, err := os.Stat(filepath.Join(dst, rel))
+		if err != nil {
+			t.Errorf("missing %s: %v", rel, err)
+			continue
+		}
+		if info.Mode().Perm() != want {
+			t.Errorf("%s mode = %o, want %o", rel, info.Mode().Perm(), want)
+		}
+	}
+	got, _ := os.ReadFile(filepath.Join(dst, "sub", "note.txt")) //nolint:gosec // test-written file
+	if string(got) != "hi" {
+		t.Errorf("nested content = %q", got)
+	}
+}
+
+func TestListToFileAtomicPreservesMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(p, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ListToFile(p, []string{"new1\n", "new2\n"}); err != nil {
+		t.Fatalf("ListToFile error = %v", err)
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %o, want 600 (must be preserved across the rewrite)", info.Mode().Perm())
+	}
+	got, _ := os.ReadFile(p) //nolint:gosec // test-written file
+	if string(got) != "new1\nnew2\n" {
+		t.Errorf("content = %q", got)
+	}
+	// No temporary files should be left behind in the directory.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
 	}
 }

--- a/internal/lib/file_test.go
+++ b/internal/lib/file_test.go
@@ -16,101 +16,165 @@
 package mb
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// fixtures builds the test files and directories in a per-test temporary
+// directory and returns its path. Using t.TempDir() instead of a shared
+// /tmp/mimixbox/ut tree (previously created by test/ut/prepareUnitTest.sh) makes
+// these tests self-contained — "go test ./..." passes on a clean checkout — and
+// parallel-safe, since each test owns its own fixtures.
+func fixtures(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	files := map[string]os.FileMode{
+		"Executable.txt":    0o755,
+		"Writable.txt":      0o644,
+		"Readable.txt":      0o444,
+		"NonExecutable.txt": 0o644,
+		"NonWritable.txt":   0o444,
+		"NonReadable.txt":   0o000,
+		"AllZero.txt":       0o000,
+		".hidden.txt":       0o644,
+	}
+	for name, mode := range files {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, nil, 0o644); err != nil { //nolint:gosec // fixture file
+			t.Fatal(err)
+		}
+		if err := os.Chmod(p, mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := os.Symlink(filepath.Join(dir, "Executable.txt"), filepath.Join(dir, "symbolic.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	noEmpty := filepath.Join(dir, "NoEmptyDir")
+	if err := os.MkdirAll(noEmpty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"aaa.txt", "bbb.txt", "ccc.txt"} {
+		if err := os.WriteFile(filepath.Join(noEmpty, name), nil, 0o644); err != nil { //nolint:gosec // fixture file
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "NoWritableDir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(dir, "NoWritableDir"), 0o555); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 func TestIsFile(t *testing.T) {
-	assert.Equal(t, true, IsFile("/tmp/mimixbox/ut/Readable.txt"))
-	assert.Equal(t, true, IsFile("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, false, IsFile("/tmp/mimixbox/ut"))
-	assert.Equal(t, true, IsFile("/tmp/mimixbox/ut/AllZero.txt"))
-	assert.Equal(t, false, IsFile("/tmp/mimixbox/ut/NoReadableDir"))
-	assert.Equal(t, true, IsFile("/tmp/mimixbox/ut/.hidden.txt"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, true, IsFile(filepath.Join(dir, "Readable.txt")))
+	assert.Equal(t, true, IsFile(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, false, IsFile(dir))
+	assert.Equal(t, true, IsFile(filepath.Join(dir, "AllZero.txt")))
+	assert.Equal(t, false, IsFile(filepath.Join(dir, "NoEmptyDir")))
+	assert.Equal(t, true, IsFile(filepath.Join(dir, ".hidden.txt")))
 	assert.Equal(t, false, IsFile("abcdef"))
 }
 
 func TestExists(t *testing.T) {
-	assert.Equal(t, true, Exists("/tmp/mimixbox/ut/Readable.txt"))
-	assert.Equal(t, true, Exists("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, true, Exists("/tmp/mimixbox/ut"))
-	assert.Equal(t, true, Exists("/tmp/mimixbox/ut/AllZero.txt"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, true, Exists(filepath.Join(dir, "Readable.txt")))
+	assert.Equal(t, true, Exists(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, true, Exists(dir))
+	assert.Equal(t, true, Exists(filepath.Join(dir, "AllZero.txt")))
 	assert.Equal(t, true, Exists("/"))
-	assert.Equal(t, true, Exists("/tmp/mimixbox"))
 	assert.Equal(t, false, Exists("abcdef"))
 }
 
 func TestIsDir(t *testing.T) {
-	assert.Equal(t, false, IsDir("/tmp/mimixbox/ut/Readable.txt"))
-	assert.Equal(t, false, IsDir("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, true, IsDir("/tmp/mimixbox/ut"))
-	assert.Equal(t, false, IsDir("/tmp/mimixbox/ut/AllZero.txt"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, false, IsDir(filepath.Join(dir, "Readable.txt")))
+	assert.Equal(t, false, IsDir(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, true, IsDir(dir))
+	assert.Equal(t, false, IsDir(filepath.Join(dir, "AllZero.txt")))
 	assert.Equal(t, true, IsDir("/"))
-	assert.Equal(t, true, IsDir("/tmp/mimixbox"))
 	assert.Equal(t, false, IsDir("abcdef"))
-	assert.Equal(t, true, IsDir("/tmp/mimixbox/ut/NoWritableDir"))
+	assert.Equal(t, true, IsDir(filepath.Join(dir, "NoWritableDir")))
 }
 
 func TestIsSymlink(t *testing.T) {
-	assert.Equal(t, false, IsSymlink("/tmp/mimixbox/ut/Readable.txt"))
-	assert.Equal(t, true, IsSymlink("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, false, IsSymlink("/tmp/mimixbox/ut"))
-	assert.Equal(t, false, IsSymlink("/tmp/mimixbox/ut/AllZero.txt"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, false, IsSymlink(filepath.Join(dir, "Readable.txt")))
+	assert.Equal(t, true, IsSymlink(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, false, IsSymlink(dir))
+	assert.Equal(t, false, IsSymlink(filepath.Join(dir, "AllZero.txt")))
 	assert.Equal(t, false, IsSymlink("/"))
-	assert.Equal(t, false, IsSymlink("/tmp/mimixbox"))
 	assert.Equal(t, false, IsSymlink("abcdef"))
 }
 
 func TestIsZero(t *testing.T) {
-	assert.Equal(t, true, IsZero("/tmp/mimixbox/ut/Readable.txt"))
-	assert.Equal(t, true, IsZero("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, false, IsZero("/tmp/mimixbox/ut"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, true, IsZero(filepath.Join(dir, "Readable.txt")))
+	assert.Equal(t, true, IsZero(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, false, IsZero(dir))
 	assert.Equal(t, false, IsZero("abcdef"))
-	assert.Equal(t, true, IsZero("/tmp/mimixbox/ut/AllZero.txt"))
+	assert.Equal(t, true, IsZero(filepath.Join(dir, "AllZero.txt")))
 }
 
 func TestIsReadable(t *testing.T) {
-	assert.Equal(t, true, IsReadable("/tmp/mimixbox/ut/Readable.txt"))
-	assert.Equal(t, true, IsReadable("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, true, IsReadable("/tmp/mimixbox/ut"))
-	assert.Equal(t, true, IsReadable("/tmp/mimixbox"))
-	assert.Equal(t, false, IsReadable("/tmp/mimixbox/ut/NonReadable.txt"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, true, IsReadable(filepath.Join(dir, "Readable.txt")))
+	assert.Equal(t, true, IsReadable(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, true, IsReadable(dir))
+	assert.Equal(t, false, IsReadable(filepath.Join(dir, "NonReadable.txt")))
 	assert.Equal(t, false, IsReadable("abcdef"))
-	assert.Equal(t, false, IsReadable("/tmp/mimixbox/ut/AllZero.txt"))
+	assert.Equal(t, false, IsReadable(filepath.Join(dir, "AllZero.txt")))
 }
 
 func TestIsWritable(t *testing.T) {
-	assert.Equal(t, true, IsWritable("/tmp/mimixbox/ut/Writable.txt"))
-	assert.Equal(t, true, IsWritable("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, true, IsWritable("/tmp/mimixbox/ut"))
-	assert.Equal(t, true, IsWritable("/tmp/mimixbox"))
-	assert.Equal(t, false, IsWritable("/tmp/mimixbox/ut/NonWritable.txt"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, true, IsWritable(filepath.Join(dir, "Writable.txt")))
+	assert.Equal(t, true, IsWritable(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, true, IsWritable(dir))
+	assert.Equal(t, false, IsWritable(filepath.Join(dir, "NonWritable.txt")))
 	assert.Equal(t, false, IsWritable("abcdef"))
-	assert.Equal(t, false, IsWritable("/tmp/mimixbox/ut/AllZero.txt"))
+	assert.Equal(t, false, IsWritable(filepath.Join(dir, "AllZero.txt")))
 }
+
 func TestIsExecutable(t *testing.T) {
-	assert.Equal(t, true, IsExecutable("/tmp/mimixbox/ut/Executable.txt"))
-	assert.Equal(t, true, IsExecutable("/tmp/mimixbox/ut/symbolic.txt"))
-	assert.Equal(t, true, IsExecutable("/tmp/mimixbox/ut"))
-	assert.Equal(t, true, IsExecutable("/tmp/mimixbox"))
-	assert.Equal(t, false, IsExecutable("/tmp/mimixbox/ut/NonExecutable.txt"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, true, IsExecutable(filepath.Join(dir, "Executable.txt")))
+	assert.Equal(t, true, IsExecutable(filepath.Join(dir, "symbolic.txt")))
+	assert.Equal(t, true, IsExecutable(dir))
+	assert.Equal(t, false, IsExecutable(filepath.Join(dir, "NonExecutable.txt")))
 	assert.Equal(t, false, IsExecutable("abcdef"))
-	assert.Equal(t, false, IsExecutable("/tmp/mimixbox/ut/AllZero.txt"))
+	assert.Equal(t, false, IsExecutable(filepath.Join(dir, "AllZero.txt")))
 }
 
 func TestIsHiddenFile(t *testing.T) {
-	assert.Equal(t, false, IsHiddenFile("/tmp/mimixbox/ut/Executable.txt"))
-	assert.Equal(t, true, IsHiddenFile("/tmp/mimixbox/ut/.hidden.txt"))
-	assert.Equal(t, false, IsHiddenFile("/tmp/mimixbox"))
-	assert.Equal(t, false, IsHiddenFile("/tmp/mimixbox/ut/"))
-	assert.Equal(t, false, IsHiddenFile("/tmp/mimixbox/ut"))
+	t.Parallel()
+	dir := fixtures(t)
+	assert.Equal(t, false, IsHiddenFile(filepath.Join(dir, "Executable.txt")))
+	assert.Equal(t, true, IsHiddenFile(filepath.Join(dir, ".hidden.txt")))
+	assert.Equal(t, false, IsHiddenFile(dir))
 	assert.Equal(t, false, IsHiddenFile("abcdef"))
 	assert.Equal(t, false, IsHiddenFile(".abcdef"))
-	assert.Equal(t, false, IsHiddenFile(".HiddenDir"))
 }
 
 func TestBaseNameWithoutExt(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "Executable", BaseNameWithoutExt("/tmp/mimixbox/ut/Executable.txt"))
 	assert.Equal(t, ".hidden", BaseNameWithoutExt("/tmp/mimixbox/ut/.hidden.txt"))
 	assert.Equal(t, "file", BaseNameWithoutExt("./file.go"))

--- a/internal/textproc/textproc.go
+++ b/internal/textproc/textproc.go
@@ -139,30 +139,49 @@ type Numberer struct {
 }
 
 // WriteTo copies r to w, numbering lines according to the Numberer's settings.
+// It reads r one line at a time rather than slurping it all into memory, so it
+// streams arbitrarily large input (a pipe or a multi-gigabyte file) in constant
+// space.
 func (n Numberer) WriteTo(w io.Writer, r io.Reader) error {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
+	br := bufio.NewReader(r)
 	num := n.Start
-	for _, line := range splitKeepNewline(string(data)) {
-		body, nl := line.body, line.newline
-		if n.numbered(body) {
-			if _, err := io.WriteString(w, n.format(num)+n.Separator+body+nl); err != nil {
-				return err
+	for {
+		chunk, err := br.ReadString('\n')
+		if chunk != "" {
+			body, nl := chunk, ""
+			if strings.HasSuffix(chunk, "\n") {
+				body, nl = chunk[:len(chunk)-1], "\n"
 			}
-			num += n.Increment
-			continue
+			numbered, werr := n.emitLine(w, body, nl, num)
+			if werr != nil {
+				return werr
+			}
+			if numbered {
+				num += n.Increment
+			}
 		}
-		prefix := ""
-		if n.PadBlank {
-			prefix = strings.Repeat(" ", n.Width+len(n.Separator))
+		if err == io.EOF {
+			return nil
 		}
-		if _, err := io.WriteString(w, prefix+body+nl); err != nil {
+		if err != nil {
 			return err
 		}
 	}
-	return nil
+}
+
+// emitLine writes one numbered (or blank-padded) line and reports whether it
+// consumed a line number.
+func (n Numberer) emitLine(w io.Writer, body, nl string, num int) (bool, error) {
+	if n.numbered(body) {
+		_, err := io.WriteString(w, n.format(num)+n.Separator+body+nl)
+		return true, err
+	}
+	prefix := ""
+	if n.PadBlank {
+		prefix = strings.Repeat(" ", n.Width+len(n.Separator))
+	}
+	_, err := io.WriteString(w, prefix+body+nl)
+	return false, err
 }
 
 func (n Numberer) numbered(body string) bool {
@@ -185,27 +204,6 @@ func (n Numberer) format(num int) string {
 	default:
 		return fmt.Sprintf("%*d", n.Width, num)
 	}
-}
-
-type line struct {
-	body    string
-	newline string
-}
-
-// splitKeepNewline splits s into lines, recording for each whether it ended
-// with a newline so the original line endings can be reproduced exactly.
-func splitKeepNewline(s string) []line {
-	var lines []line
-	for s != "" {
-		i := strings.IndexByte(s, '\n')
-		if i < 0 {
-			lines = append(lines, line{body: s})
-			break
-		}
-		lines = append(lines, line{body: s[:i], newline: "\n"})
-		s = s[i+1:]
-	}
-	return lines
 }
 
 // HeadLines writes the first n lines of r to w, preserving line endings.

--- a/internal/textproc/textproc_test.go
+++ b/internal/textproc/textproc_test.go
@@ -3,6 +3,7 @@ package textproc_test
 import (
 	"bytes"
 	"strings"
+	"testing/iotest"
 	"testing"
 
 	"github.com/nao1215/mimixbox/internal/textproc"
@@ -232,5 +233,21 @@ func TestTailBytes(t *testing.T) {
 	}
 	if buf.String() != "world" {
 		t.Errorf("TailBytes = %q, want %q", buf.String(), "world")
+	}
+}
+
+func TestNumbererStreamsAcrossReads(t *testing.T) {
+	t.Parallel()
+	n := textproc.Numberer{Style: textproc.NumberAll, Start: 1, Increment: 1, Width: 6, Separator: "\t"}
+	var buf bytes.Buffer
+	// OneByteReader delivers one byte per Read; WriteTo must still assemble
+	// whole lines (it streams with bufio rather than reading everything at once).
+	src := iotest.OneByteReader(strings.NewReader("a\nbb\nccc"))
+	if err := n.WriteTo(&buf, src); err != nil {
+		t.Fatalf("WriteTo error = %v", err)
+	}
+	want := "     1\ta\n     2\tbb\n     3\tccc"
+	if buf.String() != want {
+		t.Errorf("streamed = %q, want %q", buf.String(), want)
 	}
 }

--- a/test/it/shellutils/cp_perm_test.sh
+++ b/test/it/shellutils/cp_perm_test.sh
@@ -1,0 +1,23 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    mkdir -p ${TEST_DIR}
+    printf '#!/bin/sh\necho hi\n' > ${TEST_DIR}/script.sh
+    chmod 755 ${TEST_DIR}/script.sh
+    mkdir -m 700 ${TEST_DIR}/private
+}
+CleanUp() { chmod -R u+w /tmp/mimixbox/it 2>/dev/null; rm -rf /tmp/mimixbox/it; }
+TestCpPreservesExecBit() {
+    cp ${TEST_DIR}/script.sh ${TEST_DIR}/copy.sh
+    stat -c '%a' ${TEST_DIR}/copy.sh
+}
+TestCpPreservesDirMode() {
+    cp -r ${TEST_DIR}/private ${TEST_DIR}/private_copy
+    stat -c '%a' ${TEST_DIR}/private_copy
+}
+TestCpForceOverwritesReadonly() {
+    printf 'old\n' > ${TEST_DIR}/dst.txt
+    chmod 444 ${TEST_DIR}/dst.txt
+    printf 'new\n' > ${TEST_DIR}/src.txt
+    cp -f ${TEST_DIR}/src.txt ${TEST_DIR}/dst.txt
+    cat ${TEST_DIR}/dst.txt
+}

--- a/test/it/spec/convert_mode_spec.sh
+++ b/test/it/spec/convert_mode_spec.sh
@@ -1,0 +1,15 @@
+Describe 'dos2unix/unix2dos preserve file mode'
+    Include textutils/convert_mode_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+    It 'dos2unix keeps the original mode'
+        When call TestDos2unixKeepsMode
+        The output should equal '600'
+        The status should be success
+    End
+    It 'unix2dos keeps the original mode'
+        When call TestUnix2dosKeepsMode
+        The output should equal '600'
+        The status should be success
+    End
+End

--- a/test/it/spec/cp_perm_spec.sh
+++ b/test/it/spec/cp_perm_spec.sh
@@ -1,0 +1,20 @@
+Describe 'cp preserves permissions'
+    Include shellutils/cp_perm_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+    It 'keeps the source file mode (execute bit)'
+        When call TestCpPreservesExecBit
+        The output should equal '755'
+        The status should be success
+    End
+    It 'keeps a private directory mode'
+        When call TestCpPreservesDirMode
+        The output should equal '700'
+        The status should be success
+    End
+    It 'overwrites a read-only destination with -f'
+        When call TestCpForceOverwritesReadonly
+        The output should equal 'new'
+        The status should be success
+    End
+End

--- a/test/it/textutils/convert_mode_test.sh
+++ b/test/it/textutils/convert_mode_test.sh
@@ -1,0 +1,17 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it
+    mkdir -p ${TEST_DIR}
+    printf 'a\r\nb\r\n' > ${TEST_DIR}/d2u.txt
+    chmod 600 ${TEST_DIR}/d2u.txt
+    printf 'a\nb\n' > ${TEST_DIR}/u2d.txt
+    chmod 600 ${TEST_DIR}/u2d.txt
+}
+CleanUp() { rm -rf /tmp/mimixbox/it; }
+TestDos2unixKeepsMode() {
+    dos2unix ${TEST_DIR}/d2u.txt >/dev/null 2>&1
+    stat -c '%a' ${TEST_DIR}/d2u.txt
+}
+TestUnix2dosKeepsMode() {
+    unix2dos ${TEST_DIR}/u2d.txt >/dev/null 2>&1
+    stat -c '%a' ${TEST_DIR}/u2d.txt
+}


### PR DESCRIPTION
Addresses the review findings, with E2E tests written first plus new unit tests. Total coverage stays at ~80%.

## High
- **cp permissions** (`cp.go`): files and directories are now created with the **source's** mode instead of a hardcoded `0644`/`0755`. A normal `cp` no longer strips the execute bit from scripts/binaries, and `cp -r` no longer widens a private `0700` tree.
- **cp -f**: the flag was parsed but never used — now a destination that cannot be opened (e.g. read-only) is removed and recreated.
- **mv across filesystems** (`mv.go`, `internal/lib/file.go`): the `EXDEV` copy+remove fallback used `os.Create`+`io.Copy`, which dropped mode/timestamps and failed on directories. It now uses `lib.CopyTree` (recursive, mode- and mtime-preserving); `lib.Copy` preserves mode and mtime.
- **In-place truncation** (`dos2unix.go`, `unix2dos.go`, `lib.ListToFile`): converters rewrote the target with `os.Create`, so an interrupted write/full disk truncated the original. They now write a temp file and `rename` it over the target, preserving the original mode.

## Medium
- **watch context** (`watch.go`): the child runs via `exec.CommandContext`, so cancelling watch interrupts a hung child instead of blocking on `ctx.Done()`.
- **cat/nl streaming** (`cat.go`, `nl.go`, `textproc.Numberer`): stream input line by line instead of reading whole files into memory; constant space on large files/pipes. `tac` is inherently non-streaming (it reverses) but no longer materializes a second full copy.
- **lib test fixtures** (`file_test.go`): tests now build fixtures with `t.TempDir()` instead of the shared `/tmp/mimixbox/ut` tree, so `go test ./...` passes on a clean checkout (no `prepareUnitTest.sh` dependency) and the suite is parallel-safe.

## Test
- New unit tests: cp mode/`-f`; `lib.Copy`/`CopyTree`/`ListToFile`; the cross-device `mv` fallback (via an injectable rename); `dos2unix`/`unix2dos` mode preservation; watch cancelling a hung child; `Numberer` streaming across reads.
- New shellspec E2E: `cp` permission preservation + `-f`; `dos2unix`/`unix2dos` mode preservation.
- `make test` green; total coverage ~80% (stable, parallel-safe). `golangci-lint` clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added recursive directory support for `mv` across filesystems.

* **Bug Fixes**
  * `cp` now preserves file permissions and timestamps.
  * `mv` preserves permissions and timestamps for directory operations.
  * `dos2unix` and `unix2dos` preserve file permissions during conversion.
  * `watch` now properly interrupts hung child processes on cancellation.

* **Changed**
  * `cat` and `nl` now use streaming to reduce memory usage on large inputs.
  * File write operations are now atomic and mode-preserving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->