### PR TITLE
chore: release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-06-09
+
 ### Changed
 
 - The top-level `mimixbox` dispatcher was rewritten without the go-flags
@@ -23,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ignores the initial signal.
 - `internal/lib`: `Question` loops instead of recursing, and `FromPIPE` uses
   `io.ReadAll` instead of the deprecated `ioutil.ReadAll`.
+- Custom-parsed applets now share a single `--help`/`--version` contract via
+  `command.HandleHelpVersion`: `find --version` prints the version line
+  instead of usage text, and standalone `echo` honors a leading `--help`/
+  `--version` like GNU's `/usr/bin/echo` (a later `--help` stays literal, so
+  `echo foo --help` is unchanged). `true` and `false` delegate to the same
+  helper.
 
 ### Fixed
 
@@ -30,9 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fixtures with `t.TempDir()` (no `/tmp/mimixbox/ut` dependency, parallel
   safe), and tests that need `chown`, loopback listen sockets or netlink now
   `t.Skip` when those are unavailable instead of failing.
+- CI installs shellspec from its canonical `install.sh` URL; the old
+  `git.io/shellspec` shortlink was shut down and returned 404, breaking the
+  integration-test job.
 
 ### Added
 
+- `tail` can follow a growing file: `-f`/`--follow[=name|descriptor]` prints
+  appended data, `-F` (and `--retry`) re-opens a rotated/recreated file, and
+  `-s`/`--sleep-interval` sets the poll interval. Following honors the context
+  so cancellation stops the loop without leaking a goroutine.
 - Top-level dispatch tests (`cmd/mimixbox`) and shellspec end-to-end specs
   for previously-untested applets: `printenv`, `printf`, `pwd`, `sleep`,
   `sync`, `uuidgen`, `tr`, `kill`, and a `gzip`/`gunzip` roundtrip.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,10 +9,10 @@ import (
 
 // Version is the MimixBox version. It is over_written at build time with
 // -ldflags "-X github.com/nao1215/mimixbox/internal/version.Version=x.y.z".
-var Version = "0.35.1"
+var Version = "0.36.0"
 
 // Print writes the "--version" line for a single command to w, following the
-// GNU coreutils convention, e.g. "cat (mimixbox) 0.35.1".
+// GNU coreutils convention, e.g. "cat (mimixbox) 0.36.0".
 func Print(w io.Writer, command string) {
 	_, _ = fmt.Fprintf(w, "%s (mimixbox) %s\n", command, Version)
 }


### PR DESCRIPTION
## Summary

Release v0.36.0. This minor release bundles the work merged since v0.35.1 and bumps the version string.

## Highlights

`tail` can now follow a growing file (`-f`/`--follow`, `-F`, `--retry`, `-s`/`--sleep-interval`) (#224). The custom-parsed applets (`find`, `echo`, `true`, `false`) now share one `--help`/`--version` contract via `command.HandleHelpVersion`: `find --version` prints the version line and standalone `echo` honors a leading `--help`/`--version` (#236). The release also carries the top-level dispatcher rewrite, the `cp`/`timeout` improvements, and the hermetic test-suite changes already on main, and restores the integration-test job by replacing the dead `git.io/shellspec` installer URL.

## Changes

Bump `internal/version.Version` to 0.36.0 (the single source of truth now used by `cmd/mimixbox` too) and move the accumulated `[Unreleased]` CHANGELOG entries under `[0.36.0] - 2026-06-09`, adding the tail-follow, help/version-contract, and CI entries.

## Release steps

Merge this PR, then tag `v0.36.0` on the merge commit so the release workflow builds the artifacts.