### PR TITLE
feat(coreutils): add users applet reading the utmp database

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 198 commands. Run `mimixbox --list` to see them on the terminal.
+There are 199 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -200,6 +200,7 @@ There are 198 commands. Run `mimixbox --list` to see them on the terminal.
 | unshadow | Combine passwd and shadow files for password auditing |
 | unxz | Decompress xz files |
 | unzip | Extract files from a ZIP archive |
+| users | Print the user names of those currently logged in |
 | usleep | Pause for N microseconds |
 | uudecode | Decode a uuencoded (or base64) file |
 | uuencode | Encode a file for transmission over text channels |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -143,6 +143,7 @@ import (
 	ap_shellutils_tty "github.com/nao1215/mimixbox/internal/applets/shellutils/tty"
 	ap_shellutils_uname "github.com/nao1215/mimixbox/internal/applets/shellutils/uname"
 	ap_shellutils_uniq "github.com/nao1215/mimixbox/internal/applets/shellutils/uniq"
+	ap_shellutils_users "github.com/nao1215/mimixbox/internal/applets/shellutils/users"
 	ap_shellutils_usleep "github.com/nao1215/mimixbox/internal/applets/shellutils/usleep"
 	ap_shellutils_uuidgen "github.com/nao1215/mimixbox/internal/applets/shellutils/uuidgen"
 	ap_shellutils_watch "github.com/nao1215/mimixbox/internal/applets/shellutils/watch"
@@ -191,7 +192,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 198)
+	Applets = make(map[string]Applet, 199)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -345,6 +346,7 @@ func init() {
 	register(ap_shellutils_tty.New())
 	register(ap_shellutils_uname.New())
 	register(ap_shellutils_uniq.New())
+	register(ap_shellutils_users.New())
 	register(ap_shellutils_usleep.New())
 	register(ap_shellutils_uuidgen.New())
 	register(ap_shellutils_watch.New())

--- a/internal/applets/shellutils/users/users.go
+++ b/internal/applets/shellutils/users/users.go
@@ -1,0 +1,107 @@
+// Package users implements the users applet: print the login names of the users
+// currently on the system, one space-separated line, read from the utmp
+// database.
+package users
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the users applet.
+type Command struct{}
+
+// New returns a users command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "users" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the user names of those currently logged in" }
+
+// utmpPath is the login record file; tests point it at a fixture.
+var utmpPath = "/var/run/utmp"
+
+// Linux struct utmp layout (x86_64): 384 bytes per record, ut_type at offset 0,
+// ut_user (32 bytes) at offset 44. USER_PROCESS is type 7.
+const (
+	recordSize  = 384
+	typeOffset  = 0
+	userOffset  = 44
+	userLen     = 32
+	userProcess = 7
+)
+
+// Run executes users.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Print, on a single space-separated line, the login name of every user currently " +
+			"logged in (one entry per active login). FILE overrides the default utmp database.",
+		Examples: []command.Example{
+			{Command: "users", Explain: "List the currently logged-in users."},
+		},
+		Notes: []string{
+			"Reads the Linux utmp format; a login appears once per session.",
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	path := utmpPath
+	if rest := fs.Args(); len(rest) > 0 {
+		path = rest[0]
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // the utmp path (or a user-named override)
+	if err != nil {
+		// A missing utmp simply means nobody is recorded as logged in.
+		_, _ = fmt.Fprintln(stdio.Out)
+		return nil
+	}
+
+	names := parse(data)
+	sort.Strings(names)
+	_, _ = fmt.Fprintln(stdio.Out, strings.Join(names, " "))
+	return nil
+}
+
+// parse extracts the user name of every USER_PROCESS record in utmp data.
+func parse(data []byte) []string {
+	var names []string
+	for off := 0; off+recordSize <= len(data); off += recordSize {
+		rec := data[off : off+recordSize]
+		if int16(binary.LittleEndian.Uint16(rec[typeOffset:])) != userProcess {
+			continue
+		}
+		if name := cstr(rec[userOffset : userOffset+userLen]); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// cstr returns the NUL-terminated string at the start of b.
+func cstr(b []byte) string {
+	if i := indexByte(b, 0); i >= 0 {
+		return string(b[:i])
+	}
+	return string(b)
+}
+
+func indexByte(b []byte, c byte) int {
+	for i, x := range b {
+		if x == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/applets/shellutils/users/users_test.go
+++ b/internal/applets/shellutils/users/users_test.go
@@ -1,0 +1,82 @@
+package users
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// record builds one 384-byte utmp record of the given type and user.
+func record(utype int16, user string) []byte {
+	b := make([]byte, recordSize)
+	binary.LittleEndian.PutUint16(b[typeOffset:], uint16(utype))
+	copy(b[userOffset:userOffset+userLen], user)
+	return b
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	var data []byte
+	data = append(data, record(userProcess, "alice")...)
+	data = append(data, record(8, "dead")...) // DEAD_PROCESS is ignored
+	data = append(data, record(userProcess, "bob")...)
+	got := parse(data)
+	if len(got) != 2 || got[0] != "alice" || got[1] != "bob" {
+		t.Errorf("parse = %v, want [alice bob]", got)
+	}
+}
+
+func run(t *testing.T, args ...string) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestRunSortsAndJoins(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "utmp")
+	var data []byte
+	for _, u := range []string{"carol", "alice", "bob"} {
+		data = append(data, record(userProcess, u)...)
+	}
+	if err := os.WriteFile(f, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := run(t, f); got != "alice bob carol\n" {
+		t.Errorf("users = %q, want %q", got, "alice bob carol\n")
+	}
+}
+
+func TestRunMissingFile(t *testing.T) {
+	t.Parallel()
+	// A missing utmp means nobody is logged in: a single empty line.
+	if got := run(t, "/no/such/users/utmp"); got != "\n" {
+		t.Errorf("missing utmp = %q, want a blank line", got)
+	}
+}
+
+func TestRunDefaultPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "utmp")
+	if err := os.WriteFile(f, record(userProcess, "dave"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := utmpPath
+	utmpPath = f
+	defer func() { utmpPath = orig }()
+	if got := run(t); got != "dave\n" {
+		t.Errorf("default path = %q, want dave", got)
+	}
+}

--- a/test/it/shellutils/users_test.sh
+++ b/test/it/shellutils/users_test.sh
@@ -1,0 +1,9 @@
+TestUsersExit() {
+    users >/dev/null 2>&1
+    echo $?
+}
+
+TestUsersMissing() {
+    out=$(users /no/such/mimixbox/utmp)
+    echo "[$out] rc=$?"
+}

--- a/test/it/spec/users_spec.sh
+++ b/test/it/spec/users_spec.sh
@@ -1,0 +1,14 @@
+Describe 'users'
+    Include shellutils/users_test.sh
+
+    It 'runs and exits successfully'
+        When call TestUsersExit
+        The output should equal '0'
+        The status should be success
+    End
+    It 'treats a missing utmp as nobody logged in'
+        When call TestUsersMissing
+        The output should equal '[] rc=0'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the coreutils batch (#243) with `users`, which prints the login names of the users currently logged in, on a single space-separated line, read from the utmp database (an optional FILE overrides it). Each active login appears once and the names are sorted. A missing utmp is treated as nobody logged in (a blank line), matching the GNU tool.

It parses the Linux utmp record format (USER_PROCESS entries); the database path is injectable so the behavior is unit-tested against crafted fixtures rather than the host.

## Tests

- Unit: `parse` extracts USER_PROCESS user names and skips other record types; `Run` sorts and joins names from a fixture file, treats a missing file as a blank line, and reads the default path (overridden in the test).
- shellspec: `users` runs and exits 0, and a missing utmp yields an empty result with exit 0.

## Verification

- `go test ./...` passes; `make test-e2e` passes (521 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #243