### PR TITLE
build: bump go directive to 1.24 and fix non-constant format strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nao1215/mimixbox
 
-go 1.18
+go 1.24
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/internal/lib/crypto.go
+++ b/internal/lib/crypto.go
@@ -87,27 +87,27 @@ func PrintChecksums(cmdName string, hash hash.Hash, paths []string) (int, error)
 	for _, path := range paths {
 		p := os.ExpandEnv(path)
 		if !Exists(p) {
-			fmt.Fprintf(os.Stderr, cmdName+": "+p+": No such file or directory")
+			fmt.Fprint(os.Stderr, cmdName+": "+p+": No such file or directory")
 			status = 1
 			continue
 		}
 
 		if IsDir(p) {
-			fmt.Fprintf(os.Stderr, cmdName+": "+p+": It is directory")
+			fmt.Fprint(os.Stderr, cmdName+": "+p+": It is directory")
 			status = 1
 			continue
 		}
 
 		r, err := os.Open(p)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, cmdName+": "+err.Error())
+			fmt.Fprint(os.Stderr, cmdName+": "+err.Error())
 			status = 1
 			continue
 		}
 		defer r.Close()
 
 		if err := ChecksumOutput(hash, r, p); err != nil {
-			fmt.Fprintf(os.Stderr, cmdName+": "+err.Error())
+			fmt.Fprint(os.Stderr, cmdName+": "+err.Error())
 			status = 1
 			continue
 		}

--- a/internal/lib/shell.go
+++ b/internal/lib/shell.go
@@ -48,7 +48,7 @@ func IsRootDir(path string) bool {
 func QuestionFrom(in io.Reader, out io.Writer, ask string) bool {
 	for {
 		var response string
-		fmt.Fprintf(out, ask+" [Y/n] ")
+		fmt.Fprintf(out, "%s [Y/n] ", ask)
 		_, err := fmt.Fscanln(in, &response)
 		if err != nil {
 			// An empty line (just Enter) reports "unexpected newline"; re-ask.


### PR DESCRIPTION
## Summary

The pending Dependabot updates for `golang.org/x/sys` and `golang.org/x/term` bump the go.mod `go` directive to a modern version, which enables the Go 1.24 `printf` vet analyzer. That analyzer flags pre-existing non-constant format strings in the tree, so `go test` (which runs `go vet`) — and therefore the UnitTest workflow — fails on those Dependabot PRs even though the dependency change itself is fine.

This PR modernizes the `go` directive and fixes the flagged calls so the tree is vet-clean under Go 1.24+, unblocking those updates.

## Changes

- `go.mod`: `go 1.18` -> `go 1.24`. `go mod tidy` produces no further changes.
- `internal/lib/crypto.go`: four `fmt.Fprintf(os.Stderr, cmdName+": "+...)` calls used a concatenated (non-constant) string as the format. They have no format verbs, so they become `fmt.Fprint` — identical output, no format-string risk.
- `internal/lib/shell.go`: `QuestionFrom` now uses `fmt.Fprintf(out, "%s [Y/n] ", ask)` instead of `fmt.Fprintf(out, ask+" [Y/n] ")`.

## Verification

- `go vet ./...` is clean (was: 5 non-constant-format-string errors under the bumped directive).
- `go test ./...` passes; `go mod tidy` is a no-op.
- `make test-e2e` passes: 439 examples, 0 failures.

After this merges, the `golang.org/x/sys` (#260) and `golang.org/x/term` (#261) Dependabot PRs can rebase and pass CI.