### PR TITLE
feat(coreutils): add sha3sum applet with selectable digest length

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 192 commands. Run `mimixbox --list` to see them on the terminal.
+There are 193 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -157,6 +157,7 @@ There are 192 commands. Run `mimixbox --list` to see them on the terminal.
 | sha1sum | Calculate or Check secure hash 1 algorithm |
 | sha256sum | Calculate or Check secure hash 256 algorithm |
 | sha384sum | Calculate or Check secure hash 384 algorithm |
+| sha3sum | Calculate or Check SHA-3 message digest |
 | sha512sum | Calculate or Check secure hash 512 algorithm |
 | shred | Overwrite a file to hide its contents |
 | shuf | Generate a random permutation of input lines |

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.15
+	golang.org/x/crypto v0.53.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -164,6 +164,7 @@ import (
 	ap_textutils_sha1sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha1sum"
 	ap_textutils_sha256sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha256sum"
 	ap_textutils_sha384sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha384sum"
+	ap_textutils_sha3sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha3sum"
 	ap_textutils_sha512sum "github.com/nao1215/mimixbox/internal/applets/textutils/sha512sum"
 	ap_textutils_shuf "github.com/nao1215/mimixbox/internal/applets/textutils/shuf"
 	ap_textutils_split "github.com/nao1215/mimixbox/internal/applets/textutils/split"
@@ -186,7 +187,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 192)
+	Applets = make(map[string]Applet, 193)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -360,6 +361,7 @@ func init() {
 	register(ap_textutils_sha1sum.New())
 	register(ap_textutils_sha256sum.New())
 	register(ap_textutils_sha384sum.New())
+	register(ap_textutils_sha3sum.New())
 	register(ap_textutils_sha512sum.New())
 	register(ap_textutils_shuf.New())
 	register(ap_textutils_split.New())

--- a/internal/applets/textutils/sha3sum/sha3sum.go
+++ b/internal/applets/textutils/sha3sum/sha3sum.go
@@ -1,0 +1,94 @@
+// Package sha3sum implements the sha3sum applet: print or check SHA-3 message
+// digests in the GNU coreutils output format. The digest length is selected with
+// -a (224, 256, 384, or 512; default 256).
+package sha3sum
+
+import (
+	"context"
+	"hash"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"github.com/nao1215/mimixbox/internal/hashsum"
+	"golang.org/x/crypto/sha3"
+)
+
+const synopsis = "Calculate or Check SHA-3 message digest"
+
+// Command is the sha3sum applet.
+type Command struct{}
+
+// New returns a sha3sum command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "sha3sum" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return synopsis }
+
+// Run executes sha3sum: it selects the digest length from -a, then delegates the
+// file handling and GNU-format output to the shared hashsum framework.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	bits, rest, err := extractAlgo(args)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	var newHash func() hash.Hash
+	switch bits {
+	case 224:
+		newHash = sha3.New224
+	case 256:
+		newHash = sha3.New256
+	case 384:
+		newHash = sha3.New384
+	case 512:
+		newHash = sha3.New512
+	default:
+		return command.Failuref("unsupported digest length %d (use 224, 256, 384, or 512)", bits)
+	}
+	return hashsum.New("sha3sum", synopsis, newHash).Run(ctx, stdio, rest)
+}
+
+// extractAlgo pulls the -a/--algorithm option (default 256) out of args so the
+// remaining arguments can be handled by the standard sum flag set.
+func extractAlgo(args []string) (bits int, rest []string, err error) {
+	bits = 256
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "-a" || a == "--algorithm":
+			if i+1 >= len(args) {
+				return 0, nil, command.Failuref("option %s requires an argument", a)
+			}
+			i++
+			if bits, err = atoi(args[i]); err != nil {
+				return 0, nil, err
+			}
+		case len(a) > 2 && a[:2] == "-a":
+			if bits, err = atoi(a[2:]); err != nil {
+				return 0, nil, err
+			}
+		case len(a) > len("--algorithm=") && a[:len("--algorithm=")] == "--algorithm=":
+			if bits, err = atoi(a[len("--algorithm="):]); err != nil {
+				return 0, nil, err
+			}
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return bits, rest, nil
+}
+
+func atoi(s string) (int, error) {
+	n := 0
+	if s == "" {
+		return 0, command.Failuref("invalid digest length %q", s)
+	}
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return 0, command.Failuref("invalid digest length %q", s)
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n, nil
+}

--- a/internal/applets/textutils/sha3sum/sha3sum_test.go
+++ b/internal/applets/textutils/sha3sum/sha3sum_test.go
@@ -1,0 +1,64 @@
+package sha3sum
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, in string, args ...string) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(in), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestDefaultIs256(t *testing.T) {
+	t.Parallel()
+	// SHA3-256 of "hello\n", verified with openssl dgst -sha3-256.
+	const want = "b314e28493eae9dab57ac4f0c6d887bddbbeb810e900d818395ace558e96516d"
+	if got := run(t, "hello\n"); !strings.HasPrefix(got, want) {
+		t.Errorf("sha3sum = %q, want prefix %q", got, want)
+	}
+}
+
+func TestAlgorithmSelection(t *testing.T) {
+	t.Parallel()
+	// SHA3-512 of "hello\n" (openssl).
+	const want512 = "ac766ba623301e0ad63c48cb2fc469d1"
+	for _, args := range [][]string{{"-a", "512"}, {"-a512"}, {"--algorithm=512"}} {
+		got := run(t, "hello\n", args...)
+		if !strings.HasPrefix(got, want512) {
+			t.Errorf("sha3sum %v = %q, want prefix %q", args, got, want512)
+		}
+	}
+}
+
+func TestExtractAlgo(t *testing.T) {
+	t.Parallel()
+	bits, rest, err := extractAlgo([]string{"-a", "384", "file.txt"})
+	if err != nil || bits != 384 || len(rest) != 1 || rest[0] != "file.txt" {
+		t.Errorf("extractAlgo = %d, %v, %v", bits, rest, err)
+	}
+	bits, _, err = extractAlgo([]string{"file.txt"})
+	if err != nil || bits != 256 {
+		t.Errorf("default bits = %d, %v; want 256", bits, err)
+	}
+	if _, _, err := extractAlgo([]string{"-a", "bad"}); err == nil {
+		t.Errorf("non-numeric -a should fail")
+	}
+}
+
+func TestUnsupportedLength(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: strings.NewReader("x"), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"-a", "999"}); err == nil {
+		t.Errorf("unsupported length should fail")
+	}
+}

--- a/test/it/spec/sha3sum_spec.sh
+++ b/test/it/spec/sha3sum_spec.sh
@@ -1,0 +1,14 @@
+Describe 'sha3sum'
+    Include textutils/checksum_test.sh
+
+    It 'defaults to SHA3-256'
+        When call TestSha3Default
+        The output should equal 'b314e28493eae9dab57ac4f0c6d887bddbbeb810e900d818395ace558e96516d'
+        The status should be success
+    End
+    It 'selects SHA3-512 with -a'
+        When call TestSha3_512
+        The output should equal 'ac766ba623301e0a'
+        The status should be success
+    End
+End

--- a/test/it/textutils/checksum_test.sh
+++ b/test/it/textutils/checksum_test.sh
@@ -17,3 +17,6 @@ TestUuBase64() {
 TestUsleep() {
     usleep 1000 && echo slept
 }
+
+TestSha3Default() { printf 'hello\n' | sha3sum | cut -d' ' -f1; }
+TestSha3_512() { printf 'hello\n' | sha3sum -a 512 | cut -c1-16; }


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with `sha3sum`, printing or checking SHA-3 digests in the GNU coreutils format. The digest length is chosen with `-a` (224, 256, 384, or 512; default 256). It reuses the shared `internal/hashsum` framework, so file operands, stdin, and `-c` checking work like the other `*sum` applets.

SHA-3 comes from golang.org/x/crypto/sha3; the default and the 512 variant were verified against `openssl dgst -sha3-256/-sha3-512`.

## Tests

- Unit: the default SHA3-256 digest of a known input; `-a 512` selection in three spellings (`-a 512`, `-a512`, `--algorithm=512`); the `extractAlgo` parser (value, default, and invalid); and the unsupported-length error.
- shellspec: the default SHA3-256 digest and `-a 512` selection.

## Verification

- `go test ./...` passes; `make test-e2e` passes (507 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243