### PR TITLE
feat(coreutils): add sha384sum, sum, and crc32 checksum applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 178 commands. Run `mimixbox --list` to see them on the terminal.
+There are 181 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -54,6 +54,7 @@ There are 178 commands. Run `mimixbox --list` to see them on the terminal.
 | cowthink | Print message in a cow's thought bubble |
 | cp | Copy file(s) to Directory(s) |
 | cpio | Copy files to and from archives |
+| crc32 | Print the CRC-32 checksum of each file |
 | cttyhack | Run PROGRAM with the current stdio (no controlling-TTY trick) |
 | cut | Remove sections from each line of files |
 | date | Print or set the system date and time |
@@ -149,6 +150,7 @@ There are 178 commands. Run `mimixbox --list` to see them on the terminal.
 | sh | Command interpreter (MimixBox mbsh compatibility front-end) |
 | sha1sum | Calculate or Check secure hash 1 algorithm |
 | sha256sum | Calculate or Check secure hash 256 algorithm |
+| sha384sum | Calculate or Check secure hash 384 algorithm |
 | sha512sum | Calculate or Check secure hash 512 algorithm |
 | shred | Overwrite a file to hide its contents |
 | shuf | Generate a random permutation of input lines |
@@ -159,6 +161,7 @@ There are 178 commands. Run `mimixbox --list` to see them on the terminal.
 | split | Split a file into pieces |
 | stat | Display file or file system status |
 | strings | Print printable character sequences in files |
+| sum | Checksum and count the blocks in a file (BSD) |
 | sync | Synchronize cached writes to persistent storage |
 | tac | Print the file contents from the end to the beginning |
 | tail | Print the last NUMBER(default=10) lines |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -144,6 +144,7 @@ import (
 	ap_textutils_cat "github.com/nao1215/mimixbox/internal/applets/textutils/cat"
 	ap_textutils_cksum "github.com/nao1215/mimixbox/internal/applets/textutils/cksum"
 	ap_textutils_comm "github.com/nao1215/mimixbox/internal/applets/textutils/comm"
+	ap_textutils_crc32 "github.com/nao1215/mimixbox/internal/applets/textutils/crc32"
 	ap_textutils_dos2unix "github.com/nao1215/mimixbox/internal/applets/textutils/dos2unix"
 	ap_textutils_expand "github.com/nao1215/mimixbox/internal/applets/textutils/expand"
 	ap_textutils_fmt "github.com/nao1215/mimixbox/internal/applets/textutils/fmt"
@@ -155,10 +156,12 @@ import (
 	ap_textutils_rev "github.com/nao1215/mimixbox/internal/applets/textutils/rev"
 	ap_textutils_sha1sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha1sum"
 	ap_textutils_sha256sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha256sum"
+	ap_textutils_sha384sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha384sum"
 	ap_textutils_sha512sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha512sum"
 	ap_textutils_shuf "github.com/nao1215/mimixbox/internal/applets/textutils/shuf"
 	ap_textutils_split "github.com/nao1215/mimixbox/internal/applets/textutils/split"
 	ap_textutils_strings "github.com/nao1215/mimixbox/internal/applets/textutils/strings"
+	ap_textutils_sum "github.com/nao1215/mimixbox/internal/applets/textutils/sum"
 	ap_textutils_tac "github.com/nao1215/mimixbox/internal/applets/textutils/tac"
 	ap_textutils_tail "github.com/nao1215/mimixbox/internal/applets/textutils/tail"
 	ap_textutils_tr "github.com/nao1215/mimixbox/internal/applets/textutils/tr"
@@ -173,7 +176,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 178)
+	Applets = make(map[string]Applet, 181)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -327,6 +330,7 @@ func init() {
 	register(ap_textutils_cat.New())
 	register(ap_textutils_cksum.New())
 	register(ap_textutils_comm.New())
+	register(ap_textutils_crc32.New())
 	register(ap_textutils_dos2unix.New())
 	register(ap_textutils_expand.New())
 	register(ap_textutils_fmt.New())
@@ -338,10 +342,12 @@ func init() {
 	register(ap_textutils_rev.New())
 	register(ap_textutils_sha1sum.New())
 	register(ap_textutils_sha256sum.New())
+	register(ap_textutils_sha384sum.New())
 	register(ap_textutils_sha512sum.New())
 	register(ap_textutils_shuf.New())
 	register(ap_textutils_split.New())
 	register(ap_textutils_strings.New())
+	register(ap_textutils_sum.New())
 	register(ap_textutils_tac.New())
 	register(ap_textutils_tail.New())
 	register(ap_textutils_tr.New())

--- a/internal/applets/textutils/crc32/crc32.go
+++ b/internal/applets/textutils/crc32/crc32.go
@@ -1,0 +1,78 @@
+// Package crc32 implements the crc32 applet: print the CRC-32 (IEEE) checksum of
+// each file (or standard input) as an 8-digit hexadecimal value.
+package crc32
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the crc32 applet.
+type Command struct{}
+
+// New returns a crc32 command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "crc32" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the CRC-32 checksum of each file" }
+
+// Run executes crc32.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the CRC-32 (IEEE) checksum of each FILE as eight hexadecimal digits, " +
+			"followed by the file name. With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "crc32 file.bin", Explain: "Print: <crc32 hex>  file.bin"},
+		},
+		ExitStatus: "0  success.\n1  a file could not be read.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+
+	var failed bool
+	for _, name := range files {
+		sum, rerr := crcOf(stdio, name)
+		if rerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "crc32: %s\n", command.FileError(name, rerr))
+			failed = true
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%08x  %s\n", sum, name)
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+func crcOf(stdio command.IO, name string) (uint32, error) {
+	r := stdio.In
+	if name != "-" {
+		f, err := os.Open(name) //nolint:gosec // user-named file
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+	h := crc32.NewIEEE()
+	if _, err := io.Copy(h, r); err != nil {
+		return 0, err
+	}
+	return h.Sum32(), nil
+}

--- a/internal/applets/textutils/crc32/crc32_test.go
+++ b/internal/applets/textutils/crc32/crc32_test.go
@@ -1,0 +1,55 @@
+package crc32
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, in string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestCrc32Stdin(t *testing.T) {
+	t.Parallel()
+	// CRC-32 (IEEE) of "hello\n" is 0x363a3020.
+	got, err := run(t, "hello\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "363a3020  -\n" {
+		t.Errorf("crc32 stdin = %q, want %q", got, "363a3020  -\n")
+	}
+}
+
+func TestCrc32File(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "h.txt")
+	if err := os.WriteFile(f, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := run(t, "", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "363a3020  "+f+"\n" {
+		t.Errorf("crc32 file = %q", got)
+	}
+}
+
+func TestCrc32Missing(t *testing.T) {
+	t.Parallel()
+	if _, err := run(t, "", "/no/such/crc/file"); err == nil {
+		t.Errorf("missing file should fail")
+	}
+}

--- a/internal/applets/textutils/sha384sum/sha384sum.go
+++ b/internal/applets/textutils/sha384sum/sha384sum.go
@@ -1,0 +1,32 @@
+// Package sha384sum implements the sha384sum applet: print or check SHA-384
+// message digests, in the GNU coreutils output format.
+package sha384sum
+
+import (
+	"context"
+	"crypto/sha512"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"github.com/nao1215/mimixbox/internal/hashsum"
+)
+
+const synopsis = "Calculate or Check secure hash 384 algorithm"
+
+// Command is the sha384sum applet.
+type Command struct{ inner *hashsum.Command }
+
+// New returns a sha384sum command.
+func New() *Command {
+	return &Command{inner: hashsum.New("sha384sum", synopsis, sha512.New384)}
+}
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.inner.Name() }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return c.inner.Synopsis() }
+
+// Run executes sha384sum.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	return c.inner.Run(ctx, stdio, args)
+}

--- a/internal/applets/textutils/sha384sum/sha384sum_test.go
+++ b/internal/applets/textutils/sha384sum/sha384sum_test.go
@@ -1,0 +1,23 @@
+package sha384sum
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestSha384Stdin(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader("hello\n"), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatal(err)
+	}
+	const want = "1d0f284efe3edea4b9ca3bd514fa134b17eae361ccc7a1eefeff801b9bd6604e01f21f6bf249ef030599f0c218f2ba8c"
+	if !strings.HasPrefix(out.String(), want) {
+		t.Errorf("sha384sum = %q, want prefix %q", out.String(), want)
+	}
+}

--- a/internal/applets/textutils/sum/sum.go
+++ b/internal/applets/textutils/sum/sum.go
@@ -1,0 +1,102 @@
+// Package sum implements the sum applet: print a BSD-style 16-bit checksum and
+// the 1024-byte block count for each file (or standard input).
+package sum
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the sum applet.
+type Command struct{}
+
+// New returns a sum command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "sum" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Checksum and count the blocks in a file (BSD)" }
+
+// Run executes sum.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print a checksum and the number of 1024-byte blocks for each FILE, using the " +
+			"BSD algorithm. With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "sum file.txt", Explain: "Print: <checksum> <blocks> file.txt"},
+		},
+		ExitStatus: "0  success.\n1  a file could not be read.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		s, blocks, rerr := bsdSum(stdio.In)
+		if rerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sum: %v\n", rerr)
+			return command.SilentFailure()
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%05d %5d\n", s, blocks)
+		return nil
+	}
+
+	var failed bool
+	for _, name := range files {
+		s, blocks, rerr := sumFile(stdio, name)
+		if rerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sum: %s\n", command.FileError(name, rerr))
+			failed = true
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%05d %5d %s\n", s, blocks, name)
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+func sumFile(stdio command.IO, name string) (uint16, int64, error) {
+	if name == "-" {
+		return bsdSum(stdio.In)
+	}
+	f, err := os.Open(name) //nolint:gosec // user-named file
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = f.Close() }()
+	return bsdSum(f)
+}
+
+// bsdSum computes the BSD 16-bit rotate checksum and the number of 1024-byte
+// blocks (rounded up) of r.
+func bsdSum(r io.Reader) (uint16, int64, error) {
+	var sum uint32
+	var total int64
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		for _, b := range buf[:n] {
+			sum = (sum >> 1) | ((sum & 1) << 15)
+			sum = (sum + uint32(b)) & 0xffff
+		}
+		total += int64(n)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return 0, 0, err
+		}
+	}
+	blocks := (total + 1023) / 1024
+	return uint16(sum), blocks, nil
+}

--- a/internal/applets/textutils/sum/sum_test.go
+++ b/internal/applets/textutils/sum/sum_test.go
@@ -1,0 +1,55 @@
+package sum
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, in string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestSumStdin(t *testing.T) {
+	t.Parallel()
+	// Verified against BSD sum: "hello\n" -> 36979, 1 block.
+	got, err := run(t, "hello\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "36979     1\n" {
+		t.Errorf("sum stdin = %q, want %q", got, "36979     1\n")
+	}
+}
+
+func TestSumFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "h.txt")
+	if err := os.WriteFile(f, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := run(t, "", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "36979     1 "+f+"\n" {
+		t.Errorf("sum file = %q", got)
+	}
+}
+
+func TestSumMissingFile(t *testing.T) {
+	t.Parallel()
+	if _, err := run(t, "", "/no/such/sum/file"); err == nil {
+		t.Errorf("missing file should fail")
+	}
+}

--- a/test/it/spec/checksum_spec.sh
+++ b/test/it/spec/checksum_spec.sh
@@ -1,0 +1,19 @@
+Describe 'checksums'
+    Include textutils/checksum_test.sh
+
+    It 'sum prints the BSD checksum and block count'
+        When call TestSum
+        The output should equal '36979     1'
+        The status should be success
+    End
+    It 'crc32 prints the CRC-32 of stdin'
+        When call TestCrc32
+        The output should equal '363a3020  -'
+        The status should be success
+    End
+    It 'sha384sum prints the SHA-384 digest'
+        When call TestSha384
+        The status should be success
+        The output should include '1d0f284efe3edea4b9ca3bd514fa134b17eae361ccc7a1eefeff801b9bd6604e'
+    End
+End

--- a/test/it/textutils/checksum_test.sh
+++ b/test/it/textutils/checksum_test.sh
@@ -1,0 +1,3 @@
+TestSum() { printf 'hello\n' | sum; }
+TestCrc32() { printf 'hello\n' | crc32; }
+TestSha384() { printf 'hello\n' | sha384sum; }


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with three checksum applets, each matching the standard output layout:

- `sha384sum` — SHA-384 digests in the GNU `<hex>  FILE` format (reuses the shared `internal/hashsum` framework, so -c/check and the `*`/space modes work like the other `*sum` applets).
- `sum` — the BSD 16-bit rotate checksum and 1024-byte block count (`<sum> <blocks> FILE`), verified byte-for-byte against the host `sum`.
- `crc32` — the CRC-32 (IEEE) of each file as eight hex digits followed by the name; reads stdin when no FILE is given.

## Tests

- Unit: `sum` and `crc32` for stdin and files (golden values verified against host `sum` and `hash/crc32`), plus missing-file errors; `sha384sum` digest of a known input.
- shellspec: `sum`, `crc32`, and `sha384sum` on a fixed input.

## Verification

- `go test ./...` passes; `make test-e2e` passes (484 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243