### PR TITLE
feat(coreutils): add bc infix calculator applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 191 commands. Run `mimixbox --list` to see them on the terminal.
+There are 192 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -35,6 +35,7 @@ There are 191 commands. Run `mimixbox --list` to see them on the terminal.
 | base64 | Base64 encode/decode from FILE(or STDIN) to STDOUT |
 | basename | Print basename (PATH without "/") from file path |
 | bash | Command interpreter (MimixBox mbsh compatibility front-end) |
+| bc | An arbitrary-precision calculator language |
 | bunzip2 | Decompress bzip2 (.bz2) files |
 | busybox | BusyBox-style multi-call front-end for MimixBox applets |
 | bzcat | Decompress bz2 data to standard output |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -81,6 +81,7 @@ import (
 	ap_shellutils_arch "github.com/nao1215/mimixbox/internal/applets/shellutils/arch"
 	ap_shellutils_base64 "github.com/nao1215/mimixbox/internal/applets/shellutils/base64"
 	ap_shellutils_basename "github.com/nao1215/mimixbox/internal/applets/shellutils/basename"
+	ap_shellutils_bc "github.com/nao1215/mimixbox/internal/applets/shellutils/bc"
 	ap_shellutils_cal "github.com/nao1215/mimixbox/internal/applets/shellutils/cal"
 	ap_shellutils_chmod "github.com/nao1215/mimixbox/internal/applets/shellutils/chmod"
 	ap_shellutils_chroot "github.com/nao1215/mimixbox/internal/applets/shellutils/chroot"
@@ -185,7 +186,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 191)
+	Applets = make(map[string]Applet, 192)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -276,6 +277,7 @@ func init() {
 	register(ap_shellutils_arch.New())
 	register(ap_shellutils_base64.New())
 	register(ap_shellutils_basename.New())
+	register(ap_shellutils_bc.New())
 	register(ap_shellutils_cal.New())
 	register(ap_shellutils_chmod.New())
 	register(ap_shellutils_chroot.New())

--- a/internal/applets/shellutils/bc/bc.go
+++ b/internal/applets/shellutils/bc/bc.go
@@ -1,0 +1,398 @@
+// Package bc implements the bc applet: an arbitrary-precision infix calculator.
+// It supports the everyday subset - the four operators plus % and ^, parentheses
+// and precedence, unary minus, variables, and the scale precision control - which
+// covers scripted arithmetic without the full bc programming language.
+package bc
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the bc applet.
+type Command struct{}
+
+// New returns a bc command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "bc" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "An arbitrary-precision calculator language" }
+
+// num is a value with a display scale (number of fractional digits).
+type num struct {
+	v     *big.Rat
+	scale int
+}
+
+// machine holds the variables and the current precision.
+type machine struct {
+	vars  map[string]num
+	scale int
+	out   io.Writer
+	errw  io.Writer
+}
+
+// Run executes bc.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Evaluate infix arithmetic. Each non-assignment statement prints its value. " +
+			"Statements are separated by newlines or ';'. Read FILEs in order, or standard input " +
+			"when none are given.",
+		Examples: []command.Example{
+			{Command: "echo '2 + 3 * 4' | bc", Explain: "Print 14."},
+			{Command: "echo 'scale=2; 7/3' | bc", Explain: "Print 2.33."},
+		},
+		Notes: []string{
+			"Supported: + - * / % ^, parentheses, unary minus, variables, and the scale precision variable.",
+		},
+	})
+	_ = fs.BoolP("mathlib", "l", false, "accepted for compatibility; the math library is not loaded")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	m := &machine{vars: map[string]num{}, out: stdio.Out, errw: stdio.Err}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		sc := bufio.NewScanner(stdio.In)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			m.run(sc.Text())
+		}
+		return nil
+	}
+	for _, f := range files {
+		data, rerr := os.ReadFile(f) //nolint:gosec // user-named file
+		if rerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "bc: %s\n", command.FileError(f, rerr))
+			return command.SilentFailure()
+		}
+		m.run(string(data))
+	}
+	return nil
+}
+
+// run evaluates every statement in s.
+func (m *machine) run(s string) {
+	toks := lex(s)
+	p := &parser{toks: toks, m: m}
+	for !p.atEnd() {
+		p.skipSeparators()
+		if p.atEnd() {
+			break
+		}
+		printed, val, ok := p.statement()
+		if !ok {
+			return // a parse error was already reported
+		}
+		if printed {
+			_, _ = fmt.Fprintln(m.out, format(val))
+		}
+	}
+}
+
+type tokKind int
+
+const (
+	tNum tokKind = iota
+	tName
+	tOp
+	tSep
+	tEOF
+)
+
+type token struct {
+	kind tokKind
+	val  string
+}
+
+// lex splits s into tokens.
+func lex(s string) []token {
+	var toks []token
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+		switch {
+		case ch == ' ' || ch == '\t' || ch == '\r':
+			i++
+		case ch == '\n' || ch == ';':
+			toks = append(toks, token{tSep, string(ch)})
+			i++
+		case (ch >= '0' && ch <= '9') || ch == '.':
+			j := i
+			for j < len(s) && ((s[j] >= '0' && s[j] <= '9') || s[j] == '.') {
+				j++
+			}
+			toks = append(toks, token{tNum, s[i:j]})
+			i = j
+		case (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_':
+			j := i
+			for j < len(s) && ((s[j] >= 'a' && s[j] <= 'z') || (s[j] >= 'A' && s[j] <= 'Z') || (s[j] >= '0' && s[j] <= '9') || s[j] == '_') {
+				j++
+			}
+			toks = append(toks, token{tName, s[i:j]})
+			i = j
+		case strings.IndexByte("+-*/%^()=", ch) >= 0:
+			toks = append(toks, token{tOp, string(ch)})
+			i++
+		default:
+			i++ // ignore anything unrecognized
+		}
+	}
+	return append(toks, token{tEOF, ""})
+}
+
+type parser struct {
+	toks []token
+	pos  int
+	m    *machine
+	err  bool
+}
+
+func (p *parser) peek() token  { return p.toks[p.pos] }
+func (p *parser) next() token  { t := p.toks[p.pos]; p.pos++; return t }
+func (p *parser) atEnd() bool  { return p.peek().kind == tEOF }
+func (p *parser) fail(msg string) {
+	if !p.err {
+		_, _ = fmt.Fprintf(p.m.errw, "bc: %s\n", msg)
+		p.err = true
+	}
+}
+
+func (p *parser) skipSeparators() {
+	for p.peek().kind == tSep {
+		p.pos++
+	}
+}
+
+// statement parses one assignment or expression. printed reports whether the
+// value should be printed (true for a bare expression).
+func (p *parser) statement() (printed bool, val num, ok bool) {
+	// Assignment: NAME = expr.
+	if p.peek().kind == tName && p.toks[p.pos+1].kind == tOp && p.toks[p.pos+1].val == "=" {
+		name := p.next().val
+		p.next() // '='
+		v := p.expr()
+		if p.err {
+			return false, num{}, false
+		}
+		p.assign(name, v)
+		return false, num{}, true
+	}
+	v := p.expr()
+	if p.err {
+		return false, num{}, false
+	}
+	return true, v, true
+}
+
+func (p *parser) assign(name string, v num) {
+	if name == "scale" {
+		p.m.scale = int(ratToInt(v.v))
+		return
+	}
+	p.m.vars[name] = v
+}
+
+// expr -> addSub.
+func (p *parser) expr() num { return p.addSub() }
+
+func (p *parser) addSub() num {
+	left := p.mulDiv()
+	for p.peek().kind == tOp && (p.peek().val == "+" || p.peek().val == "-") {
+		op := p.next().val
+		right := p.mulDiv()
+		left = apply(p.m, op, left, right)
+	}
+	return left
+}
+
+func (p *parser) mulDiv() num {
+	left := p.unary()
+	for p.peek().kind == tOp && (p.peek().val == "*" || p.peek().val == "/" || p.peek().val == "%") {
+		op := p.next().val
+		right := p.unary()
+		left = apply(p.m, op, left, right)
+	}
+	return left
+}
+
+func (p *parser) unary() num {
+	if p.peek().kind == tOp && p.peek().val == "-" {
+		p.next()
+		v := p.unary()
+		return num{v: new(big.Rat).Neg(v.v), scale: v.scale}
+	}
+	return p.power()
+}
+
+func (p *parser) power() num {
+	base := p.primary()
+	if p.peek().kind == tOp && p.peek().val == "^" {
+		p.next()
+		exp := p.unary() // right-associative
+		return apply(p.m, "^", base, exp)
+	}
+	return base
+}
+
+func (p *parser) primary() num {
+	t := p.peek()
+	switch {
+	case t.kind == tOp && t.val == "(":
+		p.next()
+		v := p.expr()
+		if p.peek().kind == tOp && p.peek().val == ")" {
+			p.next()
+		} else {
+			p.fail("missing )")
+		}
+		return v
+	case t.kind == tNum:
+		p.next()
+		n, ok := parseNum(t.val)
+		if !ok {
+			p.fail("invalid number " + t.val)
+		}
+		return n
+	case t.kind == tName:
+		p.next()
+		if t.val == "scale" {
+			return num{v: new(big.Rat).SetInt64(int64(p.m.scale)), scale: 0}
+		}
+		if v, ok := p.m.vars[t.val]; ok {
+			return v
+		}
+		return num{v: new(big.Rat), scale: 0} // unset variables are zero
+	default:
+		p.fail("unexpected token")
+		p.next()
+		return num{v: new(big.Rat), scale: 0}
+	}
+}
+
+// parseNum converts a decimal literal to a num.
+func parseNum(tok string) (num, bool) {
+	scale := 0
+	if dot := strings.IndexByte(tok, '.'); dot >= 0 {
+		scale = len(tok) - dot - 1
+	}
+	r := new(big.Rat)
+	if _, ok := r.SetString(tok); !ok {
+		return num{}, false
+	}
+	return num{v: r, scale: scale}, true
+}
+
+// apply computes op over two operands, following bc's scale rules.
+func apply(m *machine, op string, a, b num) num {
+	res := new(big.Rat)
+	scale := 0
+	switch op {
+	case "+":
+		res.Add(a.v, b.v)
+		scale = maxInt(a.scale, b.scale)
+	case "-":
+		res.Sub(a.v, b.v)
+		scale = maxInt(a.scale, b.scale)
+	case "*":
+		res.Mul(a.v, b.v)
+		// bc caps the product scale at min(s1+s2, max(scale, s1, s2)) and truncates.
+		scale = minInt(a.scale+b.scale, maxInt(m.scale, maxInt(a.scale, b.scale)))
+		res = truncate(res, scale)
+	case "/":
+		if b.v.Sign() == 0 {
+			_, _ = fmt.Fprintln(m.errw, "bc: divide by zero")
+			return num{v: new(big.Rat), scale: 0}
+		}
+		res = truncate(new(big.Rat).Quo(a.v, b.v), m.scale)
+		scale = m.scale
+	case "%":
+		if b.v.Sign() == 0 {
+			_, _ = fmt.Fprintln(m.errw, "bc: divide by zero")
+			return num{v: new(big.Rat), scale: 0}
+		}
+		q := truncate(new(big.Rat).Quo(a.v, b.v), m.scale)
+		res.Sub(a.v, new(big.Rat).Mul(q, b.v))
+		scale = maxInt(a.scale, b.scale+m.scale)
+	case "^":
+		res = power(a.v, b.v)
+		scale = a.scale * int(ratToInt(b.v))
+		if scale < 0 {
+			scale = m.scale
+		}
+	}
+	return num{v: res, scale: scale}
+}
+
+func power(base, exp *big.Rat) *big.Rat {
+	e := ratToInt(exp)
+	neg := e < 0
+	if neg {
+		e = -e
+	}
+	result := new(big.Rat).SetInt64(1)
+	for ; e > 0; e-- {
+		result.Mul(result, base)
+	}
+	if neg && result.Sign() != 0 {
+		result.Inv(result)
+	}
+	return result
+}
+
+// truncate rounds r toward zero to k fractional digits.
+func truncate(r *big.Rat, k int) *big.Rat {
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(k)), nil)
+	scaled := new(big.Int).Mul(r.Num(), scale)
+	scaled.Quo(scaled, r.Denom())
+	return new(big.Rat).SetFrac(scaled, scale)
+}
+
+func ratToInt(r *big.Rat) int64 {
+	return new(big.Int).Quo(r.Num(), r.Denom()).Int64()
+}
+
+// format renders a num with its scale's worth of fractional digits, using bc's
+// convention of omitting the leading zero (".5", "-.5").
+func format(n num) string {
+	if n.scale <= 0 {
+		return new(big.Int).Quo(n.v.Num(), n.v.Denom()).String()
+	}
+	s := n.v.FloatString(n.scale)
+	switch {
+	case strings.HasPrefix(s, "0."):
+		return s[1:]
+	case strings.HasPrefix(s, "-0."):
+		return "-" + s[2:]
+	default:
+		return s
+	}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/applets/shellutils/bc/bc_test.go
+++ b/internal/applets/shellutils/bc/bc_test.go
@@ -1,0 +1,83 @@
+package bc
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, in string, args ...string) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return strings.TrimRight(out.String(), "\n")
+}
+
+func TestExpressions(t *testing.T) {
+	t.Parallel()
+	// All values verified against GNU bc.
+	cases := map[string]string{
+		"2 + 3 * 4":     "14",
+		"(2 + 3) * 4":   "20",
+		"2^10":          "1024",
+		"10 % 3":        "1",
+		"-3 + 1":        "-2",
+		"2.5 * 2.5":     "6.2",
+		"scale=2; 7/3":  "2.33",
+		"scale=4; 1/3":  ".3333",
+		"scale=2; -1/4": "-.25",
+		"3^3":           "27",
+		"7 - 2 - 1":     "4",
+	}
+	for in, want := range cases {
+		if got := run(t, in); got != want {
+			t.Errorf("bc %q = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestVariables(t *testing.T) {
+	t.Parallel()
+	if got := run(t, "x = 5; x * x"); got != "25" {
+		t.Errorf("variables -> %q, want 25", got)
+	}
+	if got := run(t, "a=2; b=3; a^b"); got != "8" {
+		t.Errorf("two vars -> %q, want 8", got)
+	}
+	// An unset variable is zero.
+	if got := run(t, "y + 7"); got != "7" {
+		t.Errorf("unset var -> %q, want 7", got)
+	}
+}
+
+func TestAssignmentDoesNotPrint(t *testing.T) {
+	t.Parallel()
+	// Only the bare expression prints; the assignment does not.
+	if got := run(t, "x = 9"); got != "" {
+		t.Errorf("assignment printed %q, want nothing", got)
+	}
+}
+
+func TestPrecisionPersists(t *testing.T) {
+	t.Parallel()
+	// scale set on one line applies to a later line (same machine per run call).
+	if got := run(t, "scale=3\n10/7"); got != "1.428" {
+		t.Errorf("scale across lines -> %q, want 1.428", got)
+	}
+}
+
+func TestDivideByZero(t *testing.T) {
+	t.Parallel()
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader("1/0\n"), Out: &bytes.Buffer{}, Err: errBuf}
+	_ = New().Run(context.Background(), io, nil)
+	if !strings.Contains(errBuf.String(), "divide by zero") {
+		t.Errorf("expected a divide-by-zero error, got %q", errBuf.String())
+	}
+}

--- a/test/it/shellutils/bc_test.sh
+++ b/test/it/shellutils/bc_test.sh
@@ -1,0 +1,4 @@
+TestBcPrecedence() { echo '2 + 3 * 4' | bc; }
+TestBcScale() { echo 'scale=2; 7/3' | bc; }
+TestBcVars() { printf 'x = 5\nx * x\n' | bc; }
+TestBcPower() { echo '2^10' | bc; }

--- a/test/it/spec/bc_spec.sh
+++ b/test/it/spec/bc_spec.sh
@@ -1,0 +1,24 @@
+Describe 'bc'
+    Include shellutils/bc_test.sh
+
+    It 'respects operator precedence'
+        When call TestBcPrecedence
+        The output should equal '14'
+        The status should be success
+    End
+    It 'honors scale for division'
+        When call TestBcScale
+        The output should equal '2.33'
+        The status should be success
+    End
+    It 'supports variables'
+        When call TestBcVars
+        The output should equal '25'
+        The status should be success
+    End
+    It 'computes powers'
+        When call TestBcPower
+        The output should equal '1024'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with `bc`, an arbitrary-precision infix calculator covering the everyday subset. Each non-assignment statement prints its value; statements are separated by newlines or `;`. It reads FILE operands or standard input.

Supported:

- The operators `+ - * / % ^` with correct precedence, parentheses, and unary minus, over exact fixed-point decimals (math/big).
- Variables (`x = 5`), with unset variables defaulting to 0; assignments do not print.
- The `scale` variable controlling division precision, persisting across statements.
- bc's output conventions: truncation (not rounding), the multiply scale rule `min(s1+s2, max(scale,s1,s2))`, and the omitted leading zero (`.3333`).

Output was verified against GNU bc across precedence, scale, variables, powers, modulo, and negative cases. The full bc language (functions, loops, conditionals) is out of scope for this slice; `-l` is accepted but the math library is not loaded.

## Tests

- Unit: precedence, parentheses, powers, modulo, negatives, decimal multiply, scale division, omitted-leading-zero, variables (incl. unset = 0), assignment-does-not-print, scale persistence across lines, and divide-by-zero.
- shellspec: precedence, scale division, variables, and powers.

## Verification

- `go test ./...` passes; `make test-e2e` passes (505 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243