### PR TITLE
test: make the ShellSpec e2e harness hermetic with an isolated applet PATH

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -24,14 +24,8 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- --yes
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Build
-        run: make build
-
-      - name: InstallMimixBox
-        run: sudo install -v -m 0755 -D mimixbox /usr/local/bin/.
-
-      - name: CreateSymbolicLink
-        run: mimixbox --full-install /usr/local/bin/
-
+      # `make it` (test-e2e) builds MimixBox and stages its applet symlinks in an
+      # isolated PATH directory itself, so the workflow and the local target
+      # exercise the exact same hermetic environment.
       - name: IntegrationTest
         run: make it

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ cover.html
 
 # Directory that manages licenses for dependent libraries
 licenses
+
+# Isolated applet staging directory built by `make e2e-setup`
+test/it/.mbbin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ make lint       # golangci-lint
 
 The end-to-end tests live under `test/it/` and exercise the built binary the way a user does (applet name, flags, stdin, exit codes).
 
+`make test-e2e` is hermetic: it builds MimixBox, stages one symlink per applet in an isolated directory (`test/it/.mbbin`), and runs ShellSpec with that directory first on `PATH`. Every applet therefore resolves to MimixBox, never to a host command of the same name, so the suite can be run in a clean shell without installing MimixBox system-wide. Specs must invoke applets by bare name (e.g. `cat`, `unix2dos`) and must not hardcode an install prefix such as `/usr/local/bin`. `spec/hermetic_spec.sh` guards this contract by asserting that common applets resolve to the MimixBox binary.
+
 ## Architecture
 
 Each applet is a small `Command` built on the `internal/command` framework:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-APP        := mimixbox
-PREPARE_UT := test/ut/prepareUnitTest.sh
-INSTALLER  := scripts/installer.sh
-MK_JAIL    := scripts/mkJailForDebianFamily.sh
-RELEASE    := scripts/release.sh
+APP         := mimixbox
+PREPARE_UT  := test/ut/prepareUnitTest.sh
+INSTALLER   := scripts/installer.sh
+MK_JAIL     := scripts/mkJailForDebianFamily.sh
+RELEASE     := scripts/release.sh
+# Isolated directory holding the freshly built MimixBox binary and one symlink
+# per applet. The end-to-end suite prepends it to PATH so every applet resolves
+# to MimixBox, never to whatever the host happens to provide.
+E2E_BIN_DIR := $(CURDIR)/test/it/.mbbin
 
 build:  ## Build the mimixbox binary
 	go build "-ldflags=-s -w" -trimpath -o $(APP) cmd/mimixbox/main.go
@@ -15,6 +19,7 @@ clean: ## Clean project
 	-rm -rf /tmp/mimixbox/ut/*
 	-rm -rf release
 	-rm -rf licenses
+	-rm -rf $(E2E_BIN_DIR)
 
 docker: ## Run container for testing mimixbox
 	docker image build -t mimixbox/test:latest .
@@ -36,8 +41,15 @@ test: pre_ut  ## Run unit tests with coverage (writes cover.out / cover.html)
 	rm -rf /tmp/mimixbox/ut/*; \
 	exit $$status
 
-test-e2e: ## Run the shellspec end-to-end tests against the built binary
-	cd test/it && shellspec --shell /bin/bash
+e2e-setup: ## Build MimixBox and stage its applet symlinks in an isolated PATH directory
+	go build "-ldflags=-s -w" -trimpath -o $(APP) cmd/mimixbox/main.go
+	rm -rf "$(E2E_BIN_DIR)"
+	mkdir -p "$(E2E_BIN_DIR)"
+	install -m 0755 $(APP) "$(E2E_BIN_DIR)/$(APP)"
+	"$(E2E_BIN_DIR)/$(APP)" --full-install "$(E2E_BIN_DIR)" >/dev/null
+
+test-e2e: e2e-setup ## Run the shellspec end-to-end tests against MimixBox applets in an isolated PATH
+	cd test/it && PATH="$(E2E_BIN_DIR):$$PATH" shellspec --shell /bin/bash
 
 lint: ## Run golangci-lint
 	golangci-lint run ./...
@@ -64,7 +76,7 @@ ut: test  ## Alias for "make test"
 it: test-e2e  ## Alias for "make test-e2e"
 
 .DEFAULT_GOAL := help
-.PHONY: build clean docker install full-install remove test test-e2e lint command-list jail release licenses pre_ut ut it help
+.PHONY: build clean docker install full-install remove test e2e-setup test-e2e lint command-list jail release licenses pre_ut ut it help
 
 help:
 	@grep -E '^[0-9a-zA-Z_-]+[[:blank:]]*:.*?## .*$$' $(MAKEFILE_LIST) | sort \

--- a/test/it/shellutils/hermetic_test.sh
+++ b/test/it/shellutils/hermetic_test.sh
@@ -1,0 +1,14 @@
+# Helpers asserting that the end-to-end harness is hermetic: every applet on
+# PATH must resolve to the MimixBox binary, never to a host command of the same
+# name (GitHub issue #270).
+
+# ResolvesToMimixBox prints "mimixbox" when the named command resolves, through
+# the MimixBox-installed symlink, to the MimixBox binary. It prints whatever the
+# real target's basename is otherwise, so a host binary makes the test fail
+# loudly instead of passing silently.
+ResolvesToMimixBox() {
+    path=$(command -v "$1") || return 1
+    # Follow the symlink chain to the concrete binary it points at.
+    real=$(readlink -f "${path}")
+    basename "${real}"
+}

--- a/test/it/spec/hermetic_spec.sh
+++ b/test/it/spec/hermetic_spec.sh
@@ -1,0 +1,19 @@
+Describe 'hermetic harness'
+    Include shellutils/hermetic_test.sh
+
+    # These applets all have host equivalents (coreutils), so if the suite were
+    # not hermetic they would resolve to the host binary and these cases would
+    # fail. cat/head/base64 are external programs, not shell builtins, so
+    # `command -v` returns a real path that we can follow to the MimixBox binary.
+    Parameters
+        cat
+        head
+        base64
+    End
+
+    It "resolves $1 to the MimixBox binary, not the host command"
+        When call ResolvesToMimixBox "$1"
+        The output should equal 'mimixbox'
+        The status should be success
+    End
+End

--- a/test/it/spec/which_spec.sh
+++ b/test/it/spec/which_spec.sh
@@ -1,8 +1,13 @@
+# The expected paths are derived from wherever MimixBox actually resolves on
+# PATH, so the suite stays correct under the isolated end-to-end harness
+# (test/it/.mbbin) without hardcoding an install prefix like /usr/local/bin.
+mb_bindir() { dirname "$(command -v mimixbox)"; }
+
 Describe 'Search mimixbox'
     Include shellutils/which_test.sh
-    It 'print /usr/local/bin/mimixbox'
+    It 'prints the MimixBox path'
         When call TestWhichExistBinary
-        The output should equal '/usr/local/bin/mimixbox'
+        The output should equal "$(mb_bindir)/mimixbox"
         The status should be success
     End
 End
@@ -19,10 +24,9 @@ End
 Describe 'Search three binary.'
     Include shellutils/which_test.sh
 
-    result() { %text
-      #|/usr/local/bin/mimixbox
-      #|/usr/local/bin/cat
-      #|/usr/local/bin/tac
+    result() {
+        d=$(mb_bindir)
+        printf '%s\n%s\n%s\n' "$d/mimixbox" "$d/cat" "$d/tac"
     }
 
     It 'print paths of three binary'
@@ -35,9 +39,9 @@ End
 Describe 'Search three binary. One of three binary does not exist'
     Include shellutils/which_test.sh
 
-    result() { %text
-      #|/usr/local/bin/mimixbox
-      #|/usr/local/bin/tac
+    result() {
+        d=$(mb_bindir)
+        printf '%s\n%s\n' "$d/mimixbox" "$d/tac"
     }
 
     It 'print paths of two binary and exit-status is fail'

--- a/test/it/textutils/unix2dos_test.sh
+++ b/test/it/textutils/unix2dos_test.sh
@@ -19,36 +19,36 @@ Cleanup() {
 }
 
 TestUnix2dosCRLF() {
-    /usr/local/bin/unix2dos ${TEST_FILE1}
+    unix2dos ${TEST_FILE1}
     file ${TEST_FILE1}
 }
 
 TestUnix2dosCRLFStatus() {
-    /usr/local/bin/unix2dos ${TEST_FILE1}
+    unix2dos ${TEST_FILE1}
 }
 
 TestUnix2dosThreeFileAtSameTime() {
-    /usr/local/bin/unix2dos ${TEST_FILE1} ${TEST_FILE2} ${TEST_FILE3}
+    unix2dos ${TEST_FILE1} ${TEST_FILE2} ${TEST_FILE3}
     file ${TEST_FILE1}
     file ${TEST_FILE2}
     file ${TEST_FILE3}
 }
 
 TestUnix2dosThreeFileAtSameTime() {
-    /usr/local/bin/unix2dos ${TEST_FILE1} ${TEST_FILE2} ${TEST_FILE3}
+    unix2dos ${TEST_FILE1} ${TEST_FILE2} ${TEST_FILE3}
     file ${TEST_FILE1}
     file ${TEST_FILE2}
     file ${TEST_FILE3}
 }
 
 TestUnix2dosThreeFileAtSameTimeStatus() {
-    /usr/local/bin/unix2dos ${TEST_FILE1} ${TEST_FILE2} ${TEST_FILE3}
+    unix2dos ${TEST_FILE1} ${TEST_FILE2} ${TEST_FILE3}
 }
 
 TestUnix2dosDir() {
-    /usr/local/bin/unix2dos ${TEST_DIR}
+    unix2dos ${TEST_DIR}
 }
 
 TestUnix2dosOneOfThreeFail() {
-    /usr/local/bin/unix2dos ${TEST_FILE1}  ${TEST_DIR} ${TEST_FILE3} 
+    unix2dos ${TEST_FILE1}  ${TEST_DIR} ${TEST_FILE3} 
 }


### PR DESCRIPTION
## Summary

`make test-e2e` ran ShellSpec directly, without building MimixBox or putting its applets on PATH, so the suite could silently pass against host commands instead of MimixBox applets. The Make target and the CI integration workflow also enforced different environments (CI built, installed, and ran `--full-install`; the local target did none of that).

This PR makes the local end-to-end target self-sufficient and hermetic, and points CI at the same target.

## Changes

- Add an `e2e-setup` target that builds MimixBox and stages one symlink per applet in an isolated directory (`test/it/.mbbin`). `test-e2e` now depends on it and runs ShellSpec with that directory first on PATH, so every applet resolves to MimixBox, never to a host binary of the same name.
- Point the IntegrationTest workflow at `make it` and drop its bespoke build/install/`--full-install` steps, so the workflow and the local target share one hermetic environment. The staging dir is user-writable, so no `sudo` install is needed.
- Add `spec/hermetic_spec.sh`, a regression case that asserts common applets (`cat`, `head`, `base64`) resolve to the MimixBox binary; it fails if a host binary were used instead.
- Fix specs that the hermetic harness exposed as non-hermetic: `which_spec.sh` derives the expected paths from where MimixBox actually resolves instead of hardcoding `/usr/local/bin`, and `unix2dos_test.sh` invokes the applet by bare name instead of the absolute `/usr/local/bin/unix2dos` path (which did not even exist in a clean environment).
- Ignore `test/it/.mbbin` and remove it on `make clean`. Document the hermetic local test contract in `CONTRIBUTING.md`.

## Verification

- `make test-e2e` in a clean shell builds MimixBox, stages the symlinks, and runs the full suite: 408 examples, 0 failures.
- Because the staging directory is first on PATH, shadowing an applet later on the host PATH cannot affect resolution; `hermetic_spec.sh` confirms `cat`/`head`/`base64` resolve to the MimixBox binary.

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added hermetic test suite to verify applets resolve correctly in isolated environment.
  * Updated end-to-end tests to run against locally-built binaries instead of host system.

* **Documentation**
  * Updated contributor guidelines documenting hermetic testing approach.

* **Chores**
  * Refactored CI/CD workflows and build configuration for isolated test environment setup.
  * Updated ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->