### PR TITLE
feat(util-linux): add hexdump and hd applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 171 commands. Run `mimixbox --list` to see them on the terminal.
+There are 173 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -80,7 +80,9 @@ There are 171 commands. Run `mimixbox --list` to see them on the terminal.
 | gunzip | Decompress gzip (.gz) files |
 | gzip | Compress or uncompress FILEs (by default, compress FILES in-place) |
 | halt | Halt the system |
+| hd | Dump a file in canonical hex+ASCII (hexdump -C) |
 | head | Print the first NUMBER(default=10) lines |
+| hexdump | Display a file in hexadecimal (and other formats) |
 | hostid | Print the numeric identifier (in hexadecimal) for the current host |
 | hostname | Show the system's host name |
 | http-status-code | Explain HTTP status codes and their RFC references |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -163,12 +163,13 @@ import (
 	ap_textutils_unix2dos "github.com/nao1215/mimixbox/internal/applets/textutils/unix2dos"
 	ap_textutils_wc "github.com/nao1215/mimixbox/internal/applets/textutils/wc"
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
+	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 171)
+	Applets = make(map[string]Applet, 173)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -340,4 +341,6 @@ func init() {
 	register(ap_textutils_unix2dos.New())
 	register(ap_textutils_wc.New())
 	register(ap_textutils_xxd.New())
+	register(ap_util_linux_hexdump.NewHd())
+	register(ap_util_linux_hexdump.NewHexdump())
 }

--- a/internal/applets/util-linux/hexdump/hexdump.go
+++ b/internal/applets/util-linux/hexdump/hexdump.go
@@ -1,0 +1,170 @@
+// Package hexdump implements the hexdump and hd applets: dump a file (or
+// standard input) as hexadecimal. hexdump defaults to two-byte little-endian
+// words; hd (and hexdump -C) use the canonical hex+ASCII layout.
+package hexdump
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the hexdump/hd applet.
+type Command struct {
+	name      string
+	canonical bool // hd forces the -C layout
+}
+
+// NewHexdump returns the hexdump applet.
+func NewHexdump() *Command { return &Command{name: "hexdump"} }
+
+// NewHd returns the hd applet (hexdump -C).
+func NewHd() *Command { return &Command{name: "hd", canonical: true} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	if c.canonical {
+		return "Dump a file in canonical hex+ASCII (hexdump -C)"
+	}
+	return "Display a file in hexadecimal (and other formats)"
+}
+
+// Run executes the applet.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(c.help())
+	canonical := fs.BoolP("canonical", "C", false, "canonical hex+ASCII display")
+	length := fs.IntP("length", "n", -1, "interpret only LENGTH bytes of input")
+	skip := fs.Int64P("skip", "s", 0, "skip OFFSET bytes from the beginning")
+	_ = fs.BoolP("no-squeezing", "v", true, "display all input data (the default; squeezing is not implemented)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	data, err := readInput(stdio, fs.Args())
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", c.Name(), err)
+		return command.SilentFailure()
+	}
+	if *skip > 0 {
+		if *skip >= int64(len(data)) {
+			data = nil
+		} else {
+			data = data[*skip:]
+		}
+	}
+	if *length >= 0 && *length < len(data) {
+		data = data[:*length]
+	}
+
+	if c.canonical || *canonical {
+		writeCanonical(stdio.Out, *skip, data)
+	} else {
+		writeTwoByte(stdio.Out, *skip, data)
+	}
+	return nil
+}
+
+// readInput concatenates the named files, or reads standard input when none are
+// given (or when "-" is given).
+func readInput(stdio command.IO, files []string) ([]byte, error) {
+	if len(files) == 0 || (len(files) == 1 && files[0] == "-") {
+		return io.ReadAll(stdio.In)
+	}
+	var out []byte
+	for _, f := range files {
+		b, err := os.ReadFile(f) //nolint:gosec // user-named file
+		if err != nil {
+			return nil, errors.New(command.FileError(f, err))
+		}
+		out = append(out, b...)
+	}
+	return out, nil
+}
+
+// writeCanonical writes the "hexdump -C" / hd layout to w.
+func writeCanonical(w io.Writer, base int64, data []byte) {
+	var b strings.Builder
+	for off := 0; off < len(data); off += 16 {
+		end := off + 16
+		if end > len(data) {
+			end = len(data)
+		}
+		row := data[off:end]
+		fmt.Fprintf(&b, "%08x  ", base+int64(off))
+		for i := 0; i < 16; i++ {
+			if i == 8 {
+				b.WriteByte(' ')
+			}
+			if i < len(row) {
+				fmt.Fprintf(&b, "%02x ", row[i])
+			} else {
+				b.WriteString("   ")
+			}
+		}
+		b.WriteString(" |")
+		for _, ch := range row {
+			if ch >= 0x20 && ch <= 0x7e {
+				b.WriteByte(ch)
+			} else {
+				b.WriteByte('.')
+			}
+		}
+		b.WriteString("|\n")
+	}
+	fmt.Fprintf(&b, "%08x\n", base+int64(len(data)))
+	_, _ = io.WriteString(w, b.String())
+}
+
+// writeTwoByte writes the default hexdump layout: two-byte little-endian words.
+func writeTwoByte(w io.Writer, base int64, data []byte) {
+	var b strings.Builder
+	for off := 0; off < len(data); off += 16 {
+		end := off + 16
+		if end > len(data) {
+			end = len(data)
+		}
+		row := data[off:end]
+		fmt.Fprintf(&b, "%07x", base+int64(off))
+		for i := 0; i < 16; i += 2 {
+			switch {
+			case i+1 < len(row):
+				fmt.Fprintf(&b, " %02x%02x", row[i+1], row[i])
+			case i < len(row):
+				fmt.Fprintf(&b, " %04x", uint16(row[i])) // a trailing odd byte
+			default:
+				b.WriteString("     ") // pad missing words to keep 8 columns
+			}
+		}
+		b.WriteByte('\n')
+	}
+	fmt.Fprintf(&b, "%07x\n", base+int64(len(data)))
+	_, _ = io.WriteString(w, b.String())
+}
+
+func (c *Command) help() command.Help {
+	desc := "Display FILE (or standard input) as hexadecimal. The default format is two-byte " +
+		"little-endian words; -C selects the canonical hex+ASCII layout."
+	if c.canonical {
+		desc = "Display FILE (or standard input) in the canonical hex+ASCII layout (hexdump -C)."
+	}
+	return command.Help{
+		Description: desc,
+		Examples: []command.Example{
+			{Command: c.Name() + " file.bin", Explain: "Dump the whole file."},
+			{Command: c.Name() + " -n 64 file.bin", Explain: "Dump only the first 64 bytes."},
+		},
+		Notes: []string{
+			"Repeated-line squeezing (the '*' line) is not implemented; all lines are shown.",
+		},
+	}
+}

--- a/internal/applets/util-linux/hexdump/hexdump_test.go
+++ b/internal/applets/util-linux/hexdump/hexdump_test.go
@@ -1,0 +1,74 @@
+package hexdump
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, c *Command, in string, args ...string) (string, string) {
+	t.Helper()
+	out, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: errBuf}
+	if err := c.Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errBuf.String())
+	}
+	return out.String(), errBuf.String()
+}
+
+// These golden strings were verified byte-for-byte against util-linux hd /
+// hexdump.
+func TestHdCanonical(t *testing.T) {
+	t.Parallel()
+	want := "00000000  68 65 6c 6c 6f 20 77 6f  72 6c 64 0a              |hello world.|\n0000000c\n"
+	if got, _ := run(t, NewHd(), "hello world\n"); got != want {
+		t.Errorf("hd =\n%q\nwant\n%q", got, want)
+	}
+	// hexdump -C is the same as hd.
+	if got, _ := run(t, NewHexdump(), "hello world\n", "-C"); got != want {
+		t.Errorf("hexdump -C =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestHexdumpTwoByte(t *testing.T) {
+	t.Parallel()
+	want := "0000000 6568 6c6c 206f 6f77 6c72 0a64          \n000000c\n"
+	if got, _ := run(t, NewHexdump(), "hello world\n"); got != want {
+		t.Errorf("hexdump =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestLengthAndSkip(t *testing.T) {
+	t.Parallel()
+	// -n 4 keeps the first four bytes; the trailing offset is 00000004.
+	got, _ := run(t, NewHd(), "abcdefgh", "-n", "4")
+	if !strings.HasPrefix(got, "00000000  61 62 63 64 ") || !strings.Contains(got, "|abcd|") {
+		t.Errorf("hd -n 4 = %q", got)
+	}
+	if !strings.HasSuffix(got, "00000004\n") {
+		t.Errorf("hd -n 4 final offset = %q", got)
+	}
+	// -s 4 skips the first four bytes.
+	got, _ = run(t, NewHd(), "abcdefgh", "-s", "4")
+	if !strings.Contains(got, "|efgh|") || strings.Contains(got, "|abcd|") {
+		t.Errorf("hd -s 4 = %q", got)
+	}
+}
+
+func TestEmptyInput(t *testing.T) {
+	t.Parallel()
+	if got, _ := run(t, NewHd(), ""); got != "00000000\n" {
+		t.Errorf("hd of empty = %q, want %q", got, "00000000\n")
+	}
+}
+
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, NewHexdump(), "", "--help")
+	if !strings.Contains(out, "Usage: hexdump") {
+		t.Errorf("--help = %q", out)
+	}
+}

--- a/test/it/spec/hexdump_spec.sh
+++ b/test/it/spec/hexdump_spec.sh
@@ -1,0 +1,20 @@
+Describe 'hexdump / hd'
+    Include util-linux/hexdump_test.sh
+
+    It 'hd shows the canonical hex+ASCII layout'
+        When call TestHd
+        The status should be success
+        The output should include '00000000  68 65 6c 6c 6f 20 77 6f  72 6c 64 0a'
+        The output should include '|hello world.|'
+    End
+    It 'hexdump -C matches hd'
+        When call TestHexdumpCanonical
+        The status should be success
+        The output should include '|hello world.|'
+    End
+    It 'hexdump default shows two-byte words'
+        When call TestHexdumpDefault
+        The status should be success
+        The output should include '6568 6c6c 206f'
+    End
+End

--- a/test/it/util-linux/hexdump_test.sh
+++ b/test/it/util-linux/hexdump_test.sh
@@ -1,0 +1,11 @@
+TestHd() {
+    printf 'hello world\n' | hd
+}
+
+TestHexdumpCanonical() {
+    printf 'hello world\n' | hexdump -C
+}
+
+TestHexdumpDefault() {
+    printf 'hello world\n' | hexdump
+}


### PR DESCRIPTION
## Summary

Advances the util-linux inspection batch (#248) with the hex dumpers:

- `hexdump` — defaults to the two-byte little-endian word format; `-C` selects the canonical hex+ASCII layout; supports `-n LENGTH` and `-s SKIP`.
- `hd` — the canonical hex+ASCII layout (`hexdump -C`).

Both formats were verified byte-for-byte against the host `hexdump`/`hd` across single-byte, multi-line, and full-line inputs. They read files or standard input.

## Tests

- Unit (golden strings verified against util-linux): `hd` and `hexdump -C` canonical layout, `hexdump` two-byte layout, `-n`/`-s`, empty input, and `--help`.
- shellspec: `hd`, `hexdump -C`, and default `hexdump` on a fixed input.

## Verification

- `go test ./...` passes; `make test-e2e` passes (475 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

## Note

`--squeezing` (the repeated-line `*`) is documented as not yet implemented. This PR adds 2 of #248's applets, advancing the batch.

Part of #248