### PR TITLE
feat(coreutils): add uuencode, uudecode, and usleep applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 181 commands. Run `mimixbox --list` to see them on the terminal.
+There are 184 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -186,6 +186,9 @@ There are 181 commands. Run `mimixbox --list` to see them on the terminal.
 | unshadow | Combine passwd and shadow files for password auditing |
 | unxz | Decompress xz files |
 | unzip | Extract files from a ZIP archive |
+| usleep | Pause for N microseconds |
+| uudecode | Decode a uuencoded (or base64) file |
+| uuencode | Encode a file for transmission over text channels |
 | uuidgen | Print UUID (Universally Unique IDentifier) |
 | valid-shell | Verify if /etc/shells is valid |
 | vi | A minimal vi-style screen text editor |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -134,6 +134,7 @@ import (
 	ap_shellutils_tty "github.com/nao1215/mimixbox/internal/applets/shellutils/tty"
 	ap_shellutils_uname "github.com/nao1215/mimixbox/internal/applets/shellutils/uname"
 	ap_shellutils_uniq "github.com/nao1215/mimixbox/internal/applets/shellutils/uniq"
+	ap_shellutils_usleep "github.com/nao1215/mimixbox/internal/applets/shellutils/usleep"
 	ap_shellutils_uuidgen "github.com/nao1215/mimixbox/internal/applets/shellutils/uuidgen"
 	ap_shellutils_watch "github.com/nao1215/mimixbox/internal/applets/shellutils/watch"
 	ap_shellutils_wget "github.com/nao1215/mimixbox/internal/applets/shellutils/wget"
@@ -167,6 +168,7 @@ import (
 	ap_textutils_tr "github.com/nao1215/mimixbox/internal/applets/textutils/tr"
 	ap_textutils_unexpand "github.com/nao1215/mimixbox/internal/applets/textutils/unexpand"
 	ap_textutils_unix2dos "github.com/nao1215/mimixbox/internal/applets/textutils/unix2dos"
+	ap_textutils_uucode "github.com/nao1215/mimixbox/internal/applets/textutils/uucode"
 	ap_textutils_wc "github.com/nao1215/mimixbox/internal/applets/textutils/wc"
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
@@ -176,7 +178,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 181)
+	Applets = make(map[string]Applet, 184)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -320,6 +322,7 @@ func init() {
 	register(ap_shellutils_tty.New())
 	register(ap_shellutils_uname.New())
 	register(ap_shellutils_uniq.New())
+	register(ap_shellutils_usleep.New())
 	register(ap_shellutils_uuidgen.New())
 	register(ap_shellutils_watch.New())
 	register(ap_shellutils_wget.New())
@@ -353,6 +356,8 @@ func init() {
 	register(ap_textutils_tr.New())
 	register(ap_textutils_unexpand.New())
 	register(ap_textutils_unix2dos.New())
+	register(ap_textutils_uucode.NewUudecode())
+	register(ap_textutils_uucode.NewUuencode())
 	register(ap_textutils_wc.New())
 	register(ap_textutils_xxd.New())
 	register(ap_util_linux_getopt.New())

--- a/internal/applets/shellutils/usleep/usleep.go
+++ b/internal/applets/shellutils/usleep/usleep.go
@@ -1,0 +1,51 @@
+// Package usleep implements the usleep applet: pause for a number of
+// microseconds.
+package usleep
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the usleep applet.
+type Command struct{}
+
+// New returns a usleep command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "usleep" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Pause for N microseconds" }
+
+// sleep is time.Sleep, indirected so tests do not actually wait.
+var sleep = time.Sleep
+
+// Run executes usleep.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[N]", stdio.Err).WithHelp(command.Help{
+		Description: "Pause for N microseconds (default 0). N must be a non-negative integer.",
+		Examples: []command.Example{
+			{Command: "usleep 500000", Explain: "Pause for half a second."},
+		},
+		ExitStatus: "0  success.\n1  N was not a valid non-negative integer.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	micro := int64(0)
+	if rest := fs.Args(); len(rest) > 0 {
+		micro, err = strconv.ParseInt(rest[0], 10, 64)
+		if err != nil || micro < 0 {
+			return command.Failuref("invalid number of microseconds: %q", rest[0])
+		}
+	}
+	sleep(time.Duration(micro) * time.Microsecond)
+	return nil
+}

--- a/internal/applets/shellutils/usleep/usleep_test.go
+++ b/internal/applets/shellutils/usleep/usleep_test.go
@@ -1,0 +1,47 @@
+package usleep
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestUsleepDuration(t *testing.T) {
+	var got time.Duration
+	orig := sleep
+	sleep = func(d time.Duration) { got = d }
+	defer func() { sleep = orig }()
+
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"1500"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if got != 1500*time.Microsecond {
+		t.Errorf("slept %v, want 1500µs", got)
+	}
+}
+
+func TestUsleepNoArg(t *testing.T) {
+	var got time.Duration
+	orig := sleep
+	sleep = func(d time.Duration) { got = d }
+	defer func() { sleep = orig }()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if got != 0 {
+		t.Errorf("no arg should sleep 0, got %v", got)
+	}
+}
+
+func TestUsleepInvalid(t *testing.T) {
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"-5"}); err == nil {
+		t.Errorf("negative value should fail")
+	}
+}

--- a/internal/applets/textutils/uucode/uucode.go
+++ b/internal/applets/textutils/uucode/uucode.go
@@ -1,0 +1,278 @@
+// Package uucode implements the uuencode and uudecode applets. uuencode wraps a
+// file (or standard input) in the historical uuencoding (or base64 with -m);
+// uudecode reverses either form back to the original bytes and file name.
+package uucode
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the uuencode or uudecode applet.
+type Command struct{ name string }
+
+// NewUuencode returns the uuencode applet.
+func NewUuencode() *Command { return &Command{name: "uuencode"} }
+
+// NewUudecode returns the uudecode applet.
+func NewUudecode() *Command { return &Command{name: "uudecode"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	if c.name == "uudecode" {
+		return "Decode a uuencoded (or base64) file"
+	}
+	return "Encode a file for transmission over text channels"
+}
+
+// Run dispatches to the encoder or decoder.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	if c.name == "uudecode" {
+		return runUudecode(stdio, args)
+	}
+	return runUuencode(stdio, args)
+}
+
+// runUuencode implements: uuencode [-m] [FILE] NAME.
+func runUuencode(stdio command.IO, args []string) error {
+	fs := command.NewFlagSet("uuencode", "[-m] [FILE] NAME", stdio.Err).WithHelp(command.Help{
+		Description: "Read FILE (or standard input) and write it, encoded, to standard output, " +
+			"wrapped so it survives text-only channels. NAME is the file name recorded in the " +
+			"header for uudecode to recreate. -m uses base64 instead of historical uuencoding.",
+		Examples: []command.Example{
+			{Command: "uuencode data.bin data.bin > data.uue", Explain: "Encode data.bin."},
+			{Command: "uuencode -m img.png img.png", Explain: "Encode using base64."},
+		},
+	})
+	useBase64 := fs.BoolP("base64", "m", false, "use base64 encoding")
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	operands := fs.Args()
+	var data []byte
+	var name string
+	switch len(operands) {
+	case 1:
+		name = operands[0]
+		data, err = io.ReadAll(stdio.In)
+	case 2:
+		name = operands[1]
+		data, err = os.ReadFile(operands[0]) //nolint:gosec // user-named file
+	default:
+		_, _ = fmt.Fprintln(stdio.Err, "uuencode: usage: uuencode [-m] [FILE] NAME")
+		return command.SilentFailure()
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "uuencode: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	if *useBase64 {
+		writeBase64(stdio.Out, name, data)
+	} else {
+		writeUU(stdio.Out, name, data)
+	}
+	return nil
+}
+
+func writeUU(w io.Writer, name string, data []byte) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "begin 644 %s\n", name)
+	for off := 0; off < len(data); off += 45 {
+		end := off + 45
+		if end > len(data) {
+			end = len(data)
+		}
+		line := data[off:end]
+		b.WriteByte(enc(byte(len(line))))
+		for i := 0; i < len(line); i += 3 {
+			var g [3]byte
+			copy(g[:], line[i:])
+			b.WriteByte(enc(g[0] >> 2))
+			b.WriteByte(enc((g[0]<<4 | g[1]>>4) & 0x3f))
+			b.WriteByte(enc((g[1]<<2 | g[2]>>6) & 0x3f))
+			b.WriteByte(enc(g[2] & 0x3f))
+		}
+		b.WriteByte('\n')
+	}
+	b.WriteByte(enc(0))
+	b.WriteString("\nend\n")
+	_, _ = io.WriteString(w, b.String())
+}
+
+func writeBase64(w io.Writer, name string, data []byte) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "begin-base64 644 %s\n", name)
+	encoded := base64.StdEncoding.EncodeToString(data)
+	for off := 0; off < len(encoded); off += 60 {
+		end := off + 60
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		b.WriteString(encoded[off:end])
+		b.WriteByte('\n')
+	}
+	b.WriteString("====\n")
+	_, _ = io.WriteString(w, b.String())
+}
+
+// enc encodes a 6-bit value as a uuencode character (0 becomes '`').
+func enc(c byte) byte {
+	if c == 0 {
+		return '`'
+	}
+	return (c & 0x3f) + 0x20
+}
+
+// dec decodes a uuencode character to its 6-bit value.
+func dec(c byte) byte { return (c - 0x20) & 0x3f }
+
+// runUudecode implements: uudecode [-o OUTPUT] [FILE].
+func runUudecode(stdio command.IO, args []string) error {
+	fs := command.NewFlagSet("uudecode", "[-o OUTPUT] [FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Decode a uuencoded or base64 (begin-base64) stream from FILE or standard " +
+			"input, writing the result to the file named in its header (or to OUTPUT with -o; " +
+			"use -o - for standard output).",
+		Examples: []command.Example{
+			{Command: "uudecode data.uue", Explain: "Recreate the encoded file."},
+			{Command: "uudecode -o - data.uue", Explain: "Write the decoded bytes to standard output."},
+		},
+	})
+	output := fs.StringP("output-file", "o", "", "write to OUTPUT (- for standard output)")
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	src := stdio.In
+	if rest := fs.Args(); len(rest) > 0 && rest[0] != "-" {
+		f, oerr := os.Open(rest[0]) //nolint:gosec // user-named file
+		if oerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "uudecode: %s\n", command.FileError(rest[0], oerr))
+			return command.SilentFailure()
+		}
+		defer func() { _ = f.Close() }()
+		src = f
+	}
+
+	name, data, err := decode(src)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "uudecode: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	dest := *output
+	if dest == "" {
+		dest = name
+	}
+	if dest == "-" {
+		_, _ = stdio.Out.Write(data)
+		return nil
+	}
+	if err := os.WriteFile(dest, data, 0o644); err != nil { //nolint:gosec // recreate with the documented default mode
+		_, _ = fmt.Fprintf(stdio.Err, "uudecode: %v\n", err)
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// decode reads a uuencoded or base64 stream and returns the embedded name and
+// the decoded bytes.
+func decode(r io.Reader) (string, []byte, error) {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	name := ""
+	base64Mode := false
+	started := false
+	var out []byte
+
+	for sc.Scan() {
+		line := sc.Text()
+		if !started {
+			switch {
+			case strings.HasPrefix(line, "begin-base64 "):
+				base64Mode = true
+				name = headerName(line, "begin-base64 ")
+				started = true
+			case strings.HasPrefix(line, "begin "):
+				name = headerName(line, "begin ")
+				started = true
+			}
+			continue
+		}
+		if base64Mode {
+			if line == "====" {
+				break
+			}
+			chunk, err := base64.StdEncoding.DecodeString(strings.TrimSpace(line))
+			if err != nil {
+				return "", nil, err
+			}
+			out = append(out, chunk...)
+			continue
+		}
+		if line == "end" {
+			break
+		}
+		if line == "" || line == "`" {
+			continue
+		}
+		n := int(dec(line[0]))
+		if n == 0 {
+			continue
+		}
+		decoded := decodeUULine(line[1:])
+		if n > len(decoded) {
+			n = len(decoded)
+		}
+		out = append(out, decoded[:n]...)
+	}
+	if err := sc.Err(); err != nil {
+		return "", nil, err
+	}
+	if !started {
+		return "", nil, fmt.Errorf("no begin line found")
+	}
+	return name, out, nil
+}
+
+// headerName extracts the file name from a "begin[-base64] MODE NAME" line.
+func headerName(line, prefix string) string {
+	rest := strings.TrimPrefix(line, prefix)
+	fields := strings.SplitN(strings.TrimSpace(rest), " ", 2)
+	if len(fields) == 2 {
+		return fields[1]
+	}
+	if _, err := strconv.Atoi(strings.TrimSpace(rest)); err == nil {
+		return ""
+	}
+	return strings.TrimSpace(rest)
+}
+
+// decodeUULine decodes the body characters of one uuencoded line to bytes.
+func decodeUULine(s string) []byte {
+	var out []byte
+	for i := 0; i+3 < len(s); i += 4 {
+		c0, c1, c2, c3 := dec(s[i]), dec(s[i+1]), dec(s[i+2]), dec(s[i+3])
+		out = append(out,
+			c0<<2|c1>>4,
+			c1<<4|c2>>2,
+			c2<<6|c3,
+		)
+	}
+	return out
+}

--- a/internal/applets/textutils/uucode/uucode_test.go
+++ b/internal/applets/textutils/uucode/uucode_test.go
@@ -1,0 +1,93 @@
+package uucode
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func encode(t *testing.T, data []byte, args ...string) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: bytes.NewReader(data), Out: out, Err: &bytes.Buffer{}}
+	if err := NewUuencode().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("uuencode error = %v", err)
+	}
+	return out.String()
+}
+
+func decodeToStdout(t *testing.T, encoded string) []byte {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(encoded), Out: out, Err: &bytes.Buffer{}}
+	if err := NewUudecode().Run(context.Background(), io, []string{"-o", "-"}); err != nil {
+		t.Fatalf("uudecode error = %v", err)
+	}
+	return out.Bytes()
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+	payloads := [][]byte{
+		[]byte("hello world\n"),
+		{0x00, 0x01, 0x02, 0xff, 0xfe, '\n', 'x'},
+		bytes.Repeat([]byte("The quick brown fox. "), 20),
+		{},
+	}
+	for _, mode := range []string{"uu", "base64"} {
+		for i, p := range payloads {
+			var enc string
+			if mode == "base64" {
+				enc = encode(t, p, "-m", "name")
+			} else {
+				enc = encode(t, p, "name")
+			}
+			got := decodeToStdout(t, enc)
+			if !bytes.Equal(got, p) {
+				t.Errorf("%s payload %d round-trip mismatch:\n got %v\nwant %v", mode, i, got, p)
+			}
+		}
+	}
+}
+
+func TestHeaderName(t *testing.T) {
+	t.Parallel()
+	enc := encode(t, []byte("x"), "myfile.bin")
+	if !strings.HasPrefix(enc, "begin 644 myfile.bin\n") {
+		t.Errorf("header = %q", enc[:20])
+	}
+	if !strings.HasSuffix(enc, "end\n") {
+		t.Errorf("missing end trailer: %q", enc)
+	}
+}
+
+func TestDecodeToNamedFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "decoded.bin")
+	enc := encode(t, []byte("payload\n"), target)
+	io := command.IO{In: strings.NewReader(enc), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := NewUudecode().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("uudecode error = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "payload\n" {
+		t.Errorf("decoded file = %q", got)
+	}
+}
+
+func TestDecodeNoBegin(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: strings.NewReader("not encoded data\n"), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := NewUudecode().Run(context.Background(), io, []string{"-o", "-"}); err == nil {
+		t.Errorf("input without a begin line should fail")
+	}
+}

--- a/test/it/spec/uucode_spec.sh
+++ b/test/it/spec/uucode_spec.sh
@@ -1,0 +1,19 @@
+Describe 'uuencode / uudecode / usleep'
+    Include textutils/checksum_test.sh
+
+    It 'uuencode | uudecode round-trips (traditional)'
+        When call TestUuRoundTrip
+        The output should equal 'round trip data'
+        The status should be success
+    End
+    It 'uuencode -m | uudecode round-trips (base64)'
+        When call TestUuBase64
+        The output should equal 'base64 round trip'
+        The status should be success
+    End
+    It 'usleep waits and exits 0'
+        When call TestUsleep
+        The output should equal 'slept'
+        The status should be success
+    End
+End

--- a/test/it/textutils/checksum_test.sh
+++ b/test/it/textutils/checksum_test.sh
@@ -1,3 +1,19 @@
 TestSum() { printf 'hello\n' | sum; }
 TestCrc32() { printf 'hello\n' | crc32; }
 TestSha384() { printf 'hello\n' | sha384sum; }
+
+TestUuRoundTrip() {
+    d=$(mktemp -d); printf 'round trip data\n' > "$d/in"
+    uuencode "$d/in" out | uudecode -o -
+    rm -rf "$d"
+}
+
+TestUuBase64() {
+    d=$(mktemp -d); printf 'base64 round trip\n' > "$d/in"
+    uuencode -m "$d/in" out | uudecode -o -
+    rm -rf "$d"
+}
+
+TestUsleep() {
+    usleep 1000 && echo slept
+}


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with the uuencoding pair and the microsecond sleep:

- `uuencode` — wrap a file (or stdin) in the historical uuencoding, or base64 with `-m`, recording NAME in the header (`uuencode [-m] [FILE] NAME`).
- `uudecode` — decode either a `begin`/`end` uuencoded stream or a `begin-base64`/`====` base64 stream back to the original bytes, writing to the header's file name or to `-o OUTPUT` (`-o -` for stdout).
- `usleep` — pause for N microseconds.

`uuencode | uudecode` round-trips arbitrary binary content (including NUL and high bytes) in both the traditional and base64 forms.

## Tests

- Unit: round-trip of several payloads (text, binary, long, empty) through both uuencoding and base64; header name and `end` trailer; decode to the embedded file name; missing-begin error. `usleep` duration (via an injected sleep), default 0, and invalid-input error.
- shellspec: traditional and base64 `uuencode | uudecode` round-trips, and `usleep`.

## Verification

- `go test ./...` passes; `make test-e2e` passes (487 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243