### PR TITLE
fix(vi): decode terminal escape sequences instead of running them as commands

### DIFF
--- a/internal/applets/editors/vi/editor.go
+++ b/internal/applets/editors/vi/editor.go
@@ -24,7 +24,23 @@ type editor struct {
 	quit     bool   // set when the editor should stop
 	save     bool   // set when the buffer should be written on quit
 	message  string // status message (e.g. for :q with unsaved changes)
+
+	// Terminal escape-sequence decoding state. Arrow keys and similar keys
+	// arrive as multi-byte sequences (ESC [ A, ...); decoding them here keeps
+	// the trailing byte from being mistaken for an editing command.
+	escSt  escState
+	csiBuf []byte // parameter/intermediate bytes of a CSI sequence
 }
+
+// escState tracks where we are in decoding a terminal escape sequence.
+type escState int
+
+const (
+	escNone   escState = iota // not in a sequence
+	escGotEsc                 // saw ESC; the next byte decides
+	escCSI                    // saw ESC [ ; collecting until a final byte
+	escSS3                    // saw ESC O ; the next byte is the key
+)
 
 // newEditor builds an editor over the given file contents.
 func newEditor(filename, content string) *editor {
@@ -40,8 +56,54 @@ func (e *editor) content() string {
 	return strings.Join(e.lines, "\n") + "\n"
 }
 
-// feed processes one input byte according to the current mode.
+const esc = 0x1b
+
+// feed processes one input byte, first decoding terminal escape sequences
+// (arrow keys, Home/End, Delete, ...) into editor actions so their trailing
+// byte is never mistaken for an editing command, then dispatching ordinary keys
+// to the current mode.
 func (e *editor) feed(b byte) {
+	switch e.escSt {
+	case escGotEsc:
+		e.escSt = escNone
+		switch b {
+		case '[':
+			e.escSt = escCSI
+			e.csiBuf = e.csiBuf[:0]
+		case 'O':
+			e.escSt = escSS3
+		default:
+			// A lone ESC (not the start of a sequence): apply it, then process
+			// this byte normally.
+			e.handleEsc()
+			e.dispatch(b)
+		}
+		return
+	case escCSI:
+		// A CSI sequence ends at a final byte in 0x40..0x7e; earlier bytes are
+		// parameters/intermediates.
+		if b >= 0x40 && b <= 0x7e {
+			e.escSt = escNone
+			e.decodeCSI(append(e.csiBuf, b))
+		} else {
+			e.csiBuf = append(e.csiBuf, b)
+		}
+		return
+	case escSS3:
+		e.escSt = escNone
+		e.decodeArrow(b)
+		return
+	}
+
+	if b == esc {
+		e.escSt = escGotEsc
+		return
+	}
+	e.dispatch(b)
+}
+
+// dispatch routes an ordinary (non-escape) byte to the current mode.
+func (e *editor) dispatch(b byte) {
 	switch e.mode {
 	case modeInsert:
 		e.feedInsert(b)
@@ -52,14 +114,80 @@ func (e *editor) feed(b byte) {
 	}
 }
 
-// feedString feeds every byte of s in order (handy for tests and batch mode).
+// handleEsc applies a standalone Escape key: it leaves insert/command mode for
+// normal mode (a no-op when already in normal mode).
+func (e *editor) handleEsc() {
+	switch e.mode {
+	case modeInsert:
+		e.mode = modeNormal
+		if e.cx > 0 {
+			e.cx--
+		}
+	case modeCommand:
+		e.mode = modeNormal
+		e.cmdline = ""
+	}
+}
+
+// decodeCSI turns a CSI sequence (the bytes after ESC [) into a cursor motion
+// or edit. Unknown sequences are ignored so they can never mutate the buffer in
+// surprising ways.
+func (e *editor) decodeCSI(seq []byte) {
+	if len(seq) == 0 {
+		return
+	}
+	final := seq[len(seq)-1]
+	param := string(seq[:len(seq)-1])
+	switch final {
+	case 'A', 'B', 'C', 'D', 'H', 'F':
+		e.decodeArrow(final)
+	case '~':
+		switch param {
+		case "1", "7": // Home
+			e.cx = 0
+		case "4", "8": // End
+			e.cx = lastCol(e.lines[e.cy])
+		case "3": // Delete
+			e.deleteRune()
+		}
+	}
+}
+
+// decodeArrow maps a final byte shared by CSI and SS3 cursor keys to a motion.
+func (e *editor) decodeArrow(final byte) {
+	switch final {
+	case 'A':
+		e.moveUp()
+	case 'B':
+		e.moveDown()
+	case 'C':
+		e.moveRight()
+	case 'D':
+		e.moveLeft()
+	case 'H': // Home
+		e.cx = 0
+	case 'F': // End
+		e.cx = lastCol(e.lines[e.cy])
+	}
+}
+
+// flush resolves any pending escape state at end of input: a lone trailing ESC
+// is applied, and an incomplete sequence is dropped.
+func (e *editor) flush() {
+	if e.escSt == escGotEsc {
+		e.handleEsc()
+	}
+	e.escSt = escNone
+}
+
+// feedString feeds every byte of s in order (handy for tests and batch mode),
+// then flushes any pending escape state.
 func (e *editor) feedString(s string) {
 	for i := 0; i < len(s) && !e.quit; i++ {
 		e.feed(s[i])
 	}
+	e.flush()
 }
-
-const esc = 0x1b
 
 // feedNormal handles a key in normal mode.
 func (e *editor) feedNormal(b byte) {
@@ -119,14 +247,10 @@ func (e *editor) feedNormal(b byte) {
 	}
 }
 
-// feedInsert handles a key in insert mode.
+// feedInsert handles a key in insert mode. Escape is decoded earlier (see feed
+// and handleEsc), so it never reaches here.
 func (e *editor) feedInsert(b byte) {
 	switch b {
-	case esc:
-		e.mode = modeNormal
-		if e.cx > 0 {
-			e.cx--
-		}
 	case '\r', '\n':
 		e.splitLine()
 	case 0x7f, 0x08: // DEL / backspace
@@ -141,9 +265,6 @@ func (e *editor) feedCommand(b byte) {
 	switch b {
 	case '\r', '\n':
 		e.runExCommand(e.cmdline)
-		e.mode = modeNormal
-		e.cmdline = ""
-	case esc:
 		e.mode = modeNormal
 		e.cmdline = ""
 	case 0x7f, 0x08:

--- a/internal/applets/editors/vi/editor_test.go
+++ b/internal/applets/editors/vi/editor_test.go
@@ -147,8 +147,8 @@ func TestSplitAndBackspace(t *testing.T) {
 
 	// Backspace joining: on line 2 col 0, insert-mode backspace joins lines.
 	e2 := newEditor("f", "ab\ncd")
-	e2.feedString("j")  // line 2
-	e2.feedString("i")  // insert at col 0
+	e2.feedString("j")    // line 2
+	e2.feedString("i")    // insert at col 0
 	e2.feedString("\x7f") // backspace -> join
 	if len(e2.lines) != 1 || e2.lines[0] != "abcd" {
 		t.Errorf("after join lines = %v, want [abcd]", e2.lines)
@@ -309,5 +309,100 @@ func TestRunInteractiveFallsBackOnPipe(t *testing.T) {
 	}
 	if !e.save || !e.quit {
 		t.Errorf("batch fallback should have run :wq (save=%v quit=%v)", e.save, e.quit)
+	}
+}
+
+func TestEscapeArrowsMoveCursor(t *testing.T) {
+	t.Parallel()
+	e := drive("abc\ndef", "\x1b[B\x1b[C\x1b[C") // Down, Right, Right
+	if e.cy != 1 || e.cx != 2 {
+		t.Errorf("after Down,Right,Right cursor = (%d,%d), want (1,2)", e.cy, e.cx)
+	}
+	e.feedString("\x1b[A\x1b[D") // Up, Left
+	if e.cy != 0 || e.cx != 1 {
+		t.Errorf("after Up,Left cursor = (%d,%d), want (0,1)", e.cy, e.cx)
+	}
+	if e.mode != modeNormal {
+		t.Errorf("arrows must not change mode, mode = %s", modeName(e.mode))
+	}
+	if e.dirty {
+		t.Errorf("arrows must not modify the buffer")
+	}
+}
+
+// TestEscapeUpArrowDoesNotAppend is the issue #235 regression: ESC [ A (Up)
+// must move/ignore, never let its trailing 'A' trigger append/insert.
+func TestEscapeUpArrowDoesNotAppend(t *testing.T) {
+	t.Parallel()
+	e := drive("abc", "\x1b[A")
+	if e.mode != modeNormal {
+		t.Errorf("ESC[A switched to %s mode; it must stay normal", modeName(e.mode))
+	}
+	if e.dirty || e.lines[0] != "abc" {
+		t.Errorf("ESC[A modified the buffer: dirty=%v lines=%q", e.dirty, e.lines)
+	}
+}
+
+func TestEscapeHomeEndDelete(t *testing.T) {
+	t.Parallel()
+	e := drive("hello", "\x1b[F") // End
+	if e.cx != lastCol("hello") {
+		t.Errorf("End: cx = %d, want %d", e.cx, lastCol("hello"))
+	}
+	e.feedString("\x1b[H") // Home
+	if e.cx != 0 {
+		t.Errorf("Home: cx = %d, want 0", e.cx)
+	}
+	e.feedString("\x1b[1~") // Home (numbered form)
+	if e.cx != 0 {
+		t.Errorf("Home (1~): cx = %d, want 0", e.cx)
+	}
+	e.feedString("\x1b[3~") // Delete the char under the cursor
+	if e.lines[0] != "ello" {
+		t.Errorf("Delete: line = %q, want %q", e.lines[0], "ello")
+	}
+}
+
+func TestEscapeUnknownAndIncompleteIgnored(t *testing.T) {
+	t.Parallel()
+	// Unknown final byte.
+	e := drive("abc", "\x1b[Z")
+	if e.dirty || e.mode != modeNormal || e.lines[0] != "abc" {
+		t.Errorf("unknown CSI mutated state: dirty=%v mode=%s lines=%q", e.dirty, modeName(e.mode), e.lines)
+	}
+	// Incomplete sequence (just ESC [) is dropped on flush.
+	e = drive("abc", "\x1b[")
+	if e.dirty || e.mode != modeNormal || e.lines[0] != "abc" {
+		t.Errorf("incomplete CSI mutated state: dirty=%v mode=%s", e.dirty, modeName(e.mode))
+	}
+	// A lone trailing ESC is harmless.
+	e = drive("abc", "\x1b")
+	if e.dirty || e.mode != modeNormal {
+		t.Errorf("lone ESC mutated state: dirty=%v mode=%s", e.dirty, modeName(e.mode))
+	}
+}
+
+// TestEscapeSequenceThenCommand reproduces the full issue #235 scenario:
+// ESC[A ! ESC :wq must leave the buffer unchanged and save it.
+func TestEscapeSequenceThenCommand(t *testing.T) {
+	t.Parallel()
+	e := drive("abc", "\x1b[A!\x1b:wq\r")
+	if e.content() != "abc\n" {
+		t.Errorf("content = %q, want %q (no spurious append)", e.content(), "abc\n")
+	}
+	if !e.save || !e.quit {
+		t.Errorf("the :wq must still save and quit (save=%v quit=%v)", e.save, e.quit)
+	}
+}
+
+func TestEscapeSS3Arrows(t *testing.T) {
+	t.Parallel()
+	// Some terminals send cursor keys as SS3 (ESC O A) rather than CSI.
+	e := drive("abc\ndef", "\x1bOB\x1bOC") // Down, Right
+	if e.cy != 1 || e.cx != 1 {
+		t.Errorf("SS3 Down,Right cursor = (%d,%d), want (1,1)", e.cy, e.cx)
+	}
+	if e.dirty || e.mode != modeNormal {
+		t.Errorf("SS3 arrows mutated state: dirty=%v mode=%s", e.dirty, modeName(e.mode))
 	}
 }

--- a/internal/applets/editors/vi/vi.go
+++ b/internal/applets/editors/vi/vi.go
@@ -137,6 +137,7 @@ func runInteractive(stdio command.IO, ed *editor) {
 		}
 		ed.feed(buf[0])
 	}
+	ed.flush()
 	redraw(stdio.Out, ed)
 }
 

--- a/test/it/editors/vi_test.sh
+++ b/test/it/editors/vi_test.sh
@@ -23,3 +23,11 @@ TestViNewFile() {
     printf 'icreated\033:wq\r' | vi ${TEST_DIR}/new.txt
     printf '%s' "$(< ${TEST_DIR}/new.txt)"
 }
+
+TestViArrowNoAppend() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    # Up-arrow (ESC [ A) must not be treated as 'A' (append); the file with the
+    # following '!' must stay unchanged after :wq.
+    printf '\033[A!\033:wq\r' | vi ${TEST_DIR}/a.txt
+    printf '%s' "$(< ${TEST_DIR}/a.txt)"
+}

--- a/test/it/spec/vi_spec.sh
+++ b/test/it/spec/vi_spec.sh
@@ -19,4 +19,10 @@ world'
         The output should equal 'created'
         The status should be success
     End
+    It 'treats an arrow-key escape sequence as a motion, not an edit'
+        When call TestViArrowNoAppend
+        The output should equal 'hello
+world'
+        The status should be success
+    End
 End


### PR DESCRIPTION
## Summary

Interactive `vi` fed raw bytes straight into the normal-mode keymap, so terminal escape sequences were not decoded. An arrow key arrives as `ESC [ A`; `ESC` and `[` were ignored and the trailing `A` was run as "append at end of line", switching to insert mode and mutating the file:

```
$ printf 'abc\n' > /tmp/a.txt
$ printf '\033[A!\033:wq\r' | vi /tmp/a.txt
$ cat /tmp/a.txt
abc!
```

## Fix

Add a small escape-sequence decoder in front of the keymap (`editor.feed`). It recognizes ESC, then a CSI (`ESC [`) or SS3 (`ESC O`) introducer, collects the sequence, and turns it into a cursor motion or edit before any byte reaches the mode dispatch:

- Up/Down/Left/Right (CSI and SS3 forms), Home (`H`, `1~`, `7~`), End (`F`, `4~`, `8~`), and Delete (`3~`).
- A lone ESC still leaves insert/command mode (handled in one place, `handleEsc`).
- Unknown or incomplete sequences are dropped, so an escape sequence can never trigger an unrelated editing command or mutate the buffer.

Batch and interactive input flush any pending escape state at end of input.

## Tests

- Unit (`internal/applets/editors/vi`): arrows move the cursor without changing mode or the buffer; the issue's exact `ESC[A!ESC:wq` scenario leaves the buffer unchanged and still saves; Home/End/Delete; SS3 arrows; and unknown/incomplete/lone-ESC sequences are ignored.
- shellspec (`vi_spec.sh`): feeding `ESC[A` to a file leaves it unchanged after `:wq`.

## Verification

- `go test ./...` passes; `make test-e2e` passes (452 examples, 0 failures); `golangci-lint` clean.

Closes #235