### PR TITLE
test: add ShellSpec CLI-contract coverage for 15 untested applets

### DIFF
--- a/test/it/console-tools/clear_test.sh
+++ b/test/it/console-tools/clear_test.sh
@@ -1,0 +1,4 @@
+ClearHelp() { clear --help; }
+# Discard the screen-clearing escape sequence; this contract test only asserts
+# that clear exits successfully.
+ClearRun() { clear >/dev/null; }

--- a/test/it/console-tools/reset_test.sh
+++ b/test/it/console-tools/reset_test.sh
@@ -1,0 +1,1 @@
+ResetHelp() { reset --help; }

--- a/test/it/debianutils/add-shell_test.sh
+++ b/test/it/debianutils/add-shell_test.sh
@@ -1,0 +1,2 @@
+AddShellHelp() { add-shell --help; }
+AddShellNoArg() { add-shell; }

--- a/test/it/debianutils/ischroot_test.sh
+++ b/test/it/debianutils/ischroot_test.sh
@@ -1,0 +1,1 @@
+IschrootHelp() { ischroot --help; }

--- a/test/it/debianutils/remove-shell_test.sh
+++ b/test/it/debianutils/remove-shell_test.sh
@@ -1,0 +1,2 @@
+RemoveShellHelp() { remove-shell --help; }
+RemoveShellNoArg() { remove-shell; }

--- a/test/it/debianutils/valid-shell_test.sh
+++ b/test/it/debianutils/valid-shell_test.sh
@@ -1,0 +1,9 @@
+ValidShellHelp() { valid-shell --help; }
+ValidShellValidFile() {
+    f=$(mktemp)
+    printf '/bin/sh\n/bin/bash\n' > "${f}"
+    valid-shell "${f}"
+    rc=$?
+    rm -f "${f}"
+    return ${rc}
+}

--- a/test/it/fileutils/chgrp_contract_test.sh
+++ b/test/it/fileutils/chgrp_contract_test.sh
@@ -1,0 +1,2 @@
+ChgrpHelp() { chgrp --help; }
+ChgrpNoArg() { chgrp; }

--- a/test/it/fileutils/chown_contract_test.sh
+++ b/test/it/fileutils/chown_contract_test.sh
@@ -1,0 +1,2 @@
+ChownHelp() { chown --help; }
+ChownNoArg() { chown; }

--- a/test/it/games/lifegame_test.sh
+++ b/test/it/games/lifegame_test.sh
@@ -1,0 +1,1 @@
+LifegameHelp() { lifegame --help; }

--- a/test/it/jokeutils/cowsay_test.sh
+++ b/test/it/jokeutils/cowsay_test.sh
@@ -1,0 +1,2 @@
+CowsayHelp() { cowsay --help; }
+CowsaySpeak() { cowsay hello; }

--- a/test/it/jokeutils/fakemovie_test.sh
+++ b/test/it/jokeutils/fakemovie_test.sh
@@ -1,0 +1,2 @@
+FakemovieHelp() { fakemovie --help; }
+FakemovieNoArg() { fakemovie; }

--- a/test/it/shellutils/chroot_test.sh
+++ b/test/it/shellutils/chroot_test.sh
@@ -1,0 +1,2 @@
+ChrootHelp() { chroot --help; }
+ChrootNoArg() { chroot; }

--- a/test/it/shellutils/ghrdc_test.sh
+++ b/test/it/shellutils/ghrdc_test.sh
@@ -1,0 +1,2 @@
+GhrdcHelp() { ghrdc --help; }
+GhrdcNoArg() { ghrdc; }

--- a/test/it/shellutils/sddf_contract_test.sh
+++ b/test/it/shellutils/sddf_contract_test.sh
@@ -1,0 +1,2 @@
+SddfHelp() { sddf --help; }
+SddfNoArg() { sddf; }

--- a/test/it/shellutils/wget_test.sh
+++ b/test/it/shellutils/wget_test.sh
@@ -1,0 +1,2 @@
+WgetHelp() { wget --help; }
+WgetNoArg() { wget; }

--- a/test/it/spec/add-shell_spec.sh
+++ b/test/it/spec/add-shell_spec.sh
@@ -1,0 +1,13 @@
+Describe 'add-shell CLI contract'
+    Include debianutils/add-shell_test.sh
+    It 'prints usage with --help and exits 0'
+        When call AddShellHelp
+        The status should be success
+        The output should include 'Usage: add-shell'
+    End
+    It 'fails with a message when given no operand'
+        When call AddShellNoArg
+        The status should be failure
+        The error should include 'add-shell'
+    End
+End

--- a/test/it/spec/chgrp_spec.sh
+++ b/test/it/spec/chgrp_spec.sh
@@ -1,0 +1,13 @@
+Describe 'chgrp CLI contract'
+    Include fileutils/chgrp_contract_test.sh
+    It 'prints usage with --help and exits 0'
+        When call ChgrpHelp
+        The status should be success
+        The output should include 'Usage: chgrp'
+    End
+    It 'fails with a message when given no operand'
+        When call ChgrpNoArg
+        The status should be failure
+        The error should include 'chgrp'
+    End
+End

--- a/test/it/spec/chown_spec.sh
+++ b/test/it/spec/chown_spec.sh
@@ -1,0 +1,13 @@
+Describe 'chown CLI contract'
+    Include fileutils/chown_contract_test.sh
+    It 'prints usage with --help and exits 0'
+        When call ChownHelp
+        The status should be success
+        The output should include 'Usage: chown'
+    End
+    It 'fails with a message when given no operand'
+        When call ChownNoArg
+        The status should be failure
+        The error should include 'chown'
+    End
+End

--- a/test/it/spec/chroot_spec.sh
+++ b/test/it/spec/chroot_spec.sh
@@ -1,0 +1,13 @@
+Describe 'chroot CLI contract'
+    Include shellutils/chroot_test.sh
+    It 'prints usage with --help and exits 0'
+        When call ChrootHelp
+        The status should be success
+        The output should include 'Usage: chroot'
+    End
+    It 'fails with a message when given no operand'
+        When call ChrootNoArg
+        The status should be failure
+        The error should include 'chroot'
+    End
+End

--- a/test/it/spec/clear_spec.sh
+++ b/test/it/spec/clear_spec.sh
@@ -1,0 +1,12 @@
+Describe 'clear CLI contract'
+    Include console-tools/clear_test.sh
+    It 'prints usage with --help and exits 0'
+        When call ClearHelp
+        The status should be success
+        The output should include 'Usage: clear'
+    End
+    It 'exits 0 when clearing the screen'
+        When call ClearRun
+        The status should be success
+    End
+End

--- a/test/it/spec/cowsay_spec.sh
+++ b/test/it/spec/cowsay_spec.sh
@@ -1,0 +1,13 @@
+Describe 'cowsay CLI contract'
+    Include jokeutils/cowsay_test.sh
+    It 'prints usage with --help and exits 0'
+        When call CowsayHelp
+        The status should be success
+        The output should include 'Usage: cowsay'
+    End
+    It 'renders the message in the speech bubble'
+        When call CowsaySpeak
+        The status should be success
+        The output should include 'hello'
+    End
+End

--- a/test/it/spec/fakemovie_spec.sh
+++ b/test/it/spec/fakemovie_spec.sh
@@ -1,0 +1,13 @@
+Describe 'fakemovie CLI contract'
+    Include jokeutils/fakemovie_test.sh
+    It 'prints usage with --help and exits 0'
+        When call FakemovieHelp
+        The status should be success
+        The output should include 'Usage: fakemovie'
+    End
+    It 'fails with a message when given no operand'
+        When call FakemovieNoArg
+        The status should be failure
+        The error should include 'fakemovie'
+    End
+End

--- a/test/it/spec/ghrdc_spec.sh
+++ b/test/it/spec/ghrdc_spec.sh
@@ -1,0 +1,13 @@
+Describe 'ghrdc CLI contract'
+    Include shellutils/ghrdc_test.sh
+    It 'prints usage with --help and exits 0'
+        When call GhrdcHelp
+        The status should be success
+        The output should include 'Usage: ghrdc'
+    End
+    It 'fails with a message when given no operand'
+        When call GhrdcNoArg
+        The status should be failure
+        The error should include 'ghrdc'
+    End
+End

--- a/test/it/spec/ischroot_spec.sh
+++ b/test/it/spec/ischroot_spec.sh
@@ -1,0 +1,8 @@
+Describe 'ischroot CLI contract'
+    Include debianutils/ischroot_test.sh
+    It 'prints usage with --help and exits 0'
+        When call IschrootHelp
+        The status should be success
+        The output should include 'Usage: ischroot'
+    End
+End

--- a/test/it/spec/lifegame_spec.sh
+++ b/test/it/spec/lifegame_spec.sh
@@ -1,0 +1,8 @@
+Describe 'lifegame CLI contract'
+    Include games/lifegame_test.sh
+    It 'prints usage with --help and exits 0'
+        When call LifegameHelp
+        The status should be success
+        The output should include 'Usage: lifegame'
+    End
+End

--- a/test/it/spec/remove-shell_spec.sh
+++ b/test/it/spec/remove-shell_spec.sh
@@ -1,0 +1,13 @@
+Describe 'remove-shell CLI contract'
+    Include debianutils/remove-shell_test.sh
+    It 'prints usage with --help and exits 0'
+        When call RemoveShellHelp
+        The status should be success
+        The output should include 'Usage: remove-shell'
+    End
+    It 'fails with a message when given no operand'
+        When call RemoveShellNoArg
+        The status should be failure
+        The error should include 'remove-shell'
+    End
+End

--- a/test/it/spec/reset_spec.sh
+++ b/test/it/spec/reset_spec.sh
@@ -1,0 +1,8 @@
+Describe 'reset CLI contract'
+    Include console-tools/reset_test.sh
+    It 'prints usage with --help and exits 0'
+        When call ResetHelp
+        The status should be success
+        The output should include 'Usage: reset'
+    End
+End

--- a/test/it/spec/sddf_spec.sh
+++ b/test/it/spec/sddf_spec.sh
@@ -1,0 +1,13 @@
+Describe 'sddf CLI contract'
+    Include shellutils/sddf_contract_test.sh
+    It 'prints usage with --help and exits 0'
+        When call SddfHelp
+        The status should be success
+        The output should include 'Usage: sddf'
+    End
+    It 'fails with a message when given no operand'
+        When call SddfNoArg
+        The status should be failure
+        The error should include 'sddf'
+    End
+End

--- a/test/it/spec/valid-shell_spec.sh
+++ b/test/it/spec/valid-shell_spec.sh
@@ -1,0 +1,13 @@
+Describe 'valid-shell CLI contract'
+    Include debianutils/valid-shell_test.sh
+    It 'prints usage with --help and exits 0'
+        When call ValidShellHelp
+        The status should be success
+        The output should include 'Usage: valid-shell'
+    End
+    It 'accepts a file listing existing shells'
+        When call ValidShellValidFile
+        The status should be success
+        The output should include 'OK'
+    End
+End

--- a/test/it/spec/wget_spec.sh
+++ b/test/it/spec/wget_spec.sh
@@ -1,0 +1,13 @@
+Describe 'wget CLI contract'
+    Include shellutils/wget_test.sh
+    It 'prints usage with --help and exits 0'
+        When call WgetHelp
+        The status should be success
+        The output should include 'Usage: wget'
+    End
+    It 'fails with a message when given no operand'
+        When call WgetNoArg
+        The status should be failure
+        The error should include 'wget'
+    End
+End


### PR DESCRIPTION
## Summary

Several shipped applets had no ShellSpec coverage of their user-facing shell contract (argv parsing, exit codes, stdout/stderr routing). This PR adds at least one shell-level contract test for each of the 15 applets listed in #271, run under the hermetic e2e harness so every applet resolves to MimixBox.

## Coverage added

For each applet, a `--help` contract test asserts a successful exit and `Usage: <applet>` on stdout. Where safe, an additional check is included:

- Argument-validation (missing-operand fails with a message on stderr): `add-shell`, `chgrp`, `chown`, `chroot`, `fakemovie`, `ghrdc`, `remove-shell`, `sddf`, `wget`.
- Safe functional behavior: `cowsay` renders the message in its bubble; `clear` exits 0; `valid-shell` accepts a temp file of existing shells.
- Help-only (interactive or environment-dependent runtime behavior): `ischroot`, `lifegame`, `reset`.

Root-, network-, and destruction-sensitive applets (`chgrp`/`chown`/`chroot`/`add-shell`/`remove-shell`/`ghrdc`/`wget`/`sddf`/`fakemovie`) are exercised only through `--help` and argument validation, never through privileged or network execution, per the issue's safety guidance. The specs use only `t.TempDir`-style temp files and no external network.

## Verification

- `make test-e2e` (hermetic harness) passes: 440 examples, 0 failures, 0 warnings (up from 412).

Closes #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test coverage for 15+ CLI tools with support for help output and error handling validation.
  * Implemented CLI contract specification tests to verify expected behavior including usage message output and error responses for invalid invocations.
  * Added test helper functions for consistent command invocation and validation across multiple utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->