### PR TITLE
build: inject version from the git tag across build and release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ builds:
   - main: ./cmd/mimixbox
     ldflags:
       - -s -w
+      - -X github.com/nao1215/mimixbox/internal/version.Version={{ .Version }}
     env:
       - CGO_ENABLED=0
     goos:

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,14 @@ RELEASE     := scripts/release.sh
 # per applet. The end-to-end suite prepends it to PATH so every applet resolves
 # to MimixBox, never to whatever the host happens to provide.
 E2E_BIN_DIR := $(CURDIR)/test/it/.mbbin
+# Canonical version source: the latest git tag (without its leading "v"),
+# falling back to "dev" outside a tagged checkout. Injected into the binary so
+# `mimixbox --version` matches the tag it was built from.
+VERSION     := $(shell v=$$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//'); echo "$${v:-dev}")
+LDFLAGS     := -s -w -X github.com/nao1215/mimixbox/internal/version.Version=$(VERSION)
 
 build:  ## Build the mimixbox binary
-	go build "-ldflags=-s -w" -trimpath -o $(APP) cmd/mimixbox/main.go
+	go build -ldflags="$(LDFLAGS)" -trimpath -o $(APP) cmd/mimixbox/main.go
 	$(MAKE) licenses
 
 clean: ## Clean project
@@ -42,7 +47,7 @@ test: pre_ut  ## Run unit tests with coverage (writes cover.out / cover.html)
 	exit $$status
 
 e2e-setup: ## Build MimixBox and stage its applet symlinks in an isolated PATH directory
-	go build "-ldflags=-s -w" -trimpath -o $(APP) cmd/mimixbox/main.go
+	go build -ldflags="$(LDFLAGS)" -trimpath -o $(APP) cmd/mimixbox/main.go
 	rm -rf "$(E2E_BIN_DIR)"
 	mkdir -p "$(E2E_BIN_DIR)"
 	install -m 0755 $(APP) "$(E2E_BIN_DIR)/$(APP)"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,9 +7,11 @@ import (
 	"io"
 )
 
-// Version is the MimixBox version. It is over_written at build time with
+// Version is the MimixBox version. The canonical source is the git tag: both
+// `make build` and the GoReleaser release inject it via
 // -ldflags "-X github.com/nao1215/mimixbox/internal/version.Version=x.y.z".
-var Version = "0.36.0"
+// "dev" is the fallback for a plain `go build`/`go install` with no injection.
+var Version = "dev"
 
 // Print writes the "--version" line for a single command to w, following the
 // GNU coreutils convention, e.g. "cat (mimixbox) 0.36.0".

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,11 +5,14 @@ CWD=$(pwd)
 RELEASE=${CWD}/release
 BIN_INFO_TXT=${RELEASE}/binary_info.txt
 ROOT_DIR=$(git rev-parse --show-toplevel)
-MAIN_CODE="${ROOT_DIR}/cmd/mimixbox/main.go"
 # Not build windows binary.
 OS="linux darwin"
 ARCH="386 amd64 arm arm64"
-VERSION=$(grep "const version" ${MAIN_CODE} | sed -e "s/const version = \"\(.*\)\"/\1/g")
+# Canonical version source: the latest git tag (without its leading "v"). This
+# matches the value `make build` and GoReleaser inject into the binary, instead
+# of the long-removed `const version` that this script used to scrape.
+VERSION=$(git -C "${ROOT_DIR}" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+VERSION=${VERSION:-dev}
 
 function mkReleaseDir() {
     cd  ${CWD}


### PR DESCRIPTION
## Summary

Versioning was split across three out-of-sync sources: a hardcoded `Version = "0.36.0"` in `internal/version`, a comment claiming a build-time `-ldflags` override that never actually happened, and `scripts/release.sh` scraping a `const version` from `cmd/mimixbox/main.go` that no longer exists. This could make `mimixbox --version` wrong and broke the release script.

This makes the git tag the single canonical version source and injects it consistently.

## Changes

- `internal/version/version.go`: default `Version` is now `"dev"` (the honest value for an un-injected `go build`/`go install`), with the comment corrected to describe the real injection.
- `Makefile`: derive `VERSION` from `git describe --tags --abbrev=0` (leading `v` stripped, `dev` fallback) and inject it via `-ldflags "-X .../internal/version.Version=..."` in both `build` and `e2e-setup`.
- `.goreleaser.yml`: inject `-X .../internal/version.Version={{ .Version }}`, so release binaries report the tag.
- `scripts/release.sh`: derive `VERSION` from the git tag instead of grepping the removed `const version`.

## Verification

- `make build` at tag `v0.36.0` produces a binary whose `mimixbox --version` prints `mimixbox (mimixbox) 0.36.0`.
- A plain `go build` (no injection) prints `mimixbox (mimixbox) dev`.
- The empty-tag fallback resolves to `dev` (the `||` previously bound to `sed`, so this is handled with `$\{v:-dev\}`).
- `go test ./...` passes; `make test-e2e` passes (439 examples, 0 failures). No remaining dependency on `const version` in `cmd/mimixbox/main.go`.

Closes #268