### PR TITLE
feat(util-linux): add setsid and fallocate applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 188 commands. Run `mimixbox --list` to see them on the terminal.
+There are 190 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -71,6 +71,7 @@ There are 188 commands. Run `mimixbox --list` to see them on the terminal.
 | expr | Evaluate expressions |
 | factor | Print the prime factors of each NUMBER |
 | fakemovie | Adds a video playback button to the image |
+| fallocate | Preallocate or extend space for a file |
 | false | Do nothing. Return failure(1) |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |
@@ -149,6 +150,7 @@ There are 188 commands. Run `mimixbox --list` to see them on the terminal.
 | sed | Stream editor for filtering and transforming text |
 | seq | Print a column of numbers |
 | serial | Rename the file to the name with a serial number |
+| setsid | Run a program in a new session |
 | sh | Command interpreter (MimixBox mbsh compatibility front-end) |
 | sha1sum | Calculate or Check secure hash 1 algorithm |
 | sha256sum | Calculate or Check secure hash 256 algorithm |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -175,14 +175,16 @@ import (
 	ap_textutils_uucode "github.com/nao1215/mimixbox/internal/applets/textutils/uucode"
 	ap_textutils_wc "github.com/nao1215/mimixbox/internal/applets/textutils/wc"
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
+	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
+	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 188)
+	Applets = make(map[string]Applet, 190)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -368,7 +370,9 @@ func init() {
 	register(ap_textutils_uucode.NewUuencode())
 	register(ap_textutils_wc.New())
 	register(ap_textutils_xxd.New())
+	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
+	register(ap_util_linux_setsid.New())
 }

--- a/internal/applets/util-linux/fallocate/fallocate.go
+++ b/internal/applets/util-linux/fallocate/fallocate.go
@@ -1,0 +1,113 @@
+// Package fallocate implements the fallocate applet: preallocate (or extend) the
+// space for a file to a given length.
+package fallocate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fallocate applet.
+type Command struct{}
+
+// New returns a fallocate command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fallocate" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Preallocate or extend space for a file" }
+
+// Run executes fallocate.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-l LENGTH FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Ensure each FILE is at least LENGTH bytes, creating it if necessary. LENGTH " +
+			"accepts a plain byte count or a K/M/G suffix (powers of 1024).",
+		Examples: []command.Example{
+			{Command: "fallocate -l 1M big.bin", Explain: "Make big.bin one mebibyte."},
+		},
+		ExitStatus: "0  success.\n1  the length was missing/invalid or a file could not be sized.",
+	})
+	length := fs.StringP("length", "l", "", "allocate LENGTH bytes (K/M/G suffixes allowed)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if *length == "" {
+		_, _ = fmt.Fprintln(stdio.Err, "fallocate: option -l (length) is required")
+		return command.SilentFailure()
+	}
+	size, err := parseSize(*length)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "fallocate: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "fallocate: missing file operand")
+		return command.SilentFailure()
+	}
+
+	var failed bool
+	for _, name := range files {
+		if err := allocate(name, size); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "fallocate: %s\n", command.FileError(name, err))
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// allocate sizes name to at least size bytes, never shrinking it.
+func allocate(name string, size int64) error {
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size() >= size {
+		return nil // never shrink an existing file
+	}
+	return f.Truncate(size)
+}
+
+// parseSize parses a byte count with an optional K/M/G (1024-based) suffix.
+func parseSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("invalid length %q", s)
+	}
+	mult := int64(1)
+	switch s[len(s)-1] {
+	case 'K', 'k':
+		mult = 1024
+	case 'M', 'm':
+		mult = 1024 * 1024
+	case 'G', 'g':
+		mult = 1024 * 1024 * 1024
+	}
+	if mult != 1 {
+		s = s[:len(s)-1]
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid length %q", s)
+	}
+	return n * mult, nil
+}

--- a/internal/applets/util-linux/fallocate/fallocate_test.go
+++ b/internal/applets/util-linux/fallocate/fallocate_test.go
@@ -1,0 +1,85 @@
+package fallocate
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestParseSize(t *testing.T) {
+	t.Parallel()
+	cases := map[string]int64{"0": 0, "1024": 1024, "1K": 1024, "2M": 2 * 1024 * 1024, "1G": 1024 * 1024 * 1024}
+	for in, want := range cases {
+		got, err := parseSize(in)
+		if err != nil || got != want {
+			t.Errorf("parseSize(%q) = %d, %v; want %d", in, got, err, want)
+		}
+	}
+	for _, bad := range []string{"", "abc", "-5", "1X2"} {
+		if _, err := parseSize(bad); err == nil {
+			t.Errorf("parseSize(%q) should fail", bad)
+		}
+	}
+}
+
+func size(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.Size()
+}
+
+func TestFallocateCreates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "new.bin")
+	if err := run(t, "-l", "2048", f); err != nil {
+		t.Fatalf("fallocate error = %v", err)
+	}
+	if size(t, f) != 2048 {
+		t.Errorf("size = %d, want 2048", size(t, f))
+	}
+}
+
+func TestFallocateNeverShrinks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "big.bin")
+	if err := os.WriteFile(f, make([]byte, 100), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(t, "-l", "10", f); err != nil {
+		t.Fatalf("fallocate error = %v", err)
+	}
+	if size(t, f) != 100 {
+		t.Errorf("size = %d, want 100 (unchanged)", size(t, f))
+	}
+}
+
+func TestFallocateErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "x")
+	if err := run(t, f); err == nil {
+		t.Errorf("missing -l should fail")
+	}
+	if err := run(t, "-l", "1024"); err == nil {
+		t.Errorf("missing file should fail")
+	}
+	if err := run(t, "-l", "bad", f); err == nil {
+		t.Errorf("invalid length should fail")
+	}
+}

--- a/internal/applets/util-linux/setsid/setsid.go
+++ b/internal/applets/util-linux/setsid/setsid.go
@@ -1,0 +1,68 @@
+// Package setsid implements the setsid applet: run a program in a new session,
+// detached from the calling process's controlling terminal.
+package setsid
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the setsid applet.
+type Command struct{}
+
+// New returns a setsid command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "setsid" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program in a new session" }
+
+// Run executes setsid.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-c] PROGRAM [ARG]...", stdio.Err).WithHelp(command.Help{
+		Description: "Run PROGRAM in a new session (setsid(2)), so it becomes a session and process " +
+			"group leader with no controlling terminal. With -c, also set the controlling terminal " +
+			"to the current one when standard input is a terminal.",
+		Examples: []command.Example{
+			{Command: "setsid mydaemon", Explain: "Start mydaemon detached from this terminal."},
+		},
+		ExitStatus: "The exit status of PROGRAM (127 if it could not be run).",
+	})
+	fs.SetInterspersed(false)
+	ctty := fs.BoolP("ctty", "c", false, "set the controlling terminal to the current one")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "setsid: missing PROGRAM operand")
+		return command.SilentFailure()
+	}
+
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running a user-named program is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if *ctty {
+		cmd.SysProcAttr.Setctty = true
+	}
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		_, _ = fmt.Fprintf(stdio.Err, "setsid: %s: %v\n", rest[0], err)
+		return &command.ExitError{Code: 127}
+	}
+	return nil
+}

--- a/internal/applets/util-linux/setsid/setsid_test.go
+++ b/internal/applets/util-linux/setsid/setsid_test.go
@@ -1,0 +1,50 @@
+package setsid
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestSetsidRunsProgram(t *testing.T) {
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skipf("echo not on PATH: %v", err)
+	}
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"echo", "hello"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "hello") {
+		t.Errorf("output = %q", out.String())
+	}
+}
+
+func TestSetsidPropagatesExit(t *testing.T) {
+	if _, err := exec.LookPath("false"); err != nil {
+		t.Skipf("false not on PATH: %v", err)
+	}
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, []string{"false"})
+	var ee *command.ExitError
+	if err == nil {
+		t.Fatal("false should produce a non-zero exit")
+	}
+	if e, ok := err.(*command.ExitError); ok {
+		ee = e
+	}
+	if ee == nil || ee.Code != 1 {
+		t.Errorf("err = %v, want exit 1", err)
+	}
+}
+
+func TestSetsidMissingProgram(t *testing.T) {
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("missing program should fail")
+	}
+}

--- a/test/it/spec/setsid_fallocate_spec.sh
+++ b/test/it/spec/setsid_fallocate_spec.sh
@@ -1,0 +1,21 @@
+Describe 'setsid / fallocate'
+    Include util-linux/setsid_fallocate_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'setsid runs a program in a new session'
+        When call TestSetsid
+        The output should equal 'session ok'
+        The status should be success
+    End
+    It 'fallocate sizes a file to the requested length'
+        When call TestFallocate
+        The status should be success
+        The output should include '4096'
+    End
+    It 'fallocate without -l fails'
+        When call TestFallocateNoLength
+        The output should equal '1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/setsid_fallocate_test.sh
+++ b/test/it/util-linux/setsid_fallocate_test.sh
@@ -1,0 +1,20 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/fallocate
+    mkdir -p ${TEST_DIR}
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/fallocate; }
+
+TestSetsid() {
+    setsid echo "session ok"
+}
+
+TestFallocate() {
+    fallocate -l 4096 ${TEST_DIR}/f
+    wc -c < ${TEST_DIR}/f
+}
+
+TestFallocateNoLength() {
+    fallocate ${TEST_DIR}/x 2>/dev/null
+    echo $?
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with two more applets:

- `setsid` — run a program in a new session (setsid(2)) so it becomes a session/process-group leader with no controlling terminal; `-c` also sets the controlling terminal. Option parsing stops at the program so its own flags pass through. The program's exit status is propagated (127 when it cannot be run).
- `fallocate` — ensure each file is at least `-l LENGTH` bytes (creating it if needed), where LENGTH accepts a byte count or a K/M/G suffix. It never shrinks an existing file.

## Tests

- Unit: setsid runs a program, propagates a non-zero exit, and rejects a missing program; fallocate's size parser (plain and K/M/G, plus invalid inputs), file creation to the requested size, never-shrink behavior, and the missing-length / missing-file / invalid-length errors.
- shellspec: setsid runs a program in a new session, fallocate sizes a file to 4096 bytes, and fallocate without -l fails.

## Verification

- `go test ./...` passes; `make test-e2e` passes (497 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248