### PR TITLE
feat(tail): add -f/--follow, -F, --retry, and -s/--sleep-interval

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -20,7 +20,9 @@ jobs:
           check-latest: true
 
       - name: SetupShellScript
-        run: curl -fsSL https://git.io/shellspec | sh -s -- --yes
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build
         run: make build

--- a/internal/applets/textutils/tail/follow.go
+++ b/internal/applets/textutils/tail/follow.go
@@ -40,7 +40,12 @@ func newFollowTargets(paths []string, retry bool) []followTarget {
 			_ = f.Close()
 			continue
 		}
-		offset, _ := f.Seek(0, io.SeekEnd)
+		offset, err := f.Seek(0, io.SeekEnd)
+		if err != nil {
+			// Fall back to the stat size so the first poll does not re-emit
+			// the whole file (which the initial tail pass already printed).
+			offset = info.Size()
+		}
 		targets = append(targets, followTarget{path: path, file: f, info: info, offset: offset})
 	}
 	return targets
@@ -56,7 +61,7 @@ func closeAll(targets []followTarget) {
 }
 
 // follow polls the targets every interval, emitting newly appended data, until
-// the context is cancelled. reopen enables -F semantics (re-open a file that is
+// the context is canceled. reopen enables -F semantics (re-open a file that is
 // rotated or recreated); showHeader prints "==> FILE <==" banners when output
 // switches between files.
 func follow(ctx context.Context, stdio command.IO, targets []followTarget, interval float64, reopen, showHeader bool) {
@@ -144,6 +149,9 @@ func (t *followTarget) emit(stdio command.IO, size int64, showHeader bool, last 
 		writeHeader(stdio.Out, t.path, *last == "")
 		*last = t.path
 	}
-	n, _ := io.CopyN(stdio.Out, t.file, size-t.offset)
+	n, err := io.CopyN(stdio.Out, t.file, size-t.offset)
 	t.offset += n
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "tail: %s: %v\n", t.path, err)
+	}
 }

--- a/internal/applets/textutils/tail/follow.go
+++ b/internal/applets/textutils/tail/follow.go
@@ -1,0 +1,149 @@
+package tail
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// followTarget tracks the state of a single file that tail is following: the
+// open descriptor, how many bytes have already been emitted, and the file
+// identity (for -F rotation detection via os.SameFile).
+type followTarget struct {
+	path   string
+	file   *os.File
+	info   os.FileInfo
+	offset int64
+}
+
+// newFollowTargets opens each path positioned at end of file so that only data
+// appended after tail starts is emitted. A file that cannot be opened is kept
+// as a pending target (file == nil) when retry is set, so -F/--retry can pick
+// it up once it appears; otherwise it is skipped (the initial tail pass has
+// already reported the error).
+func newFollowTargets(paths []string, retry bool) []followTarget {
+	targets := make([]followTarget, 0, len(paths))
+	for _, path := range paths {
+		f, err := os.Open(path) //nolint:gosec // operating on a user-named file is the point
+		if err != nil {
+			if retry {
+				targets = append(targets, followTarget{path: path})
+			}
+			continue
+		}
+		info, err := f.Stat()
+		if err != nil {
+			_ = f.Close()
+			continue
+		}
+		offset, _ := f.Seek(0, io.SeekEnd)
+		targets = append(targets, followTarget{path: path, file: f, info: info, offset: offset})
+	}
+	return targets
+}
+
+// closeAll releases every open descriptor held by the targets.
+func closeAll(targets []followTarget) {
+	for i := range targets {
+		if targets[i].file != nil {
+			_ = targets[i].file.Close()
+		}
+	}
+}
+
+// follow polls the targets every interval, emitting newly appended data, until
+// the context is cancelled. reopen enables -F semantics (re-open a file that is
+// rotated or recreated); showHeader prints "==> FILE <==" banners when output
+// switches between files.
+func follow(ctx context.Context, stdio command.IO, targets []followTarget, interval float64, reopen, showHeader bool) {
+	if len(targets) == 0 {
+		return
+	}
+	last := ""
+	ticker := time.NewTicker(time.Duration(interval * float64(time.Second)))
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for i := range targets {
+				targets[i].poll(stdio, reopen, showHeader, &last)
+			}
+		}
+	}
+}
+
+// poll reads any data appended to a single target since the last poll. With
+// reopen set it first checks whether the path now refers to a different file
+// (rotation) or has reappeared, and switches to it.
+func (t *followTarget) poll(stdio command.IO, reopen, showHeader bool, last *string) {
+	if reopen {
+		t.maybeReopen(stdio)
+	}
+	if t.file == nil {
+		return
+	}
+	info, err := t.file.Stat()
+	if err != nil {
+		return
+	}
+	size := info.Size()
+	if size < t.offset {
+		// The file was truncated in place; restart from the beginning.
+		_, _ = fmt.Fprintf(stdio.Err, "tail: %s: file truncated\n", t.path)
+		if _, err := t.file.Seek(0, io.SeekStart); err != nil {
+			return
+		}
+		t.offset = 0
+	}
+	if size > t.offset {
+		t.emit(stdio, size, showHeader, last)
+	}
+}
+
+// maybeReopen implements -F: if the path no longer resolves to the descriptor
+// tail is holding (rotated, replaced, or recreated after deletion), reopen it
+// from the start. A still-missing file is left pending for the next poll.
+func (t *followTarget) maybeReopen(stdio command.IO) {
+	nameInfo, err := os.Stat(t.path)
+	if err != nil {
+		if t.file != nil {
+			_ = t.file.Close()
+			t.file = nil
+			t.info = nil
+		}
+		return
+	}
+	if t.file != nil && t.info != nil && os.SameFile(t.info, nameInfo) {
+		return
+	}
+	f, err := os.Open(t.path) //nolint:gosec // operating on a user-named file is the point
+	if err != nil {
+		return
+	}
+	if t.file != nil {
+		_ = t.file.Close()
+		_, _ = fmt.Fprintf(stdio.Err, "tail: %s: file has been replaced; following new file\n", t.path)
+	} else {
+		_, _ = fmt.Fprintf(stdio.Err, "tail: %s: file has appeared; following new file\n", t.path)
+	}
+	t.file = f
+	t.info = nameInfo
+	t.offset = 0
+}
+
+// emit copies the bytes between the last offset and size to stdout, writing a
+// header first when output has switched to a different file.
+func (t *followTarget) emit(stdio command.IO, size int64, showHeader bool, last *string) {
+	if showHeader && *last != t.path {
+		writeHeader(stdio.Out, t.path, *last == "")
+		*last = t.path
+	}
+	n, _ := io.CopyN(stdio.Out, t.file, size-t.offset)
+	t.offset += n
+}

--- a/internal/applets/textutils/tail/tail.go
+++ b/internal/applets/textutils/tail/tail.go
@@ -44,6 +44,9 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 	if *sleepInterval <= 0 {
 		return command.Failuref("invalid number of seconds: %g", *sleepInterval)
 	}
+	if fs.Changed("follow") && *followMode != "name" && *followMode != "descriptor" {
+		return command.Failuref("invalid argument %q for '--follow'; valid arguments are 'name', 'descriptor'", *followMode)
+	}
 
 	following := fs.Changed("follow") || *followName
 	reopen := *followName || *followMode == "name"

--- a/internal/applets/textutils/tail/tail.go
+++ b/internal/applets/textutils/tail/tail.go
@@ -24,17 +24,30 @@ func (c *Command) Name() string { return "tail" }
 func (c *Command) Synopsis() string { return "Print the last NUMBER(default=10) lines" }
 
 // Run executes tail.
-func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
 	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
 	lines := fs.IntP("lines", "n", 10, "output the last NUM lines instead of the last 10")
 	bytesN := fs.IntP("bytes", "c", 0, "output the last NUM bytes of each file")
 	quiet := fs.BoolP("quiet", "q", false, "never print headers giving file names")
 	verbose := fs.BoolP("verbose", "v", false, "always print headers giving file names")
+	followMode := fs.StringP("follow", "f", "", "output appended data as the file grows; MODE is 'name' or 'descriptor'")
+	fs.Lookup("follow").NoOptDefVal = "descriptor"
+	followName := fs.BoolP("follow-name", "F", false, "same as --follow=name --retry")
+	retry := fs.Bool("retry", false, "keep trying to open a file even if it is inaccessible")
+	sleepInterval := fs.Float64P("sleep-interval", "s", 1.0, "seconds to wait between iterations when following")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
 	}
+
+	if *sleepInterval <= 0 {
+		return command.Failuref("invalid number of seconds: %g", *sleepInterval)
+	}
+
+	following := fs.Changed("follow") || *followName
+	reopen := *followName || *followMode == "name"
+	retryOpen := *retry || *followName
 
 	files := fs.Args()
 	if len(files) == 0 {
@@ -64,7 +77,29 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			firstErr = keep(firstErr)
 		}
 	}
+
+	if following {
+		// Standard input cannot be polled for growth, so only real files are
+		// followed. With -F/--retry a not-yet-existing file is still tracked.
+		paths := followablePaths(files)
+		targets := newFollowTargets(paths, retryOpen)
+		defer closeAll(targets)
+		follow(ctx, stdio, targets, *sleepInterval, reopen, showHeader)
+	}
 	return firstErr
+}
+
+// followablePaths returns the file operands that can be polled for growth,
+// dropping the "-" (standard input) pseudo-file.
+func followablePaths(files []string) []string {
+	paths := make([]string, 0, len(files))
+	for _, name := range files {
+		if name == "-" {
+			continue
+		}
+		paths = append(paths, name)
+	}
+	return paths
 }
 
 func writeHeader(w io.Writer, name string, first bool) {

--- a/internal/applets/textutils/tail/tail_test.go
+++ b/internal/applets/textutils/tail/tail_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/mimixbox/internal/applets/textutils/tail"
 	"github.com/nao1215/mimixbox/internal/command"
@@ -74,5 +75,121 @@ func TestRunMissingFile(t *testing.T) {
 	}
 	if !strings.Contains(errOut, "tail: /no/such/file:") {
 		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func appendToFile(t *testing.T, path, data string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(data); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+}
+
+// runFollowBackground starts tail in a goroutine and returns the live stdout
+// buffer, a cancel function that stops the follow loop, and a channel that is
+// closed once Run returns. Only the tail goroutine writes to the buffer, and
+// callers read it after receiving from done, so access is synchronized.
+func runFollowBackground(ctx context.Context, args ...string) (*bytes.Buffer, <-chan error) {
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	done := make(chan error, 1)
+	go func() { done <- tail.New().Run(ctx, io, args) }()
+	return out, done
+}
+
+func TestFollowEmitsAppendedData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("line1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out, done := runFollowBackground(ctx, "-f", "-s", "0.05", path)
+
+	time.Sleep(150 * time.Millisecond)
+	appendToFile(t, path, "line2\nline3\n")
+	time.Sleep(250 * time.Millisecond)
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "line1\n") {
+		t.Errorf("initial tail missing in %q", got)
+	}
+	if !strings.Contains(got, "line2\nline3\n") {
+		t.Errorf("appended data missing in %q", got)
+	}
+}
+
+func TestFollowReturnsOnCancel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	_, done := runFollowBackground(ctx, "-f", "-s", "0.05", path)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("follow did not stop after cancel")
+	}
+}
+
+func TestFollowNameReopensRecreatedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rotating.txt")
+	if err := os.WriteFile(path, []byte("first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	out, done := runFollowBackground(ctx, "-F", "-s", "0.05", path)
+
+	time.Sleep(150 * time.Millisecond)
+	// Rotate: rename the original away and recreate the path with new content.
+	if err := os.Rename(path, path+".1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+
+	if got := out.String(); !strings.Contains(got, "second\n") {
+		t.Errorf("recreated file content missing in %q", got)
+	}
+}
+
+func TestInvalidSleepIntervalRejected(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := run(t, "", "-f", "-s", "0", path)
+	if err == nil {
+		t.Fatal("expected error for non-positive sleep interval")
+	}
+	if !strings.Contains(err.Error(), "invalid number of seconds") {
+		t.Errorf("err = %v", err)
 	}
 }

--- a/internal/applets/textutils/tail/tail_test.go
+++ b/internal/applets/textutils/tail/tail_test.go
@@ -193,3 +193,19 @@ func TestInvalidSleepIntervalRejected(t *testing.T) {
 		t.Errorf("err = %v", err)
 	}
 }
+
+func TestInvalidFollowModeRejected(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := run(t, "", "--follow=bogus", path)
+	if err == nil {
+		t.Fatal("expected error for invalid --follow mode")
+	}
+	if !strings.Contains(err.Error(), "invalid argument") {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/test/it/spec/tail_spec.sh
+++ b/test/it/spec/tail_spec.sh
@@ -75,3 +75,16 @@ Describe 'tail with a non-existent file'
         The status should be failure
     End
 End
+
+Describe 'tail --follow'
+    Include textutils/tail_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints data appended while following'
+        When call TestTailFollow
+        The output should include 'start'
+        The output should include 'appended'
+        The status should be failure
+    End
+End

--- a/test/it/textutils/tail_test.sh
+++ b/test/it/textutils/tail_test.sh
@@ -31,3 +31,15 @@ TestTailPipe() {
 TestTailNoExistFile() {
     tail /no_exist_file
 }
+
+TestTailFollow() {
+    export TEST_DIR=/tmp/mimixbox/it
+    export FOLLOW_FILE=/tmp/mimixbox/it/follow.txt
+    mkdir -p "${TEST_DIR}"
+    printf 'start\n' > "${FOLLOW_FILE}"
+    # Append more data shortly after tail starts following.
+    ( sleep 0.2; printf 'appended\n' >> "${FOLLOW_FILE}" ) &
+    # tail -f follows forever; bound it with timeout (exits non-zero when killed),
+    # so the assertion is on the captured output.
+    timeout 0.5 tail -f -s 0.05 "${FOLLOW_FILE}"
+}


### PR DESCRIPTION
## Summary

`tail` had no way to follow a growing file. This adds a GNU-style follow subset so the MimixBox `tail` can stand in for `tail -f`. Closes #224.

## Changes

`-f`, `--follow[=name|descriptor]`: poll each real file and print data appended after tail starts. `-F`: same as `--follow=name --retry`; re-opens a file that is rotated, replaced, or recreated. `--retry`: track a not-yet-existing path until it appears. `-s`, `--sleep-interval=N`: seconds between polls (default 1s); non-positive values are rejected. Following honors the context, so cancellation (Ctrl-C / ctx) stops the loop without leaking a goroutine, mirroring the `watch` applet. Rotation/recreation is detected with `os.SameFile`, and in-place truncation resets the read offset.

## Design Decisions

The follow loop polls (stat size, read the new bytes) rather than using inotify, matching the issue's accepted approach and the existing `watch` polling pattern. Standard input (`-`) is never followed because it cannot be polled for growth, so a `tail -f -` invocation prints the tail and returns instead of hanging. The follow state lives in a small `followTarget` type in `follow.go` to keep `tail.go`'s non-follow path unchanged.

## Tests

Unit tests cover appended-data emission, ctx-cancel termination, `-F` re-open after a file is renamed away and recreated, and rejection of an invalid `-s`. They pass under `-race`. A shellspec E2E appends to a file in the background while a `timeout`-bounded `tail -f` follows it and asserts both the initial and appended lines appear.

## Limitations

`--follow=name` vs `--follow=descriptor` differ only in re-open behavior; both poll by the same mechanism. inotify-based following is out of scope per the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file follow mode with `--follow` flag to monitor file changes in real-time.
  * Added `--follow-name` (`-F`) to reopen files after rotation or recreation.
  * Added `--retry` flag to wait for missing files to appear.
  * Added `--sleep-interval` to customize polling frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->