### PR TITLE
feat(coreutils): add factor, tsort, egrep, and fgrep applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 174 commands. Run `mimixbox --list` to see them on the terminal.
+There are 178 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -64,11 +64,14 @@ There are 174 commands. Run `mimixbox --list` to see them on the terminal.
 | dos2unix | Change CRLF to LF |
 | du | Estimate file space usage |
 | echo | Display a line of text |
+| egrep | Search with extended regular expressions (grep -E) |
 | env | Run a program in a modified environment / print the environment |
 | expand | Convert TAB to N space (default:N=8) |
 | expr | Evaluate expressions |
+| factor | Print the prime factors of each NUMBER |
 | fakemovie | Adds a video playback button to the image |
 | false | Do nothing. Return failure(1) |
+| fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |
 | fmt | Simple optimal text formatter |
 | fold | Wrap each input line to fit in specified width |
@@ -167,6 +170,7 @@ There are 174 commands. Run `mimixbox --list` to see them on the terminal.
 | tr | Translate or delete characters |
 | true | Do nothing. Return success(0) |
 | truncate | Shrink or extend the size of a file to a given size |
+| tsort | Topological sort of a directed graph |
 | tty | Print the file name of the terminal connected to stdin |
 | uname | Print system information |
 | uncompress | Decompress LZW (.Z) files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -57,6 +57,7 @@ import (
 	ap_fileutils_unlink "github.com/nao1215/mimixbox/internal/applets/fileutils/unlink"
 	ap_findutils_find "github.com/nao1215/mimixbox/internal/applets/findutils/find"
 	ap_findutils_grep "github.com/nao1215/mimixbox/internal/applets/findutils/grep"
+	ap_findutils_grepalias "github.com/nao1215/mimixbox/internal/applets/findutils/grepalias"
 	ap_findutils_xargs "github.com/nao1215/mimixbox/internal/applets/findutils/xargs"
 	ap_games_lifegame "github.com/nao1215/mimixbox/internal/applets/games/lifegame"
 	ap_jokeutils_banner "github.com/nao1215/mimixbox/internal/applets/jokeutils/banner"
@@ -93,6 +94,7 @@ import (
 	ap_shellutils_echo "github.com/nao1215/mimixbox/internal/applets/shellutils/echo"
 	ap_shellutils_env "github.com/nao1215/mimixbox/internal/applets/shellutils/env"
 	ap_shellutils_expr "github.com/nao1215/mimixbox/internal/applets/shellutils/expr"
+	ap_shellutils_factor "github.com/nao1215/mimixbox/internal/applets/shellutils/factor"
 	ap_shellutils_false "github.com/nao1215/mimixbox/internal/applets/shellutils/false"
 	ap_shellutils_free "github.com/nao1215/mimixbox/internal/applets/shellutils/free"
 	ap_shellutils_ghrdc "github.com/nao1215/mimixbox/internal/applets/shellutils/ghrdc"
@@ -128,6 +130,7 @@ import (
 	ap_shellutils_test "github.com/nao1215/mimixbox/internal/applets/shellutils/test"
 	ap_shellutils_timeout "github.com/nao1215/mimixbox/internal/applets/shellutils/timeout"
 	ap_shellutils_true "github.com/nao1215/mimixbox/internal/applets/shellutils/true"
+	ap_shellutils_tsort "github.com/nao1215/mimixbox/internal/applets/shellutils/tsort"
 	ap_shellutils_tty "github.com/nao1215/mimixbox/internal/applets/shellutils/tty"
 	ap_shellutils_uname "github.com/nao1215/mimixbox/internal/applets/shellutils/uname"
 	ap_shellutils_uniq "github.com/nao1215/mimixbox/internal/applets/shellutils/uniq"
@@ -170,7 +173,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 174)
+	Applets = make(map[string]Applet, 178)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -234,6 +237,8 @@ func init() {
 	register(ap_fileutils_unlink.New())
 	register(ap_findutils_find.New())
 	register(ap_findutils_grep.New())
+	register(ap_findutils_grepalias.NewEgrep())
+	register(ap_findutils_grepalias.NewFgrep())
 	register(ap_findutils_xargs.New())
 	register(ap_games_lifegame.New())
 	register(ap_jokeutils_banner.New())
@@ -272,6 +277,7 @@ func init() {
 	register(ap_shellutils_echo.New())
 	register(ap_shellutils_env.New())
 	register(ap_shellutils_expr.New())
+	register(ap_shellutils_factor.New())
 	register(ap_shellutils_false.New())
 	register(ap_shellutils_free.New())
 	register(ap_shellutils_ghrdc.New())
@@ -307,6 +313,7 @@ func init() {
 	register(ap_shellutils_test.New())
 	register(ap_shellutils_timeout.New())
 	register(ap_shellutils_true.New())
+	register(ap_shellutils_tsort.New())
 	register(ap_shellutils_tty.New())
 	register(ap_shellutils_uname.New())
 	register(ap_shellutils_uniq.New())

--- a/internal/applets/findutils/grepalias/grepalias.go
+++ b/internal/applets/findutils/grepalias/grepalias.go
@@ -1,0 +1,40 @@
+// Package grepalias implements the egrep and fgrep compatibility applets as thin
+// wrappers over the grep applet: egrep forces -E (extended regular expressions)
+// and fgrep forces -F (fixed strings), so neither can drift from grep's
+// behavior.
+package grepalias
+
+import (
+	"context"
+
+	"github.com/nao1215/mimixbox/internal/applets/findutils/grep"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the egrep or fgrep alias.
+type Command struct {
+	name string
+	flag string
+}
+
+// NewEgrep returns the egrep alias (grep -E).
+func NewEgrep() *Command { return &Command{name: "egrep", flag: "-E"} }
+
+// NewFgrep returns the fgrep alias (grep -F).
+func NewFgrep() *Command { return &Command{name: "fgrep", flag: "-F"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	if c.flag == "-F" {
+		return "Search for fixed strings (grep -F)"
+	}
+	return "Search with extended regular expressions (grep -E)"
+}
+
+// Run delegates to grep with the alias's mode flag prepended.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	return grep.New().Run(ctx, stdio, append([]string{c.flag}, args...))
+}

--- a/internal/applets/findutils/grepalias/grepalias_test.go
+++ b/internal/applets/findutils/grepalias/grepalias_test.go
@@ -1,0 +1,34 @@
+package grepalias
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, c *Command, in string, args ...string) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: &bytes.Buffer{}}
+	_ = c.Run(context.Background(), io, args)
+	return out.String()
+}
+
+func TestEgrepUsesExtendedRegex(t *testing.T) {
+	t.Parallel()
+	got := run(t, NewEgrep(), "foo\nbar\nbaz\n", "ba(r|z)")
+	if got != "bar\nbaz\n" {
+		t.Errorf("egrep = %q, want bar/baz", got)
+	}
+}
+
+func TestFgrepIsFixedString(t *testing.T) {
+	t.Parallel()
+	got := run(t, NewFgrep(), "a.b\naxb\n", "a.b")
+	if got != "a.b\n" {
+		t.Errorf("fgrep = %q, want only the literal a.b line", got)
+	}
+}

--- a/internal/applets/shellutils/factor/factor.go
+++ b/internal/applets/shellutils/factor/factor.go
@@ -1,0 +1,111 @@
+// Package factor implements the factor applet: print the prime factorization of
+// each integer operand (or of integers read from standard input).
+package factor
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the factor applet.
+type Command struct{}
+
+// New returns a factor command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "factor" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the prime factors of each NUMBER" }
+
+// Run executes factor.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[NUMBER]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the prime factors of each NUMBER. With no NUMBER, read whitespace-" +
+			"separated numbers from standard input. Numbers must fit in a 64-bit unsigned integer.",
+		Examples: []command.Example{
+			{Command: "factor 360", Explain: "Print: 360: 2 2 2 3 3 5"},
+			{Command: "echo 97 | factor", Explain: "Factor numbers read from standard input."},
+		},
+		ExitStatus: "0  all operands were factored.\n1  an operand was not a valid number.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	numbers := fs.Args()
+	if len(numbers) == 0 {
+		return factorStream(stdio)
+	}
+
+	var failed bool
+	for _, n := range numbers {
+		if err := factorOne(stdio, n); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "factor: %v\n", err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// factorStream factors every whitespace-separated token on standard input.
+func factorStream(stdio command.IO) error {
+	sc := bufio.NewScanner(stdio.In)
+	sc.Split(bufio.ScanWords)
+	var failed bool
+	for sc.Scan() {
+		if err := factorOne(stdio, sc.Text()); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "factor: %v\n", err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// factorOne prints "N: f1 f2 ..." for a single token.
+func factorOne(stdio command.IO, token string) error {
+	n, err := strconv.ParseUint(strings.TrimSpace(token), 10, 64)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid positive integer", token)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d:", n)
+	for _, f := range primeFactors(n) {
+		fmt.Fprintf(&b, " %d", f)
+	}
+	_, _ = fmt.Fprintln(stdio.Out, b.String())
+	return nil
+}
+
+// primeFactors returns n's prime factors in ascending order (with multiplicity).
+// 0 and 1 have no prime factors.
+func primeFactors(n uint64) []uint64 {
+	var factors []uint64
+	for n%2 == 0 {
+		factors = append(factors, 2)
+		n /= 2
+	}
+	for f := uint64(3); f*f <= n; f += 2 {
+		for n%f == 0 {
+			factors = append(factors, f)
+			n /= f
+		}
+	}
+	if n > 1 {
+		factors = append(factors, n)
+	}
+	return factors
+}

--- a/internal/applets/shellutils/factor/factor_test.go
+++ b/internal/applets/shellutils/factor/factor_test.go
@@ -1,0 +1,56 @@
+package factor
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, in string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestFactorArgs(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"360": "360: 2 2 2 3 3 5\n",
+		"97":  "97: 97\n",
+		"1":   "1:\n",
+		"2":   "2: 2\n",
+		"100": "100: 2 2 5 5\n",
+	}
+	for in, want := range cases {
+		got, err := run(t, "", in)
+		if err != nil {
+			t.Fatalf("factor %s error = %v", in, err)
+		}
+		if got != want {
+			t.Errorf("factor %s = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFactorStdin(t *testing.T) {
+	t.Parallel()
+	got, err := run(t, "12 13\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "12: 2 2 3\n13: 13\n" {
+		t.Errorf("factor stdin = %q", got)
+	}
+}
+
+func TestFactorInvalid(t *testing.T) {
+	t.Parallel()
+	if _, err := run(t, "", "abc"); err == nil {
+		t.Errorf("factor abc should fail")
+	}
+}

--- a/internal/applets/shellutils/tsort/tsort.go
+++ b/internal/applets/shellutils/tsort/tsort.go
@@ -1,0 +1,155 @@
+// Package tsort implements the tsort applet: topological sort. It reads
+// whitespace-separated pairs (each "a b" meaning a must come before b) from a
+// file or standard input and prints a total ordering, one item per line.
+package tsort
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the tsort applet.
+type Command struct{}
+
+// New returns a tsort command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "tsort" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Topological sort of a directed graph" }
+
+// Run executes tsort.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Read pairs of items (whitespace-separated; each pair 'a b' means a precedes b) " +
+			"from FILE or standard input, and write a total ordering consistent with those " +
+			"constraints, one item per line. A lone item with no pair is still listed.",
+		Examples: []command.Example{
+			{Command: "printf 'a b\\nb c\\n' | tsort", Explain: "Print a, b, c in dependency order."},
+		},
+		ExitStatus: "0  a valid ordering was produced.\n1  the input contained a cycle or an odd token.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	r := stdio.In
+	if rest := fs.Args(); len(rest) > 0 && rest[0] != "-" {
+		f, oerr := os.Open(rest[0]) //nolint:gosec // user-named file
+		if oerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "tsort: %s\n", command.FileError(rest[0], oerr))
+			return command.SilentFailure()
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+
+	tokens, err := readTokens(r)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "tsort: %v\n", err)
+		return command.SilentFailure()
+	}
+	if len(tokens)%2 != 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "tsort: input contains an odd number of tokens")
+		return command.SilentFailure()
+	}
+
+	order, cyclic := topoSort(tokens)
+	for _, n := range order {
+		_, _ = fmt.Fprintln(stdio.Out, n)
+	}
+	if cyclic {
+		_, _ = fmt.Fprintln(stdio.Err, "tsort: input contains a loop")
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+func readTokens(r io.Reader) ([]string, error) {
+	sc := bufio.NewScanner(r)
+	sc.Split(bufio.ScanWords)
+	var tokens []string
+	for sc.Scan() {
+		tokens = append(tokens, sc.Text())
+	}
+	return tokens, sc.Err()
+}
+
+// topoSort returns a topological order of the graph built from consecutive
+// token pairs, using Kahn's algorithm with deterministic tie-breaking. cyclic is
+// true when not all nodes could be ordered (a loop), in which case the remaining
+// nodes are appended in name order so output is still complete.
+func topoSort(tokens []string) (order []string, cyclic bool) {
+	adj := map[string]map[string]bool{}
+	indeg := map[string]int{}
+	var nodesInOrder []string
+	seen := map[string]bool{}
+
+	note := func(n string) {
+		if !seen[n] {
+			seen[n] = true
+			nodesInOrder = append(nodesInOrder, n)
+			indeg[n] = 0
+			adj[n] = map[string]bool{}
+		}
+	}
+
+	for i := 0; i+1 < len(tokens); i += 2 {
+		a, b := tokens[i], tokens[i+1]
+		note(a)
+		note(b)
+		if a != b && !adj[a][b] {
+			adj[a][b] = true
+			indeg[b]++
+		}
+	}
+
+	// Ready set, kept sorted for deterministic output.
+	var ready []string
+	for _, n := range nodesInOrder {
+		if indeg[n] == 0 {
+			ready = append(ready, n)
+		}
+	}
+	sort.Strings(ready)
+
+	placed := map[string]bool{}
+	for len(ready) > 0 {
+		n := ready[0]
+		ready = ready[1:]
+		order = append(order, n)
+		placed[n] = true
+		var newly []string
+		for m := range adj[n] {
+			indeg[m]--
+			if indeg[m] == 0 {
+				newly = append(newly, m)
+			}
+		}
+		sort.Strings(newly)
+		ready = append(ready, newly...)
+		sort.Strings(ready)
+	}
+
+	if len(order) != len(nodesInOrder) {
+		cyclic = true
+		var leftover []string
+		for _, n := range nodesInOrder {
+			if !placed[n] {
+				leftover = append(leftover, n)
+			}
+		}
+		sort.Strings(leftover)
+		order = append(order, leftover...)
+	}
+	return order, cyclic
+}

--- a/internal/applets/shellutils/tsort/tsort_test.go
+++ b/internal/applets/shellutils/tsort/tsort_test.go
@@ -1,0 +1,68 @@
+package tsort
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, in string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+// indexOf returns the line index of s in the newline-separated output.
+func indexOf(out, s string) int {
+	for i, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == s {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestTopologicalOrder(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "a b\nb c\nd c\n")
+	if err != nil {
+		t.Fatalf("tsort error = %v", err)
+	}
+	// Constraints: a before b, b before c, d before c.
+	if indexOf(out, "a") >= indexOf(out, "b") || indexOf(out, "b") >= indexOf(out, "c") || indexOf(out, "d") >= indexOf(out, "c") {
+		t.Errorf("order violates constraints:\n%s", out)
+	}
+}
+
+func TestDeterministic(t *testing.T) {
+	t.Parallel()
+	a, _ := run(t, "x y\nz y\n")
+	b, _ := run(t, "x y\nz y\n")
+	if a != b {
+		t.Errorf("tsort not deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestCycle(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "a b\nb a\n")
+	if err == nil {
+		t.Errorf("a cycle should fail")
+	}
+	// Output still lists the nodes.
+	if !strings.Contains(out, "a") || !strings.Contains(out, "b") {
+		t.Errorf("cycle output should still list nodes, got %q", out)
+	}
+}
+
+func TestOddTokens(t *testing.T) {
+	t.Parallel()
+	if _, err := run(t, "a b c\n"); err == nil {
+		t.Errorf("an odd number of tokens should fail")
+	}
+}

--- a/test/it/coreutils/coreutils_test.sh
+++ b/test/it/coreutils/coreutils_test.sh
@@ -1,0 +1,4 @@
+TestFactor() { factor 360; }
+TestTsort() { printf 'a b\nb c\n' | tsort; }
+TestEgrep() { printf 'foo\nbar\nbaz\n' | egrep 'ba(r|z)'; }
+TestFgrep() { printf 'a.b\naxb\n' | fgrep 'a.b'; }

--- a/test/it/spec/coreutils_slice_spec.sh
+++ b/test/it/spec/coreutils_slice_spec.sh
@@ -1,0 +1,27 @@
+Describe 'coreutils slice'
+    Include coreutils/coreutils_test.sh
+
+    It 'factor prints prime factors'
+        When call TestFactor
+        The output should equal '360: 2 2 2 3 3 5'
+        The status should be success
+    End
+    It 'tsort topologically sorts'
+        When call TestTsort
+        The output should equal 'a
+b
+c'
+        The status should be success
+    End
+    It 'egrep uses extended regular expressions'
+        When call TestEgrep
+        The output should equal 'bar
+baz'
+        The status should be success
+    End
+    It 'fgrep matches fixed strings literally'
+        When call TestFgrep
+        The output should equal 'a.b'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with four hermetic, pure applets:

- `factor` — print the prime factorization of each NUMBER (or numbers from stdin). Output matches GNU factor (e.g. `360: 2 2 2 3 3 5`); 64-bit unsigned range.
- `tsort` — topological sort: read `a b` pairs from a file or stdin and print a total ordering (Kahn's algorithm, deterministic tie-breaking, loop detection with a non-zero exit).
- `egrep` / `fgrep` — thin wrappers that force grep's `-E` / `-F`, so they cannot drift from the underlying grep.

## Tests

- Unit: factor of representative numbers (incl. 1, primes, stdin, invalid input); tsort ordering constraints, determinism, cycle and odd-token errors; egrep extended-regex and fgrep fixed-string matching.
- shellspec: `factor 360`, a `tsort` chain, `egrep 'ba(r|z)'`, and `fgrep 'a.b'` (literal dot).

## Verification

- `go test ./...` passes; `make test-e2e` passes (481 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243