### PR TITLE
refactor: dispatch applets in memory via command.Execute without mutating os.Args

### DIFF
--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -71,21 +72,16 @@ func run(argv []string, stdio command.IO) int {
 	return runOption(first, rest[1:], stdio)
 }
 
-// runApplet runs the named applet with args. The applet entry points still read
-// the process-level os.Args and streams (via internal/command.Adapt), so os.Args
-// is set to "<applet> <args...>" before the call. runApplet is a variable so
-// tests can substitute a fake dispatcher.
+// runApplet runs the named applet with args. The applet is executed through
+// internal/command.Execute with the injected IO, so dispatch touches neither
+// os.Args nor the process streams and can be exercised entirely in memory.
+// runApplet is a variable so tests can substitute a fake dispatcher.
 var runApplet = func(name string, args []string, stdio command.IO) int {
 	app, ok := applets.Applets[name]
 	if !ok {
 		return unsupported(name, stdio)
 	}
-	os.Args = append([]string{name}, args...)
-	status, err := app.Ep()
-	if err != nil {
-		_, _ = fmt.Fprintln(stdio.Err, name+": "+err.Error())
-	}
-	return status
+	return command.Execute(context.Background(), app.Cmd, stdio, args)
 }
 
 // runOption handles MimixBox's own options (everything that is not an applet).

--- a/cmd/mimixbox/main_test.go
+++ b/cmd/mimixbox/main_test.go
@@ -178,6 +178,50 @@ func TestInstallRequiresDirOperand(t *testing.T) {
 	}
 }
 
+func TestRunDispatchesRealAppletInMemory(t *testing.T) {
+	// A concrete applet (echo) runs through the real dispatch path, and its
+	// output is captured entirely in memory via the injected IO — no os.Args
+	// mutation and no process stdio. This is the end-to-end property issue #273
+	// asks for.
+	io, out, errBuf := newIO()
+	if code := run([]string{"mimixbox", "echo", "hello", "world"}, io); code != command.ExitSuccess {
+		t.Fatalf("echo exit = %d, want 0", code)
+	}
+	if got := out.String(); got != "hello world\n" {
+		t.Errorf("echo stdout = %q, want %q", got, "hello world\n")
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("echo stderr = %q, want empty", errBuf.String())
+	}
+}
+
+func TestRunRealAppletErrorIsCapturedInMemory(t *testing.T) {
+	// A failing applet (cat of a missing file) reports its error through the
+	// injected stderr and a non-zero exit code, again without touching process
+	// globals.
+	io, out, errBuf := newIO()
+	code := run([]string{"mimixbox", "cat", "/no/such/file/mimixbox-test"}, io)
+	if code == command.ExitSuccess {
+		t.Errorf("cat of a missing file should fail, got exit 0")
+	}
+	if out.Len() != 0 {
+		t.Errorf("cat stdout = %q, want empty", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "cat:") {
+		t.Errorf("cat stderr = %q, want it to mention the applet", errBuf.String())
+	}
+}
+
+func TestRunDoesNotMutateOSArgs(t *testing.T) {
+	// Dispatching an applet must leave the process-global os.Args untouched.
+	saved := append([]string(nil), os.Args...)
+	io, _, _ := newIO()
+	_ = run([]string{"mimixbox", "echo", "x"}, io)
+	if strings.Join(os.Args, " ") != strings.Join(saved, " ") {
+		t.Errorf("os.Args mutated by dispatch: got %v, want %v", os.Args, saved)
+	}
+}
+
 func TestRunUnsupportedAppletViaRunApplet(t *testing.T) {
 	// runApplet itself reports an unknown applet (e.g. a stale symlink).
 	io, _, errBuf := newIO()

--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -181,20 +181,21 @@ import (
 	"github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
 )
 
-type EntryPoint func() (int, error)
-
 type Applet struct {
-	Ep   EntryPoint
+	// Cmd is the applet itself. The top-level dispatcher runs it through
+	// internal/command.Execute with an injected command.IO, so an applet can be
+	// dispatched entirely in memory without mutating os.Args or touching the
+	// process streams.
+	Cmd  command.Command
 	Desc string
 }
 
 var Applets map[string]Applet
 
-// reg builds an Applet entry for a command that has been migrated to the
-// internal/command framework. The command's own Synopsis becomes the listed
-// description, so the two never drift apart.
+// reg builds an Applet entry for a command. The command's own Synopsis becomes
+// the listed description, so the two never drift apart.
 func reg(c command.Command) Applet {
-	return Applet{Ep: command.Adapt(c), Desc: c.Synopsis()}
+	return Applet{Cmd: c, Desc: c.Synopsis()}
 }
 
 func init() {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 )
 
 // Execute runs c with the given IO and arguments and returns the process exit
@@ -33,15 +32,4 @@ func Execute(ctx context.Context, c Command, io IO, args []string) int {
 
 	_, _ = fmt.Fprintf(io.Err, "%s: %s\n", c.Name(), err)
 	return ExitFailure
-}
-
-// Adapt bridges a Command to the legacy applet entry-point signature used by
-// internal/applets. It wires the command to the process streams and reports the
-// exit code; the error is always nil because Execute has already printed any
-// message, so the caller need only exit with the returned code.
-func Adapt(c Command) func() (int, error) {
-	return func() (int, error) {
-		stdio := IO{In: os.Stdin, Out: os.Stdout, Err: os.Stderr}
-		return Execute(context.Background(), c, stdio, os.Args[1:]), nil
-	}
 }


### PR DESCRIPTION
## Summary

The top-level dispatcher was testable in shape, but applet execution still fell back to global process state: `runApplet` set `os.Args` before each call, and `internal/command.Adapt` bound every applet to `os.Stdin`/`os.Stdout`/`os.Stderr`, ignoring the injected `command.IO`. That made dispatch non-idiomatic and impossible to exercise end to end in memory.

## Changes

- Store the `command.Command` on each registry entry (`Applet.Cmd`) instead of a pre-adapted `Ep` closure. `reg()` keeps using the command's own `Synopsis()` for the description.
- Dispatch applets via `command.Execute(ctx, app.Cmd, stdio, args)`, so the injected IO is honored and `os.Args` is no longer mutated for normal applet dispatch.
- Remove the now-unused `command.Adapt` adapter and the `EntryPoint` type; nothing else referenced them.

No user-visible CLI behavior changes: `main` still passes the real process streams as the `command.IO`, so applets read/write exactly as before.

## Tests

- `TestRunDispatchesRealAppletInMemory`: runs `echo` through the real dispatch path and asserts the output is captured in the injected buffer ("hello world\n").
- `TestRunRealAppletErrorIsCapturedInMemory`: runs `cat` on a missing file and asserts the error reaches the injected stderr with a non-zero exit.
- `TestRunDoesNotMutateOSArgs`: asserts dispatch leaves `os.Args` untouched.

## Verification

- `go test ./cmd/mimixbox ./internal/command ./...` passes.
- `make test-e2e` (hermetic harness, real binary) passes: 412 examples, 0 failures, confirming CLI behavior is preserved.

Closes #273