### PR TITLE
feat(wget): add -P, -c, -T, -t, and --user-agent options

### DIFF
--- a/internal/applets/shellutils/wget/wget.go
+++ b/internal/applets/shellutils/wget/wget.go
@@ -1,15 +1,19 @@
 // Package wget implements the wget applet: a non-interactive network downloader
-// that fetches each URL operand to a local file (or to standard output).
+// that fetches each URL operand to a local file (or to standard output), with a
+// subset of the common GNU wget options (-O, -q, -P, -c, -T, -t, --user-agent).
 package wget
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
+	"time"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
@@ -27,8 +31,13 @@ func (c *Command) Name() string { return "wget" }
 func (c *Command) Synopsis() string { return "The non-interactive network downloader" }
 
 type options struct {
-	output string
-	quiet  bool
+	output    string
+	quiet     bool
+	prefix    string
+	cont      bool
+	timeout   float64
+	tries     int
+	userAgent string
 }
 
 // Run executes wget.
@@ -36,19 +45,26 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 	fs := command.NewFlagSet(c.Name(), "[OPTION]... URL...", stdio.Err).WithHelp(command.Help{
 		Description: "Download each URL over HTTP(S). By default the response is saved to a file " +
 			"named after the URL in the current directory; -O writes to a specific file, or to " +
-			"standard output when given -.",
+			"standard output when given -. -P chooses a destination directory and -c resumes a " +
+			"partial download.",
 		Examples: []command.Example{
 			{Command: "wget https://example.com/a.tar.gz", Explain: "Save to a.tar.gz in the current directory."},
-			{Command: "wget -O out.html https://example.com", Explain: "Save the response to out.html."},
+			{Command: "wget -P downloads https://example.com/a.tar.gz", Explain: "Save under the downloads/ directory."},
+			{Command: "wget -c https://example.com/big.iso", Explain: "Resume a partially downloaded file."},
 			{Command: "wget -O - https://example.com | grep title", Explain: "Stream the body to standard output."},
 		},
 		ExitStatus: "0  the download succeeded.\n1  a request failed or a file could not be written.",
 		Notes: []string{
-			"Only a subset of GNU wget options is supported (currently -O and -q).",
+			"A subset of GNU wget: -O, -q, -P, -c, -T (timeout), -t (tries), and --user-agent.",
 		},
 	})
 	output := fs.StringP("output-document", "O", "", "write documents to FILE (- for standard output)")
 	quiet := fs.BoolP("quiet", "q", false, "quiet (no output)")
+	prefix := fs.StringP("directory-prefix", "P", "", "save files to DIR")
+	cont := fs.BoolP("continue", "c", false, "resume getting a partially downloaded file")
+	timeout := fs.Float64P("timeout", "T", 0, "set the network timeout to SECONDS (0 = none)")
+	tries := fs.IntP("tries", "t", 1, "set the number of attempts to N")
+	userAgent := fs.String("user-agent", "", "identify as STRING to the HTTP server")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -61,8 +77,20 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		return command.SilentFailure()
 	}
 
-	opts := options{output: *output, quiet: *quiet}
+	opts := options{
+		output:    *output,
+		quiet:     *quiet,
+		prefix:    *prefix,
+		cont:      *cont,
+		timeout:   *timeout,
+		tries:     *tries,
+		userAgent: *userAgent,
+	}
+
 	client := &http.Client{}
+	if opts.timeout > 0 {
+		client.Timeout = time.Duration(opts.timeout * float64(time.Second))
+	}
 	return download(ctx, client, stdio, opts, urls)
 }
 
@@ -82,9 +110,45 @@ func download(ctx context.Context, client *http.Client, stdio command.IO, opts o
 	return firstErr
 }
 
-// fetch downloads a single URL and writes it to its destination (the file named
-// by -O, standard output when -O is "-", or a name derived from the URL path).
+// retryableErr marks an error as worth retrying (a network failure or a 5xx
+// response) so fetch can honor -t/--tries.
+type retryableErr struct{ err error }
+
+func (e *retryableErr) Error() string { return e.err.Error() }
+func (e *retryableErr) Unwrap() error { return e.err }
+
+func retryable(err error) error { return &retryableErr{err: err} }
+
+func isRetryable(err error) bool {
+	var re *retryableErr
+	return errors.As(err, &re)
+}
+
+// fetch downloads one URL, retrying transient failures up to opts.tries times.
 func fetch(ctx context.Context, client *http.Client, stdio command.IO, opts options, rawURL string) error {
+	attempts := opts.tries
+	if attempts < 1 {
+		attempts = 1
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		err := fetchOnce(ctx, client, stdio, opts, rawURL)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			return err
+		}
+	}
+	return lastErr
+}
+
+// fetchOnce performs a single download attempt, writing to the file named by -O,
+// to standard output when -O is "-", or to a name derived from the URL (placed
+// under -P when given). With -c it resumes an existing partial file via a Range
+// request.
+func fetchOnce(ctx context.Context, client *http.Client, stdio command.IO, opts options, rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return err
@@ -93,9 +157,25 @@ func fetch(ctx context.Context, client *http.Client, stdio command.IO, opts opti
 		return fmt.Errorf("invalid URL %q", rawURL)
 	}
 
+	dest := destination(opts, parsed)
+	toStdout := dest == "-"
+
+	var resumeFrom int64
+	if opts.cont && !toStdout {
+		if fi, statErr := os.Stat(dest); statErr == nil && fi.Size() > 0 {
+			resumeFrom = fi.Size()
+		}
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return err
+	}
+	if opts.userAgent != "" {
+		req.Header.Set("User-Agent", opts.userAgent)
+	}
+	if resumeFrom > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", resumeFrom))
 	}
 
 	if !opts.quiet {
@@ -104,63 +184,88 @@ func fetch(ctx context.Context, client *http.Client, stdio command.IO, opts opti
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return retryable(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	appendMode := false
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Server ignored the range (or none was sent): write from the start.
+	case http.StatusPartialContent:
+		appendMode = true
+	case http.StatusRequestedRangeNotSatisfiable:
+		// The local file already has the whole body.
+		return nil
+	default:
+		if resp.StatusCode >= 500 {
+			return retryable(fmt.Errorf("server returned %s", resp.Status))
+		}
 		return fmt.Errorf("server returned %s", resp.Status)
 	}
 
-	dest := destination(opts, parsed)
-	w, toStdout, err := openDest(stdio, dest)
+	w, closeFn, err := openDest(stdio, dest, appendMode)
 	if err != nil {
 		return err
 	}
 
-	n, err := io.Copy(w, resp.Body)
-	if !toStdout {
-		if cerr := w.(io.Closer).Close(); cerr != nil && err == nil {
-			err = cerr
+	n, copyErr := io.Copy(w, resp.Body)
+	if closeFn != nil {
+		if cerr := closeFn(); cerr != nil && copyErr == nil {
+			copyErr = cerr
 		}
 	}
-	if err != nil {
-		return err
+	if copyErr != nil {
+		return copyErr
 	}
 
 	if !opts.quiet {
 		if toStdout {
 			_, _ = fmt.Fprintf(stdio.Err, "wget: %d bytes written to standard output\n", n)
 		} else {
-			_, _ = fmt.Fprintf(stdio.Err, "wget: %q saved [%d]\n", dest, n)
+			_, _ = fmt.Fprintf(stdio.Err, "wget: %q saved [%d]\n", dest, resumeFrom+n)
 		}
 	}
 	return nil
 }
 
-// destination returns the local filename for a download, honoring -O and
-// falling back to the base name of the URL path (or "index.html").
+// destination returns the local path for a download, honoring -O (exact path)
+// and -P (a directory prefix for the URL-derived name).
 func destination(opts options, parsed *url.URL) string {
 	if opts.output != "" {
 		return opts.output
 	}
 	name := path.Base(parsed.Path)
 	if name == "" || name == "." || name == "/" {
-		return "index.html"
+		name = "index.html"
+	}
+	if opts.prefix != "" {
+		return filepath.Join(opts.prefix, name)
 	}
 	return name
 }
 
-// openDest returns the writer for dest. When dest is "-" the writer is
-// stdio.Out and toStdout is true; otherwise a file is created and the caller is
-// responsible (via the returned io.Closer) for closing it.
-func openDest(stdio command.IO, dest string) (io.Writer, bool, error) {
+// openDest returns the writer for dest and an optional close function. When dest
+// is "-" the writer is stdio.Out (no close); otherwise a file is created (its
+// parent directory is created as needed), opened for append when resuming.
+func openDest(stdio command.IO, dest string, appendMode bool) (io.Writer, func() error, error) {
 	if dest == "-" {
-		return stdio.Out, true, nil
+		return stdio.Out, nil, nil
 	}
-	f, err := os.Create(dest) //nolint:gosec // operating on a user-named file is the whole point
+	if dir := filepath.Dir(dest); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, nil, err
+		}
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if appendMode {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	f, err := os.OpenFile(dest, flags, 0o644) //nolint:gosec // operating on a user-named file is the whole point
 	if err != nil {
-		return nil, false, err
+		return nil, nil, err
 	}
-	return f, false, nil
+	return f, f.Close, nil
 }

--- a/internal/applets/shellutils/wget/wget_test.go
+++ b/internal/applets/shellutils/wget/wget_test.go
@@ -3,13 +3,16 @@ package wget_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/wget"
 	"github.com/nao1215/mimixbox/internal/command"
@@ -161,4 +164,121 @@ func asExitError(err error, target **command.ExitError) bool {
 		return true
 	}
 	return false
+}
+
+func TestDownloadDirectoryPrefix(t *testing.T) {
+	t.Parallel()
+	srv := newServer(t)
+	dir := t.TempDir()
+
+	if _, stderr, err := run(t, "-P", dir, srv.URL+"/file.txt"); err != nil {
+		t.Fatalf("Run error = %v (%s)", err, stderr)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "file.txt"))
+	if err != nil {
+		t.Fatalf("-P should write under the prefix dir: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("content = %q, want %q", got, body)
+	}
+}
+
+func TestDownloadUserAgent(t *testing.T) {
+	t.Parallel()
+	requireLoopback(t)
+	var gotUA atomic.Value
+	gotUA.Store("")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA.Store(r.Header.Get("User-Agent"))
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, stderr, err := run(t, "--user-agent", "MimixAgent/1.0", "-O", "-", srv.URL+"/f"); err != nil {
+		t.Fatalf("Run error = %v (%s)", err, stderr)
+	}
+	if ua := gotUA.Load().(string); ua != "MimixAgent/1.0" {
+		t.Errorf("server saw User-Agent %q, want %q", ua, "MimixAgent/1.0")
+	}
+}
+
+func TestDownloadContinueResumes(t *testing.T) {
+	t.Parallel()
+	requireLoopback(t)
+	const full = "0123456789ABCDEF"
+	var gotRange atomic.Value
+	gotRange.Store("")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHdr := r.Header.Get("Range")
+		gotRange.Store(rangeHdr)
+		if rangeHdr != "" {
+			var start int
+			_, _ = fmt.Sscanf(rangeHdr, "bytes=%d-", &start)
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, len(full)-1, len(full)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte(full[start:]))
+			return
+		}
+		_, _ = w.Write([]byte(full))
+	}))
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.bin")
+	// Pretend the first 5 bytes were already downloaded.
+	if err := os.WriteFile(dest, []byte(full[:5]), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, stderr, err := run(t, "-c", "-O", dest, srv.URL+"/big"); err != nil {
+		t.Fatalf("Run error = %v (%s)", err, stderr)
+	}
+
+	if r := gotRange.Load().(string); r != "bytes=5-" {
+		t.Errorf("server saw Range %q, want %q", r, "bytes=5-")
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != full {
+		t.Errorf("resumed file = %q, want %q", got, full)
+	}
+}
+
+func TestDownloadTimeout(t *testing.T) {
+	t.Parallel()
+	requireLoopback(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(2 * time.Second):
+			_, _ = w.Write([]byte(body))
+		case <-r.Context().Done(): // client gave up; return promptly
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := run(t, "-T", "0.1", "-O", "-", srv.URL+"/slow")
+	if err == nil {
+		t.Errorf("-T 0.1 against a slow server should fail")
+	}
+}
+
+func TestDownloadRetries(t *testing.T) {
+	t.Parallel()
+	requireLoopback(t)
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, _, err := run(t, "-t", "3", "-O", "-", srv.URL+"/fail"); err == nil {
+		t.Errorf("a persistently failing server should make wget fail")
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Errorf("server was hit %d times, want 3 (the -t value)", got)
+	}
 }

--- a/test/it/spec/wget_spec.sh
+++ b/test/it/spec/wget_spec.sh
@@ -10,4 +10,13 @@ Describe 'wget CLI contract'
         The status should be failure
         The error should include 'wget'
     End
+    It 'documents the added download options'
+        When call WgetHelp
+        The status should be success
+        The output should include '--directory-prefix'
+        The output should include '--continue'
+        The output should include '--timeout'
+        The output should include '--tries'
+        The output should include '--user-agent'
+    End
 End


### PR DESCRIPTION
## Summary

`wget` only exposed `-O` and `-q`. This adds the most common options expected of a wget replacement, on the `internal/command` framework with GNU-compatible names.

## Options added

- `-P, --directory-prefix=DIR`: save the URL-derived file under DIR (the directory is created as needed).
- `-c, --continue`: resume a partial download — if the destination file already has bytes, wget sends a `Range: bytes=N-` request and appends the rest (handling 206 Partial Content, and 416/200 correctly).
- `-T, --timeout=SECONDS`: set the HTTP client timeout.
- `-t, --tries=N`: retry transient failures (network errors and 5xx) up to N attempts.
- `--user-agent=STRING`: set the User-Agent header.
- The default output name is still derived from the URL when `-O` is absent (now also honoring `-P`).

## Tests

- Unit (table-driven, hermetic via `httptest` + the existing `requireLoopback` skip): `-P` writes into the prefix dir; `-c` resumes from a partial file and the server receives `Range: bytes=5-`; `-T 0.1` against a deliberately slow handler fails; `-t 3` hits a persistently-failing server exactly 3 times before failing; `--user-agent` reaches the server. Existing `-O`/`-q`/404 tests still pass.
- shellspec (`wget_spec.sh`): asserts the new options appear in `--help` (the real download paths are covered hermetically by the unit tests, so the E2E stays network-free).

## Verification

- `go test ./...` passes; `make test-e2e` passes (449 examples, 0 failures); `golangci-lint` clean.

Closes #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `wget` now supports `--directory-prefix` to save downloads to a specified directory
  * Added `--continue` option to resume interrupted downloads
  * Added `--timeout` option to set request timeouts
  * Added `--tries` option to configure retry attempts for failed downloads
  * Added `--user-agent` option to set custom User-Agent headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->