### PR TITLE
fix(tree): address CodeRabbit feedback on the tree applet

### DIFF
--- a/internal/applets/shellutils/tree/tree.go
+++ b/internal/applets/shellutils/tree/tree.go
@@ -49,7 +49,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		ExitStatus: "0  success.\n1  a directory could not be read.",
 	})
 	all := fs.BoolP("all", "a", false, "list entries starting with a dot")
-	dirsOnly := fs.BoolP("dirsfirst", "d", false, "list directories only")
+	dirsOnly := fs.BoolP("dirs-only", "d", false, "list directories only")
 	level := fs.IntP("level", "L", -1, "descend only LEVEL directories deep")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/test/it/shellutils/tree_test.sh
+++ b/test/it/shellutils/tree_test.sh
@@ -1,22 +1,22 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/tree
+    mkdir -p ${TEST_DIR}/sub
+    touch ${TEST_DIR}/sub/leaf.txt ${TEST_DIR}/root.txt
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/tree; }
+
 # The tree body uses multibyte box-drawing characters; shellspec's output
 # capture cannot carry those through the hermetic toolchain, and the exact
 # formatting is already covered by the Go unit tests. Here we assert on the
 # ASCII summary line, which confirms the traversal counted every entry.
 TestTreeSummary() {
-    d=$(mktemp -d)
-    mkdir -p "$d/sub"
-    touch "$d/sub/leaf.txt" "$d/root.txt"
-    tree "$d" | grep directories
-    rm -rf "$d"
+    tree ${TEST_DIR} | grep directories
 }
 
 TestTreeStatus() {
-    d=$(mktemp -d)
-    touch "$d/f.txt"
-    tree "$d" > /dev/null
-    status=$?
-    rm -rf "$d"
-    echo "$status"
+    tree ${TEST_DIR} > /dev/null
+    echo $?
 }
 
 TestNicePrints() {

--- a/test/it/spec/tree_spec.sh
+++ b/test/it/spec/tree_spec.sh
@@ -1,5 +1,7 @@
 Describe 'tree / nice'
     Include shellutils/tree_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
 
     It 'tree counts directories and files in its summary'
         When call TestTreeSummary


### PR DESCRIPTION
## Summary

Follow-up to #304 addressing two CodeRabbit Major findings:

- Rename the `tree -d` long option from `--dirsfirst` to `--dirs-only`. The old name implied sorting directories before files, but the flag filters to directories only; the new name matches the behavior and help text. The `-d` shorthand is unchanged.
- Align the tree/nice ShellSpec fixture with the repository convention: a deterministic `/tmp/mimixbox/it/tree` directory created in `BeforeEach Setup` and removed in `AfterEach CleanUp`, instead of `mktemp -d`.

## Verification

- `go test ./...` passes; `make test-e2e` passes (490 examples, 0 failures); `golangci-lint` clean.

Part of #243