### PR TITLE
test: make unit-test failures fail make test and the UnitTest workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ make test-e2e   # shellspec end-to-end tests against the built binary
 make lint       # golangci-lint
 ```
 
+`make test` (and its `make ut` alias) exits non-zero when any unit test fails, so a failing `go test` fails the local build and the `UnitTest` GitHub Actions workflow. Coverage HTML generation and the temporary-directory cleanup still run afterwards, but they never mask a real test failure.
+
 The end-to-end tests live under `test/it/` and exercise the built binary the way a user does (applet name, flags, stdin, exit codes).
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ remove: ## Remove mimixbox-symbolic link
 	mimixbox --remove /usr/local/bin
 
 test: pre_ut  ## Run unit tests with coverage (writes cover.out / cover.html)
-	-@go test -cover ./... -coverpkg=./... -coverprofile=cover.out
-	-@go tool cover -html=cover.out -o cover.html
-	-@rm -rf /tmp/mimixbox/ut/*
+	@go test -cover ./... -coverpkg=./... -coverprofile=cover.out; status=$$?; \
+	go tool cover -html=cover.out -o cover.html || true; \
+	rm -rf /tmp/mimixbox/ut/*; \
+	exit $$status
 
 test-e2e: ## Run the shellspec end-to-end tests against the built binary
 	cd test/it && shellspec --shell /bin/bash


### PR DESCRIPTION
## Summary

The unit-test target prefixed `go test` and the coverage commands with `-@`, which tells GNU Make to ignore non-zero exits. A failing `go test` therefore reported success, so `make test`, `make ut`, and the `UnitTest` GitHub Actions job (which runs `make ut`) could stay green while real regressions merged unnoticed.

## Changes

- Rewrite the `test` target so `go test`'s exit status is captured and re-raised after cleanup. A failing test now fails `make test` and `make ut`.
- Keep the auxiliary steps: coverage HTML generation still runs (tolerating its own hiccups via `|| true`) and the `/tmp/mimixbox/ut` cleanup still runs, but neither can mask a test failure.
- Document the expected local behavior in `CONTRIBUTING.md`.

## Verification

Verified locally by intentionally adding a failing unit test:

- `make test` exits non-zero (status 2) when a test fails, and `0` when all pass.
- `make ut` (the alias used by the `UnitTest` workflow) exits non-zero on the same failure.
- The coverage HTML is still written and the temporary unit-test directory is still cleaned up on a failing run.

Since the `UnitTest` workflow runs `make ut` verbatim, the job now fails whenever unit tests fail.

Closes #266