### PR TITLE
help: make applet help self-describing for humans and LLMs

### DIFF
--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -158,6 +158,15 @@ Options:
   -l, --list               list the applets MimixBox provides
   -v, --version            print version information and exit
   -h, --help               print this help and exit
+
+Examples:
+  mimixbox --list                    Show every applet and its one-line description.
+  mimixbox cat file.txt              Run the cat applet directly.
+  cat file.txt                       Same, when invoked through an installed symlink.
+  mimixbox APPLET --help             Show the applet's own help, options, and examples.
+  sudo mimixbox --full-install /usr/local/bin   Install a symlink for every applet.
+
+Run "mimixbox APPLET --help" for an applet's description, options, and examples.
 `)
 }
 

--- a/internal/applets/editors/vi/vi.go
+++ b/internal/applets/editors/vi/vi.go
@@ -32,7 +32,19 @@ func (c *Command) Synopsis() string { return "A minimal vi-style screen text edi
 
 // Run executes vi.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "A minimal vi-style screen editor. It opens FILE (or an empty buffer) in a " +
+			"full-screen terminal. Like vi it starts in normal mode; press i to insert text and " +
+			"Esc to return to normal mode.",
+		Examples: []command.Example{
+			{Command: "vi notes.txt", Explain: "Edit notes.txt (created on save if missing)."},
+			{Command: "vi", Explain: "Open an empty buffer."},
+		},
+		Notes: []string{
+			"Normal mode: h j k l move, i insert, x delete a char, dd delete a line, :w save, :q quit, :wq save and quit.",
+			"Only this minimal key set is implemented; most ex commands and motions are not yet available.",
+		},
+	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err

--- a/internal/applets/fileutils/cp/cp.go
+++ b/internal/applets/fileutils/cp/cp.go
@@ -37,7 +37,21 @@ type options struct {
 
 // Run executes cp.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... SOURCE... DEST", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... SOURCE... DEST", stdio.Err).WithHelp(command.Help{
+		Description: "Copy SOURCE to DEST, or one or more SOURCEs into a DEST directory. " +
+			"With -r/-R, directories are copied recursively. By default an existing " +
+			"destination is overwritten; -i prompts first and -n never overwrites.",
+		Examples: []command.Example{
+			{Command: "cp a.txt b.txt", Explain: "Copy a file."},
+			{Command: "cp -r src/ dst/", Explain: "Copy a directory tree."},
+			{Command: "cp -a src/ dst/", Explain: "Copy recursively, preserving mode and timestamps (= -rp)."},
+			{Command: "cp -i a.txt dir/", Explain: "Prompt before overwriting dir/a.txt."},
+		},
+		ExitStatus: "0  all files were copied successfully.\n1  one or more files could not be copied.",
+		Notes: []string{
+			"Symlink-handling flags (-L, -P, -d, -H) are not yet implemented; symlinks are followed.",
+		},
+	})
 	recursive := fs.BoolP("recursive", "r", false, "copy directories recursively (-R is an alias)")
 	// -R is the other GNU spelling of -r; pflag cannot give one flag two
 	// shorthands, so it is a hidden alias whose value is OR'd into recursive.

--- a/internal/applets/findutils/find/find.go
+++ b/internal/applets/findutils/find/find.go
@@ -239,7 +239,17 @@ func printPath(stdio command.IO, path string, zero bool) {
 
 func printUsage(w interface{ Write([]byte) (int, error) }) {
 	_, _ = w.Write([]byte("Usage: find [PATH]... [EXPRESSION]\n\n" +
+		"Search each PATH (default: the current directory) recursively and act on the\n" +
+		"entries that match EXPRESSION. With no expression, every entry is printed.\n\n" +
 		"Tests: -name, -iname, -path, -type [f|d|l|p|s], -empty\n" +
 		"Depth: -maxdepth N, -mindepth N\n" +
-		"Actions: -print (default), -print0\n"))
+		"Actions: -print (default), -print0\n\n" +
+		"Examples:\n" +
+		"  find .                       Print every entry under the current directory.\n" +
+		"  find . -name '*.go'          Find files whose name ends in .go.\n" +
+		"  find /tmp -type d -empty     Find empty directories under /tmp.\n" +
+		"  find . -type f -print0       Print file paths separated by NUL (for xargs -0).\n\n" +
+		"Notes:\n" +
+		"  - This is a subset of GNU find: the tests, depth limits, and actions listed above.\n" +
+		"  - -print0 pairs with 'xargs -0' to handle paths that contain spaces or newlines.\n"))
 }

--- a/internal/applets/shellutils/mbsh/mbsh.go
+++ b/internal/applets/shellutils/mbsh/mbsh.go
@@ -47,7 +47,19 @@ type shell struct {
 // from stdio.In, and executes it. The loop ends, returning nil, when the reader
 // reaches EOF or the user types "exit".
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "MimixBox Shell: a minimal interactive shell. It reads a command and its " +
+			"arguments from each line and runs the matching MimixBox applet. With no terminal " +
+			"it reads commands from standard input, so it can run a script piped on stdin.",
+		Examples: []command.Example{
+			{Command: "mbsh", Explain: "Start an interactive prompt; type 'exit' or Ctrl-D to quit."},
+			{Command: "echo 'echo hello' | mbsh", Explain: "Run commands fed on standard input."},
+		},
+		Notes: []string{
+			"Whitespace splits tokens; quoting, parameter expansion, pipelines, and redirections are not yet supported.",
+			"Each line runs one applet; there is no scripting (if/for/while) or variable assignment.",
+		},
+	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err

--- a/internal/applets/shellutils/wget/wget.go
+++ b/internal/applets/shellutils/wget/wget.go
@@ -33,7 +33,20 @@ type options struct {
 
 // Run executes wget.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... URL...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... URL...", stdio.Err).WithHelp(command.Help{
+		Description: "Download each URL over HTTP(S). By default the response is saved to a file " +
+			"named after the URL in the current directory; -O writes to a specific file, or to " +
+			"standard output when given -.",
+		Examples: []command.Example{
+			{Command: "wget https://example.com/a.tar.gz", Explain: "Save to a.tar.gz in the current directory."},
+			{Command: "wget -O out.html https://example.com", Explain: "Save the response to out.html."},
+			{Command: "wget -O - https://example.com | grep title", Explain: "Stream the body to standard output."},
+		},
+		ExitStatus: "0  the download succeeded.\n1  a request failed or a file could not be written.",
+		Notes: []string{
+			"Only a subset of GNU wget options is supported (currently -O and -q).",
+		},
+	})
 	output := fs.StringP("output-document", "O", "", "write documents to FILE (- for standard output)")
 	quiet := fs.BoolP("quiet", "q", false, "quiet (no output)")
 

--- a/internal/applets/textutils/tail/tail.go
+++ b/internal/applets/textutils/tail/tail.go
@@ -25,7 +25,18 @@ func (c *Command) Synopsis() string { return "Print the last NUMBER(default=10) 
 
 // Run executes tail.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the last part of each FILE (10 lines by default) to standard output. " +
+			"With no FILE, or when FILE is -, read standard input. With -f the output keeps " +
+			"growing as the file does, which is useful for watching logs.",
+		Examples: []command.Example{
+			{Command: "tail file.log", Explain: "Print the last 10 lines."},
+			{Command: "tail -n 50 file.log", Explain: "Print the last 50 lines."},
+			{Command: "tail -f app.log", Explain: "Follow the file and print new lines as they arrive."},
+			{Command: "tail -F app.log", Explain: "Follow by name and retry if the file is rotated."},
+		},
+		ExitStatus: "0  success.\n1  a file could not be opened (without --retry).",
+	})
 	lines := fs.IntP("lines", "n", 10, "output the last NUM lines instead of the last 10")
 	bytesN := fs.IntP("bytes", "c", 0, "output the last NUM bytes of each file")
 	quiet := fs.BoolP("quiet", "q", false, "never print headers giving file names")

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -14,12 +14,32 @@ import (
 // end options, and operands interspersed with options), plus the standard
 // --help and --version flags. Using pflag is what lets a MimixBox applet stand
 // in for the system command of the same name.
+// Example is one worked example shown in --help: the command line and a short
+// explanation of what it does.
+type Example struct {
+	Command string
+	Explain string
+}
+
+// Help holds the optional, self-describing sections an applet can attach to its
+// --help output so that a human or an LLM can understand the command without
+// prior knowledge: a one-paragraph description, worked examples, an exit-status
+// summary, and compatibility notes. All fields are optional; empty sections are
+// not rendered.
+type Help struct {
+	Description string
+	Examples    []Example
+	ExitStatus  string
+	Notes       []string
+}
+
 type FlagSet struct {
 	*pflag.FlagSet
 	name    string
 	usage   string
 	help    *bool
 	version *bool
+	doc     Help
 }
 
 // NewFlagSet returns a FlagSet for command name. usage is the operand summary
@@ -34,6 +54,14 @@ func NewFlagSet(name, usage string, stderr io.Writer) *FlagSet {
 	f := &FlagSet{FlagSet: pf, name: name, usage: usage}
 	f.help = pf.Bool("help", false, "display this help and exit")
 	f.version = pf.Bool("version", false, "output version information and exit")
+	return f
+}
+
+// WithHelp attaches self-describing help sections (description, examples, exit
+// status, notes) that WriteUsage renders below the options. It returns the
+// FlagSet so it can be chained onto NewFlagSet.
+func (f *FlagSet) WithHelp(h Help) *FlagSet {
+	f.doc = h
 	return f
 }
 
@@ -58,8 +86,9 @@ func (f *FlagSet) Parse(io IO, args []string) (proceed bool, err error) {
 	return true, nil
 }
 
-// WriteUsage writes a GNU-style usage block (a "Usage:" line followed by the
-// option descriptions) to w.
+// WriteUsage writes a GNU-style usage block to w: a "Usage:" line, an optional
+// one-paragraph description, the option descriptions, and any optional
+// Examples / Exit status / Notes sections attached via WithHelp.
 func (f *FlagSet) WriteUsage(w io.Writer) {
 	var b strings.Builder
 	b.WriteString("Usage: ")
@@ -68,7 +97,60 @@ func (f *FlagSet) WriteUsage(w io.Writer) {
 		b.WriteByte(' ')
 		b.WriteString(f.usage)
 	}
-	b.WriteString("\n\nOptions:\n")
+	b.WriteByte('\n')
+
+	if f.doc.Description != "" {
+		b.WriteByte('\n')
+		b.WriteString(f.doc.Description)
+		b.WriteByte('\n')
+	}
+
+	b.WriteString("\nOptions:\n")
 	b.WriteString(f.FlagUsages())
+
+	if len(f.doc.Examples) > 0 {
+		b.WriteString("\nExamples:\n")
+		width := 0
+		for _, ex := range f.doc.Examples {
+			if len(ex.Command) > width {
+				width = len(ex.Command)
+			}
+		}
+		for _, ex := range f.doc.Examples {
+			fmt.Fprintf(&b, "  %-*s", width, ex.Command)
+			if ex.Explain != "" {
+				b.WriteString("  ")
+				b.WriteString(ex.Explain)
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	if f.doc.ExitStatus != "" {
+		b.WriteString("\nExit status:\n")
+		b.WriteString(indentLines(f.doc.ExitStatus))
+	}
+
+	if len(f.doc.Notes) > 0 {
+		b.WriteString("\nNotes:\n")
+		for _, note := range f.doc.Notes {
+			b.WriteString("  - ")
+			b.WriteString(note)
+			b.WriteByte('\n')
+		}
+	}
+
 	_, _ = io.WriteString(w, b.String())
+}
+
+// indentLines indents every line of s with two spaces, ensuring a trailing
+// newline so sections stack cleanly.
+func indentLines(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(s, "\n"), "\n") {
+		b.WriteString("  ")
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }

--- a/internal/command/usage_test.go
+++ b/internal/command/usage_test.go
@@ -1,0 +1,89 @@
+package command_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// TestWriteUsageSections verifies that WithHelp's sections (description,
+// examples, exit status, notes) are rendered in --help, and that a plain
+// FlagSet with no rich help still renders just the Usage/Options block.
+func TestWriteUsageSections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rich help renders every section", func(t *testing.T) {
+		t.Parallel()
+		var errBuf bytes.Buffer
+		fs := command.NewFlagSet("demo", "[OPTION]... FILE", &errBuf).WithHelp(command.Help{
+			Description: "Demo does a thing.",
+			Examples: []command.Example{
+				{Command: "demo a", Explain: "Do it to a."},
+				{Command: "demo -x b", Explain: "Do it to b with -x."},
+			},
+			ExitStatus: "0  ok.\n1  failure.",
+			Notes:      []string{"This is a note.", "Another note."},
+		})
+
+		var out bytes.Buffer
+		fs.WriteUsage(&out)
+		got := out.String()
+
+		for _, want := range []string{
+			"Usage: demo [OPTION]... FILE",
+			"Demo does a thing.",
+			"Options:",
+			"--help",
+			"Examples:",
+			"demo a",
+			"Do it to a.",
+			"demo -x b",
+			"Exit status:",
+			"  0  ok.",
+			"Notes:",
+			"  - This is a note.",
+			"  - Another note.",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("usage output is missing %q\n--- got ---\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("examples align on the widest command", func(t *testing.T) {
+		t.Parallel()
+		var errBuf bytes.Buffer
+		fs := command.NewFlagSet("demo", "", &errBuf).WithHelp(command.Help{
+			Examples: []command.Example{
+				{Command: "a", Explain: "short"},
+				{Command: "longcommand", Explain: "long"},
+			},
+		})
+		var out bytes.Buffer
+		fs.WriteUsage(&out)
+		got := out.String()
+		// The short command is padded to the width of the longest one.
+		if !strings.Contains(got, "  a            short") {
+			t.Errorf("examples not aligned:\n%s", got)
+		}
+	})
+
+	t.Run("no rich help renders only usage and options", func(t *testing.T) {
+		t.Parallel()
+		var errBuf bytes.Buffer
+		fs := command.NewFlagSet("bare", "[FILE]", &errBuf)
+		var out bytes.Buffer
+		fs.WriteUsage(&out)
+		got := out.String()
+		if !strings.Contains(got, "Usage: bare [FILE]") || !strings.Contains(got, "Options:") {
+			t.Errorf("bare usage missing core sections:\n%s", got)
+		}
+		for _, unwanted := range []string{"Examples:", "Exit status:", "Notes:"} {
+			if strings.Contains(got, unwanted) {
+				t.Errorf("bare usage should not contain %q:\n%s", unwanted, got)
+			}
+		}
+	})
+}

--- a/test/it/shellutils/richhelp_test.sh
+++ b/test/it/shellutils/richhelp_test.sh
@@ -1,0 +1,7 @@
+# Helpers for the self-describing --help smoke tests (GitHub issue #237).
+CpHelp() { cp --help; }
+TailHelp() { tail --help; }
+WgetHelp() { wget --help; }
+MbshHelp() { mbsh --help; }
+ViHelp() { vi --help; }
+FindHelp() { find --help; }

--- a/test/it/spec/mimixbox_spec.sh
+++ b/test/it/spec/mimixbox_spec.sh
@@ -5,6 +5,7 @@ Describe 'mimixbox top-level CLI'
         When call MbHelp
         The status should be success
         The output should include 'Usage: mimixbox'
+        The output should include 'Examples:'
     End
 
     It 'lists the applets with --list'

--- a/test/it/spec/richhelp_spec.sh
+++ b/test/it/spec/richhelp_spec.sh
@@ -1,0 +1,44 @@
+Describe 'self-describing --help'
+    Include shellutils/richhelp_test.sh
+
+    It 'cp --help has a description, examples, and exit status'
+        When call CpHelp
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+    End
+
+    It 'tail --help documents follow mode with examples'
+        When call TailHelp
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Follow the file'
+    End
+
+    It 'wget --help has examples and compatibility notes'
+        When call WgetHelp
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Notes:'
+    End
+
+    It 'mbsh --help describes the shell and its limits'
+        When call MbshHelp
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Notes:'
+    End
+
+    It 'vi --help lists the supported keys'
+        When call ViHelp
+        The status should be success
+        The output should include 'Normal mode'
+    End
+
+    It 'find --help has examples and notes'
+        When call FindHelp
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Notes:'
+    End
+End


### PR DESCRIPTION
## Summary

Most applets exposed only a `Usage:` line and raw flags — enough for someone who already knows the command, but not for discovery, onboarding, or LLM-assisted use. This extends the help model so applets can attach a description, worked examples, an exit-status summary, and compatibility notes, and migrates a first wave of high-impact commands.

## Changes

### Help framework (`internal/command`)

- Add `command.Help` (Description, Examples, ExitStatus, Notes) and `command.Example` (Command + Explain).
- Add `FlagSet.WithHelp(Help)` (chainable onto `NewFlagSet`).
- `WriteUsage` now renders, in order: Usage, Description, Options, Examples (aligned), Exit status, Notes. Sections are omitted when empty, so existing applets are unchanged until they opt in.

### Migrated commands

- `cp`, `tail`, `wget`, `mbsh`, `vi` opt into `WithHelp` with descriptions, examples, exit-status and/or compatibility notes (e.g. cp documents the unimplemented -L/-P/-d/-H, mbsh its tokenization limits, vi its supported keys).
- `find` (custom expression parser) and the top-level `mimixbox` help (custom writer) get the same treatment inline: a description, an Examples block, and notes.

### Synopsis typos

The malformed `Synopsis()` strings called out in the issue (base64 `FILR`, cp `otr`, ghrdc `Relase`, uuidgen's missing `)`) were already fixed in #272, so README and `--list` are already clean; no regeneration was needed.

## Tests

- `internal/command/usage_test.go`: asserts each section renders (and aligns), and that a bare FlagSet still renders only Usage/Options.
- `test/it/spec/richhelp_spec.sh`: shellspec smoke tests that each migrated applet's `--help` contains the expected sections (Examples/Exit status/Notes/keys), plus an `Examples:` check on the top-level `mimixbox --help`.

## Verification

- `go test ./...` passes; `make test-e2e` passes (445 examples, 0 failures); `golangci-lint` clean.

Closes #237