### PR TITLE
feat(coreutils): add time and fsync applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 186 commands. Run `mimixbox --list` to see them on the terminal.
+There are 188 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -78,6 +78,7 @@ There are 186 commands. Run `mimixbox --list` to see them on the terminal.
 | fold | Wrap each input line to fit in specified width |
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
+| fsync | Flush a file's data to storage with fsync(2) |
 | getopt | Parse command options (enhanced, like util-linux getopt) |
 | ghrdc | GitHub Release Download Counter |
 | grep | Print lines that match patterns |
@@ -169,6 +170,7 @@ There are 186 commands. Run `mimixbox --list` to see them on the terminal.
 | tar | Archive files (create, list, extract) |
 | tee | Read from standard input and write to standard output and files |
 | test | Evaluate a conditional expression |
+| time | Run a command and report how long it took |
 | timeout | Run a command with a time limit |
 | touch | Update the access and modification times of each FILE to the current time |
 | tr | Translate or delete characters |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -97,6 +97,7 @@ import (
 	ap_shellutils_factor "github.com/nao1215/mimixbox/internal/applets/shellutils/factor"
 	ap_shellutils_false "github.com/nao1215/mimixbox/internal/applets/shellutils/false"
 	ap_shellutils_free "github.com/nao1215/mimixbox/internal/applets/shellutils/free"
+	ap_shellutils_fsync "github.com/nao1215/mimixbox/internal/applets/shellutils/fsync"
 	ap_shellutils_ghrdc "github.com/nao1215/mimixbox/internal/applets/shellutils/ghrdc"
 	ap_shellutils_groups "github.com/nao1215/mimixbox/internal/applets/shellutils/groups"
 	ap_shellutils_hostid "github.com/nao1215/mimixbox/internal/applets/shellutils/hostid"
@@ -129,6 +130,7 @@ import (
 	ap_shellutils_sync "github.com/nao1215/mimixbox/internal/applets/shellutils/sync"
 	ap_shellutils_tee "github.com/nao1215/mimixbox/internal/applets/shellutils/tee"
 	ap_shellutils_test "github.com/nao1215/mimixbox/internal/applets/shellutils/test"
+	ap_shellutils_timecmd "github.com/nao1215/mimixbox/internal/applets/shellutils/timecmd"
 	ap_shellutils_timeout "github.com/nao1215/mimixbox/internal/applets/shellutils/timeout"
 	ap_shellutils_tree "github.com/nao1215/mimixbox/internal/applets/shellutils/tree"
 	ap_shellutils_true "github.com/nao1215/mimixbox/internal/applets/shellutils/true"
@@ -180,7 +182,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 186)
+	Applets = make(map[string]Applet, 188)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -287,6 +289,7 @@ func init() {
 	register(ap_shellutils_factor.New())
 	register(ap_shellutils_false.New())
 	register(ap_shellutils_free.New())
+	register(ap_shellutils_fsync.New())
 	register(ap_shellutils_ghrdc.New())
 	register(ap_shellutils_groups.New())
 	register(ap_shellutils_hostid.New())
@@ -319,6 +322,7 @@ func init() {
 	register(ap_shellutils_sync.New())
 	register(ap_shellutils_tee.New())
 	register(ap_shellutils_test.New())
+	register(ap_shellutils_timecmd.New())
 	register(ap_shellutils_timeout.New())
 	register(ap_shellutils_tree.New())
 	register(ap_shellutils_true.New())

--- a/internal/applets/shellutils/fsync/fsync.go
+++ b/internal/applets/shellutils/fsync/fsync.go
@@ -1,0 +1,66 @@
+// Package fsync implements the fsync applet: flush a file's buffered data and
+// metadata to the underlying storage with fsync(2).
+package fsync
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fsync applet.
+type Command struct{}
+
+// New returns an fsync command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fsync" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Flush a file's data to storage with fsync(2)" }
+
+// Run executes fsync.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Flush each FILE's buffered data and metadata to the underlying storage device " +
+			"by calling fsync(2) on it. At least one FILE is required.",
+		Examples: []command.Example{
+			{Command: "fsync data.db", Explain: "Ensure data.db is durably on disk."},
+		},
+		ExitStatus: "0  every file was synced.\n1  a file could not be opened or synced.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "fsync: missing file operand")
+		return command.SilentFailure()
+	}
+
+	var failed bool
+	for _, name := range files {
+		if err := syncFile(name); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "fsync: %s\n", command.FileError(name, err))
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+func syncFile(name string) error {
+	f, err := os.Open(name) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return f.Sync()
+}

--- a/internal/applets/shellutils/fsync/fsync_test.go
+++ b/internal/applets/shellutils/fsync/fsync_test.go
@@ -1,0 +1,60 @@
+package fsync
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestFsyncFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(f, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(t, f); err != nil {
+		t.Errorf("fsync of an existing file should succeed, got %v", err)
+	}
+}
+
+func TestFsyncMultiple(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	var files []string
+	for _, n := range []string{"a", "b"} {
+		f := filepath.Join(dir, n)
+		if err := os.WriteFile(f, []byte(n), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, f)
+	}
+	if err := run(t, files...); err != nil {
+		t.Errorf("fsync of two files should succeed, got %v", err)
+	}
+}
+
+func TestFsyncMissing(t *testing.T) {
+	t.Parallel()
+	if err := run(t, "/no/such/fsync/file"); err == nil {
+		t.Errorf("fsync of a missing file should fail")
+	}
+}
+
+func TestFsyncNoOperand(t *testing.T) {
+	t.Parallel()
+	if err := run(t); err == nil {
+		t.Errorf("fsync with no operand should fail")
+	}
+}

--- a/internal/applets/shellutils/nice/nice.go
+++ b/internal/applets/shellutils/nice/nice.go
@@ -47,6 +47,9 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		},
 		ExitStatus: "0  success.\n1  the adjustment or command was invalid.\n127  COMMAND was not found.",
 	})
+	// Stop parsing at COMMAND so its own flags (e.g. nice -n 5 sort -r) are
+	// passed through rather than consumed by nice.
+	fs.SetInterspersed(false)
 	adjust := fs.IntP("adjustment", "n", 10, "add ADJUST to the niceness")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/timecmd/timecmd.go
+++ b/internal/applets/shellutils/timecmd/timecmd.go
@@ -1,0 +1,95 @@
+// Package timecmd implements the time applet: run a command and report how long
+// it took (real, user, and system time).
+package timecmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the time applet.
+type Command struct{}
+
+// New returns a time command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "time" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a command and report how long it took" }
+
+// now is indirected so tests can supply a deterministic clock.
+var now = time.Now
+
+// Run executes time.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-p] COMMAND [ARG]...", stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND with its arguments and, after it finishes, print the elapsed real, " +
+			"user, and system time to standard error. With -p the times use the POSIX format.",
+		Examples: []command.Example{
+			{Command: "time sleep 1", Explain: "Time a command."},
+			{Command: "time -p ls", Explain: "Use the portable (POSIX) output format."},
+		},
+		ExitStatus: "The exit status of COMMAND (127 if it could not be run).",
+	})
+	// Stop parsing at the command so its own flags are not consumed.
+	fs.SetInterspersed(false)
+	posix := fs.BoolP("portable", "p", false, "use the POSIX output format")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "time: missing command")
+		return command.SilentFailure()
+	}
+
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running a user-named command is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+
+	start := now()
+	runErr := cmd.Run()
+	real := now().Sub(start)
+
+	var user, sys time.Duration
+	if cmd.ProcessState != nil {
+		user = cmd.ProcessState.UserTime()
+		sys = cmd.ProcessState.SystemTime()
+	}
+	report(stdio, *posix, real, user, sys)
+
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		_, _ = fmt.Fprintf(stdio.Err, "time: %s: %v\n", rest[0], runErr)
+		return &command.ExitError{Code: 127}
+	}
+	return nil
+}
+
+// report writes the three timing lines to standard error.
+func report(stdio command.IO, posix bool, real, user, sys time.Duration) {
+	if posix {
+		_, _ = fmt.Fprintf(stdio.Err, "real %.2f\nuser %.2f\nsys %.2f\n", real.Seconds(), user.Seconds(), sys.Seconds())
+		return
+	}
+	_, _ = fmt.Fprintf(stdio.Err, "real\t%s\nuser\t%s\nsys\t%s\n", clock(real), clock(user), clock(sys))
+}
+
+// clock formats a duration as "<minutes>m<seconds>.<millis>s".
+func clock(d time.Duration) string {
+	minutes := int(d / time.Minute)
+	seconds := d.Seconds() - float64(minutes*60)
+	return fmt.Sprintf("%dm%.3fs", minutes, seconds)
+}

--- a/internal/applets/shellutils/timecmd/timecmd_test.go
+++ b/internal/applets/shellutils/timecmd/timecmd_test.go
@@ -1,0 +1,84 @@
+package timecmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// fakeClock makes now return base, then base+elapsed on subsequent calls.
+func fakeClock(t *testing.T, elapsed time.Duration) func() {
+	t.Helper()
+	base := time.Unix(1000, 0)
+	seq := []time.Time{base, base.Add(elapsed)}
+	i := 0
+	orig := now
+	now = func() time.Time {
+		v := seq[i]
+		if i < len(seq)-1 {
+			i++
+		}
+		return v
+	}
+	return func() { now = orig }
+}
+
+func requireCmd(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s not on PATH: %v", name, err)
+	}
+}
+
+func TestTimeReportsReal(t *testing.T) {
+	requireCmd(t, "true")
+	defer fakeClock(t, 1500*time.Millisecond)()
+
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: errBuf}
+	if err := New().Run(context.Background(), io, []string{"true"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "real\t0m1.500s") {
+		t.Errorf("stderr = %q, want a real time of 0m1.500s", errBuf.String())
+	}
+}
+
+func TestTimePosixFormat(t *testing.T) {
+	requireCmd(t, "true")
+	defer fakeClock(t, 2*time.Second)()
+
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: errBuf}
+	if err := New().Run(context.Background(), io, []string{"-p", "true"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "real 2.00") {
+		t.Errorf("stderr = %q, want 'real 2.00'", errBuf.String())
+	}
+}
+
+func TestTimePropagatesExitCode(t *testing.T) {
+	requireCmd(t, "false")
+	defer fakeClock(t, time.Second)()
+
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, []string{"false"})
+	var ee *command.ExitError
+	if !errors.As(err, &ee) || ee.Code != 1 {
+		t.Errorf("err = %v, want exit code 1", err)
+	}
+}
+
+func TestTimeMissingCommand(t *testing.T) {
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("missing command should fail")
+	}
+}

--- a/test/it/shellutils/timefsync_test.sh
+++ b/test/it/shellutils/timefsync_test.sh
@@ -1,0 +1,26 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/timefsync
+    mkdir -p ${TEST_DIR}
+    printf 'data\n' > ${TEST_DIR}/f.txt
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/timefsync; }
+
+# Use env to invoke the PATH "time" binary regardless of any shell keyword.
+TestTimeOutput() {
+    env time echo timed 2>/dev/null
+}
+
+TestTimeReportsReal() {
+    env time echo x 2>&1 1>/dev/null | grep -c real
+}
+
+TestFsync() {
+    fsync ${TEST_DIR}/f.txt
+    echo $?
+}
+
+TestFsyncMissing() {
+    fsync /no/such/mimixbox/file 2>/dev/null
+    echo $?
+}

--- a/test/it/spec/timefsync_spec.sh
+++ b/test/it/spec/timefsync_spec.sh
@@ -1,0 +1,26 @@
+Describe 'time / fsync'
+    Include shellutils/timefsync_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'time runs the command and passes its output through'
+        When call TestTimeOutput
+        The output should equal 'timed'
+        The status should be success
+    End
+    It 'time reports the real elapsed time on stderr'
+        When call TestTimeReportsReal
+        The output should equal '1'
+        The status should be success
+    End
+    It 'fsync succeeds on an existing file'
+        When call TestFsync
+        The output should equal '0'
+        The status should be success
+    End
+    It 'fsync fails on a missing file'
+        When call TestFsyncMissing
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with two more applets:

- `time` — run COMMAND and print the elapsed real, user, and system time to stderr after it finishes; `-p` selects the POSIX format. The command's exit status is propagated (127 when it cannot be run).
- `fsync` — flush each file's buffered data and metadata to storage with fsync(2).

Both stop option parsing at the operand (`SetInterspersed(false)`) so a command's own flags are passed through, e.g. `time ls -l`.

This branch also fixes `nice` (merged in #304) the same way: without it, `nice -n 5 sort -r` mis-parsed `-r` as a nice option. The fix is a separate commit.

## Tests

- Unit: `time` reports the real elapsed time (via an injected clock), the POSIX `-p` format, exit-code propagation, and the missing-command error; `fsync` on one and several existing files, a missing file, and no operand.
- shellspec: `time` passes a command's output through and reports a real-time line on stderr; `fsync` succeeds on an existing file and fails on a missing one.

## Verification

- `go test ./...` passes; `make test-e2e` passes (494 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243