### PR TITLE
feat(coreutils): add ls applet with the common desktop subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 196 commands. Run `mimixbox --list` to see them on the terminal.
+There are 197 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -108,6 +108,7 @@ There are 196 commands. Run `mimixbox --list` to see them on the terminal.
 | ln | Create hard or symbolic link |
 | log-collect | Gather system log files into one directory |
 | logname | Print the name of the current user |
+| ls | List directory contents |
 | lzcat | Decompress lzma data to standard output |
 | lzma | Compress or decompress files (lzma) |
 | mbsh | Mimix Box Shell |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -45,6 +45,7 @@ import (
 	ap_fileutils_cp "github.com/nao1215/mimixbox/internal/applets/fileutils/cp"
 	ap_fileutils_link "github.com/nao1215/mimixbox/internal/applets/fileutils/link"
 	ap_fileutils_ln "github.com/nao1215/mimixbox/internal/applets/fileutils/ln"
+	ap_fileutils_ls "github.com/nao1215/mimixbox/internal/applets/fileutils/ls"
 	ap_fileutils_mkdir "github.com/nao1215/mimixbox/internal/applets/fileutils/mkdir"
 	ap_fileutils_mkfifo "github.com/nao1215/mimixbox/internal/applets/fileutils/mkfifo"
 	ap_fileutils_mountpoint "github.com/nao1215/mimixbox/internal/applets/fileutils/mountpoint"
@@ -189,7 +190,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 196)
+	Applets = make(map[string]Applet, 197)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -242,6 +243,7 @@ func init() {
 	register(ap_fileutils_cp.New())
 	register(ap_fileutils_link.New())
 	register(ap_fileutils_ln.New())
+	register(ap_fileutils_ls.New())
 	register(ap_fileutils_mkdir.New())
 	register(ap_fileutils_mkfifo.New())
 	register(ap_fileutils_mountpoint.New())

--- a/internal/applets/fileutils/ls/ls.go
+++ b/internal/applets/fileutils/ls/ls.go
@@ -1,0 +1,329 @@
+// Package ls implements the ls applet: list directory contents. It covers the
+// everyday desktop subset - plain, -1, -a, -A, -d, -l, -F, -h, -R - with stable
+// name sorting and deterministic error reporting.
+package ls
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the ls applet.
+type Command struct{}
+
+// New returns an ls command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ls" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List directory contents" }
+
+type options struct {
+	all       bool // -a: include . and ..
+	almostAll bool // -A: include dotfiles but not . and ..
+	long      bool // -l
+	dirSelf   bool // -d
+	classify  bool // -F
+	human     bool // -h
+	recursive bool // -R
+}
+
+// Run executes ls.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "List information about FILEs (the current directory by default), sorted by name.",
+		Examples: []command.Example{
+			{Command: "ls -la", Explain: "Long format, including dotfiles."},
+			{Command: "ls -R dir", Explain: "List dir and its subdirectories recursively."},
+		},
+		ExitStatus: "0  success.\n2  a FILE could not be accessed.",
+	})
+	all := fs.BoolP("all", "a", false, "do not ignore entries starting with .")
+	almost := fs.BoolP("almost-all", "A", false, "like -a but omit . and ..")
+	long := fs.BoolP("long", "l", false, "use a long listing format")
+	dirSelf := fs.BoolP("directory", "d", false, "list directories themselves, not their contents")
+	classify := fs.BoolP("classify", "F", false, "append an indicator (one of */=@|) to entries")
+	human := fs.BoolP("human-readable", "h", false, "with -l, print sizes like 1K 234M")
+	recursive := fs.BoolP("recursive", "R", false, "list subdirectories recursively")
+	_ = fs.BoolP("one-per-line", "1", false, "list one file per line (the default for non-terminals)")
+	_ = fs.String("color", "never", "colorize the output; only 'never' is supported")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	opts := options{all: *all, almostAll: *almost, long: *long, dirSelf: *dirSelf, classify: *classify, human: *human, recursive: *recursive}
+
+	operands := fs.Args()
+	if len(operands) == 0 {
+		operands = []string{"."}
+	}
+
+	var files []string
+	var dirs []string
+	exitErr := false
+	for _, name := range operands {
+		info, err := os.Lstat(name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "ls: cannot access '%s': %s\n", name, errMessage(err))
+			exitErr = true
+			continue
+		}
+		if info.IsDir() && !opts.dirSelf {
+			dirs = append(dirs, name)
+		} else {
+			files = append(files, name)
+		}
+	}
+
+	if len(files) > 0 {
+		c.listNames(stdio.Out, "", files, opts)
+		if len(dirs) > 0 {
+			_, _ = fmt.Fprintln(stdio.Out)
+		}
+	}
+
+	header := len(operands) > 1 || opts.recursive
+	for i, dir := range dirs {
+		if header {
+			if i > 0 || len(files) > 0 {
+				_, _ = fmt.Fprintln(stdio.Out)
+			}
+			_, _ = fmt.Fprintf(stdio.Out, "%s:\n", dir)
+		}
+		if err := c.listDir(stdio.Out, stdio.Err, dir, opts); err != nil {
+			exitErr = true
+		}
+	}
+
+	if exitErr {
+		return &command.ExitError{Code: 2}
+	}
+	return nil
+}
+
+// listDir lists one directory's entries, recursing when -R is set.
+func (c *Command) listDir(out, errw io.Writer, dir string, opts options) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		_, _ = fmt.Fprintf(errw, "ls: cannot open directory '%s': %s\n", dir, errMessage(err))
+		return err
+	}
+
+	names := make([]string, 0, len(entries)+2)
+	if opts.all {
+		names = append(names, ".", "..")
+	}
+	for _, e := range entries {
+		if !opts.all && !opts.almostAll && strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	c.listNames(out, dir, names, opts)
+
+	if opts.recursive {
+		var subdirs []string
+		for _, n := range names {
+			if n == "." || n == ".." {
+				continue
+			}
+			full := filepath.Join(dir, n)
+			if info, err := os.Lstat(full); err == nil && info.IsDir() {
+				subdirs = append(subdirs, full)
+			}
+		}
+		for _, sd := range subdirs {
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintf(out, "%s:\n", sd)
+			if err := c.listDir(out, errw, sd, opts); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// listNames prints the given names (which live in dir) in the selected format.
+func (c *Command) listNames(out io.Writer, dir string, names []string, opts options) {
+	if !opts.long {
+		for _, n := range names {
+			_, _ = fmt.Fprintln(out, n+c.indicator(dir, n, opts))
+		}
+		return
+	}
+	for _, n := range names {
+		_, _ = fmt.Fprintln(out, c.longLine(dir, n, opts))
+	}
+}
+
+// indicator returns the -F suffix for a name, or "" when -F is off.
+func (c *Command) indicator(dir, name string, opts options) string {
+	if !opts.classify {
+		return ""
+	}
+	info, err := os.Lstat(pathOf(dir, name))
+	if err != nil {
+		return ""
+	}
+	switch {
+	case info.IsDir():
+		return "/"
+	case info.Mode()&os.ModeSymlink != 0:
+		return "@"
+	case info.Mode()&0o111 != 0 && info.Mode().IsRegular():
+		return "*"
+	default:
+		return ""
+	}
+}
+
+// longLine formats one entry for -l.
+func (c *Command) longLine(dir, name string, opts options) string {
+	info, err := os.Lstat(pathOf(dir, name))
+	if err != nil {
+		return name
+	}
+	mode := modeString(info)
+	nlink := uint64(1)
+	owner, group := "?", "?"
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		nlink = uint64(st.Nlink)
+		owner = lookupUser(st.Uid)
+		group = lookupGroup(st.Gid)
+	}
+	size := sizeString(info.Size(), opts.human)
+	when := timeString(info.ModTime())
+	display := name + c.indicator(dir, name, opts)
+	if info.Mode()&os.ModeSymlink != 0 {
+		if target, err := os.Readlink(pathOf(dir, name)); err == nil {
+			display = name + " -> " + target
+		}
+	}
+	return fmt.Sprintf("%s %d %s %s %s %s %s", mode, nlink, owner, group, size, when, display)
+}
+
+func pathOf(dir, name string) string {
+	if dir == "" || name == "." || name == ".." {
+		if dir == "" {
+			return name
+		}
+	}
+	return filepath.Join(dir, name)
+}
+
+// modeString renders the rwx-style permission string for ls -l.
+func modeString(info os.FileInfo) string {
+	m := info.Mode()
+	var b strings.Builder
+	switch {
+	case m&os.ModeDir != 0:
+		b.WriteByte('d')
+	case m&os.ModeSymlink != 0:
+		b.WriteByte('l')
+	case m&os.ModeDevice != 0 && m&os.ModeCharDevice != 0:
+		b.WriteByte('c')
+	case m&os.ModeDevice != 0:
+		b.WriteByte('b')
+	case m&os.ModeNamedPipe != 0:
+		b.WriteByte('p')
+	case m&os.ModeSocket != 0:
+		b.WriteByte('s')
+	default:
+		b.WriteByte('-')
+	}
+	const rwx = "rwxrwxrwx"
+	perm := m.Perm()
+	for i := 0; i < 9; i++ {
+		if perm&(1<<uint(8-i)) != 0 {
+			b.WriteByte(rwx[i])
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+func sizeString(size int64, human bool) string {
+	if !human {
+		return strconv.FormatInt(size, 10)
+	}
+	const unit = 1024
+	if size < unit {
+		return strconv.FormatInt(size, 10)
+	}
+	div, exp := int64(unit), 0
+	for n := size / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	value := float64(size) / float64(div)
+	suffix := "KMGTPE"[exp]
+	if value < 10 {
+		return fmt.Sprintf("%.1f%c", value, suffix)
+	}
+	return fmt.Sprintf("%.0f%c", value, suffix)
+}
+
+// timeString formats a modification time the way ls does (recent vs old).
+func timeString(t time.Time) string {
+	now := time.Now()
+	sixMonths := time.Hour * 24 * 182
+	if now.Sub(t) > sixMonths || t.Sub(now) > sixMonths {
+		return t.Format("Jan _2  2006")
+	}
+	return t.Format("Jan _2 15:04")
+}
+
+var userCache = map[uint32]string{}
+var groupCache = map[uint32]string{}
+
+func lookupUser(uid uint32) string {
+	if name, ok := userCache[uid]; ok {
+		return name
+	}
+	name := strconv.FormatUint(uint64(uid), 10)
+	if u, err := user.LookupId(name); err == nil {
+		name = u.Username
+	}
+	userCache[uid] = name
+	return name
+}
+
+func lookupGroup(gid uint32) string {
+	if name, ok := groupCache[gid]; ok {
+		return name
+	}
+	name := strconv.FormatUint(uint64(gid), 10)
+	if g, err := user.LookupGroupId(name); err == nil {
+		name = g.Name
+	}
+	groupCache[gid] = name
+	return name
+}
+
+// errMessage returns the human-friendly tail of a path error.
+func errMessage(err error) string {
+	if os.IsNotExist(err) {
+		return "No such file or directory"
+	}
+	if os.IsPermission(err) {
+		return "Permission denied"
+	}
+	return err.Error()
+}

--- a/internal/applets/fileutils/ls/ls_test.go
+++ b/internal/applets/fileutils/ls/ls_test.go
@@ -1,0 +1,146 @@
+package ls
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, f := range []string{"b.txt", "a.txt", ".hidden"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "inner.txt"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestDefaultSorted(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, fixture(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "a.txt\nb.txt\nsub\n" {
+		t.Errorf("default = %q", out)
+	}
+}
+
+func TestAll(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "-a", fixture(t))
+	if out != ".\n..\n.hidden\na.txt\nb.txt\nsub\n" {
+		t.Errorf("-a = %q", out)
+	}
+}
+
+func TestAlmostAll(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "-A", fixture(t))
+	if out != ".hidden\na.txt\nb.txt\nsub\n" {
+		t.Errorf("-A = %q", out)
+	}
+}
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "-F", fixture(t))
+	if !strings.Contains(out, "sub/") {
+		t.Errorf("-F should mark directories: %q", out)
+	}
+}
+
+func TestDirectorySelf(t *testing.T) {
+	t.Parallel()
+	dir := fixture(t)
+	out, _ := run(t, "-d", dir)
+	if out != dir+"\n" {
+		t.Errorf("-d = %q, want %q", out, dir+"\n")
+	}
+}
+
+func TestLong(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "-l", fixture(t))
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("-l produced %d lines: %q", len(lines), out)
+	}
+	// Each line begins with a 10-char mode string and ends with the name.
+	if !strings.HasPrefix(lines[0], "-rw") || !strings.HasSuffix(lines[0], "a.txt") {
+		t.Errorf("-l line = %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[2], "d") {
+		t.Errorf("directory mode should start with d: %q", lines[2])
+	}
+}
+
+func TestRecursive(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "-R", fixture(t))
+	if !strings.Contains(out, "sub:") || !strings.Contains(out, "inner.txt") {
+		t.Errorf("-R = %q", out)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := run(t, "/no/such/ls/file")
+	var ee *command.ExitError
+	if err == nil {
+		t.Fatal("missing file should fail")
+	}
+	if e, ok := err.(*command.ExitError); ok {
+		ee = e
+	}
+	if ee == nil || ee.Code != 2 {
+		t.Errorf("err = %v, want exit 2", err)
+	}
+}
+
+func TestModeString(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "x")
+	if err := os.WriteFile(f, []byte("x"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	info, _ := os.Lstat(f)
+	if got := modeString(info); got != "-rw-r-----" {
+		t.Errorf("modeString = %q, want -rw-r-----", got)
+	}
+}
+
+func TestSizeString(t *testing.T) {
+	t.Parallel()
+	cases := map[int64]string{0: "0", 512: "512", 1024: "1.0K", 1048576: "1.0M"}
+	for in, want := range cases {
+		if got := sizeString(in, true); got != want {
+			t.Errorf("sizeString(%d) = %q, want %q", in, got, want)
+		}
+	}
+	if got := sizeString(2048, false); got != "2048" {
+		t.Errorf("sizeString plain = %q", got)
+	}
+}

--- a/test/it/fileutils/ls_test.sh
+++ b/test/it/fileutils/ls_test.sh
@@ -1,0 +1,13 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/ls
+    mkdir -p ${TEST_DIR}/sub
+    : > ${TEST_DIR}/a.txt
+    : > ${TEST_DIR}/b.txt
+    : > ${TEST_DIR}/.hidden
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/ls; }
+
+TestLsDefault() { ls ${TEST_DIR}; }
+TestLsAll() { ls -a ${TEST_DIR}; }
+TestLsClassify() { ls -F ${TEST_DIR}; }

--- a/test/it/spec/ls_spec.sh
+++ b/test/it/spec/ls_spec.sh
@@ -1,0 +1,23 @@
+Describe 'ls'
+    Include fileutils/ls_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'lists entries sorted, hiding dotfiles'
+        When call TestLsDefault
+        The output should equal 'a.txt
+b.txt
+sub'
+        The status should be success
+    End
+    It 'includes dotfiles with -a'
+        When call TestLsAll
+        The output should include '.hidden'
+        The status should be success
+    End
+    It 'marks directories with -F'
+        When call TestLsClassify
+        The output should include 'sub/'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with `ls`, covering the everyday desktop subset with stable name sorting and deterministic error reporting:

- Plain listing (one entry per line, matching `ls -1` for non-terminals) and `-1`.
- `-a` (include . and ..), `-A` (dotfiles but not . / ..).
- `-l` long format: the rwx mode string, link count, owner/group (resolved from uid/gid), size, time (recent `Mon _2 15:04` vs old `Mon _2  2006`), and `name -> target` for symlinks.
- `-d` (the directory itself), `-F` (type indicators `/ * @`), `-h` (human-readable sizes), `-R` (recursive with section headers). `--color` is accepted (never).
- Missing operands report `ls: cannot access '<name>': ...` and exit 2.

The default listing was verified byte-for-byte against host `ls -1`, and `ls -dl` of a symlink against host `ls -dl`.

## Tests

- Unit: default sorting, `-a`, `-A`, `-F`, `-d`, `-l` structure (mode prefix, directory `d`), `-R`, the exit-2 missing-file error, and the `modeString` / `sizeString` helpers.
- shellspec: default sorted listing, `-a` dotfiles, and `-F` directory marks.

## Note

This also restores the ShellSpec harness: shellspec's launcher resolves its own path with `ls -dl` and parses the `name -> target` field, so `ls -l` showing symlink targets (a standard ls feature) was required for the hermetic suite to run.

## Verification

- `go test ./...` passes; `make test-e2e` passes (516 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243