### PR TITLE
fix(wget): validate resume Content-Range and retry mid-transfer failures

### DIFF
--- a/internal/applets/shellutils/wget/wget.go
+++ b/internal/applets/shellutils/wget/wget.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -193,6 +194,16 @@ func fetchOnce(ctx context.Context, client *http.Client, stdio command.IO, opts 
 	case http.StatusOK:
 		// Server ignored the range (or none was sent): write from the start.
 	case http.StatusPartialContent:
+		// Only append when the server confirms it is resuming from exactly the
+		// byte we asked for; a mismatched Content-Range would corrupt the file.
+		if resumeFrom <= 0 {
+			return fmt.Errorf("server returned %s without a resume request", resp.Status)
+		}
+		var start, end, total int64
+		cr := resp.Header.Get("Content-Range")
+		if _, scanErr := fmt.Sscanf(cr, "bytes %d-%d/%d", &start, &end, &total); scanErr != nil || start != resumeFrom {
+			return fmt.Errorf("unexpected Content-Range %q for resume offset %d", cr, resumeFrom)
+		}
 		appendMode = true
 	case http.StatusRequestedRangeNotSatisfiable:
 		// The local file already has the whole body.
@@ -216,6 +227,13 @@ func fetchOnce(ctx context.Context, client *http.Client, stdio command.IO, opts 
 		}
 	}
 	if copyErr != nil {
+		// A failure partway through the body is transient, so let -t/--tries
+		// retry it (the next attempt resumes from the larger file under -c, or
+		// restarts from scratch otherwise).
+		var nerr net.Error
+		if errors.As(copyErr, &nerr) || errors.Is(copyErr, io.ErrUnexpectedEOF) || errors.Is(copyErr, context.DeadlineExceeded) {
+			return retryable(copyErr)
+		}
 		return copyErr
 	}
 

--- a/internal/applets/shellutils/wget/wget_test.go
+++ b/internal/applets/shellutils/wget/wget_test.go
@@ -282,3 +282,28 @@ func TestDownloadRetries(t *testing.T) {
 		t.Errorf("server was hit %d times, want 3 (the -t value)", got)
 	}
 }
+
+func TestDownloadContinueRejectsBadContentRange(t *testing.T) {
+	t.Parallel()
+	requireLoopback(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Claim a range starting at 0 even though byte 5 was requested.
+		w.Header().Set("Content-Range", "bytes 0-15/16")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("WRONGDATA"))
+	}))
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.bin")
+	if err := os.WriteFile(dest, []byte("01234"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := run(t, "-c", "-O", dest, srv.URL+"/big"); err == nil {
+		t.Errorf("a mismatched Content-Range should fail, not corrupt the file")
+	}
+	if got, _ := os.ReadFile(dest); string(got) != "01234" {
+		t.Errorf("partial file was modified to %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses two Major issues CodeRabbit raised on #225:

1. **Resume could corrupt the file.** A `206 Partial Content` response switched to append mode without checking that the server actually resumed from the requested offset. A server that returned a different `Content-Range` would have its bytes appended at the wrong position. `fetchOnce` now parses `Content-Range` and only appends when its start equals the resume offset (and rejects a 206 that arrives without a resume request); otherwise it errors without touching the local file.

2. **`-t/--tries` skipped mid-transfer failures.** Errors from `io.Copy` (a connection dropped partway through the body) were returned directly, so they were treated as non-retryable. They are now wrapped as retryable when they are `net.Error`, `io.ErrUnexpectedEOF`, or `context.DeadlineExceeded`, so `-t` retries them — resuming from the larger file under `-c`, or restarting otherwise.

## Tests

- Add `TestDownloadContinueRejectsBadContentRange`: a server that lies about its `Content-Range` makes wget fail and leaves the partial file untouched.
- Existing resume/retry/timeout tests still pass (the resume test sends a correct `Content-Range`).

## Verification

- `go test ./...` passes; `golangci-lint` clean.