### PR TITLE
fix(mbsh): share stdin position so launched commands read remaining input

### DIFF
--- a/internal/applets/shellutils/mbsh/mbsh.go
+++ b/internal/applets/shellutils/mbsh/mbsh.go
@@ -10,7 +10,6 @@
 package mbsh
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -66,11 +65,19 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 	}
 
 	sh := &shell{}
-	reader := bufio.NewReader(stdio.In)
+	// Read commands one byte at a time rather than through a buffered reader.
+	// A buffered reader would read past the current line, so a command launched
+	// below (which shares stdio.In) would see EOF instead of the bytes still
+	// sitting in the shell's buffer. Reading byte by byte leaves stdio.In
+	// positioned exactly after the line, which is what POSIX shells do when
+	// their input is a non-seekable stream. In script mode this means a
+	// stdin-consuming command (cat, sed, ...) reads the rest of the script, just
+	// as it would under any other shell; in interactive mode each Enter yields
+	// one line and the foreground command shares the terminal.
 	for {
 		_, _ = fmt.Fprint(stdio.Out, sh.prompt())
 
-		line, err := reader.ReadString('\n')
+		line, err := readLine(stdio.In)
 		if err != nil {
 			// Run whatever was read before EOF (a final line without a
 			// trailing newline), then stop the loop cleanly.
@@ -88,6 +95,27 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 
 		if stop := sh.execInput(ctx, stdio, line); stop {
 			return nil
+		}
+	}
+}
+
+// readLine reads a single line (including the trailing newline) from r without
+// reading any further, so r is left positioned exactly after the line. The
+// returned error is io.EOF when the stream ends; any bytes read before EOF are
+// still returned so a final line without a newline is executed.
+func readLine(r io.Reader) (string, error) {
+	var b strings.Builder
+	buf := make([]byte, 1)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			b.WriteByte(buf[0])
+			if buf[0] == '\n' {
+				return b.String(), nil
+			}
+		}
+		if err != nil {
+			return b.String(), err
 		}
 	}
 }

--- a/internal/applets/shellutils/mbsh/mbsh_test.go
+++ b/internal/applets/shellutils/mbsh/mbsh_test.go
@@ -13,15 +13,28 @@ import (
 	"github.com/nao1215/mimixbox/internal/command"
 )
 
-// run drives the REPL with script as its input and returns stdout, stderr and
-// the Run error.
+// run drives the REPL with script delivered through an os.Pipe, so stdio.In is
+// a real *os.File and a command launched by the shell shares the same file
+// descriptor — the configuration a piped script has in production. (A strings
+// reader would not work here: os/exec read-aheads a non-*os.File stdin, racily
+// consuming the script before a non-reading command exits.) It returns stdout,
+// stderr and the Run error.
 func run(t *testing.T, script string) (string, string, error) {
 	t.Helper()
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_, _ = pw.WriteString(script)
+		_ = pw.Close()
+	}()
 	out := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
-	stdio := command.IO{In: strings.NewReader(script), Out: out, Err: errBuf}
-	err := mbsh.New().Run(context.Background(), stdio, nil)
-	return out.String(), errBuf.String(), err
+	stdio := command.IO{In: pr, Out: out, Err: errBuf}
+	rerr := mbsh.New().Run(context.Background(), stdio, nil)
+	_ = pr.Close()
+	return out.String(), errBuf.String(), rerr
 }
 
 func TestRunExecutesExternalCommand(t *testing.T) {
@@ -219,30 +232,6 @@ func TestHelp(t *testing.T) {
 	}
 }
 
-// runPipe drives the REPL with script delivered through an os.Pipe, so stdio.In
-// is a real *os.File and a command launched by the shell shares the same file
-// descriptor. This is the configuration that exercises stdin hand-off the way a
-// piped script does in production.
-func runPipe(t *testing.T, script string) (string, string) {
-	t.Helper()
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	go func() {
-		_, _ = pw.WriteString(script)
-		_ = pw.Close()
-	}()
-	out := &bytes.Buffer{}
-	errBuf := &bytes.Buffer{}
-	stdio := command.IO{In: pr, Out: out, Err: errBuf}
-	if rerr := mbsh.New().Run(context.Background(), stdio, nil); rerr != nil {
-		t.Fatalf("Run error = %v (stderr=%q)", rerr, errBuf.String())
-	}
-	_ = pr.Close()
-	return out.String(), errBuf.String()
-}
-
 func requireCmd(t *testing.T, name string) {
 	t.Helper()
 	if _, err := exec.LookPath(name); err != nil {
@@ -252,7 +241,7 @@ func requireCmd(t *testing.T, name string) {
 
 func TestCatConsumesRemainingScriptInput(t *testing.T) {
 	requireCmd(t, "cat")
-	out, errOut := runPipe(t, "cat\nhello\nexit\n")
+	out, errOut, _ := run(t, "cat\nhello\nexit\n")
 	if !strings.Contains(out, "hello") {
 		t.Errorf("cat should print the remaining input; stdout = %q", out)
 	}
@@ -264,7 +253,7 @@ func TestCatConsumesRemainingScriptInput(t *testing.T) {
 
 func TestNonStdinCommandsRunInSequence(t *testing.T) {
 	requireCmd(t, "echo")
-	out, _ := runPipe(t, "echo first\necho second\nexit\n")
+	out, _, _ := run(t, "echo first\necho second\nexit\n")
 	if !strings.Contains(out, "first") || !strings.Contains(out, "second") {
 		t.Errorf("a command that ignores stdin must not swallow the next line; stdout = %q", out)
 	}
@@ -275,7 +264,7 @@ func TestPartialStdinConsumptionNoByteLoss(t *testing.T) {
 	requireCmd(t, "cat")
 	// echo ignores stdin and runs; then cat consumes exactly the remaining
 	// lines with no loss or duplication.
-	out, _ := runPipe(t, "echo top\ncat\nr1\nr2\nexit\n")
+	out, _, _ := run(t, "echo top\ncat\nr1\nr2\nexit\n")
 	for _, want := range []string{"top", "r1", "r2"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("stdout = %q, want it to contain %q", out, want)

--- a/internal/applets/shellutils/mbsh/mbsh_test.go
+++ b/internal/applets/shellutils/mbsh/mbsh_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -215,5 +216,69 @@ func TestHelp(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "mbsh:") {
 		t.Errorf("--help should not print a prompt: %q", out.String())
+	}
+}
+
+// runPipe drives the REPL with script delivered through an os.Pipe, so stdio.In
+// is a real *os.File and a command launched by the shell shares the same file
+// descriptor. This is the configuration that exercises stdin hand-off the way a
+// piped script does in production.
+func runPipe(t *testing.T, script string) (string, string) {
+	t.Helper()
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_, _ = pw.WriteString(script)
+		_ = pw.Close()
+	}()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	stdio := command.IO{In: pr, Out: out, Err: errBuf}
+	if rerr := mbsh.New().Run(context.Background(), stdio, nil); rerr != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", rerr, errBuf.String())
+	}
+	_ = pr.Close()
+	return out.String(), errBuf.String()
+}
+
+func requireCmd(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s not on PATH: %v", name, err)
+	}
+}
+
+func TestCatConsumesRemainingScriptInput(t *testing.T) {
+	requireCmd(t, "cat")
+	out, errOut := runPipe(t, "cat\nhello\nexit\n")
+	if !strings.Contains(out, "hello") {
+		t.Errorf("cat should print the remaining input; stdout = %q", out)
+	}
+	// The remaining input must be consumed by cat, not re-parsed as commands.
+	if strings.Contains(errOut, "not a mimixbox command") || strings.Contains(errOut, "command not found") {
+		t.Errorf("remaining stdin was reparsed as commands; stderr = %q", errOut)
+	}
+}
+
+func TestNonStdinCommandsRunInSequence(t *testing.T) {
+	requireCmd(t, "echo")
+	out, _ := runPipe(t, "echo first\necho second\nexit\n")
+	if !strings.Contains(out, "first") || !strings.Contains(out, "second") {
+		t.Errorf("a command that ignores stdin must not swallow the next line; stdout = %q", out)
+	}
+}
+
+func TestPartialStdinConsumptionNoByteLoss(t *testing.T) {
+	requireCmd(t, "echo")
+	requireCmd(t, "cat")
+	// echo ignores stdin and runs; then cat consumes exactly the remaining
+	// lines with no loss or duplication.
+	out, _ := runPipe(t, "echo top\ncat\nr1\nr2\nexit\n")
+	for _, want := range []string{"top", "r1", "r2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout = %q, want it to contain %q", out, want)
+		}
 	}
 }

--- a/test/it/shellutils/mbsh_test.sh
+++ b/test/it/shellutils/mbsh_test.sh
@@ -23,3 +23,15 @@ TestMbshCd() {
     export TEST_DIR=/tmp/mimixbox/it/mbsh
     printf 'cd %s\npwd\nexit\n' "${TEST_DIR}" | mbsh 2>/dev/null
 }
+
+TestMbshCatConsumesInput() {
+    printf 'cat\nhello\nexit\n' | mbsh 2>/dev/null
+}
+
+TestMbshNoReparse() {
+    err=$(printf 'cat\nhello\nexit\n' | mbsh 2>&1 >/dev/null)
+    case "${err}" in
+        *"not a mimixbox command"*) echo reparsed ;;
+        *) echo ok ;;
+    esac
+}

--- a/test/it/spec/mbsh_spec.sh
+++ b/test/it/spec/mbsh_spec.sh
@@ -17,6 +17,16 @@ Describe 'mbsh'
         The output should include 'status=1'
         The status should be success
     End
+    It 'lets a stdin-consuming command read the remaining script input'
+        When call TestMbshCatConsumesInput
+        The output should include 'hello'
+        The status should be success
+    End
+    It 'does not reparse command-consumed stdin as later commands'
+        When call TestMbshNoReparse
+        The output should equal 'ok'
+        The status should be success
+    End
 End
 
 Describe 'mbsh cd'


### PR DESCRIPTION
## Summary

`mbsh` read command lines through a `bufio.Reader`, but launched commands were given `cmd.Stdin = stdio.In`. The buffered reader read past the current line, so a command that consumed stdin (`cat`, `sed`, ...) saw EOF while the bytes it should have read were stuck in the shell's buffer — and the shell then reparsed them as later commands:

```
$ printf 'cat\nhello\nexit\n' | mbsh
... mimixbox: "hello" is not a mimixbox command or option
```

## Fix

Read command lines one byte at a time instead of through a buffered reader, so `stdio.In` is left positioned exactly after each line — which is what POSIX shells do when their input is a non-seekable stream. Because the launched command already shares `stdio.In` (an `*os.File` in production, passed straight through by `os/exec` with no read-ahead), it now reads the remaining input, and the shell resumes from the correct position afterwards. The intended script-vs-interactive semantics are documented in the loop.

A command that does not read stdin (`echo`) leaves the stream untouched, so the next line still runs — no byte loss either way.

## Tests

- Unit (`internal/applets/shellutils/mbsh`), driven through an `os.Pipe` so `stdio.In` is a real `*os.File`: `cat` consumes the remaining script input and it is not reparsed; two `echo`s run in sequence; `echo` then `cat` consumes exactly the rest with no loss.
- shellspec (`mbsh_spec.sh`): `printf 'cat\nhello\nexit\n' | mbsh` prints `hello` and no longer emits a "not a mimixbox command" error for the consumed input.

## Verification

- `go test ./...` passes; `make test-e2e` passes (451 examples, 0 failures); `golangci-lint` clean.

Closes #233