### PR TITLE
feat(mbsh): support separators, pipelines, and redirections

### DIFF
--- a/internal/applets/shellutils/mbsh/executor.go
+++ b/internal/applets/shellutils/mbsh/executor.go
@@ -1,0 +1,338 @@
+package mbsh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh/builtin"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// redirect is one I/O redirection on a simple command.
+type redirect struct {
+	op   string // "<", ">", or ">>"
+	file string
+}
+
+// simpleCommand is a single command: temporary NAME=value assignments, the
+// command word and its arguments, and any redirections.
+type simpleCommand struct {
+	assigns []string
+	args    []string
+	redirs  []redirect
+}
+
+// pipeline is one or more simple commands joined by "|".
+type pipeline struct {
+	cmds []simpleCommand
+}
+
+// commandList is one or more pipelines joined by ";". Its exit status is that of
+// the last pipeline; a pipeline's exit status is that of its last command.
+type commandList struct {
+	pipelines []pipeline
+}
+
+// parse turns a token stream into a commandList, returning an error for malformed
+// input (an operator with no command, a redirection with no target, ...).
+func parse(toks []token) (commandList, error) {
+	var list commandList
+	pl := pipeline{}
+	cmd := simpleCommand{}
+
+	finishCmd := func() error {
+		if len(cmd.args) == 0 && len(cmd.assigns) == 0 && len(cmd.redirs) == 0 {
+			return errors.New("syntax error near unexpected operator")
+		}
+		pl.cmds = append(pl.cmds, cmd)
+		cmd = simpleCommand{}
+		return nil
+	}
+	finishPipeline := func() error {
+		if err := finishCmd(); err != nil {
+			return err
+		}
+		list.pipelines = append(list.pipelines, pl)
+		pl = pipeline{}
+		return nil
+	}
+
+	for i := 0; i < len(toks); i++ {
+		t := toks[i]
+		if t.kind == tokOp {
+			switch t.value {
+			case ";":
+				if err := finishPipeline(); err != nil {
+					return commandList{}, err
+				}
+			case "|":
+				if err := finishCmd(); err != nil {
+					return commandList{}, err
+				}
+			case "<", ">", ">>":
+				if i+1 >= len(toks) || toks[i+1].kind != tokWord {
+					return commandList{}, fmt.Errorf("syntax error: %s needs a filename", t.value)
+				}
+				i++
+				cmd.redirs = append(cmd.redirs, redirect{op: t.value, file: toks[i].value})
+			}
+			continue
+		}
+		// A NAME=value word is an assignment only before the command word.
+		if t.assignKey != "" && len(cmd.args) == 0 {
+			cmd.assigns = append(cmd.assigns, t.assignKey+"="+t.assignVal)
+			continue
+		}
+		cmd.args = append(cmd.args, t.value)
+	}
+
+	// Flush the trailing pipeline unless the line ended at a ";".
+	if len(cmd.args) > 0 || len(cmd.assigns) > 0 || len(cmd.redirs) > 0 || len(pl.cmds) > 0 {
+		if err := finishPipeline(); err != nil {
+			return commandList{}, err
+		}
+	}
+	return list, nil
+}
+
+// execList runs each pipeline in order and returns the last one's exit status.
+func (sh *shell) execList(ctx context.Context, stdio command.IO, list commandList) int {
+	status := 0
+	for _, pl := range list.pipelines {
+		status = sh.execPipeline(ctx, stdio, pl)
+		if sh.stop {
+			break
+		}
+	}
+	return status
+}
+
+// execPipeline runs a pipeline, returning the exit status of its last command.
+func (sh *shell) execPipeline(ctx context.Context, stdio command.IO, pl pipeline) int {
+	if len(pl.cmds) == 1 {
+		return sh.execSimple(ctx, stdio, pl.cmds[0])
+	}
+
+	n := len(pl.cmds)
+	cmds := make([]*exec.Cmd, n)
+	var pipeFiles []*os.File   // pipe ends to close in the parent after Start
+	var redirFiles []io.Closer // redirection files to close after Wait
+	defer func() {
+		for _, f := range redirFiles {
+			_ = f.Close()
+		}
+	}()
+
+	for i, sc := range pl.cmds {
+		if len(sc.args) == 0 {
+			_, _ = fmt.Fprintln(stdio.Err, "mbsh: missing command in pipeline")
+			return 2
+		}
+		path, argv, ok := resolveCommand(sc.args)
+		if !ok {
+			_, _ = fmt.Fprintf(stdio.Err, "mbsh: %s: command not found\n", sc.args[0])
+			return 127
+		}
+		c := exec.CommandContext(ctx, path, argv...) //nolint:gosec // user-typed command
+		if len(sc.assigns) > 0 {
+			c.Env = append(os.Environ(), sc.assigns...)
+		}
+		c.Stderr = stdio.Err
+		if i == 0 {
+			c.Stdin = stdio.In
+		}
+		if i == n-1 {
+			c.Stdout = stdio.Out
+		}
+		cmds[i] = c
+	}
+
+	// Wire one pipe between each adjacent pair of commands.
+	for i := 0; i < n-1; i++ {
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
+			return 1
+		}
+		cmds[i].Stdout = pw
+		cmds[i+1].Stdin = pr
+		pipeFiles = append(pipeFiles, pr, pw)
+	}
+
+	// Redirections override the pipe/standard wiring for the affected stage.
+	for i, sc := range pl.cmds {
+		f, err := applyRedirs(cmds[i], sc.redirs)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
+			for _, pf := range pipeFiles {
+				_ = pf.Close()
+			}
+			return 1
+		}
+		redirFiles = append(redirFiles, f...)
+	}
+
+	for _, c := range cmds {
+		if err := c.Start(); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
+		}
+	}
+	// Close the parent's copies of the pipe fds so EOF propagates between stages.
+	for _, pf := range pipeFiles {
+		_ = pf.Close()
+	}
+
+	status := 0
+	for i, c := range cmds {
+		err := c.Wait()
+		if i == n-1 {
+			status = waitStatus(err)
+		}
+	}
+	return status
+}
+
+// execSimple runs a single command with its redirections, dispatching to a
+// builtin or an external/applet command.
+func (sh *shell) execSimple(ctx context.Context, stdio command.IO, sc simpleCommand) int {
+	io := stdio
+	var closers []interface{ Close() error }
+	defer func() {
+		for _, c := range closers {
+			_ = c.Close()
+		}
+	}()
+	for _, r := range sc.redirs {
+		f, err := openRedir(r)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
+			return 1
+		}
+		closers = append(closers, f)
+		if r.op == "<" {
+			io.In = f
+		} else {
+			io.Out = f
+		}
+	}
+
+	if len(sc.args) == 0 {
+		// A line of only assignments sets them for the session.
+		for _, kv := range sc.assigns {
+			if k, v, ok := cut(kv); ok {
+				_ = os.Setenv(k, v)
+			}
+		}
+		return 0
+	}
+
+	switch sc.args[0] {
+	case "exit", "quit":
+		sh.stop = true
+		return 0
+	}
+
+	if builtin.IsBuiltinCmd(sc.args[0]) {
+		if err := builtin.Run(io, sc.args[0], sc.args[1:]); err != nil {
+			_, _ = fmt.Fprintln(io.Err, err)
+			return 1
+		}
+		return 0
+	}
+
+	path, argv, ok := resolveCommand(sc.args)
+	if !ok {
+		_, _ = fmt.Fprintf(stdio.Err, "mbsh: %s: command not found\n", sc.args[0])
+		return 127
+	}
+	c := exec.CommandContext(ctx, path, argv...) //nolint:gosec // user-typed command
+	c.Stdin, c.Stdout, c.Stderr = io.In, io.Out, io.Err
+	if len(sc.assigns) > 0 {
+		c.Env = append(os.Environ(), sc.assigns...)
+	}
+	if err := c.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode()
+		}
+		_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
+		return 127
+	}
+	return 0
+}
+
+// resolveCommand maps a command and its args to the executable path and argv to
+// run: the PATH binary when present, otherwise this MimixBox binary re-invoked
+// as the applet. ok is false only when the running binary cannot be located.
+func resolveCommand(args []string) (path string, argv []string, ok bool) {
+	name := args[0]
+	if _, err := exec.LookPath(name); err == nil {
+		return name, args[1:], true
+	}
+	if self, err := os.Executable(); err == nil {
+		return self, args, true
+	}
+	return "", nil, false
+}
+
+// openRedir opens the file for one redirection.
+func openRedir(r redirect) (*os.File, error) {
+	switch r.op {
+	case "<":
+		return os.Open(r.file) //nolint:gosec // user-named file
+	case ">":
+		return os.Create(r.file) //nolint:gosec // user-named file
+	case ">>":
+		return os.OpenFile(r.file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec // user-named file
+	default:
+		return nil, fmt.Errorf("unknown redirection %q", r.op)
+	}
+}
+
+// applyRedirs opens and applies a stage's redirections to an exec.Cmd, returning
+// the opened files for the caller to close after the command finishes.
+func applyRedirs(c *exec.Cmd, redirs []redirect) ([]io.Closer, error) {
+	var files []io.Closer
+	for _, r := range redirs {
+		f, err := openRedir(r)
+		if err != nil {
+			for _, of := range files {
+				_ = of.Close()
+			}
+			return nil, err
+		}
+		files = append(files, f)
+		if r.op == "<" {
+			c.Stdin = f
+		} else {
+			c.Stdout = f
+		}
+	}
+	return files, nil
+}
+
+// waitStatus extracts a process exit status from an exec Wait error.
+func waitStatus(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 127
+}
+
+// cut splits "k=v" into k and v.
+func cut(s string) (string, string, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '=' {
+			return s[:i], s[i+1:], true
+		}
+	}
+	return s, "", false
+}

--- a/internal/applets/shellutils/mbsh/executor_test.go
+++ b/internal/applets/shellutils/mbsh/executor_test.go
@@ -1,0 +1,155 @@
+package mbsh
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func parseLine(t *testing.T, input string) commandList {
+	t.Helper()
+	toks, err := tokenize(input, 0)
+	if err != nil {
+		t.Fatalf("tokenize(%q) error = %v", input, err)
+	}
+	list, err := parse(toks)
+	if err != nil {
+		t.Fatalf("parse(%q) error = %v", input, err)
+	}
+	return list
+}
+
+func TestParseStructure(t *testing.T) {
+	t.Run("sequence", func(t *testing.T) {
+		list := parseLine(t, "echo a; echo b")
+		if len(list.pipelines) != 2 {
+			t.Fatalf("pipelines = %d, want 2", len(list.pipelines))
+		}
+	})
+	t.Run("pipeline", func(t *testing.T) {
+		list := parseLine(t, "echo a | wc -c")
+		if len(list.pipelines) != 1 || len(list.pipelines[0].cmds) != 2 {
+			t.Fatalf("pipeline shape = %+v", list.pipelines)
+		}
+		if got := list.pipelines[0].cmds[1].args; strings.Join(got, " ") != "wc -c" {
+			t.Errorf("second command = %v, want [wc -c]", got)
+		}
+	})
+	t.Run("redirections", func(t *testing.T) {
+		list := parseLine(t, "cat < in.txt > out.txt")
+		redirs := list.pipelines[0].cmds[0].redirs
+		if len(redirs) != 2 || redirs[0].op != "<" || redirs[0].file != "in.txt" || redirs[1].op != ">" || redirs[1].file != "out.txt" {
+			t.Errorf("redirs = %+v", redirs)
+		}
+	})
+	t.Run("append", func(t *testing.T) {
+		list := parseLine(t, "echo x >> log")
+		redirs := list.pipelines[0].cmds[0].redirs
+		if len(redirs) != 1 || redirs[0].op != ">>" {
+			t.Errorf("redirs = %+v, want one >> redirect", redirs)
+		}
+	})
+}
+
+func TestParseErrors(t *testing.T) {
+	for _, input := range []string{"| echo", "echo |", "; echo", "echo >", "echo < "} {
+		toks, err := tokenize(input, 0)
+		if err != nil {
+			continue // a tokenizer error is also a rejection
+		}
+		if _, err := parse(toks); err == nil {
+			t.Errorf("parse(%q) should have failed", input)
+		}
+	}
+}
+
+// execLine drives the executor for one input line and returns stdout and the
+// list's exit status.
+func execLine(t *testing.T, input string) (string, int) {
+	t.Helper()
+	sh := &shell{}
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	list := parseLine(t, input)
+	status := sh.execList(context.Background(), io, list)
+	return out.String(), status
+}
+
+func requireCmds(t *testing.T, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		if _, err := exec.LookPath(n); err != nil {
+			t.Skipf("%s not on PATH: %v", n, err)
+		}
+	}
+}
+
+func TestExecSequence(t *testing.T) {
+	requireCmds(t, "echo")
+	out, _ := execLine(t, "echo one; echo two")
+	if out != "one\ntwo\n" {
+		t.Errorf("sequence output = %q, want %q", out, "one\ntwo\n")
+	}
+}
+
+func TestExecPipeline(t *testing.T) {
+	requireCmds(t, "printf", "wc")
+	out, status := execLine(t, "printf foo | wc -c")
+	if strings.TrimSpace(out) != "3" {
+		t.Errorf("pipeline output = %q, want 3", out)
+	}
+	if status != 0 {
+		t.Errorf("pipeline status = %d, want 0", status)
+	}
+}
+
+func TestExecRedirections(t *testing.T) {
+	requireCmds(t, "echo", "cat", "wc")
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.txt")
+
+	execLine(t, "echo hi > "+out)
+	if got, _ := os.ReadFile(out); string(got) != "hi\n" {
+		t.Errorf("after > the file = %q, want %q", got, "hi\n")
+	}
+
+	execLine(t, "echo more >> "+out)
+	if got, _ := os.ReadFile(out); string(got) != "hi\nmore\n" {
+		t.Errorf("after >> the file = %q, want %q", got, "hi\nmore\n")
+	}
+
+	stdout, _ := execLine(t, "wc -l < "+out)
+	if strings.TrimSpace(stdout) != "2" {
+		t.Errorf("wc -l < file = %q, want 2", stdout)
+	}
+}
+
+// TestExecPipelineStatusIsLast documents that a pipeline's status is its last
+// command's.
+func TestExecPipelineStatusIsLast(t *testing.T) {
+	requireCmds(t, "true", "false")
+	if _, status := execLine(t, "false | true"); status != 0 {
+		t.Errorf("false | true status = %d, want 0 (last command)", status)
+	}
+	if _, status := execLine(t, "true | false"); status == 0 {
+		t.Errorf("true | false status = 0, want non-zero (last command)")
+	}
+}
+
+func TestExecExitStops(t *testing.T) {
+	sh := &shell{}
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	list := parseLine(t, "exit")
+	sh.execList(context.Background(), io, list)
+	if !sh.stop {
+		t.Errorf("exit should set the stop flag")
+	}
+}

--- a/internal/applets/shellutils/mbsh/mbsh.go
+++ b/internal/applets/shellutils/mbsh/mbsh.go
@@ -15,10 +15,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 
-	"github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh/builtin"
 	"github.com/nao1215/mimixbox/internal/command"
 )
 
@@ -35,9 +33,11 @@ func (c *Command) Name() string { return "mbsh" }
 func (c *Command) Synopsis() string { return "Mimix Box Shell" }
 
 // shell holds the small amount of mutable state the REPL keeps between lines:
-// the exit status of the last command (exposed as $?).
+// the exit status of the last command (exposed as $?) and a stop flag set by
+// the "exit"/"quit" command.
 type shell struct {
 	lastStatus int
+	stop       bool
 }
 
 // Run starts the read-eval-print loop. It parses its own flags (only the
@@ -52,10 +52,14 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		Examples: []command.Example{
 			{Command: "mbsh", Explain: "Start an interactive prompt; type 'exit' or Ctrl-D to quit."},
 			{Command: "echo 'echo hello' | mbsh", Explain: "Run commands fed on standard input."},
+			{Command: "echo one; echo two", Explain: "Run commands in sequence."},
+			{Command: "echo hi | wc -c", Explain: "Pipe one command into another."},
+			{Command: "echo hi > out.txt", Explain: "Redirect output (>, >>, < are supported)."},
 		},
 		Notes: []string{
 			"Tokenizing supports single/double quotes, backslash escapes, $VAR/${VAR}/$? expansion, ~ home expansion, and NAME=value prefixes.",
-			"Each line runs one command; pipelines, redirections, and scripting (if/for/while) are not yet supported.",
+			"Operators: ; sequences commands, | pipes them, and < > >> redirect I/O. A pipeline's status is its last command's; a list's is its last pipeline's.",
+			"Scripting (if/for/while) and background jobs are not yet supported.",
 		},
 	})
 	proceed, err := fs.Parse(stdio, args)
@@ -143,92 +147,21 @@ func (sh *shell) execInput(ctx context.Context, stdio command.IO, input string) 
 		return false
 	}
 
-	// Tokenize with quote handling, backslash escapes, and $VAR/${VAR}/$?/~
-	// expansion (see parser.go).
+	// Tokenize (quotes, escapes, $VAR/${VAR}/$?/~ expansion, operators), then
+	// parse into a list of pipelines and run it. See parser.go and executor.go.
 	toks, err := tokenize(input, sh.lastStatus)
 	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
 		sh.lastStatus = 2
 		return false
 	}
-
-	// Leading NAME=value words are temporary environment assignments for the
-	// command; the rest are the command and its arguments.
-	var env []string
-	idx := 0
-	for idx < len(toks) && toks[idx].assignKey != "" {
-		env = append(env, toks[idx].assignKey+"="+toks[idx].assignVal)
-		idx++
-	}
-	args := make([]string, 0, len(toks)-idx)
-	for ; idx < len(toks); idx++ {
-		args = append(args, toks[idx].value)
-	}
-
-	if len(args) == 0 {
-		// A line of only assignments (FOO=bar) sets them for the session.
-		for _, kv := range env {
-			if k, v, ok := strings.Cut(kv, "="); ok {
-				_ = os.Setenv(k, v)
-			}
-		}
-		sh.lastStatus = 0
-		return false
-	}
-
-	switch args[0] {
-	case "exit", "quit":
-		return true
-	}
-
-	// A built-in is preferred over an external command of the same name.
-	if builtin.IsBuiltinCmd(args[0]) {
-		if err := builtin.Run(stdio, args[0], args[1:]); err != nil {
-			_, _ = fmt.Fprintln(stdio.Err, err)
-			sh.lastStatus = 1
-		} else {
-			sh.lastStatus = 0
-		}
-		return false
-	}
-
-	sh.lastStatus = sh.runExternal(ctx, stdio, args, env)
-	return false
-}
-
-// runExternal runs args[0] as an external program, falling back to running it as
-// a MimixBox applet (by re-executing this binary) when it is not on the PATH.
-// It returns the command's exit status.
-func (sh *shell) runExternal(ctx context.Context, stdio command.IO, args, env []string) int {
-	name := args[0]
-	if _, err := exec.LookPath(name); err != nil {
-		if self, e := os.Executable(); e == nil {
-			return run(ctx, stdio, self, append([]string{name}, args[1:]...), env)
-		}
-		_, _ = fmt.Fprintf(stdio.Err, "mbsh: %s: command not found\n", name)
-		return 127
-	}
-	return run(ctx, stdio, name, args[1:], env)
-}
-
-// run executes name with argv wired to the shell streams and returns its exit
-// status (127 when it cannot start). env holds NAME=value temporary assignments
-// to add to the child's environment.
-func run(ctx context.Context, stdio command.IO, name string, argv, env []string) int {
-	cmd := exec.CommandContext(ctx, name, argv...) //nolint:gosec // running a user-typed command is the whole point of a shell
-	cmd.Stdin = stdio.In
-	cmd.Stdout = stdio.Out
-	cmd.Stderr = stdio.Err
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
-	}
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return exitErr.ExitCode()
-		}
+	list, err := parse(toks)
+	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
-		return 127
+		sh.lastStatus = 2
+		return false
 	}
-	return 0
+
+	sh.lastStatus = sh.execList(ctx, stdio, list)
+	return sh.stop
 }

--- a/internal/applets/shellutils/mbsh/parser.go
+++ b/internal/applets/shellutils/mbsh/parser.go
@@ -8,12 +8,27 @@ import (
 	"strings"
 )
 
-// token is one word produced by the tokenizer: its fully expanded value, plus
-// the split name/value when the word is an unquoted NAME=value assignment.
+// tokKind distinguishes a word from a shell operator.
+type tokKind int
+
+const (
+	tokWord tokKind = iota
+	tokOp           // ; | < > >>
+)
+
+// token is one word or operator produced by the tokenizer. For a word it also
+// carries the split name/value when the word is an unquoted NAME=value
+// assignment.
 type token struct {
-	value     string // expanded word as a command argument
+	kind      tokKind
+	value     string // expanded word, or the operator string
 	assignKey string // non-empty when the word is an unquoted NAME=... assignment
 	assignVal string // expanded value part of an assignment
+}
+
+// isOperatorByte reports whether c begins an unquoted shell operator.
+func isOperatorByte(c byte) bool {
+	return c == ';' || c == '|' || c == '<' || c == '>'
 }
 
 // tokenize splits a command line into words the way a POSIX-ish shell does:
@@ -31,6 +46,12 @@ func tokenize(input string, lastStatus int) ([]token, error) {
 		if i >= n {
 			break
 		}
+		if isOperatorByte(input[i]) {
+			op, next := parseOperator(input, i)
+			toks = append(toks, token{kind: tokOp, value: op})
+			i = next
+			continue
+		}
 		tok, next, err := parseWord(input, i, lastStatus)
 		if err != nil {
 			return nil, err
@@ -39,6 +60,15 @@ func tokenize(input string, lastStatus int) ([]token, error) {
 		i = next
 	}
 	return toks, nil
+}
+
+// parseOperator reads the operator at input[i] (">>" or one of ; | < >) and
+// returns it with the index just past it.
+func parseOperator(input string, i int) (string, int) {
+	if input[i] == '>' && i+1 < len(input) && input[i+1] == '>' {
+		return ">>", i + 2
+	}
+	return string(input[i]), i + 1
 }
 
 // parseWord scans one word starting at start and returns it with the index just
@@ -54,7 +84,7 @@ func parseWord(input string, start, lastStatus int) (token, int, error) {
 	i, n := start, len(input)
 	for i < n {
 		c := input[i]
-		if c == ' ' || c == '\t' {
+		if c == ' ' || c == '\t' || isOperatorByte(c) {
 			break
 		}
 

--- a/test/it/shellutils/mbsh_test.sh
+++ b/test/it/shellutils/mbsh_test.sh
@@ -51,3 +51,25 @@ TestMbshVarExpand() {
 TestMbshEnvAssignment() {
     printf 'FOO=bar env\nexit\n' | mbsh 2>/dev/null | grep '^FOO=bar$'
 }
+
+TestMbshSequence() {
+    d=$(mktemp -d)
+    printf 'echo one > %s/o; echo two >> %s/o\nexit\n' "$d" "$d" | mbsh >/dev/null 2>&1
+    cat "$d/o"
+    rm -rf "$d"
+}
+
+TestMbshPipeline() {
+    d=$(mktemp -d)
+    printf 'printf foo | wc -c > %s/o\nexit\n' "$d" | mbsh >/dev/null 2>&1
+    tr -d ' \n' < "$d/o"
+    rm -rf "$d"
+}
+
+TestMbshRedirectIn() {
+    d=$(mktemp -d)
+    printf 'a\nb\nc\n' > "$d/in"
+    printf 'wc -l < %s/in > %s/o\nexit\n' "$d" "$d" | mbsh >/dev/null 2>&1
+    tr -d ' \n' < "$d/o"
+    rm -rf "$d"
+}

--- a/test/it/spec/mbsh_spec.sh
+++ b/test/it/spec/mbsh_spec.sh
@@ -42,6 +42,22 @@ Describe 'mbsh'
         The output should include 'FOO=bar'
         The status should be success
     End
+    It 'runs commands in sequence and redirects output'
+        When call TestMbshSequence
+        The output should equal 'one
+two'
+        The status should be success
+    End
+    It 'pipes one command into another'
+        When call TestMbshPipeline
+        The output should equal '3'
+        The status should be success
+    End
+    It 'redirects input with <'
+        When call TestMbshRedirectIn
+        The output should equal '3'
+        The status should be success
+    End
 End
 
 Describe 'mbsh cd'


### PR DESCRIPTION
## Summary

`mbsh` treated each line as a single argv vector, so `;`, `|`, and `< > >>` were printed literally instead of executed. This adds a parser/AST and an executor for them.

## Changes

- The tokenizer now emits operator tokens (`;`, `|`, `<`, `>`, `>>`) and stops words at unquoted operators (operators inside quotes stay literal).
- New `executor.go` parses tokens into a `commandList` (pipelines joined by `;`) of `pipeline`s (simple commands joined by `|`), each with redirections, and executes them: sequences run in order, pipelines connect stages with `os.Pipe`, and `< > >>` open files and override a stage's stdin/stdout.
- Builtins and `exit`/`quit` still work for a single command; pipeline stages run as external/applet commands.

## Exit-status semantics (documented in code)

- A pipeline's status is its last command's status; a list's status is its last pipeline's status.

## Tests

- Unit (`executor_test.go`): parser shape and error cases; executor for `;`, `|`, `>`/`>>`/`<`, pipeline last-command status (`false | true` -> 0, `true | false` -> non-zero), and `exit` setting the stop flag.
- shellspec (`mbsh_spec.sh`): sequence + redirect, pipeline (`printf foo | wc -c` -> 3), input redirect (`wc -l < f` -> 3).

## Verification

- `go test ./...` passes; `make test-e2e` passes (458 examples, 0 failures); `golangci-lint` clean.

Closes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell now supports command sequencing with `;` and piping with `|`.
  * Added I/O redirection capabilities: input (`<`), output overwrite (`>`), and append (`>>`).
  * Environment variable assignments can be specified temporarily per command.

* **Documentation**
  * Updated help text to document new shell features and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->