### PR TITLE
chore: release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-06-08
+
 ### Fixed
 
 - `cp` now copies files and directories with the **source's** permission

--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -54,7 +54,7 @@ type options struct {
 
 var osExit = os.Exit
 
-const version = "0.35.0"
+const version = "0.35.1"
 
 func main() {
 	var opts options

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,10 +9,10 @@ import (
 
 // Version is the MimixBox version. It is over_written at build time with
 // -ldflags "-X github.com/nao1215/mimixbox/internal/version.Version=x.y.z".
-var Version = "0.35.0"
+var Version = "0.35.1"
 
 // Print writes the "--version" line for a single command to w, following the
-// GNU coreutils convention, e.g. "cat (mimixbox) 0.35.0".
+// GNU coreutils convention, e.g. "cat (mimixbox) 0.35.1".
 func Print(w io.Writer, command string) {
 	_, _ = fmt.Fprintf(w, "%s (mimixbox) %s\n", command, Version)
 }


### PR DESCRIPTION
## Summary

Release **v0.35.1** (patch). Bumps the version string (in `internal/version` and the `mimixbox` multiplexer) and records the release in `CHANGELOG.md`.

This patch release ships the correctness/safety fixes from #221:

- `cp` preserves the source file/dir mode (no more stripped execute bits or widened private trees); `cp -f` now works.
- `mv` across filesystems preserves mode/timestamps and moves directories recursively.
- `dos2unix`, `unix2dos` and `internal/lib.ListToFile` rewrite files atomically (temp + rename) and keep the original mode.
- `watch` interrupts a hung child when cancelled.
- `cat` and `nl` stream their input in constant memory.
- `internal/lib` file tests are self-contained (`t.TempDir()`), so `go test ./...` passes on a clean checkout.

## Test

`make test` green; total coverage ~80.4%; `mimixbox --version` prints `0.35.1`.