### PR TITLE
fix(compliance): normalize --help/--version for custom-parsed applets

### DIFF
--- a/internal/applets/findutils/find/find.go
+++ b/internal/applets/findutils/find/find.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
+	"github.com/nao1215/mimixbox/internal/version"
 )
 
 // Command is the find applet.
@@ -45,14 +46,15 @@ type config struct {
 // Run executes find.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
 	// find has its own non-getopt expression grammar, so handle --help/--version
-	// by hand before splitting paths from the expression.
+	// by hand before splitting paths from the expression. --version prints the
+	// version line (not usage), matching every other applet's contract.
 	for _, a := range args {
 		switch a {
 		case "--help":
 			printUsage(stdio.Out)
 			return nil
 		case "--version":
-			printUsage(stdio.Out)
+			version.Print(stdio.Out, c.Name())
 			return nil
 		}
 	}

--- a/internal/applets/findutils/find/find_test.go
+++ b/internal/applets/findutils/find/find_test.go
@@ -262,3 +262,19 @@ func TestHelp(t *testing.T) {
 		t.Errorf("help = %q", out)
 	}
 }
+
+// TestVersion verifies that --version prints the version line, not usage text
+// (the bug fixed for issue #236).
+func TestVersion(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--version")
+	if err != nil {
+		t.Fatalf("version err = %v", err)
+	}
+	if !strings.Contains(out, "find (mimixbox)") {
+		t.Errorf("version = %q", out)
+	}
+	if strings.Contains(out, "Usage:") {
+		t.Errorf("version output should not contain usage text: %q", out)
+	}
+}

--- a/internal/applets/shellutils/echo/echo.go
+++ b/internal/applets/shellutils/echo/echo.go
@@ -1,7 +1,9 @@
 // Package echo implements the echo applet: write its arguments to standard
-// output. Like the GNU shell builtin, echo does not use getopt parsing: it only
-// recognizes a leading run of -n, -e and -E flags and treats everything else,
-// including --help and --version, as literal text.
+// output. echo does not use getopt parsing: it only recognizes a leading run of
+// -n, -e and -E flags and treats everything else as literal text. Like GNU's
+// standalone echo (and unlike the bash builtin), it honors --help and --version
+// when one is the first argument; anywhere else they are ordinary text, so
+// `echo foo --help` still prints "foo --help".
 package echo
 
 import (
@@ -27,6 +29,10 @@ func (c *Command) Synopsis() string { return "Display a line of text" }
 
 // Run executes echo.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	if command.HandleHelpVersion(stdio, c.Name(), "[OPTION]... [STRING]...", args) {
+		return nil
+	}
+
 	noNewline := false
 	interpret := false
 

--- a/internal/applets/shellutils/echo/echo_test.go
+++ b/internal/applets/shellutils/echo/echo_test.go
@@ -29,7 +29,8 @@ func TestRun(t *testing.T) {
 		{"no args", nil, "\n"},
 		{"no newline", []string{"-n", "hi"}, "hi"},
 		{"unknown flag is literal", []string{"-x", "y"}, "-x y\n"},
-		{"help is literal", []string{"--help"}, "--help\n"},
+		{"help not first is literal", []string{"foo", "--help"}, "foo --help\n"},
+		{"version not first is literal", []string{"foo", "--version"}, "foo --version\n"},
 		{"escapes off by default", []string{`a\tb`}, "a\\tb\n"},
 		{"escapes on", []string{"-e", `a\tb`}, "a\tb\n"},
 		{"combined flags", []string{"-ne", `a\nb`}, "a\nb"},
@@ -49,5 +50,31 @@ func TestRun(t *testing.T) {
 				t.Errorf("out = %q, want %q", out, tt.want)
 			}
 		})
+	}
+}
+
+// TestHelpAsFirstArg verifies that a leading --help prints usage rather than
+// echoing the literal text, matching GNU's standalone echo.
+func TestHelpAsFirstArg(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "Usage: echo") {
+		t.Errorf("help out = %q", out)
+	}
+}
+
+// TestVersionAsFirstArg verifies that a leading --version prints the version
+// line rather than echoing the literal text.
+func TestVersionAsFirstArg(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "--version")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "echo (mimixbox)") {
+		t.Errorf("version out = %q", out)
 	}
 }

--- a/internal/applets/shellutils/false/false.go
+++ b/internal/applets/shellutils/false/false.go
@@ -22,15 +22,8 @@ func (c *Command) Synopsis() string { return "Do nothing. Return unsuccess(1)" }
 // Run always fails with exit status 1. Like GNU false it ignores its operands,
 // except that a leading --help or --version is honored and exits successfully.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	if len(args) > 0 {
-		switch args[0] {
-		case "--help":
-			command.NewFlagSet(c.Name(), "[IGNORED]...", stdio.Err).WriteUsage(stdio.Out)
-			return nil
-		case "--version":
-			_, _ = command.NewFlagSet(c.Name(), "", stdio.Err).Parse(stdio, []string{"--version"})
-			return nil
-		}
+	if command.HandleHelpVersion(stdio, c.Name(), "[IGNORED]...", args) {
+		return nil
 	}
 	return &command.ExitError{Code: command.ExitFailure}
 }

--- a/internal/applets/shellutils/false/false_test.go
+++ b/internal/applets/shellutils/false/false_test.go
@@ -31,3 +31,16 @@ func TestRunHelpSucceeds(t *testing.T) {
 		t.Errorf("help out = %q", out.String())
 	}
 }
+
+func TestRunVersionSucceeds(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	code := command.Execute(context.Background(), boolfalse.New(), io, []string{"--version"})
+	if code != command.ExitSuccess {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "false (mimixbox)") {
+		t.Errorf("version out = %q", out.String())
+	}
+}

--- a/internal/applets/shellutils/true/true.go
+++ b/internal/applets/shellutils/true/true.go
@@ -22,13 +22,6 @@ func (c *Command) Synopsis() string { return "Do nothing. Return success(0)" }
 // Run always succeeds. Like GNU true it ignores its operands, except that a
 // leading --help or --version is honored.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	if len(args) > 0 {
-		switch args[0] {
-		case "--help":
-			command.NewFlagSet(c.Name(), "[IGNORED]...", stdio.Err).WriteUsage(stdio.Out)
-		case "--version":
-			_, _ = command.NewFlagSet(c.Name(), "", stdio.Err).Parse(stdio, []string{"--version"})
-		}
-	}
+	command.HandleHelpVersion(stdio, c.Name(), "[IGNORED]...", args)
 	return nil
 }

--- a/internal/applets/shellutils/true/true_test.go
+++ b/internal/applets/shellutils/true/true_test.go
@@ -31,3 +31,16 @@ func TestRunHelp(t *testing.T) {
 		t.Errorf("help out = %q", out.String())
 	}
 }
+
+func TestRunVersion(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	code := command.Execute(context.Background(), booltrue.New(), io, []string{"--version"})
+	if code != command.ExitSuccess {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "true (mimixbox)") {
+		t.Errorf("version out = %q", out.String())
+	}
+}

--- a/internal/command/help.go
+++ b/internal/command/help.go
@@ -1,0 +1,30 @@
+package command
+
+import "github.com/nao1215/mimixbox/internal/version"
+
+// HandleHelpVersion implements the standard --help/--version contract for
+// applets that parse their own arguments instead of using a FlagSet (echo,
+// true, false, and similar custom parsers). When the first argument is exactly
+// "--help" it writes a GNU-style usage block built from name and usage; when it
+// is "--version" it writes the version line. It reports whether it handled the
+// argument so the caller can return early.
+//
+// Only the first argument is inspected, matching the behavior of GNU's
+// standalone echo and true: a "--help" or "--version" that appears later is an
+// ordinary operand (so `echo foo --help` still prints "foo --help"). Keeping
+// this logic in one place is what stops custom-parsed applets from drifting
+// into inconsistent --help/--version behavior.
+func HandleHelpVersion(stdio IO, name, usage string, args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "--help":
+		NewFlagSet(name, usage, stdio.Err).WriteUsage(stdio.Out)
+		return true
+	case "--version":
+		version.Print(stdio.Out, name)
+		return true
+	}
+	return false
+}

--- a/internal/command/help_test.go
+++ b/internal/command/help_test.go
@@ -1,0 +1,47 @@
+package command_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHandleHelpVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		args        []string
+		wantHandled bool
+		wantOut     string // substring expected in stdout (empty = no output)
+	}{
+		{"help first", []string{"--help"}, true, "Usage: demo [OPERAND]..."},
+		{"version first", []string{"--version"}, true, "demo (mimixbox)"},
+		{"help not first", []string{"x", "--help"}, false, ""},
+		{"version not first", []string{"x", "--version"}, false, ""},
+		{"no args", nil, false, ""},
+		{"unrelated", []string{"foo"}, false, ""},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out := &bytes.Buffer{}
+			stdio := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+			handled := command.HandleHelpVersion(stdio, "demo", "[OPERAND]...", tt.args)
+			if handled != tt.wantHandled {
+				t.Errorf("handled = %v, want %v", handled, tt.wantHandled)
+			}
+			if tt.wantOut == "" {
+				if out.Len() != 0 {
+					t.Errorf("expected no output, got %q", out.String())
+				}
+				return
+			}
+			if !strings.Contains(out.String(), tt.wantOut) {
+				t.Errorf("out = %q, want substring %q", out.String(), tt.wantOut)
+			}
+		})
+	}
+}

--- a/test/it/findutils/find_test.sh
+++ b/test/it/findutils/find_test.sh
@@ -17,3 +17,9 @@ TestFindUnknown() {
     export TEST_DIR=/tmp/mimixbox/it/find
     find ${TEST_DIR} -bogus
 }
+TestFindHelp() {
+    find --help
+}
+TestFindVersion() {
+    find --version
+}

--- a/test/it/shellutils/echo_test.sh
+++ b/test/it/shellutils/echo_test.sh
@@ -23,3 +23,15 @@ TestEchoRedirect() {
     echo "MimixBox" > /tmp/it/mimixbox/echo.txt
     cat /tmp/it/mimixbox/echo.txt
 }
+
+TestEchoHelp() {
+    echo --help
+}
+
+TestEchoVersion() {
+    echo --version
+}
+
+TestEchoHelpNotFirst() {
+    echo foo --help
+}

--- a/test/it/shellutils/echo_test.sh
+++ b/test/it/shellutils/echo_test.sh
@@ -24,14 +24,17 @@ TestEchoRedirect() {
     cat /tmp/it/mimixbox/echo.txt
 }
 
+# echo is also a bash builtin, so the bare name would run the builtin instead of
+# the MimixBox applet. type -P resolves the on-PATH executable (the MimixBox
+# symlink) so these cases exercise the applet's --help/--version contract.
 TestEchoHelp() {
-    echo --help
+    "$(type -P echo)" --help
 }
 
 TestEchoVersion() {
-    echo --version
+    "$(type -P echo)" --version
 }
 
 TestEchoHelpNotFirst() {
-    echo foo --help
+    "$(type -P echo)" foo --help
 }

--- a/test/it/spec/echo_spec.sh
+++ b/test/it/spec/echo_spec.sh
@@ -56,3 +56,30 @@ Describe 'Echo redirect to file.'
         The status should be success
     End
 End
+
+Describe 'Echo --help as the first argument'
+    Include shellutils/echo_test.sh
+    It 'prints usage instead of the literal text'
+        When call TestEchoHelp
+        The output should include 'Usage: echo'
+        The status should be success
+    End
+End
+
+Describe 'Echo --version as the first argument'
+    Include shellutils/echo_test.sh
+    It 'prints the version line'
+        When call TestEchoVersion
+        The output should include 'echo (mimixbox)'
+        The status should be success
+    End
+End
+
+Describe 'Echo --help that is not the first argument'
+    Include shellutils/echo_test.sh
+    It 'stays literal'
+        When call TestEchoHelpNotFirst
+        The output should equal 'foo --help'
+        The status should be success
+    End
+End

--- a/test/it/spec/find_spec.sh
+++ b/test/it/spec/find_spec.sh
@@ -20,4 +20,16 @@ Describe 'find'
         The status should be failure
         The error should include 'unknown predicate'
     End
+
+    It 'prints usage for --help'
+        When call TestFindHelp
+        The output should include 'Usage: find'
+        The status should be success
+    End
+
+    It 'prints the version line for --version'
+        When call TestFindVersion
+        The output should include 'find (mimixbox)'
+        The status should be success
+    End
 End


### PR DESCRIPTION
## Summary

The applets that bypass `command.FlagSet` and parse their own arguments (`find`, `echo`, `true`, `false`) had an inconsistent `--help`/`--version` contract. `find --version` printed usage text instead of the version line, and `echo` treated `--help`/`--version` as literal text everywhere. Closes #236.

## Changes

Add `command.HandleHelpVersion` as the single source of truth for the custom-parser contract: when `--help` or `--version` is the first argument it writes the GNU-style usage block or the version line and returns whether it handled the request. `true` and `false` now delegate to it instead of duplicating the switch. `echo` honors `--help`/`--version` only as a leading operand, matching GNU's standalone `/usr/bin/echo` (a `--help` in any later position stays literal, so `echo foo --help` still prints `foo --help`). `find` prints the version line for `--version` while keeping its richer expression-grammar help for `--help`.

## Design Decisions

The contract is intentionally "first argument only". GNU's standalone `echo` and `true` recognize `--help`/`--version` only as the very first operand, which is what lets `echo foo --help` remain literal; centralizing that rule in one helper is what stops future custom parsers from drifting. `find` keeps its own help text because its options are an expression grammar (`-name`, `-type`, ...), not flags a `FlagSet` could render.

## Tests

Unit tests cover `HandleHelpVersion` directly (first vs. non-first, version, no-op cases) and each applet's help/version output. shellspec E2E adds `find --help`/`--version` and `echo --help`/`--version`, including the not-first-argument literal case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` support to the find command.
  * Implemented consistent help and version handling across echo, true, and false commands.
  * For echo, `--help` and `--version` are recognized as special flags only when they appear as the first argument; otherwise they are treated as literal text.

* **Tests**
  * Added comprehensive unit and integration test coverage for help and version functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->