### PR TITLE
fix(mbsh): close already-open pipe fds when os.Pipe fails

### DIFF
--- a/internal/applets/shellutils/mbsh/executor.go
+++ b/internal/applets/shellutils/mbsh/executor.go
@@ -156,6 +156,9 @@ func (sh *shell) execPipeline(ctx context.Context, stdio command.IO, pl pipeline
 		pr, pw, err := os.Pipe()
 		if err != nil {
 			_, _ = fmt.Fprintf(stdio.Err, "mbsh: %v\n", err)
+			for _, pf := range pipeFiles {
+				_ = pf.Close()
+			}
 			return 1
 		}
 		cmds[i].Stdout = pw


### PR DESCRIPTION
Addresses a Major review finding from #294: in `execPipeline`, if `os.Pipe()` fails partway through wiring a multi-stage pipeline, the descriptors already appended to `pipeFiles` were leaked. The error path now closes them before returning, avoiding fd exhaustion in a long-running shell.

`go test ./...` and `golangci-lint` pass.