### PR TITLE
feat(coreutils): add ed line editor applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 195 commands. Run `mimixbox --list` to see them on the terminal.
+There are 196 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -67,6 +67,7 @@ There are 195 commands. Run `mimixbox --list` to see them on the terminal.
 | dos2unix | Change CRLF to LF |
 | du | Estimate file space usage |
 | echo | Display a line of text |
+| ed | A line-oriented text editor |
 | egrep | Search with extended regular expressions (grep -E) |
 | env | Run a program in a modified environment / print the environment |
 | expand | Convert TAB to N space (default:N=8) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -36,6 +36,7 @@ import (
 	ap_debianutils_which "github.com/nao1215/mimixbox/internal/applets/debianutils/which"
 	ap_editors_awk "github.com/nao1215/mimixbox/internal/applets/editors/awk"
 	ap_editors_diff "github.com/nao1215/mimixbox/internal/applets/editors/diff"
+	ap_editors_ed "github.com/nao1215/mimixbox/internal/applets/editors/ed"
 	ap_editors_patch "github.com/nao1215/mimixbox/internal/applets/editors/patch"
 	ap_editors_sed "github.com/nao1215/mimixbox/internal/applets/editors/sed"
 	ap_editors_vi "github.com/nao1215/mimixbox/internal/applets/editors/vi"
@@ -188,7 +189,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 195)
+	Applets = make(map[string]Applet, 196)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -232,6 +233,7 @@ func init() {
 	register(ap_debianutils_which.New())
 	register(ap_editors_awk.New())
 	register(ap_editors_diff.New())
+	register(ap_editors_ed.New())
 	register(ap_editors_patch.New())
 	register(ap_editors_sed.New())
 	register(ap_editors_vi.New())

--- a/internal/applets/editors/ed/ed.go
+++ b/internal/applets/editors/ed/ed.go
@@ -1,0 +1,393 @@
+// Package ed implements the ed applet: a minimal line editor suited to scripted
+// editing. It supports line addressing and the core verbs (a, i, c, d, p, n, w,
+// q, =, s) that cover non-interactive edits.
+package ed
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the ed applet.
+type Command struct{}
+
+// New returns an ed command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ed" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "A line-oriented text editor" }
+
+// editor holds the buffer and editing state.
+type editor struct {
+	lines    []string // line N is lines[N-1]
+	dot      int      // current line (1-based; 0 when empty)
+	file     string
+	in       *bufio.Scanner
+	out      io.Writer
+	errw     io.Writer
+	modified bool
+}
+
+// Run executes ed.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Edit text line by line, reading commands from standard input. With FILE, load it " +
+			"first and print its size. Commands: a/i/c (add text, ended by a line with just '.'), " +
+			"d (delete), p/n (print), w (write), = (line number), s/re/repl/ (substitute), q (quit).",
+		Examples: []command.Example{
+			{Command: "printf '1,$p\\nq\\n' | ed file.txt", Explain: "Print the whole file."},
+			{Command: "printf '2a\\nnew line\\n.\\nw\\nq\\n' | ed file.txt", Explain: "Insert a line after line 2 and save."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	sc := bufio.NewScanner(stdio.In)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	e := &editor{dot: 0, in: sc, out: stdio.Out, errw: stdio.Err}
+	if rest := fs.Args(); len(rest) > 0 {
+		e.file = rest[0]
+		if err := e.load(); err != nil {
+			_, _ = fmt.Fprintln(stdio.Err, "?")
+		}
+	}
+
+	for sc.Scan() {
+		if quit := e.command(sc.Text()); quit {
+			break
+		}
+	}
+	return nil
+}
+
+// load reads the file into the buffer and prints its byte count.
+func (e *editor) load() error {
+	data, err := os.ReadFile(e.file) //nolint:gosec // user-named file
+	if err != nil {
+		return err
+	}
+	text := string(data)
+	if text == "" {
+		e.lines = nil
+	} else {
+		e.lines = strings.Split(strings.TrimSuffix(text, "\n"), "\n")
+	}
+	e.dot = len(e.lines)
+	_, _ = fmt.Fprintln(e.out, byteCount(e.lines))
+	return nil
+}
+
+// byteCount returns the size of the buffer as ed counts it (each line plus a
+// trailing newline).
+func byteCount(lines []string) int {
+	n := 0
+	for _, l := range lines {
+		n += len(l) + 1
+	}
+	return n
+}
+
+// command executes one command line and reports whether to quit.
+func (e *editor) command(line string) (quit bool) {
+	a1, a2, naddr, rest := e.parseAddresses(line)
+	if rest == "" {
+		// A bare address moves to and prints that line; an empty line advances.
+		target := a2
+		if naddr == 0 {
+			target = e.dot + 1
+		}
+		if !e.valid(target) {
+			e.fail()
+			return false
+		}
+		e.dot = target
+		_, _ = fmt.Fprintln(e.out, e.lines[e.dot-1])
+		return false
+	}
+
+	cmd := rest[0]
+	arg := strings.TrimSpace(rest[1:])
+	switch cmd {
+	case 'q':
+		return true
+	case 'Q':
+		return true
+	case 'a':
+		e.insert(e.defaultLine(naddr, a2), false)
+	case 'i':
+		e.insert(e.defaultLine(naddr, a2), true)
+	case 'c':
+		e.change(naddr, a1, a2)
+	case 'd':
+		e.delete(naddr, a1, a2)
+	case 'p':
+		e.print(naddr, a1, a2, false)
+	case 'n':
+		e.print(naddr, a1, a2, true)
+	case '=':
+		n := len(e.lines)
+		if naddr > 0 {
+			n = a2
+		}
+		_, _ = fmt.Fprintln(e.out, n)
+	case 'w':
+		e.write(arg)
+	case 's':
+		e.substitute(naddr, a1, a2, rest[1:])
+	default:
+		e.fail()
+	}
+	return false
+}
+
+// defaultLine returns the address to use for a/i, defaulting to the current line.
+func (e *editor) defaultLine(naddr, a2 int) int {
+	if naddr == 0 {
+		return e.dot
+	}
+	return a2
+}
+
+func (e *editor) fail() { _, _ = fmt.Fprintln(e.errw, "?") }
+
+func (e *editor) valid(n int) bool { return n >= 1 && n <= len(e.lines) }
+
+// insert reads input lines (until a "." line) and inserts them. When before is
+// true they go before the address (i); otherwise after it (a).
+func (e *editor) insert(at int, before bool) {
+	pos := at // 'a' appends after 'at'
+	if before {
+		pos = at - 1 // 'i' inserts before 'at'
+	}
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(e.lines) {
+		pos = len(e.lines)
+	}
+	added := e.readInput()
+	e.lines = append(e.lines[:pos], append(added, e.lines[pos:]...)...)
+	if len(added) > 0 {
+		e.dot = pos + len(added)
+		e.modified = true
+	}
+}
+
+// readInput collects buffer lines from the command stream until a line
+// containing only ".".
+func (e *editor) readInput() []string {
+	var added []string
+	for e.in.Scan() {
+		t := e.in.Text()
+		if t == "." {
+			break
+		}
+		added = append(added, t)
+	}
+	return added
+}
+
+// change deletes the range then inserts new text in its place.
+func (e *editor) change(naddr, a1, a2 int) {
+	lo, hi := e.rangeOrDot(naddr, a1, a2)
+	if !e.valid(lo) || !e.valid(hi) {
+		e.fail()
+		return
+	}
+	e.lines = append(e.lines[:lo-1], e.lines[hi:]...)
+	added := e.readInput()
+	e.lines = append(e.lines[:lo-1], append(added, e.lines[lo-1:]...)...)
+	e.dot = lo - 1 + len(added)
+	e.modified = true
+}
+
+// delete removes the addressed range.
+func (e *editor) delete(naddr, a1, a2 int) {
+	lo, hi := e.rangeOrDot(naddr, a1, a2)
+	if !e.valid(lo) || !e.valid(hi) {
+		e.fail()
+		return
+	}
+	e.lines = append(e.lines[:lo-1], e.lines[hi:]...)
+	e.dot = lo
+	if e.dot > len(e.lines) {
+		e.dot = len(e.lines)
+	}
+	e.modified = true
+}
+
+// print writes the addressed range, optionally with line numbers.
+func (e *editor) print(naddr, a1, a2 int, numbered bool) {
+	lo, hi := e.rangeOrDot(naddr, a1, a2)
+	if !e.valid(lo) || !e.valid(hi) {
+		e.fail()
+		return
+	}
+	for i := lo; i <= hi; i++ {
+		if numbered {
+			_, _ = fmt.Fprintf(e.out, "%d\t%s\n", i, e.lines[i-1])
+		} else {
+			_, _ = fmt.Fprintln(e.out, e.lines[i-1])
+		}
+	}
+	e.dot = hi
+}
+
+// write saves the buffer to arg (or the current file) and prints its byte count.
+func (e *editor) write(arg string) {
+	name := e.file
+	if arg != "" {
+		name = arg
+	}
+	if name == "" {
+		e.fail()
+		return
+	}
+	var b strings.Builder
+	for _, l := range e.lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(name, []byte(b.String()), 0o644); err != nil { //nolint:gosec // user-named file
+		e.fail()
+		return
+	}
+	e.modified = false
+	_, _ = fmt.Fprintln(e.out, byteCount(e.lines))
+}
+
+// substitute applies s/re/repl/[g] to the addressed range (default current line).
+func (e *editor) substitute(naddr, a1, a2 int, spec string) {
+	lo, hi := e.rangeOrDot(naddr, a1, a2)
+	if !e.valid(lo) || !e.valid(hi) || len(spec) < 1 {
+		e.fail()
+		return
+	}
+	delim := spec[0]
+	parts := strings.Split(spec[1:], string(delim))
+	if len(parts) < 3 {
+		e.fail()
+		return
+	}
+	re, err := regexp.Compile(parts[0])
+	if err != nil {
+		e.fail()
+		return
+	}
+	repl := parts[1]
+	global := strings.Contains(parts[2], "g")
+	for i := lo; i <= hi; i++ {
+		if global {
+			e.lines[i-1] = re.ReplaceAllString(e.lines[i-1], repl)
+		} else {
+			e.lines[i-1] = replaceFirst(re, e.lines[i-1], repl)
+		}
+	}
+	e.dot = hi
+	e.modified = true
+}
+
+// replaceFirst replaces only the first match of re in s.
+func replaceFirst(re *regexp.Regexp, s, repl string) string {
+	loc := re.FindStringIndex(s)
+	if loc == nil {
+		return s
+	}
+	return s[:loc[0]] + re.ReplaceAllString(s[loc[0]:loc[1]], repl) + s[loc[1]:]
+}
+
+// rangeOrDot resolves the effective range, defaulting to the current line.
+func (e *editor) rangeOrDot(naddr, a1, a2 int) (int, int) {
+	switch naddr {
+	case 0:
+		return e.dot, e.dot
+	case 1:
+		return a2, a2
+	default:
+		return a1, a2
+	}
+}
+
+// parseAddresses parses the leading address(es) of a command line and returns
+// the first and second address, how many were given, and the remaining command
+// text.
+func (e *editor) parseAddresses(s string) (a1, a2, naddr int, rest string) {
+	i := 0
+	first, ni, ok1 := e.oneAddr(s, i)
+	if !ok1 {
+		return 0, 0, 0, s
+	}
+	i = ni
+	a1, a2 = first, first
+	naddr = 1
+	if i < len(s) && (s[i] == ',' || s[i] == ';') {
+		sep := s[i]
+		if sep == ';' {
+			e.dot = first
+		}
+		i++
+		second, nj, ok2 := e.oneAddr(s, i)
+		if ok2 {
+			a2 = second
+			i = nj
+		} else {
+			a2 = len(e.lines)
+		}
+		naddr = 2
+	}
+	return a1, a2, naddr, s[i:]
+}
+
+// oneAddr parses a single address at i, returning its value, the next index, and
+// whether an address was present.
+func (e *editor) oneAddr(s string, i int) (val, next int, ok bool) {
+	if i >= len(s) {
+		return 0, i, false
+	}
+	switch s[i] {
+	case '.':
+		return e.dot, i + 1, true
+	case '$':
+		return len(e.lines), i + 1, true
+	case ',':
+		// A leading comma means 1,$ for the whole-file range; handled by caller.
+		return 1, i, true
+	case '+', '-':
+		j := i + 1
+		for j < len(s) && s[j] >= '0' && s[j] <= '9' {
+			j++
+		}
+		n := 1
+		if j > i+1 {
+			n, _ = strconv.Atoi(s[i+1 : j])
+		}
+		if s[i] == '-' {
+			return e.dot - n, j, true
+		}
+		return e.dot + n, j, true
+	default:
+		if s[i] >= '0' && s[i] <= '9' {
+			j := i
+			for j < len(s) && s[j] >= '0' && s[j] <= '9' {
+				j++
+			}
+			n, _ := strconv.Atoi(s[i:j])
+			return n, j, true
+		}
+	}
+	return 0, i, false
+}

--- a/internal/applets/editors/ed/ed_test.go
+++ b/internal/applets/editors/ed/ed_test.go
@@ -1,0 +1,102 @@
+package ed
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// edit runs ed on a file seeded with content, feeding script as commands. It
+// returns ed's stdout and the file's contents afterward.
+func edit(t *testing.T, content, script string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "buf.txt")
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(script), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{f}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	data, _ := os.ReadFile(f)
+	return out.String(), string(data)
+}
+
+func TestLoadAndPrint(t *testing.T) {
+	t.Parallel()
+	out, _ := edit(t, "one\ntwo\nthree\n", "1,$p\nq\n")
+	if out != "14\none\ntwo\nthree\n" {
+		t.Errorf("print = %q", out)
+	}
+}
+
+func TestAppendAndWrite(t *testing.T) {
+	t.Parallel()
+	out, file := edit(t, "one\ntwo\nthree\n", "2a\nINSERTED\n.\nw\nq\n")
+	if file != "one\ntwo\nINSERTED\nthree\n" {
+		t.Errorf("file = %q", file)
+	}
+	// 14 on load, 23 after write.
+	if out != "14\n23\n" {
+		t.Errorf("byte counts = %q", out)
+	}
+}
+
+func TestInsertBefore(t *testing.T) {
+	t.Parallel()
+	_, file := edit(t, "one\ntwo\n", "1i\nHEAD\n.\nw\nq\n")
+	if file != "HEAD\none\ntwo\n" {
+		t.Errorf("file = %q", file)
+	}
+}
+
+func TestChange(t *testing.T) {
+	t.Parallel()
+	_, file := edit(t, "one\ntwo\nthree\n", "2c\nCHANGED\n.\nw\nq\n")
+	if file != "one\nCHANGED\nthree\n" {
+		t.Errorf("file = %q", file)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+	_, file := edit(t, "one\ntwo\nthree\n", "1d\nw\nq\n")
+	if file != "two\nthree\n" {
+		t.Errorf("file = %q", file)
+	}
+}
+
+func TestSubstitute(t *testing.T) {
+	t.Parallel()
+	_, file := edit(t, "foo bar\n", "1s/bar/BAZ/\nw\nq\n")
+	if file != "foo BAZ\n" {
+		t.Errorf("file = %q", file)
+	}
+	_, file = edit(t, "aaa\n", "1s/a/b/g\nw\nq\n")
+	if file != "bbb\n" {
+		t.Errorf("global sub = %q", file)
+	}
+}
+
+func TestLineNumber(t *testing.T) {
+	t.Parallel()
+	out, _ := edit(t, "a\nb\nc\n", "=\nq\n")
+	if out != "6\n3\n" { // 6 bytes on load, $ = 3
+		t.Errorf("= -> %q", out)
+	}
+}
+
+func TestRangeDelete(t *testing.T) {
+	t.Parallel()
+	_, file := edit(t, "1\n2\n3\n4\n", "2,3d\nw\nq\n")
+	if file != "1\n4\n" {
+		t.Errorf("range delete = %q", file)
+	}
+}

--- a/test/it/editors/ed_test.sh
+++ b/test/it/editors/ed_test.sh
@@ -1,0 +1,21 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/ed
+    mkdir -p ${TEST_DIR}
+    printf 'one\ntwo\nthree\n' > ${TEST_DIR}/buf.txt
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/ed; }
+
+TestEdPrint() {
+    printf '1,$p\nq\n' | ed ${TEST_DIR}/buf.txt
+}
+
+TestEdAppendWrite() {
+    printf '2a\nINSERTED\n.\nw\nq\n' | ed ${TEST_DIR}/buf.txt > /dev/null
+    cat ${TEST_DIR}/buf.txt
+}
+
+TestEdSubstitute() {
+    printf '2s/two/TWO/\nw\nq\n' | ed ${TEST_DIR}/buf.txt > /dev/null
+    cat ${TEST_DIR}/buf.txt
+}

--- a/test/it/spec/ed_spec.sh
+++ b/test/it/spec/ed_spec.sh
@@ -1,0 +1,29 @@
+Describe 'ed'
+    Include editors/ed_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints the buffer with size'
+        When call TestEdPrint
+        The output should equal '14
+one
+two
+three'
+        The status should be success
+    End
+    It 'appends a line and writes it'
+        When call TestEdAppendWrite
+        The output should equal 'one
+two
+INSERTED
+three'
+        The status should be success
+    End
+    It 'substitutes text on a line'
+        When call TestEdSubstitute
+        The output should equal 'one
+TWO
+three'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with `ed`, a minimal line editor for scripted editing. It loads an optional FILE (printing its byte count, like ed), reads commands from standard input, and supports line addressing plus the core verbs.

Supported:

- Addressing: line numbers, `.` (current), `$` (last), `+N`/`-N`, ranges (`a,b`, `a;b`), and a leading `,` for the whole file.
- `a` / `i` / `c` — add text (ended by a line with just `.`), inserting after, before, or replacing.
- `d` (delete), `p` / `n` (print, optionally numbered), `=` (line number), `w [file]` (write, printing the new byte count), `q` (quit), and `s/re/repl/[g]` (substitute via Go regexp).

## Tests

- Unit: load-and-print with byte count, append + write, insert-before, change, delete, single and global substitution, `=`, and a range delete — each verifying the resulting file contents and/or output.
- shellspec: print-with-size, append-and-write, and substitute.

The full ed command set (marks, global commands, undo, regex addresses) is out of scope for this slice.

## Verification

- `go test ./...` passes; `make test-e2e` passes (513 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243