### PR TITLE
feat(mbsh): add quoted tokenization, parameter expansion, and env prefixes

### DIFF
--- a/internal/applets/shellutils/mbsh/mbsh.go
+++ b/internal/applets/shellutils/mbsh/mbsh.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh/builtin"
@@ -55,8 +54,8 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 			{Command: "echo 'echo hello' | mbsh", Explain: "Run commands fed on standard input."},
 		},
 		Notes: []string{
-			"Whitespace splits tokens; quoting, parameter expansion, pipelines, and redirections are not yet supported.",
-			"Each line runs one applet; there is no scripting (if/for/while) or variable assignment.",
+			"Tokenizing supports single/double quotes, backslash escapes, $VAR/${VAR}/$? expansion, ~ home expansion, and NAME=value prefixes.",
+			"Each line runs one command; pipelines, redirections, and scripting (if/for/while) are not yet supported.",
 		},
 	})
 	proceed, err := fs.Parse(stdio, args)
@@ -144,11 +143,36 @@ func (sh *shell) execInput(ctx context.Context, stdio command.IO, input string) 
 		return false
 	}
 
-	// Expand $? to the previous command's exit status before splitting.
-	input = strings.ReplaceAll(input, "$?", strconv.Itoa(sh.lastStatus))
+	// Tokenize with quote handling, backslash escapes, and $VAR/${VAR}/$?/~
+	// expansion (see parser.go).
+	toks, err := tokenize(input, sh.lastStatus)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
+		sh.lastStatus = 2
+		return false
+	}
 
-	args := strings.Fields(input)
+	// Leading NAME=value words are temporary environment assignments for the
+	// command; the rest are the command and its arguments.
+	var env []string
+	idx := 0
+	for idx < len(toks) && toks[idx].assignKey != "" {
+		env = append(env, toks[idx].assignKey+"="+toks[idx].assignVal)
+		idx++
+	}
+	args := make([]string, 0, len(toks)-idx)
+	for ; idx < len(toks); idx++ {
+		args = append(args, toks[idx].value)
+	}
+
 	if len(args) == 0 {
+		// A line of only assignments (FOO=bar) sets them for the session.
+		for _, kv := range env {
+			if k, v, ok := strings.Cut(kv, "="); ok {
+				_ = os.Setenv(k, v)
+			}
+		}
+		sh.lastStatus = 0
 		return false
 	}
 
@@ -168,32 +192,36 @@ func (sh *shell) execInput(ctx context.Context, stdio command.IO, input string) 
 		return false
 	}
 
-	sh.lastStatus = sh.runExternal(ctx, stdio, args)
+	sh.lastStatus = sh.runExternal(ctx, stdio, args, env)
 	return false
 }
 
 // runExternal runs args[0] as an external program, falling back to running it as
 // a MimixBox applet (by re-executing this binary) when it is not on the PATH.
 // It returns the command's exit status.
-func (sh *shell) runExternal(ctx context.Context, stdio command.IO, args []string) int {
+func (sh *shell) runExternal(ctx context.Context, stdio command.IO, args, env []string) int {
 	name := args[0]
 	if _, err := exec.LookPath(name); err != nil {
 		if self, e := os.Executable(); e == nil {
-			return run(ctx, stdio, self, append([]string{name}, args[1:]...))
+			return run(ctx, stdio, self, append([]string{name}, args[1:]...), env)
 		}
 		_, _ = fmt.Fprintf(stdio.Err, "mbsh: %s: command not found\n", name)
 		return 127
 	}
-	return run(ctx, stdio, name, args[1:])
+	return run(ctx, stdio, name, args[1:], env)
 }
 
 // run executes name with argv wired to the shell streams and returns its exit
-// status (127 when it cannot start).
-func run(ctx context.Context, stdio command.IO, name string, argv []string) int {
+// status (127 when it cannot start). env holds NAME=value temporary assignments
+// to add to the child's environment.
+func run(ctx context.Context, stdio command.IO, name string, argv, env []string) int {
 	cmd := exec.CommandContext(ctx, name, argv...) //nolint:gosec // running a user-typed command is the whole point of a shell
 	cmd.Stdin = stdio.In
 	cmd.Stdout = stdio.Out
 	cmd.Stderr = stdio.Err
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/applets/shellutils/mbsh/parser.go
+++ b/internal/applets/shellutils/mbsh/parser.go
@@ -1,0 +1,226 @@
+package mbsh
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// token is one word produced by the tokenizer: its fully expanded value, plus
+// the split name/value when the word is an unquoted NAME=value assignment.
+type token struct {
+	value     string // expanded word as a command argument
+	assignKey string // non-empty when the word is an unquoted NAME=... assignment
+	assignVal string // expanded value part of an assignment
+}
+
+// tokenize splits a command line into words the way a POSIX-ish shell does:
+// honoring single quotes (literal), double quotes (with $ expansion),
+// backslash escapes, $VAR / ${VAR} / $? expansion, and leading ~ expansion.
+// lastStatus supplies $?. Expansion does not re-split on whitespace, so an
+// expanded value stays a single word.
+func tokenize(input string, lastStatus int) ([]token, error) {
+	var toks []token
+	i, n := 0, len(input)
+	for i < n {
+		for i < n && (input[i] == ' ' || input[i] == '\t') {
+			i++
+		}
+		if i >= n {
+			break
+		}
+		tok, next, err := parseWord(input, i, lastStatus)
+		if err != nil {
+			return nil, err
+		}
+		toks = append(toks, tok)
+		i = next
+	}
+	return toks, nil
+}
+
+// parseWord scans one word starting at start and returns it with the index just
+// past it.
+func parseWord(input string, start, lastStatus int) (token, int, error) {
+	var sb strings.Builder
+	var nameBuf strings.Builder
+	nameScan := true   // still scanning a possible leading assignment NAME
+	tildeOK := true     // a leading '~' is eligible for home expansion
+	assignKey := ""
+	assignValStart := -1
+
+	i, n := start, len(input)
+	for i < n {
+		c := input[i]
+		if c == ' ' || c == '\t' {
+			break
+		}
+
+		switch c {
+		case '\'':
+			nameScan, tildeOK = false, false
+			i++
+			for i < n && input[i] != '\'' {
+				sb.WriteByte(input[i])
+				i++
+			}
+			if i >= n {
+				return token{}, 0, errors.New("unterminated single quote")
+			}
+			i++ // closing '
+		case '"':
+			nameScan, tildeOK = false, false
+			i++
+			for i < n && input[i] != '"' {
+				switch {
+				case input[i] == '\\' && i+1 < n && isDquoteEscape(input[i+1]):
+					sb.WriteByte(input[i+1])
+					i += 2
+				case input[i] == '$':
+					val, ni, err := expandVar(input, i, lastStatus)
+					if err != nil {
+						return token{}, 0, err
+					}
+					sb.WriteString(val)
+					i = ni
+				default:
+					sb.WriteByte(input[i])
+					i++
+				}
+			}
+			if i >= n {
+				return token{}, 0, errors.New("unterminated double quote")
+			}
+			i++ // closing "
+		case '\\':
+			nameScan, tildeOK = false, false
+			if i+1 < n {
+				sb.WriteByte(input[i+1])
+				i += 2
+			} else {
+				i++ // a trailing backslash is dropped
+			}
+		case '$':
+			nameScan, tildeOK = false, false
+			val, ni, err := expandVar(input, i, lastStatus)
+			if err != nil {
+				return token{}, 0, err
+			}
+			sb.WriteString(val)
+			i = ni
+		case '~':
+			if tildeOK && (i+1 >= n || input[i+1] == '/' || input[i+1] == ' ' || input[i+1] == '\t') {
+				sb.WriteString(os.Getenv("HOME"))
+			} else {
+				sb.WriteByte('~')
+			}
+			nameScan, tildeOK = false, false
+			i++
+		case '=':
+			if nameScan && nameBuf.Len() > 0 {
+				assignKey = nameBuf.String()
+			}
+			sb.WriteByte('=')
+			i++
+			nameScan, tildeOK = false, false
+			if assignKey != "" {
+				assignValStart = sb.Len()
+			}
+		default:
+			if nameScan {
+				if isNameChar(c, nameBuf.Len() == 0) {
+					nameBuf.WriteByte(c)
+				} else {
+					nameScan = false
+				}
+			}
+			sb.WriteByte(c)
+			tildeOK = false
+			i++
+		}
+	}
+
+	value := sb.String()
+	tok := token{value: value}
+	if assignKey != "" && assignValStart >= 0 {
+		tok.assignKey = assignKey
+		tok.assignVal = value[assignValStart:]
+	}
+	return tok, i, nil
+}
+
+// expandVar expands the variable reference beginning at input[i] (which is '$')
+// and returns its value and the index just past the reference.
+func expandVar(input string, i, lastStatus int) (string, int, error) {
+	i++ // skip '$'
+	n := len(input)
+	if i >= n {
+		return "$", i, nil // a lone trailing '$' is literal
+	}
+	switch {
+	case input[i] == '?':
+		return strconv.Itoa(lastStatus), i + 1, nil
+	case input[i] == '{':
+		i++ // skip '{'
+		start := i
+		for i < n && input[i] != '}' {
+			i++
+		}
+		if i >= n {
+			return "", 0, errors.New("bad substitution: missing '}'")
+		}
+		name := input[start:i]
+		i++ // skip '}'
+		if name == "?" {
+			return strconv.Itoa(lastStatus), i, nil
+		}
+		if !isValidName(name) {
+			return "", 0, fmt.Errorf("bad substitution: ${%s}", name)
+		}
+		return os.Getenv(name), i, nil
+	case isNameStart(input[i]):
+		start := i
+		for i < n && isNameContinue(input[i]) {
+			i++
+		}
+		return os.Getenv(input[start:i]), i, nil
+	default:
+		return "$", i, nil // '$' followed by a non-name char is literal
+	}
+}
+
+func isDquoteEscape(c byte) bool {
+	// Inside double quotes a backslash is literal except before these.
+	return c == '$' || c == '`' || c == '"' || c == '\\'
+}
+
+func isNameStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isNameContinue(c byte) bool {
+	return isNameStart(c) || (c >= '0' && c <= '9')
+}
+
+// isNameChar reports whether c can be part of an assignment name; first is true
+// for the first character (which may not be a digit).
+func isNameChar(c byte, first bool) bool {
+	if first {
+		return isNameStart(c)
+	}
+	return isNameContinue(c)
+}
+
+func isValidName(s string) bool {
+	if s == "" || !isNameStart(s[0]) {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if !isNameContinue(s[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/applets/shellutils/mbsh/parser_test.go
+++ b/internal/applets/shellutils/mbsh/parser_test.go
@@ -1,0 +1,87 @@
+package mbsh
+
+import (
+	"strings"
+	"testing"
+)
+
+// splitToks separates leading assignment tokens from the command arguments, the
+// same way execInput does.
+func splitToks(toks []token) (env, args []string) {
+	i := 0
+	for i < len(toks) && toks[i].assignKey != "" {
+		env = append(env, toks[i].assignKey+"="+toks[i].assignVal)
+		i++
+	}
+	for ; i < len(toks); i++ {
+		args = append(args, toks[i].value)
+	}
+	return env, args
+}
+
+func TestTokenize(t *testing.T) {
+	t.Setenv("FOO", "bar")
+	t.Setenv("HOME", "/home/test")
+
+	tests := []struct {
+		name       string
+		input      string
+		lastStatus int
+		wantEnv    []string
+		wantArgs   []string
+	}{
+		{name: "plain words", input: "echo hello world", wantArgs: []string{"echo", "hello", "world"}},
+		{name: "double quotes keep spaces", input: `echo "a b"`, wantArgs: []string{"echo", "a b"}},
+		{name: "single quotes are literal", input: `echo 'a $FOO'`, wantArgs: []string{"echo", "a $FOO"}},
+		{name: "dollar var expands", input: "echo $FOO", wantArgs: []string{"echo", "bar"}},
+		{name: "braced var expands", input: "echo ${FOO}x", wantArgs: []string{"echo", "barx"}},
+		{name: "var in double quotes expands", input: `echo "$FOO!"`, wantArgs: []string{"echo", "bar!"}},
+		{name: "last status", input: "echo $?", lastStatus: 7, wantArgs: []string{"echo", "7"}},
+		{name: "backslash escapes space", input: `echo a\ b`, wantArgs: []string{"echo", "a b"}},
+		{name: "escaped dollar in double quotes", input: `echo "\$FOO"`, wantArgs: []string{"echo", "$FOO"}},
+		{name: "tilde expands", input: "echo ~", wantArgs: []string{"echo", "/home/test"}},
+		{name: "tilde slash expands", input: "echo ~/x", wantArgs: []string{"echo", "/home/test/x"}},
+		{name: "undefined var is empty", input: "echo [${UNSET_VAR_XYZ}]", wantArgs: []string{"echo", "[]"}},
+		{name: "single assignment prefix", input: "FOO=baz cmd", wantEnv: []string{"FOO=baz"}, wantArgs: []string{"cmd"}},
+		{name: "multiple assignment prefixes", input: "A=1 B=2 cmd x", wantEnv: []string{"A=1", "B=2"}, wantArgs: []string{"cmd", "x"}},
+		{name: "assignment value expands", input: "P=$FOO cmd", wantEnv: []string{"P=bar"}, wantArgs: []string{"cmd"}},
+		{name: "equals after command is an argument", input: "echo A=1", wantArgs: []string{"echo", "A=1"}},
+		{name: "only assignments", input: "FOO=bar", wantEnv: []string{"FOO=bar"}},
+		{name: "empty input", input: "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toks, err := tokenize(tt.input, tt.lastStatus)
+			if err != nil {
+				t.Fatalf("tokenize(%q) error = %v", tt.input, err)
+			}
+			env, args := splitToks(toks)
+			if strings.Join(env, " ") != strings.Join(tt.wantEnv, " ") {
+				t.Errorf("env = %v, want %v", env, tt.wantEnv)
+			}
+			if strings.Join(args, "\x00") != strings.Join(tt.wantArgs, "\x00") {
+				t.Errorf("args = %q, want %q", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestTokenizeErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "unterminated double quote", input: `echo "a b`},
+		{name: "unterminated single quote", input: `echo 'a b`},
+		{name: "missing closing brace", input: "echo ${FOO"},
+		{name: "bad name in braces", input: "echo ${1bad}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tokenize(tt.input, 0); err == nil {
+				t.Errorf("tokenize(%q) should have failed", tt.input)
+			}
+		})
+	}
+}

--- a/test/it/shellutils/mbsh_test.sh
+++ b/test/it/shellutils/mbsh_test.sh
@@ -35,3 +35,19 @@ TestMbshNoReparse() {
         *) echo ok ;;
     esac
 }
+
+TestMbshDoubleQuote() {
+    printf 'echo "a b"\nexit\n' | mbsh 2>/dev/null
+}
+
+TestMbshVarExpand() {
+    out=$(printf 'echo $HOME\nexit\n' | mbsh 2>/dev/null)
+    case "${out}" in
+        *"${HOME}"*) echo expanded ;;
+        *) echo literal ;;
+    esac
+}
+
+TestMbshEnvAssignment() {
+    printf 'FOO=bar env\nexit\n' | mbsh 2>/dev/null | grep '^FOO=bar$'
+}

--- a/test/it/spec/mbsh_spec.sh
+++ b/test/it/spec/mbsh_spec.sh
@@ -27,6 +27,21 @@ Describe 'mbsh'
         The output should equal 'ok'
         The status should be success
     End
+    It 'keeps double-quoted spaces in one argument'
+        When call TestMbshDoubleQuote
+        The output should include 'a b'
+        The status should be success
+    End
+    It 'expands $HOME'
+        When call TestMbshVarExpand
+        The output should equal 'expanded'
+        The status should be success
+    End
+    It 'passes a NAME=value prefix to the command environment'
+        When call TestMbshEnvAssignment
+        The output should include 'FOO=bar'
+        The status should be success
+    End
 End
 
 Describe 'mbsh cd'


### PR DESCRIPTION
## Summary

`mbsh` tokenized each line with `strings.Fields()`, so quotes, escapes, variable expansion, and environment-assignment prefixes were all lost:

```
$ printf 'echo "a b"\nexit\n' | mbsh        ->  "a b"
$ printf 'echo $HOME\nexit\n' | mbsh         ->  $HOME
$ printf 'FOO=bar env\nexit\n' | mbsh         ->  "FOO=bar" is not a command
```

This replaces `strings.Fields()` with a real tokenizer.

## Changes

- New `parser.go` tokenizer that handles: single quotes (literal), double quotes (with expansion), backslash escapes (and the double-quote escape rules), `$VAR`/`${VAR}`/`$?` expansion, leading `~` home expansion, and `NAME=value` assignment prefixes. Expansion does not re-split on whitespace, so an expanded value stays one word.
- `execInput` splits leading `NAME=value` words into a temporary environment for the command (passed through to the child via `cmd.Env`); a line of only assignments updates the session environment. `$?` is now expanded by the tokenizer (its previous global behavior is preserved and covered).
- Updated the `--help` Notes to describe the supported syntax.

## Tests

- Table-driven unit tests (`parser_test.go`) for quotes, escapes, `$VAR`/`${VAR}`/`$?`, `~`, undefined vars, assignment prefixes (single/multiple/expanded-value), "equals after the command is an argument", and error cases (unterminated quotes, missing `}`, bad `${name}`).
- shellspec (`mbsh_spec.sh`): `echo "a b"` keeps the space; `echo $HOME` expands; `FOO=bar env` exposes `FOO=bar` to the child.

## Verification

- `go test ./...` passes; `make test-e2e` passes (455 examples, 0 failures); `golangci-lint` clean.

Closes #231