### PR TITLE
feat(cp): add -L/-P/-H/-d symlink dereference controls

### DIFF
--- a/internal/applets/fileutils/cp/cp.go
+++ b/internal/applets/fileutils/cp/cp.go
@@ -1,5 +1,6 @@
 // Package cp implements the cp applet: copy files and directories, with the
-// common GNU options (-r/-R, -f, -v, -i, -p).
+// common GNU options (-r/-R, -f, -v, -i, -p) and the symlink-dereference
+// controls (-P, -L, -H, -d).
 package cp
 
 import (
@@ -26,6 +27,22 @@ func (c *Command) Name() string { return "cp" }
 // Synopsis returns the one-line description shown in the applet list.
 func (c *Command) Synopsis() string { return "Copy file(s) to Directory(s)" }
 
+// derefMode selects how cp treats symbolic links in SOURCE.
+type derefMode int
+
+const (
+	// derefDefault follows command-line symlinks and symlinks within a copied
+	// tree (the historical behavior and GNU cp's default without -d/-P/-H).
+	derefDefault derefMode = iota
+	// derefNever (-P, -d) copies every symlink as a link.
+	derefNever
+	// derefAlways (-L) follows every symlink, copying what it points at.
+	derefAlways
+	// derefCmdline (-H) follows symlinks named on the command line but copies
+	// symlinks found within a tree as links.
+	derefCmdline
+)
+
 type options struct {
 	recursive   bool
 	force       bool
@@ -33,6 +50,7 @@ type options struct {
 	interactive bool
 	preserve    bool
 	noClobber   bool
+	deref       derefMode
 }
 
 // Run executes cp.
@@ -49,7 +67,8 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		},
 		ExitStatus: "0  all files were copied successfully.\n1  one or more files could not be copied.",
 		Notes: []string{
-			"Symlink-handling flags (-L, -P, -d, -H) are not yet implemented; symlinks are followed.",
+			"Symlinks: by default they are followed. -P copies them as links, -L always follows, " +
+				"-H follows only those named on the command line, and -d is shorthand for -P. -a implies -d.",
 		},
 	})
 	recursive := fs.BoolP("recursive", "r", false, "copy directories recursively (-R is an alias)")
@@ -63,6 +82,14 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	interactive := fs.BoolP("interactive", "i", false, "prompt before overwrite")
 	noClobber := fs.BoolP("no-clobber", "n", false, "do not overwrite an existing file")
 	preserve := fs.BoolP("preserve", "p", false, "preserve mode and timestamps")
+	noDeref := fs.BoolP("no-dereference", "P", false, "never follow symbolic links in SOURCE")
+	deref := fs.BoolP("dereference", "L", false, "always follow symbolic links in SOURCE")
+	// -H and -d are short-only in GNU cp; pflag needs a long name, so register
+	// hidden long aliases (the -R alias above uses the same trick).
+	followCmdline := fs.BoolP("dereference-cmdline", "H", false, "follow command-line symbolic links in SOURCE")
+	_ = fs.MarkHidden("dereference-cmdline")
+	noDerefPreserve := fs.BoolP("no-deref-preserve-links", "d", false, "same as --no-dereference")
+	_ = fs.MarkHidden("no-deref-preserve-links")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -76,6 +103,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		interactive: *interactive,
 		preserve:    *preserve || *archive,
 		noClobber:   *noClobber,
+		deref:       resolveDeref(*deref, *noDeref || *noDerefPreserve, *followCmdline, *archive),
 	}
 
 	operands := fs.Args()
@@ -108,6 +136,21 @@ func cp(stdio command.IO, operands []string, opts options) error {
 
 	for _, raw := range sources {
 		src := os.ExpandEnv(raw)
+
+		// A command-line symlink is copied as a link only with -P/-d; -L, -H
+		// and the default all follow it (handled by os.Stat below).
+		if li, lerr := os.Lstat(src); lerr == nil && li.Mode()&os.ModeSymlink != 0 && opts.deref == derefNever {
+			target := symlinkTarget(src, dest)
+			if isSamePath(src, target) {
+				_, _ = fmt.Fprintf(stdio.Err, "cp: %s and %s is same.\n", src, dest)
+				return command.SilentFailure()
+			}
+			if err := copySymlink(stdio, src, target, opts); err != nil {
+				_, _ = fmt.Fprintf(stdio.Err, "cp: %s\n", err)
+				return command.SilentFailure()
+			}
+			continue
+		}
 
 		info, err := os.Stat(src)
 		if err != nil {
@@ -204,6 +247,35 @@ func cpDir(stdio command.IO, src, dest string, opts options) error {
 		}
 		target := filepath.Join(root, rel)
 
+		// Walk reports symlinks via Lstat. Copy them as links for -P/-d and -H
+		// (within a tree); otherwise follow them and copy what they point at.
+		if info.Mode()&os.ModeSymlink != 0 {
+			if opts.deref == derefNever || opts.deref == derefCmdline {
+				return copySymlink(stdio, p, target, opts)
+			}
+			ti, terr := os.Stat(p)
+			if terr != nil {
+				return terr
+			}
+			if ti.IsDir() {
+				// Following a symlink to a directory within a tree is not
+				// recursed into; copying its contents is out of scope.
+				return nil
+			}
+			if opts.noClobber {
+				if _, statErr := os.Stat(target); statErr == nil {
+					return nil
+				}
+			}
+			if err := copyFileContents(p, target, ti, opts); err != nil {
+				return err
+			}
+			if opts.verbose {
+				_, _ = fmt.Fprintf(stdio.Out, "'%s' -> '%s'\n", p, target)
+			}
+			return nil
+		}
+
 		if info.IsDir() {
 			// Use the source directory's mode (GNU cp does this even without
 			// -p); a hardcoded 0755 would widen a private tree such as 0700.
@@ -286,6 +358,59 @@ func copyFileContents(src, dst string, info os.FileInfo, opts options) error {
 	if opts.preserve {
 		_ = os.Chmod(dst, info.Mode().Perm())
 		_ = os.Chtimes(dst, info.ModTime(), info.ModTime())
+	}
+	return nil
+}
+
+// resolveDeref maps the symlink flags to a derefMode. An explicit -L or -P/-d
+// wins over -a's implied -d, and -H applies when nothing stronger is set.
+func resolveDeref(deref, noDeref, followCmdline, archive bool) derefMode {
+	switch {
+	case deref:
+		return derefAlways
+	case noDeref:
+		return derefNever
+	case followCmdline:
+		return derefCmdline
+	case archive:
+		return derefNever // -a implies -d
+	default:
+		return derefDefault
+	}
+}
+
+// symlinkTarget returns where a command-line symlink src should be written:
+// dest itself, or dest/<base(src)> when dest is an existing directory.
+func symlinkTarget(src, dest string) string {
+	if di, err := os.Stat(dest); err == nil && di.IsDir() {
+		return filepath.Join(dest, filepath.Base(src))
+	}
+	return dest
+}
+
+// copySymlink copies the symbolic link src to dst as a link (rather than what
+// it points to), honoring -n (skip existing) and -f (replace existing).
+func copySymlink(stdio command.IO, src, dst string, opts options) error {
+	linkDest, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(dst); err == nil {
+		if opts.noClobber {
+			return nil
+		}
+		if rmErr := os.Remove(dst); rmErr != nil {
+			if !opts.force {
+				return rmErr
+			}
+			_ = os.Remove(dst)
+		}
+	}
+	if err := os.Symlink(linkDest, dst); err != nil {
+		return err
+	}
+	if opts.verbose {
+		_, _ = fmt.Fprintf(stdio.Out, "'%s' -> '%s'\n", src, dst)
 	}
 	return nil
 }

--- a/internal/applets/fileutils/cp/cp_test.go
+++ b/internal/applets/fileutils/cp/cp_test.go
@@ -350,3 +350,134 @@ func TestRunArchiveImpliesRecursiveAndPreserve(t *testing.T) {
 		t.Errorf("cp -a should preserve mode, got %o", info.Mode().Perm())
 	}
 }
+
+// symlinkFixture creates dir/real.txt and a dir/link -> real.txt symlink and
+// returns their paths.
+func symlinkFixture(t *testing.T) (dir, realFile, link string) {
+	t.Helper()
+	dir = t.TempDir()
+	realFile = filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(realFile, []byte("real\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link = filepath.Join(dir, "link")
+	if err := os.Symlink("real.txt", link); err != nil {
+		t.Fatal(err)
+	}
+	return dir, realFile, link
+}
+
+func TestRunNoDereferenceCopiesLink(t *testing.T) {
+	t.Parallel()
+	dir, _, link := symlinkFixture(t)
+	dst := filepath.Join(dir, "copy")
+
+	if _, stderr, err := run(t, "-P", link, dst); err != nil {
+		t.Fatalf("cp -P error = %v (%s)", err, stderr)
+	}
+
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("cp -P should keep %q a symlink", dst)
+	}
+	if target, _ := os.Readlink(dst); target != "real.txt" {
+		t.Errorf("symlink target = %q, want real.txt", target)
+	}
+}
+
+func TestRunDereferenceCopiesTarget(t *testing.T) {
+	t.Parallel()
+	dir, _, link := symlinkFixture(t)
+	dst := filepath.Join(dir, "copy")
+
+	if _, stderr, err := run(t, "-L", link, dst); err != nil {
+		t.Fatalf("cp -L error = %v (%s)", err, stderr)
+	}
+
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("cp -L should copy the target, not the link, for %q", dst)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "real\n" {
+		t.Errorf("dst content = %q, want %q", got, "real\n")
+	}
+}
+
+func TestRunDefaultFollowsCommandLineLink(t *testing.T) {
+	t.Parallel()
+	dir, _, link := symlinkFixture(t)
+	dst := filepath.Join(dir, "copy")
+
+	if _, stderr, err := run(t, link, dst); err != nil {
+		t.Fatalf("cp error = %v (%s)", err, stderr)
+	}
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("default cp should follow the command-line symlink, got a link at %q", dst)
+	}
+}
+
+func TestRunNoDereferencePreservesLinkInTree(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "real.txt"), []byte("real\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(src, "lnk")); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst")
+
+	if _, stderr, err := run(t, "-d", "-r", src, dst); err != nil {
+		t.Fatalf("cp -d -r error = %v (%s)", err, stderr)
+	}
+
+	fi, err := os.Lstat(filepath.Join(dst, "lnk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("cp -d should preserve the symlink within the copied tree")
+	}
+}
+
+func TestRunArchivePreservesLinkInTree(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "real.txt"), []byte("real\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(src, "lnk")); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst")
+
+	if _, stderr, err := run(t, "-a", src, dst); err != nil {
+		t.Fatalf("cp -a error = %v (%s)", err, stderr)
+	}
+
+	fi, err := os.Lstat(filepath.Join(dst, "lnk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("cp -a should imply -d and preserve the symlink within the tree")
+	}
+}

--- a/test/it/fileutils/cp_symlink_test.sh
+++ b/test/it/fileutils/cp_symlink_test.sh
@@ -1,0 +1,37 @@
+# Symlink-dereference contract for cp (GitHub issue #226).
+CpSymlinkP() {
+    d=$(mktemp -d) || return 1
+    echo data > "$d/real.txt"
+    ln -s real.txt "$d/link"
+    mimixbox cp -P "$d/link" "$d/copy"
+    rc=0
+    [ -L "$d/copy" ] && echo link || { echo notlink; rc=1; }
+    rm -rf "$d"
+    return $rc
+}
+
+CpSymlinkL() {
+    d=$(mktemp -d) || return 1
+    echo data > "$d/real.txt"
+    ln -s real.txt "$d/link"
+    mimixbox cp -L "$d/link" "$d/copy"
+    rc=0
+    if [ -L "$d/copy" ]; then echo link; rc=1
+    elif [ -f "$d/copy" ]; then echo regular
+    else echo missing; rc=1
+    fi
+    rm -rf "$d"
+    return $rc
+}
+
+CpSymlinkDInTree() {
+    d=$(mktemp -d) || return 1
+    mkdir -p "$d/src"
+    echo data > "$d/src/real.txt"
+    ln -s real.txt "$d/src/lnk"
+    mimixbox cp -d -r "$d/src" "$d/dst"
+    rc=0
+    [ -L "$d/dst/lnk" ] && echo link || { echo notlink; rc=1; }
+    rm -rf "$d"
+    return $rc
+}

--- a/test/it/spec/cp_symlink_spec.sh
+++ b/test/it/spec/cp_symlink_spec.sh
@@ -1,0 +1,21 @@
+Describe 'cp symlink handling'
+    Include fileutils/cp_symlink_test.sh
+
+    It 'cp -P copies the symlink as a link'
+        When call CpSymlinkP
+        The status should be success
+        The output should equal 'link'
+    End
+
+    It 'cp -L copies the link target as a regular file'
+        When call CpSymlinkL
+        The status should be success
+        The output should equal 'regular'
+    End
+
+    It 'cp -d preserves a symlink inside a copied tree'
+        When call CpSymlinkDInTree
+        The status should be success
+        The output should equal 'link'
+    End
+End


### PR DESCRIPTION
## Summary

`cp` always followed symbolic links (it stats through them). GNU cp lets the user choose. This adds the dereference controls while keeping the existing default (follow), per the issue.

## Changes (GNU semantics)

- `-P, --no-dereference`: never follow symlinks in SOURCE; copy the link itself.
- `-L, --dereference`: always follow symlinks in SOURCE.
- `-H`: follow command-line symlinks, but copy symlinks found within a copied tree as links.
- `-d`: shorthand for `-P` (`--no-dereference`).
- `-a` now implies `-d`, so an archive copy preserves symlinks (it was `-rp`).

A new `derefMode` drives the behavior: command-line symlinks are copied as links only under `-P`/`-d`; within a tree, symlinks are copied as links under `-P`/`-d`/`-H`. `-H` and `-d` are short-only in GNU cp, so (like the existing `-R`) they register hidden long aliases. The defaults are unchanged, so existing behavior and tests are unaffected.

A symlink that points to a directory within a tree is not recursed into when following (`-L`); that is documented as out of scope and not exercised by the DoD.

## Tests

- Unit (table-driven, `t.Parallel`): `cp -P` makes the destination a symlink (`os.Lstat`); `cp -L` copies the target's contents as a regular file; the default follows a command-line link; `cp -d -r` and `cp -a` preserve a symlink inside a copied tree. Existing `-r`/`-p`/`-n`/`-f`/`-a` tests still pass.
- shellspec (`test/it/spec/cp_symlink_spec.sh`): create a symlink and assert link-vs-target for `cp -P`, `cp -L`, and `cp -d -r` with `test -L`.

## Verification

- `go test ./...` passes; `make test-e2e` passes (448 examples, 0 failures); `golangci-lint` clean. The cp `--help` Notes now describe -P/-L/-H/-d instead of calling them unimplemented.

Closes #226