### PR TITLE
docs: fix synopsis typos, license statement, and release install drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ make lint       # golangci-lint
 
 The end-to-end tests live under `test/it/` and exercise the built binary the way a user does (applet name, flags, stdin, exit codes).
 
-`make test-e2e` is hermetic: it builds MimixBox, stages one symlink per applet in an isolated directory (`test/it/.mbbin`), and runs ShellSpec with that directory first on `PATH`. Every applet therefore resolves to MimixBox, never to a host command of the same name, so the suite can be run in a clean shell without installing MimixBox system-wide. Specs must invoke applets by bare name (e.g. `cat`, `unix2dos`) and must not hardcode an install prefix such as `/usr/local/bin`. `spec/hermetic_spec.sh` guards this contract by asserting that common applets resolve to the MimixBox binary.
+`make test-e2e` is hermetic: it builds MimixBox, stages one symlink per applet in an isolated directory (`test/it/.mbbin`), and runs ShellSpec with that directory first on `PATH`. Every applet therefore resolves to MimixBox, never to a host command of the same name, so the suite can be run in a clean shell without installing MimixBox system-wide. Specs must invoke applets by bare name (e.g. `cat`, `unix2dos`) and must not hardcode an install prefix such as `/usr/local/bin`. `test/it/spec/hermetic_spec.sh` guards this contract by asserting that common applets resolve to the MimixBox binary.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | awk | Pattern scanning and processing language |
 | banner | Print a string as large ASCII-art letters |
 | base32 | Base32 encode/decode from FILE(or STDIN) to STDOUT |
-| base64 | Base64 encode/decode from FILR(or STDIN) to STDOUT |
+| base64 | Base64 encode/decode from FILE(or STDIN) to STDOUT |
 | basename | Print basename (PATH without "/") from file path |
 | bunzip2 | Decompress bzip2 (.bz2) files |
 | cal | Display a calendar |
@@ -46,7 +46,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | compress | Compress files with LZW (.Z) |
 | cowsay | Print message with cow's ASCII art |
 | cowthink | Print message in a cow's thought bubble |
-| cp | Copy file(s) otr Directory(s) |
+| cp | Copy file(s) to Directory(s) |
 | cpio | Copy files to and from archives |
 | cut | Remove sections from each line of files |
 | date | Print or set the system date and time |
@@ -61,13 +61,13 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | expand | Convert TAB to N space (default:N=8) |
 | expr | Evaluate expressions |
 | fakemovie | Adds a video playback button to the image |
-| false | Do nothing. Return unsuccess(1) |
+| false | Do nothing. Return failure(1) |
 | find | Search for files in a directory hierarchy |
 | fmt | Simple optimal text formatter |
 | fold | Wrap each input line to fit in specified width |
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
-| ghrdc | GitHub Relase Download Counter |
+| ghrdc | GitHub Release Download Counter |
 | grep | Print lines that match patterns |
 | groups | Print the groups to which USERNAME belongs |
 | gunzip | Decompress gzip (.gz) files |
@@ -109,7 +109,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | posixer | Report which POSIX utilities are installed |
 | poweroff | Power off the system |
 | printenv | Print environment variable |
-| printf | Formats and print data |
+| printf | Format and print data |
 | pwcrack | Audit crypt(3) password hashes against a wordlist |
 | pwd | Print Working Directory |
 | pwgen | Generate random passwords for authorized testing |
@@ -161,7 +161,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | unlink | Remove a single file by calling the unlink function |
 | unshadow | Combine passwd and shadow files for password auditing |
 | unzip | Extract files from a ZIP archive |
-| uuidgen | Print UUID (Universal Unique IDentifier |
+| uuidgen | Print UUID (Universally Unique IDentifier) |
 | valid-shell | Verify if /etc/shells is valid |
 | vi | A minimal vi-style screen text editor |
 | watch | Execute a program periodically, showing output fullscreen |
@@ -180,12 +180,12 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 
 ## Install
 
-The release page distributes source code and binaries in ZIP and tar.gz format. Pick the binary that matches your OS and CPU architecture from [the Release Page](https://github.com/nao1215/mimixbox/releases). For example, on Linux (amd64):
+The [Release Page](https://github.com/nao1215/mimixbox/releases) distributes the binary as a `tar.gz` archive for each OS/CPU architecture, plus `.deb`, `.rpm`, and `.apk` packages. The archive is named `mimixbox_<version>_<os>_<arch>.tar.gz` and contains the `mimixbox` binary. For example, on Linux (amd64):
 
 ```shell
-$ tar xf mimixbox-0.30.0-linux-amd64.tar.gz
-$ cd mimixbox-0.30.0-linux-amd64
-$ sudo ./installer.sh
+$ tar xf mimixbox_0.36.0_linux_amd64.tar.gz
+$ sudo install -m 0755 mimixbox /usr/local/bin/
+$ sudo mimixbox --install /usr/local/bin
 ```
 
 ### Use "go install"
@@ -311,7 +311,7 @@ To report a bug or request a feature, please use [GitHub Issue](https://github.c
 
 ## License
 
-The MimixBox project is licensed under the terms of the MIT license and Apache License 2.0. See [LICENSE](./LICENSE).
+The MimixBox project is licensed under the [Apache License 2.0](./LICENSE). It also incorporates portions of third-party code distributed under the MIT License (for example the `nc`, `whris`, and `fakemovie` applets), whose original copyright and license notices are preserved in the corresponding source files.
 
 ## Contributors
 

--- a/internal/applets/fileutils/cp/cp.go
+++ b/internal/applets/fileutils/cp/cp.go
@@ -24,7 +24,7 @@ func New() *Command { return &Command{} }
 func (c *Command) Name() string { return "cp" }
 
 // Synopsis returns the one-line description shown in the applet list.
-func (c *Command) Synopsis() string { return "Copy file(s) otr Directory(s)" }
+func (c *Command) Synopsis() string { return "Copy file(s) to Directory(s)" }
 
 type options struct {
 	recursive   bool

--- a/internal/applets/shellutils/base64/base64.go
+++ b/internal/applets/shellutils/base64/base64.go
@@ -23,7 +23,7 @@ func (c *Command) Name() string { return "base64" }
 
 // Synopsis returns the one-line description shown in the applet list.
 func (c *Command) Synopsis() string {
-	return "Base64 encode/decode from FILR(or STDIN) to STDOUT"
+	return "Base64 encode/decode from FILE(or STDIN) to STDOUT"
 }
 
 // Run executes base64.

--- a/internal/applets/shellutils/false/false.go
+++ b/internal/applets/shellutils/false/false.go
@@ -17,7 +17,7 @@ func New() *Command { return &Command{} }
 func (c *Command) Name() string { return "false" }
 
 // Synopsis returns the one-line description shown in the applet list.
-func (c *Command) Synopsis() string { return "Do nothing. Return unsuccess(1)" }
+func (c *Command) Synopsis() string { return "Do nothing. Return failure(1)" }
 
 // Run always fails with exit status 1. Like GNU false it ignores its operands,
 // except that a leading --help or --version is honored and exits successfully.

--- a/internal/applets/shellutils/ghrdc/ghrdc.go
+++ b/internal/applets/shellutils/ghrdc/ghrdc.go
@@ -56,7 +56,7 @@ func New() *Command { return &Command{} }
 func (c *Command) Name() string { return "ghrdc" }
 
 // Synopsis returns the one-line description shown in the applet list.
-func (c *Command) Synopsis() string { return "GitHub Relase Download Counter" }
+func (c *Command) Synopsis() string { return "GitHub Release Download Counter" }
 
 type options struct {
 	all   bool

--- a/internal/applets/shellutils/printf/printf.go
+++ b/internal/applets/shellutils/printf/printf.go
@@ -24,7 +24,7 @@ func New() *Command { return &Command{} }
 func (c *Command) Name() string { return "printf" }
 
 // Synopsis returns the one-line description shown in the applet list.
-func (c *Command) Synopsis() string { return "Formats and print data" }
+func (c *Command) Synopsis() string { return "Format and print data" }
 
 // Run executes printf. args[0] is the FORMAT string and args[1:] are the
 // arguments consumed by the conversion specifications. When the format consumes

--- a/internal/applets/shellutils/uuidgen/uuidgen.go
+++ b/internal/applets/shellutils/uuidgen/uuidgen.go
@@ -37,7 +37,7 @@ func New() *Command { return &Command{} }
 func (c *Command) Name() string { return "uuidgen" }
 
 // Synopsis returns the one-line description shown in the applet list.
-func (c *Command) Synopsis() string { return "Print UUID (Universal Unique IDentifier" }
+func (c *Command) Synopsis() string { return "Print UUID (Universally Unique IDentifier)" }
 
 // Run executes uuidgen. It generates a random (version 4) UUID and prints it
 // lowercase, followed by a newline, to stdio.Out.


### PR DESCRIPTION
## Summary

The public docs had several user-facing mismatches and text errors. Because the README command list is generated from applet synopses, the synopsis typos were amplified into both the README and `mimixbox --list`.

## Changes

### Synopsis typos (source-of-truth fixes, README regenerated)

- base64: `FILR` -> `FILE`
- cp: `Copy file(s) otr Directory(s)` -> `Copy file(s) to Directory(s)`
- false: `Return unsuccess(1)` -> `Return failure(1)` (pairs with true's `Return success(0)`)
- ghrdc: `GitHub Relase Download Counter` -> `GitHub Release Download Counter`
- uuidgen: `Print UUID (Universal Unique IDentifier` (truncated, unmatched paren) -> `Print UUID (Universally Unique IDentifier)`
- printf: `Formats and print data` -> `Format and print data`

### Release install drift

- Reconcile the README install example with the actual GoReleaser output: the archive is `mimixbox_<version>_<os>_<arch>.tar.gz` (underscores, not the stale `mimixbox-0.30.0-linux-amd64.tar.gz`) and contains just the `mimixbox` binary. The example now extracts the binary, installs it with `install -m 0755`, and runs `mimixbox --install` — a flow that works with what the archive really ships, instead of a non-existent bundled `installer.sh`.

### License statement

- The README claimed "MIT license and Apache License 2.0" while the top-level `LICENSE` is Apache 2.0. Clarified that the project is Apache 2.0 and that it incorporates some MIT-licensed third-party code (`nc`, `whris`, `fakemovie`), whose notices are preserved in the source. This matches `LICENSE` and the GoReleaser `Apache-2.0` metadata.

### Drive-by

- Use the repo-root path `test/it/spec/hermetic_spec.sh` in CONTRIBUTING.md (CodeRabbit nitpick from #276).

## Verification

- `go test ./cmd/genlist` passes (README command list is in sync with the corrected synopses).
- `go test ./...` passes.

Closes #272