### PR TITLE
release: ship a self-contained installer in the release archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: mimixbox
 env:
   - GO111MODULE=on
@@ -19,6 +20,19 @@ builds:
       - arm64
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # Wrap the contents in a single directory and bundle the self-contained
+    # installer so `tar xf ...; cd ...; sudo ./installer.sh` works from a plain
+    # extracted archive (GitHub issue #267).
+    wrap_in_directory: true
+    files:
+      - LICENSE
+      - README.md
+      - src: scripts/installer.sh
+        strip_parent: true
+        info:
+          mode: 0755
+      - src: scripts/libshell.sh
+        strip_parent: true
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/README.md
+++ b/README.md
@@ -180,10 +180,17 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 
 ## Install
 
-The [Release Page](https://github.com/nao1215/mimixbox/releases) distributes the binary as a `tar.gz` archive for each OS/CPU architecture, plus `.deb`, `.rpm`, and `.apk` packages. The archive is named `mimixbox_<version>_<os>_<arch>.tar.gz` and contains the `mimixbox` binary. For example, on Linux (amd64):
+The [Release Page](https://github.com/nao1215/mimixbox/releases) distributes a `tar.gz` archive for each OS/CPU architecture, plus `.deb`, `.rpm`, and `.apk` packages. The archive is named `mimixbox_<version>_<os>_<arch>.tar.gz` and extracts into a directory containing the `mimixbox` binary and a self-contained `installer.sh`. For example, on Linux (amd64):
 
 ```shell
 $ tar xf mimixbox_0.36.0_linux_amd64.tar.gz
+$ cd mimixbox_0.36.0_linux_amd64
+$ sudo ./installer.sh
+```
+
+The installer copies the binary to `/usr/local/bin` and creates a symlink there for each applet. It resolves everything relative to itself, so it needs no Git checkout. If you prefer to do it by hand, just install the binary and let it create the symlinks:
+
+```shell
 $ sudo install -m 0755 mimixbox /usr/local/bin/
 $ sudo mimixbox --install /usr/local/bin
 ```

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,24 +1,53 @@
 #!/bin/bash -eu
 # [Description]
-#  This shell script is the installer for the command.
-#  This is created to be stored in tar.gz or zip for release files.
+#  Self-contained installer for MimixBox, shipped inside the release archive.
+#  It resolves everything relative to its own location (with a current-directory
+#  fallback for `make install` from a Git checkout), so it works from a plain
+#  extracted archive that has no Git metadata.
 DOC_INSTALL_DIR="/usr/share/doc/mimixbox"
-ROOT_DIR=$(git rev-parse --show-toplevel)
+INSTALL_DIR="/usr/local/bin"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
-source ${ROOT_DIR}/scripts/libshell.sh
+source "${SCRIPT_DIR}/libshell.sh"
+
+# resolveAsset prints the path to NAME, preferring the script's own directory
+# (release archive layout) and falling back to the current directory (running
+# from a Git checkout via `make install`). It prints nothing when not found.
+function resolveAsset() {
+    local name="$1"
+    if [ -e "${SCRIPT_DIR}/${name}" ]; then
+        echo "${SCRIPT_DIR}/${name}"
+    elif [ -e "./${name}" ]; then
+        echo "./${name}"
+    fi
+}
 
 function installMimixBox() {
-	install -v -m 0755 -D mimixbox /usr/local/bin/.
-	# Invoke the exact binary just installed (not a PATH lookup) so the applet
-	# symlinks are guaranteed to target /usr/local/bin/mimixbox.
-	/usr/local/bin/mimixbox --install /usr/local/bin/.
+    local bin
+    bin=$(resolveAsset mimixbox)
+    if [ -z "${bin}" ]; then
+        errMsg "mimixbox binary not found next to installer.sh or in the current directory"
+        exit 1
+    fi
+    install -v -m 0755 -D "${bin}" "${INSTALL_DIR}/mimixbox"
+    # Invoke the exact binary just installed (not a PATH lookup) so the applet
+    # symlinks are guaranteed to target ${INSTALL_DIR}/mimixbox.
+    "${INSTALL_DIR}/mimixbox" --install "${INSTALL_DIR}/."
 }
 
 function installLicense() {
-    warnMsg "Install LICENSE at ${DOC_INSTALL_DIR}"
-    mkdir -p ${DOC_INSTALL_DIR}
-    #install -v -m 0644 LICENSE ${DOC_INSTALL_DIR}
-    cp -rf licenses ${DOC_INSTALL_DIR}
+    local license licenses_dir
+    license=$(resolveAsset LICENSE)
+    licenses_dir=$(resolveAsset licenses)
+    mkdir -p "${DOC_INSTALL_DIR}"
+    if [ -n "${license}" ]; then
+        warnMsg "Install LICENSE at ${DOC_INSTALL_DIR}"
+        cp -f "${license}" "${DOC_INSTALL_DIR}/."
+    fi
+    if [ -n "${licenses_dir}" ]; then
+        warnMsg "Install dependency licenses at ${DOC_INSTALL_DIR}"
+        cp -rf "${licenses_dir}" "${DOC_INSTALL_DIR}/."
+    fi
 }
 
 IS_ROOT=$(isRoot)


### PR DESCRIPTION
## Summary

The README told users to extract a release archive and run `sudo ./installer.sh`, but the installer assumed a Git checkout: it ran `git rev-parse --show-toplevel` and sourced `libshell.sh` and other helpers through that Git root, none of which exist in an extracted archive. The archive also did not contain the installer at all.

This makes the documented archive install flow real and self-contained.

## Changes

- `scripts/installer.sh`: resolve everything relative to the script's own directory (`SCRIPT_DIR`), with a current-directory fallback for `make install` from a checkout. No more `git rev-parse`. It locates the binary, `LICENSE`, and `licenses/` via the same resolver and installs the binary to `/usr/local/bin` before creating the applet symlinks.
- `.goreleaser.yml`: `wrap_in_directory: true` and bundle `installer.sh`, `libshell.sh`, `LICENSE`, and `README.md` into the archive (installer at archive root, `mode 0755`). Also add the explicit `version: 2` that `goreleaser check` was warning about.
- `README.md`: document the real flow — extract, `cd` into the wrapped directory, `sudo ./installer.sh` — and keep the manual binary-only steps as an alternative.

## Verification

- `goreleaser check` passes; `goreleaser release --snapshot` produces `mimixbox_<ver>_<os>_<arch>.tar.gz` containing `mimixbox`, `installer.sh`, `libshell.sh`, `LICENSE`, `README.md` wrapped in one directory.
- Extracting that real archive into a temporary directory that is **not** a Git checkout and running the installer succeeds (exit 0): it installs the binary, creates the applet symlinks, and copies the license — with no dependency on `.git`.
- The archived binary reports the injected version (e.g. `mimixbox (mimixbox) 0.36.1-next`).

Closes #267