### PR TITLE
test: restore top-level mimixbox dispatch/install/remove coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 *.dll
 *.so
 *.dylib
-mimixbox
+# Anchor to the repo root so this only ignores the built ./mimixbox binary and
+# not the cmd/mimixbox/ source directory (an unanchored "mimixbox" silently hid
+# new files such as cmd/mimixbox/main_test.go from git).
+/mimixbox
 
 # Test binary, built with `go test -c`. And test directory
 *.test

--- a/cmd/mimixbox/main_test.go
+++ b/cmd/mimixbox/main_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func newIO() (command.IO, *bytes.Buffer, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	return command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}, out, errBuf
+}
+
+func TestRunHelpExitsZeroOnStdout(t *testing.T) {
+	io, out, errBuf := newIO()
+	if code := run([]string{"mimixbox", "--help"}, io); code != command.ExitSuccess {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "Usage: mimixbox") {
+		t.Errorf("help should go to stdout, got %q", out.String())
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("stderr should be empty, got %q", errBuf.String())
+	}
+}
+
+func TestRunVersionExitsZero(t *testing.T) {
+	io, out, _ := newIO()
+	if code := run([]string{"mimixbox", "--version"}, io); code != command.ExitSuccess {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "mimixbox") {
+		t.Errorf("version output = %q", out.String())
+	}
+}
+
+func TestRunListExitsZeroOnStdout(t *testing.T) {
+	io, out, _ := newIO()
+	if code := run([]string{"mimixbox", "--list"}, io); code != command.ExitSuccess {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "cat") {
+		t.Errorf("list should include applets like cat, got %q", out.String()[:80])
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	io, out, errBuf := newIO()
+	if code := run([]string{"mimixbox", "frobnicate"}, io); code != command.ExitFailure {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay clean on error, got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "not a mimixbox command") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunBareIsUsageError(t *testing.T) {
+	io, _, errBuf := newIO()
+	if code := run([]string{"mimixbox"}, io); code != command.ExitFailure {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "Usage: mimixbox") {
+		t.Errorf("bare invocation should print usage to stderr, got %q", errBuf.String())
+	}
+}
+
+func TestRunDispatchesAppletByName(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	orig := runApplet
+	runApplet = func(name string, args []string, _ command.IO) int {
+		gotName, gotArgs = name, args
+		return 0
+	}
+	t.Cleanup(func() { runApplet = orig })
+
+	io, _, _ := newIO()
+	run([]string{"mimixbox", "cat", "-n", "file.txt"}, io)
+	if gotName != "cat" {
+		t.Errorf("dispatched to %q, want cat", gotName)
+	}
+	if strings.Join(gotArgs, ",") != "-n,file.txt" {
+		t.Errorf("applet args = %v, want [-n file.txt]", gotArgs)
+	}
+}
+
+func TestRunSymlinkDispatch(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	orig := runApplet
+	runApplet = func(name string, args []string, _ command.IO) int {
+		gotName, gotArgs = name, args
+		return 0
+	}
+	t.Cleanup(func() { runApplet = orig })
+
+	// Invoked through a symlink named "cat".
+	io, _, _ := newIO()
+	run([]string{"/usr/local/bin/cat", "file.txt"}, io)
+	if gotName != "cat" || strings.Join(gotArgs, ",") != "file.txt" {
+		t.Errorf("symlink dispatch = %q %v", gotName, gotArgs)
+	}
+}
+
+func TestRunAppletFlagsReachApplet(t *testing.T) {
+	// "mimixbox cp -f a b": -f must be passed to cp, not parsed as
+	// --full-install.
+	var gotName string
+	var gotArgs []string
+	orig := runApplet
+	runApplet = func(name string, args []string, _ command.IO) int {
+		gotName, gotArgs = name, args
+		return 0
+	}
+	t.Cleanup(func() { runApplet = orig })
+
+	io, _, _ := newIO()
+	run([]string{"mimixbox", "cp", "-f", "a", "b"}, io)
+	if gotName != "cp" || strings.Join(gotArgs, ",") != "-f,a,b" {
+		t.Errorf("cp -f dispatch = %q %v", gotName, gotArgs)
+	}
+}
+
+func TestFullInstallAndRemove(t *testing.T) {
+	dir := t.TempDir()
+	io, _, _ := newIO()
+
+	if code := run([]string{"mimixbox", "--full-install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("full-install exit = %d", code)
+	}
+	// A representative applet symlink should now exist.
+	if _, err := os.Lstat(filepath.Join(dir, "cat")); err != nil {
+		t.Fatalf("expected cat symlink: %v", err)
+	}
+
+	io2, _, _ := newIO()
+	if code := run([]string{"mimixbox", "--remove", dir}, io2); code != command.ExitSuccess {
+		t.Fatalf("remove exit = %d", code)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "cat")); !os.IsNotExist(err) {
+		t.Errorf("cat symlink should have been removed")
+	}
+}
+
+func TestInstallTargetMaySharedAppletBasename(t *testing.T) {
+	// A directory whose basename collides with an applet ("cat") must still be a
+	// valid install target; this was previously rejected by the dispatch hacks.
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "cat")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	io, _, _ := newIO()
+	if code := run([]string{"mimixbox", "--full-install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("install into a dir named 'cat' exit = %d", code)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "true")); err != nil {
+		t.Errorf("expected applet symlinks inside the 'cat' directory: %v", err)
+	}
+}
+
+func TestInstallRequiresDirOperand(t *testing.T) {
+	io, _, errBuf := newIO()
+	if code := run([]string{"mimixbox", "--install"}, io); code != command.ExitFailure {
+		t.Fatalf("install with no dir exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "single DIRECTORY operand") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunUnsupportedAppletViaRunApplet(t *testing.T) {
+	// runApplet itself reports an unknown applet (e.g. a stale symlink).
+	io, _, errBuf := newIO()
+	if code := runApplet("no-such-applet", nil, io); code != command.ExitFailure {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "not a mimixbox command") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunUnknownOption(t *testing.T) {
+	// A "--foo" style token is not an applet, so it falls through to the option
+	// parser's default branch and is reported as unsupported on stderr.
+	io, out, errBuf := newIO()
+	if code := run([]string{"mimixbox", "--definitely-not-an-option"}, io); code != command.ExitFailure {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay clean on error, got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "is not a mimixbox command or option") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestFullInstallCreatesOneSymlinkPerApplet(t *testing.T) {
+	dir := t.TempDir()
+	io, _, errBuf := newIO()
+
+	if code := run([]string{"mimixbox", "--full-install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("full-install exit = %d (stderr: %s)", code, errBuf.String())
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(entries), len(applets.SortApplet()); got != want {
+		t.Errorf("full-install created %d entries, want %d (one per applet)", got, want)
+	}
+}
+
+func TestRemoveOnlyDeletesMimixBoxSymlinks(t *testing.T) {
+	// --remove must delete the symlinks MimixBox created (target path contains
+	// "mimixbox") while leaving foreign symlinks and real files untouched.
+	dir := t.TempDir()
+
+	mimixTarget := filepath.Join(dir, "mimixbox-binary")
+	if err := os.WriteFile(mimixTarget, []byte("fake"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	owned := filepath.Join(dir, "cat")
+	if err := os.Symlink(mimixTarget, owned); err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(dir, "pidof")
+	if err := os.Symlink("/bin/sh", foreign); err != nil {
+		t.Fatal(err)
+	}
+	realFile := filepath.Join(dir, "echo")
+	if err := os.WriteFile(realFile, []byte("real"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	io, _, errBuf := newIO()
+	if code := run([]string{"mimixbox", "--remove", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("remove exit = %d (stderr: %s)", code, errBuf.String())
+	}
+
+	if _, err := os.Lstat(owned); !os.IsNotExist(err) {
+		t.Errorf("MimixBox-owned symlink %q should have been removed", owned)
+	}
+	if _, err := os.Lstat(foreign); err != nil {
+		t.Errorf("foreign symlink %q should have been left in place", foreign)
+	}
+	if _, err := os.Lstat(realFile); err != nil {
+		t.Errorf("real file %q should have been left in place", realFile)
+	}
+}

--- a/test/it/shellutils/mimixbox_test.sh
+++ b/test/it/shellutils/mimixbox_test.sh
@@ -1,0 +1,34 @@
+# Helpers exercising the top-level MimixBox CLI surface (GitHub issue #234):
+# help/list output, unknown-option handling, and an install/remove smoke path
+# against a temporary directory.
+
+MbHelp() {
+    mimixbox --help
+}
+
+MbList() {
+    mimixbox --list
+}
+
+MbUnknownOption() {
+    mimixbox --definitely-not-an-option
+}
+
+# MbInstallRemoveSmoke creates applet symlinks in a fresh temp directory, then
+# removes them, asserting the round trip end to end. It prints "ok" only when
+# every step behaves as expected so the spec can assert on a single token.
+MbInstallRemoveSmoke() {
+    d=$(mktemp -d) || return 1
+    # shellcheck disable=SC2064
+    trap "rm -rf '$d'" EXIT
+
+    mimixbox --full-install "$d" >/dev/null 2>&1 || return 1
+    [ -L "$d/cat" ] || return 1     # a representative applet symlink exists
+    [ -L "$d/pidof" ] || return 1
+
+    mimixbox --remove "$d" >/dev/null 2>&1 || return 1
+    [ -L "$d/cat" ] && return 1     # MimixBox-owned symlinks are gone
+    [ -L "$d/pidof" ] && return 1
+
+    echo ok
+}

--- a/test/it/spec/mimixbox_spec.sh
+++ b/test/it/spec/mimixbox_spec.sh
@@ -1,0 +1,29 @@
+Describe 'mimixbox top-level CLI'
+    Include shellutils/mimixbox_test.sh
+
+    It 'prints usage to stdout with --help and exits success'
+        When call MbHelp
+        The status should be success
+        The output should include 'Usage: mimixbox'
+    End
+
+    It 'lists the applets with --list'
+        When call MbList
+        The status should be success
+        The output should include 'cat'
+        The output should include 'pidof'
+    End
+
+    It 'rejects an unknown option on stderr without polluting stdout'
+        When call MbUnknownOption
+        The status should be failure
+        The output should equal ''
+        The error should include 'is not a mimixbox command or option'
+    End
+
+    It 'installs and removes applet symlinks in a temp directory'
+        When call MbInstallRemoveSmoke
+        The status should be success
+        The output should equal 'ok'
+    End
+End


### PR DESCRIPTION
## Summary

`cmd/mimixbox` had no committed tests and there was no ShellSpec coverage of the top-level CLI (`--help`, `--list`, dispatch, install/remove), even though issue #223 described dispatch tests. This PR explains why that coverage vanished and restores it.

## Root cause

The `.gitignore` rule meant to ignore the built `./mimixbox` binary was the unanchored pattern `mimixbox`, which also matches the `cmd/mimixbox/` directory. Git silently ignored every new file created there, so a `cmd/mimixbox/main_test.go` added alongside the #223 dispatch rewrite was never actually tracked or committed. `git check-ignore -v cmd/mimixbox/main_test.go` pointed straight at `.gitignore:7:mimixbox`.

## Changes

- Anchor the binary ignore to the repo root (`/mimixbox`) so it only ignores the built `./mimixbox` binary, not the `cmd/mimixbox/` source directory. Verified the binary is still ignored and `cmd/mimixbox/main_test.go` is now trackable.
- Add and commit `cmd/mimixbox/main_test.go`, unit-testing `run` end to end with an injected `command.IO` and a stubbed dispatcher: zero-argument usage failure; `--help`/`--version`/`--list` success on stdout; applet dispatch vs top-level option dispatch (including `cp -f` reaching the applet, and an install target whose basename collides with an applet); symlink-style invocation; unknown command and unknown option on stderr with a clean stdout; and `--full-install`/`--remove` against `t.TempDir()`, including that `--remove` deletes only MimixBox-owned symlinks and leaves foreign symlinks and real files in place.
- Add `test/it/spec/mimixbox_spec.sh` (+ helper) covering the top-level CLI from the shell: `--help`, `--list`, an unknown option, and an install/remove smoke path in a temp directory.

## Verification

- `go test ./...` passes (15 cases in `cmd/mimixbox`).
- `make test-e2e` (hermetic harness) passes: 412 examples, 0 failures.
- All tests use `t.TempDir()` and PATH-resolved applets; none require `/usr/local/bin` or privileged paths.

Closes #234