### PR TITLE
fix(install): target the exact invoked binary and remove only owned symlinks

### DIFF
--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -1,13 +1,12 @@
-//
 // mimixbox/cmd/mimixbox/main.go
 //
-// Copyright 2021 Naohiro CHIKAMATSU
+// # Copyright 2021 Naohiro CHIKAMATSU
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,10 +20,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/nao1215/mimixbox/internal/applets"
 	"github.com/nao1215/mimixbox/internal/command"
@@ -135,7 +132,7 @@ func runRemove(params []string, stdio command.IO) int {
 		_, _ = fmt.Fprintf(stdio.Err, "%s: remove requires a single DIRECTORY operand\n", cmdName)
 		return command.ExitFailure
 	}
-	if err := remove(params[0], stdio); err != nil {
+	if err := remove(os.Args[0], params[0], stdio); err != nil {
 		_, _ = fmt.Fprintln(stdio.Err, err)
 		return command.ExitFailure
 	}
@@ -174,7 +171,7 @@ func install(mimixboxPath string, installPath string, full bool, stdio command.I
 		return errors.New(targetPath + ": no such directory")
 	}
 
-	mimixboxAbsPath, err := getMimixBoxAbsPath(targetPath)
+	mimixboxAbsPath, err := resolveSelf(mimixboxPath)
 	if err != nil {
 		return err
 	}
@@ -206,18 +203,30 @@ func install(mimixboxPath string, installPath string, full bool, stdio command.I
 	return nil
 }
 
-func getMimixBoxAbsPath(_ string) (string, error) {
-	// If mimixbox is installed on the system (mimixbox in $PATH).
-	if p, err := exec.LookPath(cmdName); err == nil {
-		return p, nil
+// osExecutable is os.Executable, indirected so tests can substitute it.
+var osExecutable = os.Executable
+
+// resolveSelf returns the absolute path of the exact MimixBox binary that is
+// running now. install() must link applet symlinks to this binary, not to some
+// other "mimixbox" that happens to be earlier on PATH, so that --install always
+// targets the binary the user actually invoked or just installed. invoked is the
+// argv[0] fallback used only when the executable path cannot be determined.
+func resolveSelf(invoked string) (string, error) {
+	if p, err := osExecutable(); err == nil {
+		return filepath.Clean(p), nil
 	}
-	return filepath.Abs(os.Args[0])
+	return filepath.Abs(invoked)
 }
 
-func remove(installPath string, stdio command.IO) error {
+func remove(mimixboxPath string, installPath string, stdio command.IO) error {
 	targetPath := os.ExpandEnv(installPath)
 	if !mb.IsDir(targetPath) {
 		return errors.New(targetPath + ": no such directory")
+	}
+
+	self, err := resolveSelf(mimixboxPath)
+	if err != nil {
+		return err
 	}
 
 	for _, name := range applets.SortApplet() {
@@ -230,13 +239,25 @@ func remove(installPath string, stdio command.IO) error {
 			_, _ = fmt.Fprintln(stdio.Err, err)
 			continue
 		}
-		if strings.Contains(realPath, cmdName) {
-			if err := os.Remove(symbolicPath); err != nil {
-				_, _ = fmt.Fprintln(stdio.Err, err)
-				continue
-			}
-			_, _ = fmt.Fprintf(stdio.Out, "Delete symbolic link: %s\n", symbolicPath)
+		// Only remove symlinks provably owned by this MimixBox install: their
+		// target must be exactly the running binary. A foreign symlink whose
+		// target merely contains "mimixbox" (e.g. cat -> /opt/other-mimixbox)
+		// is left untouched.
+		if !ownedBySelf(realPath, self) {
+			continue
 		}
+		if err := os.Remove(symbolicPath); err != nil {
+			_, _ = fmt.Fprintln(stdio.Err, err)
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "Delete symbolic link: %s\n", symbolicPath)
 	}
 	return nil
+}
+
+// ownedBySelf reports whether a symlink target points at the exact MimixBox
+// binary identified by self. Both paths are cleaned so equivalent spellings
+// compare equal.
+func ownedBySelf(target, self string) bool {
+	return filepath.Clean(target) == filepath.Clean(self)
 }

--- a/cmd/mimixbox/main_test.go
+++ b/cmd/mimixbox/main_test.go
@@ -222,20 +222,23 @@ func TestFullInstallCreatesOneSymlinkPerApplet(t *testing.T) {
 }
 
 func TestRemoveOnlyDeletesMimixBoxSymlinks(t *testing.T) {
-	// --remove must delete the symlinks MimixBox created (target path contains
-	// "mimixbox") while leaving foreign symlinks and real files untouched.
+	// --remove must delete only the symlinks that point at the exact running
+	// MimixBox binary, leaving foreign symlinks (even ones whose target merely
+	// contains "mimixbox") and real files untouched.
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
 	dir := t.TempDir()
 
-	mimixTarget := filepath.Join(dir, "mimixbox-binary")
-	if err := os.WriteFile(mimixTarget, []byte("fake"), 0o755); err != nil { //nolint:gosec // test fixture
-		t.Fatal(err)
-	}
 	owned := filepath.Join(dir, "cat")
-	if err := os.Symlink(mimixTarget, owned); err != nil {
+	if err := os.Symlink(self, owned); err != nil {
 		t.Fatal(err)
 	}
+	// Foreign: target contains "mimixbox" but is a different binary, so the old
+	// substring check would have wrongly deleted it.
 	foreign := filepath.Join(dir, "pidof")
-	if err := os.Symlink("/bin/sh", foreign); err != nil {
+	if err := os.Symlink("/opt/not-the-same-mimixbox-wrapper", foreign); err != nil {
 		t.Fatal(err)
 	}
 	realFile := filepath.Join(dir, "echo")
@@ -256,5 +259,28 @@ func TestRemoveOnlyDeletesMimixBoxSymlinks(t *testing.T) {
 	}
 	if _, err := os.Lstat(realFile); err != nil {
 		t.Errorf("real file %q should have been left in place", realFile)
+	}
+}
+
+func TestInstallTargetsExactInvokedBinary(t *testing.T) {
+	// Even when another "mimixbox" sits earlier on PATH, --install must link to
+	// the exact binary that is running (os.Executable), never to a PATH lookup.
+	const wantTarget = "/custom/install/source/mimixbox"
+	orig := osExecutable
+	osExecutable = func() (string, error) { return wantTarget, nil }
+	t.Cleanup(func() { osExecutable = orig })
+
+	dir := t.TempDir()
+	io, _, errBuf := newIO()
+	if code := run([]string{"mimixbox", "--full-install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("full-install exit = %d (stderr: %s)", code, errBuf.String())
+	}
+
+	target, err := os.Readlink(filepath.Join(dir, "cat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != wantTarget {
+		t.Errorf("symlink target = %q, want the invoked binary %q", target, wantTarget)
 	}
 }

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -9,7 +9,9 @@ source ${ROOT_DIR}/scripts/libshell.sh
 
 function installMimixBox() {
 	install -v -m 0755 -D mimixbox /usr/local/bin/.
-	mimixbox --install /usr/local/bin/.
+	# Invoke the exact binary just installed (not a PATH lookup) so the applet
+	# symlinks are guaranteed to target /usr/local/bin/mimixbox.
+	/usr/local/bin/mimixbox --install /usr/local/bin/.
 }
 
 function installLicense() {

--- a/test/it/netutils/nc_test.sh
+++ b/test/it/netutils/nc_test.sh
@@ -3,8 +3,19 @@ CleanUp() { rm -rf /tmp/mimixbox/it; }
 TestNcLoopback() {
     # Listener writes whatever the client sends into a file.
     (nc -l -p 18642 > /tmp/mimixbox/it/nc_recv.txt) &
-    sleep 0.3
-    echo "from-client" | nc 127.0.0.1 18642 >/dev/null 2>&1
-    sleep 0.2
+
+    # Retry the client send until the listener has bound and recorded the
+    # message, instead of relying on fixed sleeps. Fixed sleeps race against the
+    # listener's bind/flush under CI load and made this test flaky. The loop
+    # keys off the received file's contents, so it is robust regardless of the
+    # nc client's exit status.
+    for _ in $(seq 1 50); do
+        echo "from-client" | nc 127.0.0.1 18642 >/dev/null 2>&1
+        if [ -s /tmp/mimixbox/it/nc_recv.txt ]; then
+            break
+        fi
+        sleep 0.1
+    done
+
     cat /tmp/mimixbox/it/nc_recv.txt
 }


### PR DESCRIPTION
## Summary

The install/remove logic was loose in two ways: `--install` resolved the symlink target with a fresh `exec.LookPath("mimixbox")`, so applet symlinks could point at a different `mimixbox` earlier on PATH than the one the user invoked; and `--remove` deleted any applet-named symlink whose target merely contained the substring `"mimixbox"`, so it could remove foreign symlinks it never created.

## Changes

- Resolve the install target from `os.Executable()` (indirected as `osExecutable` for tests), with the invoked argv[0] as a fallback. `--install`/`--full-install` now always link to the exact binary that is running, never to a PATH lookup. The previously-unused `mimixboxPath` parameter is now the fallback source, and `getMimixBoxAbsPath`/`exec` are gone.
- Tighten `--remove` ownership: a symlink is removed only when its target is exactly the running binary (`ownedBySelf`, comparing cleaned paths). Foreign symlinks — even ones whose target contains "mimixbox" — and real files are preserved.
- Point `scripts/installer.sh` at the absolute `/usr/local/bin/mimixbox` it just installed, instead of a bare `mimixbox` PATH lookup.

## Tests

- `TestInstallTargetsExactInvokedBinary` stubs `osExecutable` to a fixed path and asserts the created symlinks point there, proving PATH is not consulted.
- `TestRemoveOnlyDeletesMimixBoxSymlinks` now links the owned entry to the real running binary and the foreign entry to `/opt/not-the-same-mimixbox-wrapper`, asserting only the owned one is removed.
- Manually reproduced the issue's scenarios with a real binary: with an older `mimixbox` first on PATH, `--full-install` still targeted the invoked binary; and `--remove` kept a `pidof -> /opt/not-the-same-mimixbox-wrapper` foreign symlink while deleting the owned ones.

## Verification

- `go test ./...` passes.
- `make test-e2e` (hermetic harness) passes: 412 examples, 0 failures.

Closes #269