### PR TITLE
feat(compat): add BusyBox shell front-ends and command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,24 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 153 commands. Run `mimixbox --list` to see them on the terminal.
+There are 162 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
+| [ | Evaluate a conditional expression (test alias requiring ]) |
+| [[ | Evaluate a conditional expression (test alias requiring ]]) |
 | add-shell | Add shell name to /etc/shells |
 | ar | Create, modify and extract from archives |
 | arch | Print machine hardware name (same as uname -m) |
+| ash | Command interpreter (MimixBox mbsh compatibility front-end) |
 | awk | Pattern scanning and processing language |
 | banner | Print a string as large ASCII-art letters |
 | base32 | Base32 encode/decode from FILE(or STDIN) to STDOUT |
 | base64 | Base64 encode/decode from FILE(or STDIN) to STDOUT |
 | basename | Print basename (PATH without "/") from file path |
+| bash | Command interpreter (MimixBox mbsh compatibility front-end) |
 | bunzip2 | Decompress bzip2 (.bz2) files |
+| busybox | BusyBox-style multi-call front-end for MimixBox applets |
 | cal | Display a calendar |
 | cat | Concatenate files and print on the standard output |
 | chgrp | Change the group of each FILE to GROUP |
@@ -48,6 +53,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | cowthink | Print message in a cow's thought bubble |
 | cp | Copy file(s) to Directory(s) |
 | cpio | Copy files to and from archives |
+| cttyhack | Run PROGRAM with the current stdio (no controlling-TTY trick) |
 | cut | Remove sections from each line of files |
 | date | Print or set the system date and time |
 | dd | Convert and copy a file |
@@ -77,6 +83,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | hostid | Print the numeric identifier (in hexadecimal) for the current host |
 | hostname | Show the system's host name |
 | http-status-code | Explain HTTP status codes and their RFC references |
+| hush | Command interpreter (MimixBox mbsh compatibility front-end) |
 | id | Print User ID and Group ID |
 | install | Copy files and set attributes |
 | ischroot | Detect if running in a chroot |
@@ -129,6 +136,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | sed | Stream editor for filtering and transforming text |
 | seq | Print a column of numbers |
 | serial | Rename the file to the name with a serial number |
+| sh | Command interpreter (MimixBox mbsh compatibility front-end) |
 | sha1sum | Calculate or Check secure hash 1 algorithm |
 | sha256sum | Calculate or Check secure hash 256 algorithm |
 | sha512sum | Calculate or Check secure hash 512 algorithm |
@@ -157,6 +165,7 @@ There are 153 commands. Run `mimixbox --list` to see them on the terminal.
 | uncompress | Decompress LZW (.Z) files |
 | unexpand | Convert N space to TAB(default:N=8) |
 | uniq | Report or omit repeated lines |
+| unit | BusyBox unit-test runner (not shipped by MimixBox) |
 | unix2dos | Change LF to CRLF |
 | unlink | Remove a single file by calling the unlink function |
 | unshadow | Combine passwd and shadow files for password auditing |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -17,6 +17,11 @@ import (
 	ap_archival_uncompress "github.com/nao1215/mimixbox/internal/applets/archival/uncompress"
 	ap_archival_unzip "github.com/nao1215/mimixbox/internal/applets/archival/unzip"
 	ap_archival_zip "github.com/nao1215/mimixbox/internal/applets/archival/zip"
+	ap_compat_bracket "github.com/nao1215/mimixbox/internal/applets/compat/bracket"
+	ap_compat_busybox "github.com/nao1215/mimixbox/internal/applets/compat/busybox"
+	ap_compat_cttyhack "github.com/nao1215/mimixbox/internal/applets/compat/cttyhack"
+	ap_compat_shellfront "github.com/nao1215/mimixbox/internal/applets/compat/shellfront"
+	ap_compat_unit "github.com/nao1215/mimixbox/internal/applets/compat/unit"
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
@@ -161,7 +166,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 153)
+	Applets = make(map[string]Applet, 162)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -174,6 +179,15 @@ func init() {
 	register(ap_archival_uncompress.New())
 	register(ap_archival_unzip.New())
 	register(ap_archival_zip.New())
+	register(ap_compat_bracket.NewBracket())
+	register(ap_compat_bracket.NewDoubleBracket())
+	register(ap_compat_busybox.New())
+	register(ap_compat_cttyhack.New())
+	register(ap_compat_shellfront.NewAsh())
+	register(ap_compat_shellfront.NewBash())
+	register(ap_compat_shellfront.NewHush())
+	register(ap_compat_shellfront.NewSh())
+	register(ap_compat_unit.New())
 	register(ap_console_tools_clear.New())
 	register(ap_console_tools_reset.New())
 	register(ap_console_tools_resize.New())

--- a/internal/applets/compat/bracket/bracket.go
+++ b/internal/applets/compat/bracket/bracket.go
@@ -1,0 +1,55 @@
+// Package bracket implements the "[" and "[[" test aliases: thin compatibility
+// fronts over the test applet that require a closing "]" / "]]" and otherwise
+// share test's exit-status semantics (0 true, 1 false, 2 malformed).
+package bracket
+
+import (
+	"context"
+	"errors"
+
+	testcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/test"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the "[" or "[[" alias; close holds the required closing token.
+type Command struct {
+	name  string
+	close string
+}
+
+// NewBracket returns the "[" alias.
+func NewBracket() *Command { return &Command{name: "[", close: "]"} }
+
+// NewDoubleBracket returns the "[[" alias.
+func NewDoubleBracket() *Command { return &Command{name: "[[", close: "]]"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	return "Evaluate a conditional expression (test alias requiring " + c.close + ")"
+}
+
+// Run validates the closing bracket and delegates to test.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	// --help / --version remain discoverable even though POSIX "[" has no options.
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "--version") {
+		fs := command.NewFlagSet(c.Name(), "EXPRESSION "+c.close, stdio.Err).WithHelp(command.Help{
+			Description: "Evaluate EXPRESSION as the test command does, but require a closing " +
+				c.close + ". The result is the exit status only.",
+			Examples: []command.Example{
+				{Command: c.Name() + " -f /etc/hosts " + c.close, Explain: "True when the file exists and is regular."},
+				{Command: c.Name() + ` "$x" = y ` + c.close, Explain: "True when $x equals y."},
+			},
+			ExitStatus: "0  the expression is true.\n1  the expression is false.\n2  the expression is malformed.",
+		})
+		_, _ = fs.Parse(stdio, args)
+		return nil
+	}
+
+	if len(args) == 0 || args[len(args)-1] != c.close {
+		return &command.ExitError{Code: 2, Err: errors.New("missing " + c.close)}
+	}
+	return testcmd.New().Run(ctx, stdio, args[:len(args)-1])
+}

--- a/internal/applets/compat/bracket/bracket_test.go
+++ b/internal/applets/compat/bracket/bracket_test.go
@@ -1,0 +1,62 @@
+package bracket
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee *command.ExitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+	return 1
+}
+
+func run(c *Command, args ...string) (string, int) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := c.Run(context.Background(), io, args)
+	return out.String(), exitCode(err)
+}
+
+func TestBracket(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    *Command
+		args []string
+		want int
+	}{
+		{"true", NewBracket(), []string{"1", "=", "1", "]"}, 0},
+		{"false", NewBracket(), []string{"1", "=", "2", "]"}, 1},
+		{"missing close", NewBracket(), []string{"1", "=", "1"}, 2},
+		{"empty", NewBracket(), nil, 2},
+		{"double true", NewDoubleBracket(), []string{"-n", "x", "]]"}, 0},
+		{"double missing close", NewDoubleBracket(), []string{"-n", "x"}, 2},
+		{"double with single close is malformed", NewDoubleBracket(), []string{"-n", "x", "]"}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, got := run(tt.c, tt.args...); got != tt.want {
+				t.Errorf("exit = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBracketHelp(t *testing.T) {
+	t.Parallel()
+	out, code := run(NewBracket(), "--help")
+	if code != 0 || !strings.Contains(out, "Usage: [") {
+		t.Errorf("--help out=%q code=%d", out, code)
+	}
+}

--- a/internal/applets/compat/busybox/busybox.go
+++ b/internal/applets/compat/busybox/busybox.go
@@ -1,0 +1,75 @@
+// Package busybox implements the busybox multi-call front-end: "busybox --list"
+// prints the applets, "busybox APPLET [ARG]..." dispatches to one, and unknown
+// applets are reported by the underlying dispatch with a non-zero exit.
+package busybox
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"github.com/nao1215/mimixbox/internal/version"
+)
+
+// Command is the busybox applet.
+type Command struct{}
+
+// New returns a busybox command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "busybox" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "BusyBox-style multi-call front-end for MimixBox applets" }
+
+// Run dispatches to an applet by re-invoking this binary, so an applet's
+// stdout/stderr/exit-code behavior is unchanged.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		c.flagSet(stdio).WriteUsage(stdio.Out)
+		return nil
+	}
+	if args[0] == "--version" || args[0] == "-v" {
+		version.Print(stdio.Out, c.Name())
+		return nil
+	}
+	target := args
+	if args[0] == "--list" {
+		target = []string{"--list"}
+	}
+	return dispatch(ctx, stdio, target)
+}
+
+func (c *Command) flagSet(stdio command.IO) *command.FlagSet {
+	return command.NewFlagSet(c.Name(), "[--list] | APPLET [ARG]...", stdio.Err).WithHelp(command.Help{
+		Description: "The MimixBox multi-call front-end. With --list it prints every applet; " +
+			"otherwise it runs APPLET with the remaining arguments, exactly as invoking the " +
+			"applet directly would.",
+		Examples: []command.Example{
+			{Command: "busybox --list", Explain: "List all applets."},
+			{Command: "busybox cat file.txt", Explain: "Run the cat applet."},
+		},
+	})
+}
+
+// dispatch re-invokes this binary with args and forwards the streams and exit
+// status.
+func dispatch(ctx context.Context, stdio command.IO, args []string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return command.Failuref("cannot locate the MimixBox binary: %v", err)
+	}
+	cmd := exec.CommandContext(ctx, self, args...) //nolint:gosec // dispatching to our own applets
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}

--- a/internal/applets/compat/busybox/busybox_test.go
+++ b/internal/applets/compat/busybox/busybox_test.go
@@ -1,0 +1,37 @@
+package busybox
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func out(t *testing.T, args ...string) string {
+	t.Helper()
+	o := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: o, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return o.String()
+}
+
+func TestVersion(t *testing.T) {
+	t.Parallel()
+	if got := out(t, "--version"); !strings.Contains(got, "busybox") {
+		t.Errorf("--version = %q", got)
+	}
+}
+
+func TestHelpAndNoArgs(t *testing.T) {
+	t.Parallel()
+	if got := out(t, "--help"); !strings.Contains(got, "Usage: busybox") {
+		t.Errorf("--help = %q", got)
+	}
+	if got := out(t); !strings.Contains(got, "Usage: busybox") {
+		t.Errorf("no args = %q", got)
+	}
+}

--- a/internal/applets/compat/cttyhack/cttyhack.go
+++ b/internal/applets/compat/cttyhack/cttyhack.go
@@ -1,0 +1,73 @@
+// Package cttyhack implements a compatibility cttyhack: BusyBox's cttyhack
+// allocates a controlling terminal and then execs a program. MimixBox cannot
+// perform that controlling-TTY trick portably, so this is an honest exec
+// wrapper that forwards stdio and documents the limitation rather than
+// pretending the TTY hack succeeded.
+package cttyhack
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the cttyhack applet.
+type Command struct{}
+
+// New returns a cttyhack command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "cttyhack" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run PROGRAM with the current stdio (no controlling-TTY trick)" }
+
+// Run executes the program operand, forwarding the shell's streams.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "PROGRAM [ARG]...", stdio.Err).WithHelp(command.Help{
+		Description: "Run PROGRAM with MimixBox's standard input, output, and error. Unlike BusyBox " +
+			"cttyhack it does not allocate a new controlling terminal; it is a plain exec wrapper.",
+		Examples: []command.Example{
+			{Command: "cttyhack sh", Explain: "Run sh with the current stdio."},
+		},
+		Notes: []string{
+			"The controlling-TTY allocation that BusyBox cttyhack performs is not implemented.",
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	operands := fs.Args()
+	if len(operands) == 0 {
+		return command.Failuref("missing PROGRAM operand")
+	}
+
+	path, argv := resolve(operands)
+	cmd := exec.CommandContext(ctx, path, argv...) //nolint:gosec // running a user-named program is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// resolve maps the program operand to the path and argv to run: a PATH binary
+// when present, otherwise this MimixBox binary re-invoked as the applet.
+func resolve(operands []string) (string, []string) {
+	if _, err := exec.LookPath(operands[0]); err == nil {
+		return operands[0], operands[1:]
+	}
+	if self, err := os.Executable(); err == nil {
+		return self, operands
+	}
+	return operands[0], operands[1:]
+}

--- a/internal/applets/compat/cttyhack/cttyhack_test.go
+++ b/internal/applets/compat/cttyhack/cttyhack_test.go
@@ -1,0 +1,39 @@
+package cttyhack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestRunsProgram(t *testing.T) {
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skipf("echo not on PATH: %v", err)
+	}
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"echo", "hi"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "hi") {
+		t.Errorf("output = %q", out.String())
+	}
+}
+
+func TestMissingOperand(t *testing.T) {
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: errBuf}
+	err := New().Run(context.Background(), io, nil)
+	if err == nil {
+		t.Fatal("missing PROGRAM should fail")
+	}
+	var ee *command.ExitError
+	if errors.As(err, &ee) && ee.Code == 0 {
+		t.Errorf("expected non-zero exit, got %d", ee.Code)
+	}
+}

--- a/internal/applets/compat/shellfront/shellfront.go
+++ b/internal/applets/compat/shellfront/shellfront.go
@@ -1,0 +1,93 @@
+// Package shellfront implements the BusyBox shell front-ends sh, ash, hush and
+// bash as compatibility launchers over MimixBox's own shell, mbsh. They accept
+// the common invocation forms (interactive, -c COMMAND, -s, SCRIPT [ARG]...) and
+// only show an interactive prompt when standard input is a terminal.
+package shellfront
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is one shell front-end (its name distinguishes sh/ash/hush/bash).
+type Command struct{ name string }
+
+// NewSh returns the sh front-end.
+func NewSh() *Command { return &Command{name: "sh"} }
+
+// NewAsh returns the ash front-end.
+func NewAsh() *Command { return &Command{name: "ash"} }
+
+// NewHush returns the hush front-end.
+func NewHush() *Command { return &Command{name: "hush"} }
+
+// NewBash returns the bash front-end.
+func NewBash() *Command { return &Command{name: "bash"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	return "Command interpreter (MimixBox mbsh compatibility front-end)"
+}
+
+// Run launches mbsh according to the requested invocation form.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-c COMMAND | -s | SCRIPT [ARG]...]", stdio.Err).WithHelp(command.Help{
+		Description: "A compatibility front-end over MimixBox's shell (mbsh). It runs a one-off " +
+			"COMMAND with -c, reads commands from standard input with -s or no operand, or runs " +
+			"a SCRIPT file. An interactive prompt is shown only when standard input is a terminal.",
+		Examples: []command.Example{
+			{Command: c.Name() + " -c 'echo hello'", Explain: "Run a single command and exit."},
+			{Command: c.Name() + " script.sh", Explain: "Run the commands in script.sh."},
+			{Command: "echo 'echo hi' | " + c.Name(), Explain: "Read commands from standard input."},
+		},
+		Notes: []string{
+			"This is mbsh under another name, not a full BusyBox/POSIX shell; it supports mbsh's syntax.",
+		},
+	})
+	commandStr := fs.StringP("command", "c", "", "run COMMAND and exit")
+	fromStdin := fs.BoolP("stdin", "s", false, "read commands from standard input")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	operands := fs.Args()
+
+	switch {
+	case fs.Changed("command"):
+		in := strings.NewReader(*commandStr + "\n")
+		mbsh.Interpret(ctx, command.IO{In: in, Out: stdio.Out, Err: stdio.Err}, false)
+	case *fromStdin || len(operands) == 0:
+		mbsh.Interpret(ctx, stdio, isTerminal(stdio.In))
+	default:
+		data, rerr := os.ReadFile(operands[0]) //nolint:gosec // user-named script
+		if rerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "%s: %s\n", c.Name(), command.FileError(operands[0], rerr))
+			return command.SilentFailure()
+		}
+		mbsh.Interpret(ctx, command.IO{In: bytes.NewReader(data), Out: stdio.Out, Err: stdio.Err}, false)
+	}
+	return nil
+}
+
+// isTerminal reports whether r is a character device (a real terminal).
+func isTerminal(r interface{}) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/applets/compat/shellfront/shellfront_test.go
+++ b/internal/applets/compat/shellfront/shellfront_test.go
@@ -1,0 +1,80 @@
+package shellfront
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, c *Command, in string, args ...string) (string, string) {
+	t.Helper()
+	// Use a real pipe so launched commands share an *os.File stdin.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _, _ = pw.WriteString(in); _ = pw.Close() }()
+	out, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	io := command.IO{In: pr, Out: out, Err: errBuf}
+	if rerr := c.Run(context.Background(), io, args); rerr != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", rerr, errBuf.String())
+	}
+	_ = pr.Close()
+	return out.String(), errBuf.String()
+}
+
+func requireCmd(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s not on PATH: %v", name, err)
+	}
+}
+
+func TestDashCRunsCommand(t *testing.T) {
+	requireCmd(t, "echo")
+	out, _ := run(t, NewSh(), "", "-c", "echo hello")
+	if !strings.Contains(out, "hello") {
+		t.Errorf("sh -c output = %q", out)
+	}
+	if strings.Contains(out, "mbsh:") {
+		t.Errorf("non-interactive sh must not print a prompt: %q", out)
+	}
+}
+
+func TestScriptFile(t *testing.T) {
+	requireCmd(t, "echo")
+	dir := t.TempDir()
+	script := filepath.Join(dir, "s.sh")
+	if err := os.WriteFile(script, []byte("echo fromfile\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := run(t, NewBash(), "", script)
+	if !strings.Contains(out, "fromfile") {
+		t.Errorf("script output = %q", out)
+	}
+}
+
+func TestStdinNonTTYNoPrompt(t *testing.T) {
+	requireCmd(t, "echo")
+	out, _ := run(t, NewAsh(), "echo fromstdin\n")
+	if !strings.Contains(out, "fromstdin") || strings.Contains(out, "mbsh:") {
+		t.Errorf("ash from stdin output = %q (should have no prompt)", out)
+	}
+}
+
+func TestHelp(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := NewBash().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Usage: bash") {
+		t.Errorf("--help out = %q", out.String())
+	}
+}

--- a/internal/applets/compat/unit/unit.go
+++ b/internal/applets/compat/unit/unit.go
@@ -1,0 +1,42 @@
+// Package unit implements a compatibility "unit" applet. In BusyBox, unit is the
+// developer-facing libbb unit-test runner. MimixBox does not ship that suite, so
+// rather than silently doing nothing this applet explains where MimixBox's tests
+// live and exits non-zero.
+package unit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the unit applet.
+type Command struct{}
+
+// New returns a unit command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "unit" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "BusyBox unit-test runner (not shipped by MimixBox)" }
+
+// Run reports that MimixBox has no libbb unit-test suite and exits non-zero.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "BusyBox's unit applet runs its internal libbb unit tests. MimixBox does not " +
+			"embed that suite, so this applet does nothing except point at MimixBox's own tests.",
+		Notes: []string{
+			"Run 'go test ./...' for unit tests and 'make test-e2e' for the ShellSpec suite.",
+		},
+		ExitStatus: "2  always, because there is no embedded unit-test suite to run.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	_, _ = fmt.Fprintln(stdio.Err, "unit: MimixBox ships no embedded unit-test suite; run 'go test ./...' and 'make test-e2e' instead")
+	return &command.ExitError{Code: 2}
+}

--- a/internal/applets/compat/unit/unit_test.go
+++ b/internal/applets/compat/unit/unit_test.go
@@ -1,0 +1,37 @@
+package unit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestUnitExitsNonZero(t *testing.T) {
+	t.Parallel()
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: errBuf}
+	err := New().Run(context.Background(), io, nil)
+	var ee *command.ExitError
+	if !errors.As(err, &ee) || ee.Code != 2 {
+		t.Errorf("err = %v, want ExitError code 2", err)
+	}
+	if !strings.Contains(errBuf.String(), "go test") {
+		t.Errorf("stderr should point at the real tests, got %q", errBuf.String())
+	}
+}
+
+func TestUnitHelp(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Usage: unit") {
+		t.Errorf("--help out = %q", out.String())
+	}
+}

--- a/internal/applets/shellutils/mbsh/mbsh.go
+++ b/internal/applets/shellutils/mbsh/mbsh.go
@@ -67,6 +67,16 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		return err
 	}
 
+	Interpret(ctx, stdio, true)
+	return nil
+}
+
+// Interpret runs the mbsh read-eval loop over stdio until EOF or an "exit"
+// command. When prompt is true it prints the interactive prompt before each
+// line; shell front-ends such as sh/bash pass false so non-interactive scripts
+// produce no prompt noise. It is exported so those launchers can reuse the
+// interpreter without re-implementing it.
+func Interpret(ctx context.Context, stdio command.IO, prompt bool) {
 	sh := &shell{}
 	// Read commands one byte at a time rather than through a buffered reader.
 	// A buffered reader would read past the current line, so a command launched
@@ -78,26 +88,28 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 	// as it would under any other shell; in interactive mode each Enter yields
 	// one line and the foreground command shares the terminal.
 	for {
-		_, _ = fmt.Fprint(stdio.Out, sh.prompt())
+		if prompt {
+			_, _ = fmt.Fprint(stdio.Out, sh.prompt())
+		}
 
 		line, err := readLine(stdio.In)
 		if err != nil {
 			// Run whatever was read before EOF (a final line without a
 			// trailing newline), then stop the loop cleanly.
 			if errors.Is(err, io.EOF) {
+				// At EOF the loop ends regardless, so run the final partial line
+				// (if any) for its side effects and stop.
 				if strings.TrimSpace(line) != "" {
-					if stop := sh.execInput(ctx, stdio, line); stop {
-						return nil
-					}
+					sh.execInput(ctx, stdio, line)
 				}
-				return nil
+				return
 			}
 			_, _ = fmt.Fprintln(stdio.Err, err)
-			return nil
+			return
 		}
 
 		if stop := sh.execInput(ctx, stdio, line); stop {
-			return nil
+			return
 		}
 	}
 }

--- a/test/it/compat/compat_test.sh
+++ b/test/it/compat/compat_test.sh
@@ -1,0 +1,33 @@
+# Note: bash's own builtins shadow "[" and "test", so the bracket aliases are
+# invoked explicitly through the mimixbox dispatcher.
+TestBracketTrue() {
+    mimixbox '[' -f /etc/hosts ']' && echo yes || echo no
+}
+
+TestBracketFalse() {
+    mimixbox '[' -f /no/such/mimixbox/file ']' && echo yes || echo no
+}
+
+TestBusyboxDispatch() {
+    d=$(mktemp -d)
+    printf 'hello\n' > "$d/f"
+    busybox cat "$d/f"
+    rm -rf "$d"
+}
+
+TestBusyboxList() {
+    busybox --list
+}
+
+TestShDashC() {
+    sh -c 'echo from-sh'
+}
+
+TestBashStdinNoPrompt() {
+    out=$(printf 'echo via-bash\n' | bash 2>/dev/null)
+    case "$out" in
+        *"mbsh:"*) echo prompted ;;
+        *via-bash*) echo ok ;;
+        *) echo "$out" ;;
+    esac
+}

--- a/test/it/spec/compat_spec.sh
+++ b/test/it/spec/compat_spec.sh
@@ -1,0 +1,35 @@
+Describe 'compat front-ends'
+    Include compat/compat_test.sh
+
+    It 'the [ alias returns true for an existing file'
+        When call TestBracketTrue
+        The output should equal 'yes'
+        The status should be success
+    End
+    It 'the [ alias returns false for a missing file'
+        When call TestBracketFalse
+        The output should equal 'no'
+        The status should be success
+    End
+    It 'busybox dispatches to an applet'
+        When call TestBusyboxDispatch
+        The output should equal 'hello'
+        The status should be success
+    End
+    It 'busybox --list shows applets'
+        When call TestBusyboxList
+        The status should be success
+        The output should include 'cat'
+        The output should include 'busybox'
+    End
+    It 'sh -c runs a command without a prompt'
+        When call TestShDashC
+        The output should equal 'from-sh'
+        The status should be success
+    End
+    It 'bash reads a non-interactive script from stdin without a prompt'
+        When call TestBashStdinNoPrompt
+        The output should equal 'ok'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Adds the BusyBox compatibility entry points from #242: the `[`/`[[` test aliases, the `sh`/`ash`/`hush`/`bash` shell front-ends, the `busybox` multi-call front-end, `cttyhack`, and `unit`. All nine are registered (via the generated registry), appear in `mimixbox --list` and the README, and support `--help`/`--version`.

## Applets

- **`[` / `[[`** (`compat/bracket`): thin fronts over the existing `test` applet. They require a closing `]` / `]]` and otherwise share test's exit codes (0 true, 1 false, 2 malformed).
- **`sh` / `ash` / `hush` / `bash`** (`compat/shellfront`): compatibility launchers over `mbsh`. They support `-c COMMAND`, `-s`, `SCRIPT [ARG]...`, and interactive use, and only show a prompt when stdin is a terminal. mbsh gained an exported `Interpret(ctx, io, prompt)` so the launchers reuse the interpreter without a prompt.
- **`busybox`**: `busybox --list` and `busybox APPLET [ARG]...`, dispatching by re-invoking this binary so the applet's stdout/stderr/exit code are unchanged.
- **`cttyhack`**: an honest exec wrapper that forwards stdio and documents that it does not perform the controlling-TTY allocation, rather than pretending it worked.
- **`unit`**: BusyBox's libbb test runner is not shipped; this prints where MimixBox's tests live (`go test`, `make test-e2e`) and exits 2 — a deterministic non-zero, never a silent no-op.

## Tests

- Unit tests per package: bracket true/false/missing-bracket/exit-codes and `--help`; shellfront `-c`, script file, non-TTY stdin (no prompt) and `--help`; cttyhack runs a program and rejects a missing operand; busybox `--version`/`--help`/no-args; unit's non-zero exit and message.
- shellspec (`compat_spec.sh`): `[` true/false, `busybox` dispatch and `--list`, `sh -c`, and `bash` reading a non-interactive script without a prompt.

## Verification

- `go test ./...` passes; `make test-e2e` passes (468 examples, 0 failures); `golangci-lint` clean; `go generate` registry and README are in sync.

Closes #242