### PR TITLE
feat(coreutils): add man applet for manual page lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 197 commands. Run `mimixbox --list` to see them on the terminal.
+There are 198 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -111,6 +111,7 @@ There are 197 commands. Run `mimixbox --list` to see them on the terminal.
 | ls | List directory contents |
 | lzcat | Decompress lzma data to standard output |
 | lzma | Compress or decompress files (lzma) |
+| man | Display a manual page |
 | mbsh | Mimix Box Shell |
 | md5sum | Calculate or Check md5sum message digest |
 | mkdir | Make directories |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -160,6 +160,7 @@ import (
 	ap_textutils_fmt "github.com/nao1215/mimixbox/internal/applets/textutils/fmt"
 	ap_textutils_fold "github.com/nao1215/mimixbox/internal/applets/textutils/fold"
 	ap_textutils_head "github.com/nao1215/mimixbox/internal/applets/textutils/head"
+	ap_textutils_man "github.com/nao1215/mimixbox/internal/applets/textutils/man"
 	ap_textutils_md5sum "github.com/nao1215/mimixbox/internal/applets/textutils/md5sum"
 	ap_textutils_nl "github.com/nao1215/mimixbox/internal/applets/textutils/nl"
 	ap_textutils_paste "github.com/nao1215/mimixbox/internal/applets/textutils/paste"
@@ -190,7 +191,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 197)
+	Applets = make(map[string]Applet, 198)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -361,6 +362,7 @@ func init() {
 	register(ap_textutils_fmt.New())
 	register(ap_textutils_fold.New())
 	register(ap_textutils_head.New())
+	register(ap_textutils_man.New())
 	register(ap_textutils_md5sum.New())
 	register(ap_textutils_nl.New())
 	register(ap_textutils_paste.New())

--- a/internal/applets/textutils/man/man.go
+++ b/internal/applets/textutils/man/man.go
@@ -1,0 +1,165 @@
+// Package man implements the man applet: locate and display a manual page from
+// the manual path. It finds plain or gzip-compressed pages and reports clearly
+// when a page is missing.
+package man
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the man applet.
+type Command struct{}
+
+// New returns a man command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "man" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Display a manual page" }
+
+// notFoundCode matches util-linux/man-db's exit status for a missing page.
+const notFoundCode = 16
+
+// Run executes man.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-M PATH] [SECTION] PAGE", stdio.Err).WithHelp(command.Help{
+		Description: "Locate and print a manual PAGE. The optional SECTION (a leading number) limits " +
+			"the search. Pages are looked up under -M PATH, then $MANPATH, then the standard " +
+			"system manual directories; both plain and .gz pages are supported.",
+		Examples: []command.Example{
+			{Command: "man ls", Explain: "Show the ls page from any section."},
+			{Command: "man 5 passwd", Explain: "Show the section 5 passwd page."},
+			{Command: "man -M ./man tool", Explain: "Search ./man for the tool page."},
+		},
+		ExitStatus: "0  the page was found.\n16  no manual entry was found.",
+		Notes: []string{
+			"The page is shown as stored; roff/groff formatting is not applied.",
+		},
+	})
+	manpath := fs.StringP("manpath", "M", "", "search PATH for manual pages")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	operands := fs.Args()
+	section, page := "", ""
+	switch len(operands) {
+	case 0:
+		_, _ = fmt.Fprintln(stdio.Err, "What manual page do you want?")
+		return command.SilentFailure()
+	case 1:
+		page = operands[0]
+	default:
+		if isSection(operands[0]) {
+			section, page = operands[0], operands[1]
+		} else {
+			page = operands[0]
+		}
+	}
+
+	path, err := find(searchPaths(*manpath), section, page)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "No manual entry for %s\n", page)
+		return &command.ExitError{Code: notFoundCode}
+	}
+
+	if err := display(stdio.Out, path); err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "man: %v\n", err)
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// isSection reports whether s looks like a manual section (1, 3, 3p, ...).
+func isSection(s string) bool {
+	if s == "" || s[0] < '0' || s[0] > '9' {
+		return false
+	}
+	return true
+}
+
+// searchPaths returns the manual directories to search, in priority order.
+func searchPaths(override string) []string {
+	if override != "" {
+		return splitPath(override)
+	}
+	if env := os.Getenv("MANPATH"); env != "" {
+		return splitPath(env)
+	}
+	return []string{"/usr/share/man", "/usr/local/share/man", "/usr/local/man"}
+}
+
+func splitPath(p string) []string {
+	var out []string
+	for _, part := range strings.Split(p, ":") {
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// find locates the page file under one of roots. When section is empty every
+// section directory is tried in order.
+func find(roots []string, section, page string) (string, error) {
+	sections := []string{section}
+	if section == "" {
+		sections = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "3p", "1p"}
+	}
+	for _, root := range roots {
+		for _, sec := range sections {
+			dir := filepath.Join(root, "man"+sectionDir(sec))
+			for _, cand := range []string{
+				filepath.Join(dir, page+"."+sec),
+				filepath.Join(dir, page+"."+sec+".gz"),
+			} {
+				if _, err := os.Stat(cand); err == nil {
+					return cand, nil
+				}
+			}
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+// sectionDir maps a section like "3p" to its directory suffix "3".
+func sectionDir(sec string) string {
+	if sec == "" {
+		return ""
+	}
+	return sec[:1]
+}
+
+// display writes the page to out, decompressing a .gz page on the way.
+func display(out io.Writer, path string) error {
+	f, err := os.Open(path) //nolint:gosec // resolved manual page path
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	var r io.Reader = bufio.NewReader(f)
+	if strings.HasSuffix(path, ".gz") {
+		zr, err := gzip.NewReader(r)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = zr.Close() }()
+		r = zr
+	}
+	_, err = io.Copy(out, r) //nolint:gosec // copying a local manual page
+	return err
+}

--- a/internal/applets/textutils/man/man_test.go
+++ b/internal/applets/textutils/man/man_test.go
@@ -1,0 +1,102 @@
+package man
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "man1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "man5"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "man1", "foo.1"), []byte("FOO(1)\nfoo page\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, _ = zw.Write([]byte("BAR(5)\nbar page\n"))
+	_ = zw.Close()
+	if err := os.WriteFile(filepath.Join(root, "man5", "bar.5.gz"), buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: bytes.NewReader(nil), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestPlainPage(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "-M", fixture(t), "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "FOO(1)\nfoo page\n" {
+		t.Errorf("page = %q", out)
+	}
+}
+
+func TestGzippedPage(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "-M", fixture(t), "5", "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "BAR(5)\nbar page\n" {
+		t.Errorf("gzipped page = %q", out)
+	}
+}
+
+func TestSectionSearchAll(t *testing.T) {
+	t.Parallel()
+	// No section: bar lives in section 5 and is still found.
+	out, err := run(t, "-M", fixture(t), "bar")
+	if err != nil || out != "BAR(5)\nbar page\n" {
+		t.Errorf("search-all = %q, %v", out, err)
+	}
+}
+
+func TestNotFound(t *testing.T) {
+	t.Parallel()
+	_, err := run(t, "-M", fixture(t), "missing")
+	var ee *command.ExitError
+	if err == nil {
+		t.Fatal("missing page should fail")
+	}
+	if e, ok := err.(*command.ExitError); ok {
+		ee = e
+	}
+	if ee == nil || ee.Code != 16 {
+		t.Errorf("err = %v, want exit 16", err)
+	}
+}
+
+func TestIsSection(t *testing.T) {
+	t.Parallel()
+	for _, s := range []string{"1", "3", "3p", "8"} {
+		if !isSection(s) {
+			t.Errorf("isSection(%q) = false", s)
+		}
+	}
+	for _, s := range []string{"foo", "", "ls"} {
+		if isSection(s) {
+			t.Errorf("isSection(%q) = true", s)
+		}
+	}
+}

--- a/test/it/spec/man_spec.sh
+++ b/test/it/spec/man_spec.sh
@@ -1,0 +1,23 @@
+Describe 'man'
+    Include textutils/man_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'shows a plain manual page'
+        When call TestManPlain
+        The output should equal 'FOO(1)
+the foo page'
+        The status should be success
+    End
+    It 'decompresses a gzipped manual page'
+        When call TestManGzip
+        The output should equal 'BAR(1)
+the bar page'
+        The status should be success
+    End
+    It 'reports a missing page with exit 16'
+        When call TestManNotFound
+        The output should equal 'exit=16'
+        The status should be success
+    End
+End

--- a/test/it/textutils/man_test.sh
+++ b/test/it/textutils/man_test.sh
@@ -1,0 +1,15 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/man
+    mkdir -p ${TEST_DIR}/man1
+    printf 'FOO(1)\nthe foo page\n' > ${TEST_DIR}/man1/foo.1
+    printf 'BAR(1)\nthe bar page\n' | gzip > ${TEST_DIR}/man1/bar.1.gz
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/man; }
+
+TestManPlain() { man -M ${TEST_DIR} foo; }
+TestManGzip() { man -M ${TEST_DIR} bar; }
+TestManNotFound() {
+    man -M ${TEST_DIR} missing 2>/dev/null
+    echo "exit=$?"
+}


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with `man`, which locates and prints a manual page. It finds pages under `-M PATH`, then `$MANPATH`, then the standard system manual directories, and handles both plain and gzip-compressed pages. An optional leading SECTION number narrows the search; otherwise sections are tried in order.

A missing page prints `No manual entry for <page>` and exits 16 (matching man-db). The page is shown as stored; roff/groff formatting is not applied in this slice (documented in --help).

## Tests

- Unit (temp MANPATH fixture): a plain page, a gzipped page with an explicit section, search-all-sections lookup, the exit-16 not-found case, and the `isSection` helper.
- shellspec: a plain page, a gzipped page, and the missing-page exit 16, all via a temporary `-M` manual tree.

## Verification

- `go test ./...` passes; `make test-e2e` passes (519 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243