### PR TITLE
fix(pidof): register the applet so MimixBox ships and tests its own pidof

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 152 commands. Run `mimixbox --list` to see them on the terminal.
+There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -104,6 +104,7 @@ There are 152 commands. Run `mimixbox --list` to see them on the terminal.
 | paste | Merge lines of files |
 | patch | Apply a diff file to an original |
 | path | Manipulate filename path |
+| pidof | Find the process ID of a running program |
 | ping | Send ICMP ECHO_REQUEST to network hosts |
 | posixer | Report which POSIX utilities are installed |
 | poweroff | Power off the system |

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -126,6 +126,7 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/nproc"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/od"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/path"
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/pidof"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/posixer"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/printenv"
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/printf"
@@ -281,6 +282,7 @@ func init() {
 		"paste":            reg(paste.New()),
 		"patch":            reg(patch.New()),
 		"path":             reg(path.New()),
+		"pidof":            reg(pidof.New()),
 		"posixer":          reg(posixer.New()),
 		"poweroff":         reg(halt.NewPoweroff()),
 		"printenv":         reg(printenv.New()),

--- a/internal/applets/applet_test.go
+++ b/internal/applets/applet_test.go
@@ -1,0 +1,40 @@
+// mimixbox/internal/applets/applet_test.go
+//
+// # Copyright 2021 Naohiro CHIKAMATSU
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package applets
+
+import (
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/pidof"
+)
+
+// TestPidofIsRegistered guards against the regression where pidof had a real
+// implementation and unit tests in the tree but was never wired into the applet
+// registry. Without registration, "mimixbox pidof", "--list" and
+// "--full-install" silently omit it, and the ShellSpec suite ends up exercising
+// the host pidof instead of MimixBox's own. See GitHub issue #265.
+func TestPidofIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	name := pidof.New().Name()
+	if !HasApplet(name) {
+		t.Fatalf("applet %q is implemented but not registered in Applets", name)
+	}
+
+	if got, want := Applets[name].Desc, pidof.New().Synopsis(); got != want {
+		t.Errorf("registered description drifted from the command synopsis:\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/test/it/shellutils/pidof_test.sh
+++ b/test/it/shellutils/pidof_test.sh
@@ -1,9 +1,24 @@
 TestPidofInit() {
-    pidof mimixbox >/dev/null 2>&1
+    # Invoke MimixBox's own pidof explicitly so the test can never silently
+    # validate the host system's pidof (GitHub issue #265).
+    mimixbox pidof mimixbox >/dev/null 2>&1
     # pidof of a definitely-running process: the test shell's own 'sleep'
     sleep 5 &
     SLEEP_PID=$!
-    RESULT=$(pidof sleep)
+    RESULT=$(mimixbox pidof sleep)
     kill ${SLEEP_PID} 2>/dev/null
     echo "${RESULT}" | grep -q "${SLEEP_PID}" && echo found
+}
+
+# TestPidofIsMimixBox asserts that the bare 'pidof' on PATH resolves to a
+# MimixBox-installed symlink, not the host binary. After 'mimixbox
+# --full-install', the symlink must exist and point at the mimixbox binary.
+TestPidofIsMimixBox() {
+    pidof_path=$(command -v pidof) || return 1
+    [ -L "${pidof_path}" ] || return 1
+    target=$(readlink "${pidof_path}")
+    case "${target}" in
+        *mimixbox) echo linked ;;
+        *) return 1 ;;
+    esac
 }

--- a/test/it/spec/pidof_spec.sh
+++ b/test/it/spec/pidof_spec.sh
@@ -1,8 +1,13 @@
 Describe 'pidof'
     Include shellutils/pidof_test.sh
-    It 'finds the PID of a running process'
+    It 'finds the PID of a running process via MimixBox pidof'
         When call TestPidofInit
         The output should equal 'found'
+        The status should be success
+    End
+    It 'resolves bare pidof to the MimixBox-installed symlink'
+        When call TestPidofIsMimixBox
+        The output should equal 'linked'
         The status should be success
     End
 End


### PR DESCRIPTION
## Summary

`pidof` had a real implementation and unit tests in the tree but was never wired into the applet registry. As a result `mimixbox pidof`, `mimixbox --list` and `mimixbox --full-install` all silently omitted it, and the ShellSpec suite exercised the host `pidof` instead of MimixBox's own — a dangerous false positive that would pass even though MimixBox shipped no `pidof` at all.

This PR decides that `pidof` is a shipped applet and wires it in end to end.

## Changes

- Register `pidof` in `internal/applets/applet.go` (import + registry entry) so dispatch, `--list` and `--full-install` expose it.
- Regenerate the README command list via `make command-list` (152 -> 153 commands).
- Add `internal/applets/applet_test.go` with `TestPidofIsRegistered`, a regression test that fails if `pidof` is implemented but not registered, and that also guards the listed description against drifting from the command synopsis.
- Update the ShellSpec so it invokes `mimixbox pidof` explicitly and asserts that bare `pidof` on PATH resolves to the MimixBox-installed symlink, never the host binary.

## Verification

- `go test ./...` passes, including the new regression test.
- `mimixbox --list | grep pidof` shows the applet.
- `mimixbox --full-install <tmpdir>` creates a `pidof` symlink to the mimixbox binary, and running it returns the correct PID.
- `make it` (pidof_spec) passes with a PATH that resolves `pidof` from the MimixBox install directory.

Closes #265