### PR TITLE
feat(vi): add counts, word motions, yank/paste, undo, and search

### DIFF
--- a/internal/applets/editors/vi/editor.go
+++ b/internal/applets/editors/vi/editor.go
@@ -9,6 +9,7 @@ const (
 	modeNormal mode = iota
 	modeInsert
 	modeCommand // typing a ":" ex command
+	modeSearch  // typing a "/" or "?" search pattern
 )
 
 // editor is the in-memory editing state. It is deliberately decoupled from any
@@ -30,6 +31,21 @@ type editor struct {
 	// the trailing byte from being mistaken for an editing command.
 	escSt  escState
 	csiBuf []byte // parameter/intermediate bytes of a CSI sequence
+
+	count            int        // pending numeric prefix (3j, 2x, ...)
+	register         string     // yanked text (yy/dd) for p/P
+	registerLinewise bool       // whether register holds whole lines
+	undoStack        []snapshot // states to restore with u
+	searchPat        string     // current "/" or "?" pattern being typed
+	searchForward    bool       // direction of the in-progress search
+	lastSearch       string     // last completed search pattern (for n/N)
+	lastForward      bool       // direction of the last search
+}
+
+// snapshot is a saved editor state for undo.
+type snapshot struct {
+	lines  []string
+	cx, cy int
 }
 
 // escState tracks where we are in decoding a terminal escape sequence.
@@ -109,6 +125,8 @@ func (e *editor) dispatch(b byte) {
 		e.feedInsert(b)
 	case modeCommand:
 		e.feedCommand(b)
+	case modeSearch:
+		e.feedSearch(b)
 	default:
 		e.feedNormal(b)
 	}
@@ -126,6 +144,9 @@ func (e *editor) handleEsc() {
 	case modeCommand:
 		e.mode = modeNormal
 		e.cmdline = ""
+	case modeSearch:
+		e.mode = modeNormal
+		e.searchPat = ""
 	}
 }
 
@@ -191,59 +212,369 @@ func (e *editor) feedString(s string) {
 
 // feedNormal handles a key in normal mode.
 func (e *editor) feedNormal(b byte) {
-	// Resolve a pending two-key command first.
-	if e.pending != 0 {
-		first := e.pending
-		e.pending = 0
-		switch {
-		case first == 'd' && b == 'd':
-			e.deleteLine()
-		case first == 'g' && b == 'g':
-			e.cy, e.cx = 0, 0
-		case first == 'Z' && b == 'Z':
-			e.save = true
-			e.quit = true
-		}
+	// A leading digit (or a non-leading 0) builds the count prefix.
+	if (b >= '1' && b <= '9') || (b == '0' && e.count > 0) {
+		e.count = e.count*10 + int(b-'0')
 		return
 	}
 
+	if e.pending != 0 {
+		e.handlePending(b)
+		return
+	}
+
+	// Operator/prefix keys keep the count for their second key.
+	switch b {
+	case 'd', 'g', 'Z', 'y':
+		e.pending = b
+		return
+	}
+
+	hadCount := e.count > 0
+	cnt := e.takeCount()
 	switch b {
 	case 'h':
-		e.moveLeft()
+		e.repeat(cnt, e.moveLeft)
 	case 'l':
-		e.moveRight()
+		e.repeat(cnt, e.moveRight)
 	case 'j':
-		e.moveDown()
+		e.repeat(cnt, e.moveDown)
 	case 'k':
-		e.moveUp()
+		e.repeat(cnt, e.moveUp)
+	case 'w':
+		e.repeat(cnt, e.moveWordForward)
+	case 'b':
+		e.repeat(cnt, e.moveWordBackward)
+	case 'e':
+		e.repeat(cnt, e.moveWordEnd)
 	case '0':
 		e.cx = 0
 	case '$':
 		e.cx = lastCol(e.lines[e.cy])
 	case 'G':
-		e.cy = len(e.lines) - 1
+		// With a count, go to that 1-based line; otherwise the last line.
+		if hadCount {
+			e.cy = cnt - 1
+		} else {
+			e.cy = len(e.lines) - 1
+		}
+		e.clampY()
 		e.clampX()
 	case 'x':
-		e.deleteRune()
+		e.snapshot()
+		e.repeat(cnt, e.deleteRune)
+	case 'u':
+		e.undo()
+	case 'p':
+		e.snapshot()
+		e.repeat(cnt, e.pasteBelow)
+	case 'P':
+		e.snapshot()
+		e.repeat(cnt, e.pasteAbove)
 	case 'i':
+		e.snapshot()
 		e.mode = modeInsert
 	case 'a':
+		e.snapshot()
 		if len(e.lines[e.cy]) > 0 {
 			e.cx++
 		}
 		e.mode = modeInsert
 	case 'A':
+		e.snapshot()
 		e.cx = len(e.lines[e.cy])
 		e.mode = modeInsert
 	case 'o':
+		e.snapshot()
 		e.openBelow()
 	case 'O':
+		e.snapshot()
 		e.openAbove()
-	case 'd', 'g', 'Z':
-		e.pending = b
+	case '/':
+		e.mode = modeSearch
+		e.searchForward = true
+		e.searchPat = ""
+	case '?':
+		e.mode = modeSearch
+		e.searchForward = false
+		e.searchPat = ""
+	case 'n':
+		e.searchAgain(e.lastForward)
+	case 'N':
+		e.searchAgain(!e.lastForward)
 	case ':':
 		e.mode = modeCommand
 		e.cmdline = ""
+	}
+}
+
+// handlePending resolves the second key of an operator (d, g, Z, y).
+func (e *editor) handlePending(b byte) {
+	first := e.pending
+	e.pending = 0
+	cnt := e.takeCount()
+	switch {
+	case first == 'd' && b == 'd':
+		e.snapshot()
+		e.yankLines(cnt) // dd also fills the register, like vi
+		e.repeat(cnt, e.deleteLine)
+	case first == 'y' && b == 'y':
+		e.yankLines(cnt)
+	case first == 'g' && b == 'g':
+		e.cy, e.cx = 0, 0
+	case first == 'Z' && b == 'Z':
+		e.save = true
+		e.quit = true
+	}
+}
+
+// takeCount returns the pending count (at least 1) and clears it.
+func (e *editor) takeCount() int {
+	c := e.count
+	e.count = 0
+	if c < 1 {
+		return 1
+	}
+	return c
+}
+
+// repeat runs f n times.
+func (e *editor) repeat(n int, f func()) {
+	for i := 0; i < n; i++ {
+		f()
+	}
+}
+
+// clampY keeps the cursor row within the buffer.
+func (e *editor) clampY() {
+	if e.cy < 0 {
+		e.cy = 0
+	}
+	if e.cy > len(e.lines)-1 {
+		e.cy = len(e.lines) - 1
+	}
+}
+
+// snapshot records the current buffer and cursor so u can restore them. It is
+// taken before each change (and once when entering insert mode, so a whole
+// insertion undoes as one step).
+func (e *editor) snapshot() {
+	cp := make([]string, len(e.lines))
+	copy(cp, e.lines)
+	e.undoStack = append(e.undoStack, snapshot{lines: cp, cx: e.cx, cy: e.cy})
+}
+
+// undo restores the most recent snapshot.
+func (e *editor) undo() {
+	if len(e.undoStack) == 0 {
+		return
+	}
+	s := e.undoStack[len(e.undoStack)-1]
+	e.undoStack = e.undoStack[:len(e.undoStack)-1]
+	e.lines = s.lines
+	e.cy, e.cx = s.cy, s.cx
+	e.clampY()
+	e.clampX()
+	e.dirty = true
+}
+
+// yankLines copies n lines from the cursor into the register (linewise).
+func (e *editor) yankLines(n int) {
+	end := e.cy + n
+	if end > len(e.lines) {
+		end = len(e.lines)
+	}
+	var b strings.Builder
+	for i := e.cy; i < end; i++ {
+		b.WriteString(e.lines[i])
+		b.WriteByte('\n')
+	}
+	e.register = b.String()
+	e.registerLinewise = true
+}
+
+// pasteBelow inserts the register's lines below the current line (p).
+func (e *editor) pasteBelow() {
+	if e.register == "" || !e.registerLinewise {
+		return
+	}
+	lines := strings.Split(strings.TrimSuffix(e.register, "\n"), "\n")
+	e.lines = insertLines(e.lines, e.cy+1, lines)
+	e.cy++
+	e.cx = 0
+	e.dirty = true
+}
+
+// pasteAbove inserts the register's lines above the current line (P).
+func (e *editor) pasteAbove() {
+	if e.register == "" || !e.registerLinewise {
+		return
+	}
+	lines := strings.Split(strings.TrimSuffix(e.register, "\n"), "\n")
+	e.lines = insertLines(e.lines, e.cy, lines)
+	e.cx = 0
+	e.dirty = true
+}
+
+// insertLines inserts vs into s at index i.
+func insertLines(s []string, i int, vs []string) []string {
+	out := make([]string, 0, len(s)+len(vs))
+	out = append(out, s[:i]...)
+	out = append(out, vs...)
+	out = append(out, s[i:]...)
+	return out
+}
+
+func isWordSpace(c byte) bool { return c == ' ' || c == '\t' }
+
+// moveWordForward moves to the start of the next whitespace-delimited word,
+// wrapping onto following lines.
+func (e *editor) moveWordForward() {
+	line := e.lines[e.cy]
+	i := e.cx
+	for i < len(line) && !isWordSpace(line[i]) {
+		i++
+	}
+	for i < len(line) && isWordSpace(line[i]) {
+		i++
+	}
+	if i < len(line) {
+		e.cx = i
+		return
+	}
+	if e.cy < len(e.lines)-1 {
+		e.cy++
+		l := e.lines[e.cy]
+		j := 0
+		for j < len(l) && isWordSpace(l[j]) {
+			j++
+		}
+		e.cx = j
+		e.clampX()
+		return
+	}
+	e.cx = lastCol(line)
+}
+
+// moveWordBackward moves to the start of the previous whitespace-delimited word.
+func (e *editor) moveWordBackward() {
+	line := e.lines[e.cy]
+	i := e.cx
+	if i == 0 {
+		if e.cy == 0 {
+			return
+		}
+		e.cy--
+		line = e.lines[e.cy]
+		i = len(line)
+	}
+	i--
+	for i > 0 && isWordSpace(line[i]) {
+		i--
+	}
+	for i > 0 && !isWordSpace(line[i-1]) {
+		i--
+	}
+	if i < 0 {
+		i = 0
+	}
+	e.cx = i
+}
+
+// moveWordEnd moves to the end of the next whitespace-delimited word.
+func (e *editor) moveWordEnd() {
+	line := e.lines[e.cy]
+	i := e.cx + 1
+	for i < len(line) && isWordSpace(line[i]) {
+		i++
+	}
+	for i < len(line)-1 && !isWordSpace(line[i+1]) {
+		i++
+	}
+	if i < len(line) {
+		e.cx = i
+		e.clampX()
+		return
+	}
+	if e.cy < len(e.lines)-1 {
+		e.cy++
+		l := e.lines[e.cy]
+		j := 0
+		for j < len(l) && isWordSpace(l[j]) {
+			j++
+		}
+		for j < len(l)-1 && !isWordSpace(l[j+1]) {
+			j++
+		}
+		e.cx = j
+		e.clampX()
+	}
+}
+
+// searchExecute moves the cursor to the next literal match of pat in the given
+// direction, wrapping around the buffer.
+func (e *editor) searchExecute(pat string, forward bool) {
+	if pat == "" {
+		return
+	}
+	n := len(e.lines)
+	if forward {
+		for off := 0; off < n; off++ {
+			row := (e.cy + off) % n
+			line := e.lines[row]
+			from := 0
+			if off == 0 {
+				from = e.cx + 1
+			}
+			if from <= len(line) {
+				if idx := strings.Index(line[from:], pat); idx >= 0 {
+					e.cy, e.cx = row, from+idx
+					e.clampX()
+					return
+				}
+			}
+		}
+		return
+	}
+	for off := 0; off < n; off++ {
+		row := ((e.cy-off)%n + n) % n
+		line := e.lines[row]
+		limit := len(line)
+		if off == 0 {
+			limit = e.cx
+		}
+		if limit >= 0 && limit <= len(line) {
+			if idx := strings.LastIndex(line[:limit], pat); idx >= 0 {
+				e.cy, e.cx = row, idx
+				e.clampX()
+				return
+			}
+		}
+	}
+}
+
+// searchAgain repeats the last search in the given direction (n / N).
+func (e *editor) searchAgain(forward bool) {
+	if e.lastSearch != "" {
+		e.searchExecute(e.lastSearch, forward)
+	}
+}
+
+// feedSearch accumulates a "/" or "?" pattern and runs it on Enter.
+func (e *editor) feedSearch(b byte) {
+	switch b {
+	case '\r', '\n':
+		e.mode = modeNormal
+		e.lastSearch = e.searchPat
+		e.lastForward = e.searchForward
+		e.searchExecute(e.searchPat, e.searchForward)
+		e.searchPat = ""
+	case 0x7f, 0x08:
+		if len(e.searchPat) > 0 {
+			e.searchPat = e.searchPat[:len(e.searchPat)-1]
+		}
+	default:
+		e.searchPat += string(b)
 	}
 }
 

--- a/internal/applets/editors/vi/editor_test.go
+++ b/internal/applets/editors/vi/editor_test.go
@@ -406,3 +406,95 @@ func TestEscapeSS3Arrows(t *testing.T) {
 		t.Errorf("SS3 arrows mutated state: dirty=%v mode=%s", e.dirty, modeName(e.mode))
 	}
 }
+
+func TestCountedMotion(t *testing.T) {
+	t.Parallel()
+	e := drive("a\nb\nc\nd", "3j")
+	if e.cy != 3 {
+		t.Errorf("3j -> cy=%d, want 3", e.cy)
+	}
+	e = drive("a\nb\nc\nd", "3jk")
+	if e.cy != 2 {
+		t.Errorf("3jk -> cy=%d, want 2", e.cy)
+	}
+}
+
+func TestCountedDeleteChar(t *testing.T) {
+	t.Parallel()
+	e := drive("abcdef", "2x")
+	if e.lines[0] != "cdef" {
+		t.Errorf("2x -> %q, want %q", e.lines[0], "cdef")
+	}
+}
+
+func TestCountedDeleteLine(t *testing.T) {
+	t.Parallel()
+	e := drive("l1\nl2\nl3\nl4", "3dd")
+	if e.content() != "l4\n" {
+		t.Errorf("3dd -> %q, want %q", e.content(), "l4\n")
+	}
+}
+
+func TestWordMotions(t *testing.T) {
+	t.Parallel()
+	if e := drive("foo bar baz", "w"); e.cx != 4 {
+		t.Errorf("w -> cx=%d, want 4", e.cx)
+	}
+	if e := drive("foo bar baz", "ww"); e.cx != 8 {
+		t.Errorf("ww -> cx=%d, want 8", e.cx)
+	}
+	if e := drive("foo bar baz", "e"); e.cx != 2 {
+		t.Errorf("e -> cx=%d, want 2", e.cx)
+	}
+	if e := drive("foo bar baz", "$b"); e.cx != 8 {
+		t.Errorf("$b -> cx=%d, want 8", e.cx)
+	}
+}
+
+func TestYankPaste(t *testing.T) {
+	t.Parallel()
+	if e := drive("one\ntwo", "yyp"); e.content() != "one\none\ntwo\n" {
+		t.Errorf("yyp -> %q, want %q", e.content(), "one\none\ntwo\n")
+	}
+	if e := drive("one\ntwo", "yyP"); e.content() != "one\none\ntwo\n" {
+		t.Errorf("yyP -> %q, want %q", e.content(), "one\none\ntwo\n")
+	}
+	if e := drive("one\ntwo\nthree", "2yyGp"); e.content() != "one\ntwo\nthree\none\ntwo\n" {
+		t.Errorf("2yy G p -> %q", e.content())
+	}
+}
+
+func TestUndo(t *testing.T) {
+	t.Parallel()
+	if e := drive("abc", "xu"); e.content() != "abc\n" {
+		t.Errorf("xu -> %q, want %q", e.content(), "abc\n")
+	}
+	if e := drive("l1\nl2", "ddu"); e.content() != "l1\nl2\n" {
+		t.Errorf("ddu -> %q, want %q", e.content(), "l1\nl2\n")
+	}
+	// Undo a whole insertion as one step.
+	if e := drive("abc", "Axyz\x1bu"); e.content() != "abc\n" {
+		t.Errorf("A...ESC u -> %q, want %q", e.content(), "abc\n")
+	}
+}
+
+func TestSearch(t *testing.T) {
+	t.Parallel()
+	if e := drive("alpha\nbeta\ngamma", "/beta\r"); e.cy != 1 || e.cx != 0 {
+		t.Errorf("/beta -> (%d,%d), want (1,0)", e.cy, e.cx)
+	}
+	// The forward search starts after the cursor, so the first /foo lands on the
+	// second match; n then wraps back to the first.
+	e := drive("foo\nbar\nfoo", "/foo\r")
+	if e.cy != 2 {
+		t.Errorf("/foo -> cy=%d, want 2", e.cy)
+	}
+	e.feedString("n")
+	if e.cy != 0 {
+		t.Errorf("/foo then n -> cy=%d, want 0 (wrapped)", e.cy)
+	}
+	// Backward search.
+	if e := drive("find\nmid\nfind", "G?find\r"); e.cy != 0 {
+		t.Errorf("G ?find -> cy=%d, want 0", e.cy)
+	}
+}

--- a/internal/applets/editors/vi/vi.go
+++ b/internal/applets/editors/vi/vi.go
@@ -41,8 +41,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "vi", Explain: "Open an empty buffer."},
 		},
 		Notes: []string{
-			"Normal mode: h j k l move, i insert, x delete a char, dd delete a line, :w save, :q quit, :wq save and quit.",
-			"Only this minimal key set is implemented; most ex commands and motions are not yet available.",
+			"Motions: h j k l, w b e (word), 0 $ (line), gg G (file); a count repeats them (3j, 2w).",
+			"Edits: i a A o O insert, x delete char, dd delete line, yy/p/P yank & paste, u undo (counts apply, e.g. 2x, 3dd).",
+			"Search: /pattern and ?pattern, then n / N for the next/previous match. Ex commands: :w :q :q! :wq and ZZ.",
 		},
 	})
 	proceed, err := fs.Parse(stdio, args)
@@ -153,6 +154,13 @@ func redraw(w io.Writer, ed *editor) {
 	if ed.mode == modeCommand {
 		status = ":" + ed.cmdline
 	}
+	if ed.mode == modeSearch {
+		prefix := "/"
+		if !ed.searchForward {
+			prefix = "?"
+		}
+		status = prefix + ed.searchPat
+	}
 	if ed.message != "" {
 		status = ed.message
 	}
@@ -175,6 +183,8 @@ func modeName(m mode) string {
 		return "INSERT"
 	case modeCommand:
 		return "COMMAND"
+	case modeSearch:
+		return "SEARCH"
 	default:
 		return "NORMAL"
 	}

--- a/test/it/editors/vi_test.sh
+++ b/test/it/editors/vi_test.sh
@@ -31,3 +31,33 @@ TestViArrowNoAppend() {
     printf '\033[A!\033:wq\r' | vi ${TEST_DIR}/a.txt
     printf '%s' "$(< ${TEST_DIR}/a.txt)"
 }
+
+TestViYankPaste() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    printf 'one\ntwo\n' > "${TEST_DIR}/yp.txt"
+    printf 'yyp:wq\r' | vi "${TEST_DIR}/yp.txt"
+    printf '%s' "$(< ${TEST_DIR}/yp.txt)"
+}
+
+TestViCountedDelete() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    printf 'abcdef\n' > "${TEST_DIR}/cd.txt"
+    printf '2x:wq\r' | vi "${TEST_DIR}/cd.txt"
+    printf '%s' "$(< ${TEST_DIR}/cd.txt)"
+}
+
+TestViUndo() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    printf 'keepme\n' > "${TEST_DIR}/u.txt"
+    printf 'xu:wq\r' | vi "${TEST_DIR}/u.txt"
+    printf '%s' "$(< ${TEST_DIR}/u.txt)"
+}
+
+TestViSearchNext() {
+    export TEST_DIR=/tmp/mimixbox/it/vi
+    printf 'x\nfoo\ny\nfoo\nz\n' > "${TEST_DIR}/sn.txt"
+    # /foo lands on the first match (line 2); n moves to the next (line 4); dd
+    # deletes that line.
+    printf '/foo\rndd:wq\r' | vi "${TEST_DIR}/sn.txt"
+    printf '%s' "$(< ${TEST_DIR}/sn.txt)"
+}

--- a/test/it/spec/richhelp_spec.sh
+++ b/test/it/spec/richhelp_spec.sh
@@ -32,7 +32,7 @@ Describe 'self-describing --help'
     It 'vi --help lists the supported keys'
         When call ViHelp
         The status should be success
-        The output should include 'Normal mode'
+        The output should include 'Motions:'
     End
 
     It 'find --help has examples and notes'

--- a/test/it/spec/vi_spec.sh
+++ b/test/it/spec/vi_spec.sh
@@ -25,4 +25,29 @@ world'
 world'
         The status should be success
     End
+    It 'duplicates a line with yy then p'
+        When call TestViYankPaste
+        The output should equal 'one
+one
+two'
+        The status should be success
+    End
+    It 'applies a count to an edit (2x)'
+        When call TestViCountedDelete
+        The output should equal 'cdef'
+        The status should be success
+    End
+    It 'undoes the last change with u'
+        When call TestViUndo
+        The output should equal 'keepme'
+        The status should be success
+    End
+    It 'searches with /pattern and moves to the next match with n'
+        When call TestViSearchNext
+        The output should equal 'x
+foo
+y
+z'
+        The status should be success
+    End
 End


### PR DESCRIPTION
## Summary

Extends the minimal `vi` with the everyday primitives that scripted/LLM edits reach for, keeping the editor model decoupled from the terminal so it stays cheaply unit-testable.

## Added

- Count prefixes before motions/edits: `3j`, `2w`, `2x`, `3dd`; `NG` jumps to line N.
- Word motions: `w`, `b`, `e` (whitespace-delimited words, wrapping across lines).
- Line yank/paste: `yy` (and `dd`) fill a linewise register; `p`/`P` paste below/above.
- Undo: `u` restores the previous state (a whole insert session undoes as one step) via a snapshot stack.
- Search: `/pattern` and `?pattern` (literal substring, wrapping), with `n`/`N` for the next/previous match.

The escape-sequence decoder from #235, the existing motions/edits, and ex commands are unchanged.

## Tests

- Unit (`editor_test.go`, table-driven): counted motion (`3j`, `3jk`), counted delete (`2x`, `3dd`), `w`/`b`/`e`, `yy`/`p`/`P` (incl. `2yyGp`), undo of `x`/`dd`/insert, and forward/backward search with `n` wrap.
- shellspec (`vi_spec.sh`): `yy`+`p` duplicates a line, `2x` counted edit, `u` undo, and `/foo`+`n`+`dd`.

## Docs

- `vi --help` now lists the motions, edits, and search keys.

## Verification

- `go test ./...` passes; `make test-e2e` passes (462 examples, 0 failures); `golangci-lint` clean.

Closes #232