### PR TITLE
feat(coreutils): add w and stty, completing the coreutils batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 199 commands. Run `mimixbox --list` to see them on the terminal.
+There are 201 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -173,6 +173,7 @@ There are 199 commands. Run `mimixbox --list` to see them on the terminal.
 | split | Split a file into pieces |
 | stat | Display file or file system status |
 | strings | Print printable character sequences in files |
+| stty | Print or change terminal line settings |
 | sum | Checksum and count the blocks in a file (BSD) |
 | sync | Synchronize cached writes to persistent storage |
 | tac | Print the file contents from the end to the beginning |
@@ -207,6 +208,7 @@ There are 199 commands. Run `mimixbox --list` to see them on the terminal.
 | uuidgen | Print UUID (Universally Unique IDentifier) |
 | valid-shell | Verify if /etc/shells is valid |
 | vi | A minimal vi-style screen text editor |
+| w | Show who is logged on and a system summary |
 | watch | Execute a program periodically, showing output fullscreen |
 | wc | Print newline, word, and byte counts for each file |
 | wget | The non-interactive network downloader |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -28,6 +28,7 @@ import (
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
+	ap_console_tools_stty "github.com/nao1215/mimixbox/internal/applets/console-tools/stty"
 	ap_debianutils_add_shell "github.com/nao1215/mimixbox/internal/applets/debianutils/add-shell"
 	ap_debianutils_ischroot "github.com/nao1215/mimixbox/internal/applets/debianutils/ischroot"
 	ap_debianutils_mktemp "github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
@@ -146,6 +147,7 @@ import (
 	ap_shellutils_users "github.com/nao1215/mimixbox/internal/applets/shellutils/users"
 	ap_shellutils_usleep "github.com/nao1215/mimixbox/internal/applets/shellutils/usleep"
 	ap_shellutils_uuidgen "github.com/nao1215/mimixbox/internal/applets/shellutils/uuidgen"
+	ap_shellutils_w "github.com/nao1215/mimixbox/internal/applets/shellutils/w"
 	ap_shellutils_watch "github.com/nao1215/mimixbox/internal/applets/shellutils/watch"
 	ap_shellutils_wget "github.com/nao1215/mimixbox/internal/applets/shellutils/wget"
 	ap_shellutils_who "github.com/nao1215/mimixbox/internal/applets/shellutils/who"
@@ -192,7 +194,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 199)
+	Applets = make(map[string]Applet, 201)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -228,6 +230,7 @@ func init() {
 	register(ap_console_tools_pager.NewMore())
 	register(ap_console_tools_reset.New())
 	register(ap_console_tools_resize.New())
+	register(ap_console_tools_stty.New())
 	register(ap_debianutils_add_shell.New())
 	register(ap_debianutils_ischroot.New())
 	register(ap_debianutils_mktemp.New())
@@ -349,6 +352,7 @@ func init() {
 	register(ap_shellutils_users.New())
 	register(ap_shellutils_usleep.New())
 	register(ap_shellutils_uuidgen.New())
+	register(ap_shellutils_w.New())
 	register(ap_shellutils_watch.New())
 	register(ap_shellutils_wget.New())
 	register(ap_shellutils_who.New())

--- a/internal/applets/console-tools/stty/stty.go
+++ b/internal/applets/console-tools/stty/stty.go
@@ -1,0 +1,193 @@
+// Package stty implements the stty applet: print or change the line settings of
+// the terminal on standard input. It covers the everyday workflow - showing
+// settings and toggling the common boolean modes such as echo.
+package stty
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the stty applet.
+type Command struct{}
+
+// New returns an stty command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "stty" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print or change terminal line settings" }
+
+// Injected so the print/set logic is testable without a real terminal.
+var (
+	getTermios = func(fd int) (*unix.Termios, error) { return unix.IoctlGetTermios(fd, unix.TCGETS) }
+	setTermios = func(fd int, t *unix.Termios) error { return unix.IoctlSetTermios(fd, unix.TCSETS, t) }
+)
+
+// flag describes one boolean terminal mode in the local (lflag) set.
+type flag struct {
+	name string
+	bit  uint32
+}
+
+var lflags = []flag{
+	{"echo", unix.ECHO},
+	{"echoe", unix.ECHOE},
+	{"echok", unix.ECHOK},
+	{"icanon", unix.ICANON},
+	{"isig", unix.ISIG},
+	{"iexten", unix.IEXTEN},
+}
+
+// Run executes stty.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-a] [SETTING]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print or change the terminal line settings on standard input. With no SETTING, " +
+			"print a summary; with -a, print all modes. A SETTING enables a boolean mode (e.g. echo) " +
+			"or, prefixed with '-', disables it; 'sane' restores sensible defaults.",
+		Examples: []command.Example{
+			{Command: "stty -a", Explain: "Show all terminal settings."},
+			{Command: "stty -echo", Explain: "Turn off input echoing."},
+		},
+		ExitStatus: "0  success.\n1  standard input is not a terminal or a setting was invalid.",
+	})
+
+	// Settings such as "-echo" begin with '-', so options are parsed by hand
+	// rather than through the flag set, which would treat them as flags.
+	all := false
+	var settings []string
+	for _, a := range args {
+		switch a {
+		case "--help", "-h":
+			fs.WriteUsage(stdio.Out)
+			return nil
+		case "-a", "--all":
+			all = true
+		default:
+			settings = append(settings, a)
+		}
+	}
+
+	fd, ok := fdOf(stdio.In)
+	if !ok {
+		_, _ = fmt.Fprintln(stdio.Err, "stty: standard input: not a tty")
+		return command.SilentFailure()
+	}
+	t, err := getTermios(fd)
+	if err != nil {
+		_, _ = fmt.Fprintln(stdio.Err, "stty: standard input: not a tty")
+		return command.SilentFailure()
+	}
+
+	if len(settings) == 0 {
+		printSettings(stdio.Out, t, all)
+		return nil
+	}
+
+	if err := applySettings(t, settings); err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "stty: %v\n", err)
+		return command.SilentFailure()
+	}
+	if err := setTermios(fd, t); err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "stty: %v\n", err)
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// applySettings mutates t per the requested settings.
+func applySettings(t *unix.Termios, settings []string) error {
+	for _, s := range settings {
+		switch s {
+		case "sane":
+			t.Lflag |= unix.ECHO | unix.ECHOE | unix.ECHOK | unix.ICANON | unix.ISIG | unix.IEXTEN
+			continue
+		case "raw":
+			t.Lflag &^= unix.ICANON | unix.ECHO | unix.ISIG | unix.IEXTEN
+			continue
+		case "cooked":
+			t.Lflag |= unix.ICANON | unix.ISIG
+			continue
+		}
+		off := strings.HasPrefix(s, "-")
+		name := strings.TrimPrefix(s, "-")
+		f, ok := findFlag(name)
+		if !ok {
+			return fmt.Errorf("invalid argument '%s'", s)
+		}
+		if off {
+			t.Lflag &^= f.bit
+		} else {
+			t.Lflag |= f.bit
+		}
+	}
+	return nil
+}
+
+func findFlag(name string) (flag, bool) {
+	for _, f := range lflags {
+		if f.name == name {
+			return f, true
+		}
+	}
+	return flag{}, false
+}
+
+// printSettings writes the current modes. With all, every known flag is shown;
+// otherwise only a brief summary.
+func printSettings(out io.Writer, t *unix.Termios, all bool) {
+	_, _ = fmt.Fprintf(out, "speed %d baud; line = 0;\n", baud(t))
+	var parts []string
+	for _, f := range lflags {
+		on := t.Lflag&f.bit != 0
+		switch {
+		case all:
+			if on {
+				parts = append(parts, f.name)
+			} else {
+				parts = append(parts, "-"+f.name)
+			}
+		case !on:
+			// In the brief view show only modes that differ from the common
+			// default (which has these enabled), i.e. the disabled ones.
+			parts = append(parts, "-"+f.name)
+		}
+	}
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintln(out, strings.Join(parts, " "))
+	}
+}
+
+// baud maps the termios speed code to a baud number for display.
+func baud(t *unix.Termios) int {
+	switch t.Ospeed {
+	case unix.B9600:
+		return 9600
+	case unix.B19200:
+		return 19200
+	case unix.B38400:
+		return 38400
+	case unix.B57600:
+		return 57600
+	case unix.B115200:
+		return 115200
+	default:
+		return 38400
+	}
+}
+
+// fdOf returns the file descriptor of r when it is an *os.File.
+func fdOf(r io.Reader) (int, bool) {
+	if f, ok := r.(*os.File); ok {
+		return int(f.Fd()), true
+	}
+	return 0, false
+}

--- a/internal/applets/console-tools/stty/stty_test.go
+++ b/internal/applets/console-tools/stty/stty_test.go
@@ -1,0 +1,86 @@
+package stty
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// withFakeTerminal points stdin at a real *os.File (so fdOf succeeds) and stubs
+// the termios get/set so no actual terminal is touched. It returns the captured
+// termios that a set would write.
+func withFakeTerminal(t *testing.T, initial *unix.Termios) (*os.File, *unix.Termios) {
+	t.Helper()
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	captured := &unix.Termios{}
+	origGet, origSet := getTermios, setTermios
+	getTermios = func(int) (*unix.Termios, error) { cp := *initial; return &cp, nil }
+	setTermios = func(_ int, tm *unix.Termios) error { *captured = *tm; return nil }
+	t.Cleanup(func() { getTermios, setTermios = origGet, origSet })
+	return f, captured
+}
+
+func TestNotATty(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("a non-terminal stdin should fail")
+	}
+}
+
+func TestPrintAll(t *testing.T) {
+	in, _ := withFakeTerminal(t, &unix.Termios{Lflag: unix.ECHO | unix.ICANON | unix.ISIG, Ospeed: unix.B38400})
+	out := &bytes.Buffer{}
+	io := command.IO{In: in, Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"-a"}); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "speed 38400 baud") || !strings.Contains(s, "echo") || !strings.Contains(s, "-echoe") {
+		t.Errorf("stty -a = %q", s)
+	}
+}
+
+func TestSetDisableEcho(t *testing.T) {
+	in, captured := withFakeTerminal(t, &unix.Termios{Lflag: unix.ECHO | unix.ICANON, Ospeed: unix.B38400})
+	io := command.IO{In: in, Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"-echo"}); err != nil {
+		t.Fatal(err)
+	}
+	if captured.Lflag&unix.ECHO != 0 {
+		t.Errorf("ECHO should be cleared, lflag = %x", captured.Lflag)
+	}
+	if captured.Lflag&unix.ICANON == 0 {
+		t.Errorf("ICANON should remain set")
+	}
+}
+
+func TestApplySettings(t *testing.T) {
+	t.Parallel()
+	tm := &unix.Termios{}
+	if err := applySettings(tm, []string{"echo", "icanon"}); err != nil {
+		t.Fatal(err)
+	}
+	if tm.Lflag&unix.ECHO == 0 || tm.Lflag&unix.ICANON == 0 {
+		t.Errorf("echo/icanon not set: %x", tm.Lflag)
+	}
+	if err := applySettings(tm, []string{"raw"}); err != nil {
+		t.Fatal(err)
+	}
+	if tm.Lflag&unix.ICANON != 0 || tm.Lflag&unix.ECHO != 0 {
+		t.Errorf("raw should clear icanon/echo: %x", tm.Lflag)
+	}
+	if err := applySettings(tm, []string{"bogus"}); err == nil {
+		t.Errorf("an invalid setting should fail")
+	}
+}

--- a/internal/applets/shellutils/w/w.go
+++ b/internal/applets/shellutils/w/w.go
@@ -1,0 +1,173 @@
+// Package w implements the w applet: show who is logged in, with a system
+// summary header (time, uptime, user count, and load averages) followed by one
+// row per active login.
+package w
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the w applet.
+type Command struct{}
+
+// New returns a w command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "w" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show who is logged on and a system summary" }
+
+// These are indirected so the output can be tested deterministically.
+var (
+	utmpPath    = "/var/run/utmp"
+	loadavgPath = "/proc/loadavg"
+	uptimePath  = "/proc/uptime"
+	now         = time.Now
+)
+
+// Linux utmp layout (x86_64): 384-byte records; USER_PROCESS is type 7.
+const (
+	recordSize  = 384
+	typeOffset  = 0
+	lineOffset  = 8
+	userOffset  = 44
+	hostOffset  = 76
+	tvSecOffset = 340
+	fieldLen    = 32
+	hostLen     = 256
+	userProcess = 7
+)
+
+type entry struct {
+	user  string
+	line  string
+	host  string
+	login int64
+}
+
+// Run executes w.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print a header with the current time, system uptime, the number of logged-in " +
+			"users, and the load averages, then one line per login showing the user, terminal, " +
+			"remote host, and login time.",
+		Examples: []command.Example{
+			{Command: "w", Explain: "Show who is logged in."},
+		},
+		Notes: []string{
+			"The IDLE and WHAT columns are placeholders ('-'); per-process accounting is not implemented.",
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	entries := readEntries(utmpPath)
+	_, _ = fmt.Fprintln(stdio.Out, header(now(), readUptime(), readLoadavg(), len(entries)))
+	_, _ = fmt.Fprintf(stdio.Out, "%-8s %-8s %-16s %-7s %-6s %s\n", "USER", "TTY", "FROM", "LOGIN@", "IDLE", "WHAT")
+	for _, e := range entries {
+		from := e.host
+		if from == "" {
+			from = "-"
+		}
+		login := time.Unix(e.login, 0).Format("15:04")
+		_, _ = fmt.Fprintf(stdio.Out, "%-8s %-8s %-16s %-7s %-6s %s\n", e.user, e.line, from, login, "-", "-")
+	}
+	return nil
+}
+
+// header builds the summary line.
+func header(t time.Time, uptime time.Duration, load string, users int) string {
+	word := "users"
+	if users == 1 {
+		word = "user"
+	}
+	return fmt.Sprintf(" %s up %s, %d %s,  load average: %s",
+		t.Format("15:04:05"), formatUptime(uptime), users, word, load)
+}
+
+// formatUptime renders a duration like the uptime/w tools do.
+func formatUptime(d time.Duration) string {
+	totalMin := int(d.Minutes())
+	days := totalMin / (60 * 24)
+	hours := (totalMin / 60) % 24
+	mins := totalMin % 60
+	if days > 0 {
+		dayWord := "days"
+		if days == 1 {
+			dayWord = "day"
+		}
+		return fmt.Sprintf("%d %s, %2d:%02d", days, dayWord, hours, mins)
+	}
+	return fmt.Sprintf("%2d:%02d", hours, mins)
+}
+
+// readEntries parses the USER_PROCESS records from utmp.
+func readEntries(path string) []entry {
+	data, err := os.ReadFile(path) //nolint:gosec // the utmp database path
+	if err != nil {
+		return nil
+	}
+	var entries []entry
+	for off := 0; off+recordSize <= len(data); off += recordSize {
+		rec := data[off : off+recordSize]
+		if int16(binary.LittleEndian.Uint16(rec[typeOffset:])) != userProcess {
+			continue
+		}
+		entries = append(entries, entry{
+			user:  cstr(rec[userOffset : userOffset+fieldLen]),
+			line:  cstr(rec[lineOffset : lineOffset+fieldLen]),
+			host:  cstr(rec[hostOffset : hostOffset+hostLen]),
+			login: int64(int32(binary.LittleEndian.Uint32(rec[tvSecOffset:]))),
+		})
+	}
+	return entries
+}
+
+// readUptime reads the system uptime from /proc/uptime, or 0 on failure.
+func readUptime() time.Duration {
+	data, err := os.ReadFile(uptimePath)
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0
+	}
+	secs, _ := strconv.ParseFloat(fields[0], 64)
+	return time.Duration(secs) * time.Second
+}
+
+// readLoadavg reads the three load averages from /proc/loadavg.
+func readLoadavg() string {
+	data, err := os.ReadFile(loadavgPath)
+	if err != nil {
+		return "0.00, 0.00, 0.00"
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 3 {
+		return "0.00, 0.00, 0.00"
+	}
+	return fmt.Sprintf("%s, %s, %s", fields[0], fields[1], fields[2])
+}
+
+// cstr returns the NUL-terminated string at the start of b.
+func cstr(b []byte) string {
+	for i, x := range b {
+		if x == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}

--- a/internal/applets/shellutils/w/w_test.go
+++ b/internal/applets/shellutils/w/w_test.go
@@ -1,0 +1,112 @@
+package w
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func record(user, line, host string, login int32) []byte {
+	b := make([]byte, recordSize)
+	binary.LittleEndian.PutUint16(b[typeOffset:], userProcess)
+	copy(b[lineOffset:lineOffset+fieldLen], line)
+	copy(b[userOffset:userOffset+fieldLen], user)
+	copy(b[hostOffset:hostOffset+hostLen], host)
+	binary.LittleEndian.PutUint32(b[tvSecOffset:], uint32(login))
+	return b
+}
+
+func setup(t *testing.T, recs []byte, loadavg, uptime string) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string, data []byte) string {
+		p := filepath.Join(dir, name)
+		var b []byte
+		if data != nil {
+			b = data
+		} else {
+			b = []byte(content)
+		}
+		if err := os.WriteFile(p, b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	origU, origL, origUp, origNow := utmpPath, loadavgPath, uptimePath, now
+	utmpPath = write("utmp", "", recs)
+	loadavgPath = write("loadavg", loadavg, nil)
+	uptimePath = write("uptime", uptime, nil)
+	now = func() time.Time { return time.Date(2026, 6, 9, 20, 45, 0, 0, time.UTC) }
+	t.Cleanup(func() {
+		utmpPath, loadavgPath, uptimePath, now = origU, origL, origUp, origNow
+	})
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestHeaderAndRows(t *testing.T) {
+	t.Parallel()
+	recs := append(record("alice", "pts/0", "10.0.0.1", 0), record("bob", "tty1", "", 0)...)
+	setup(t, recs, "0.50 0.40 0.30 1/100 999\n", "90000.0 1.0\n")
+
+	out := run(t)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if !strings.Contains(lines[0], "load average: 0.50, 0.40, 0.30") {
+		t.Errorf("header load = %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "2 users") {
+		t.Errorf("header users = %q", lines[0])
+	}
+	// 90000s = 1 day, 1:00.
+	if !strings.Contains(lines[0], "up 1 day,  1:00") {
+		t.Errorf("header uptime = %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "USER") {
+		t.Errorf("column header = %q", lines[1])
+	}
+	if !strings.Contains(out, "alice") || !strings.Contains(out, "pts/0") || !strings.Contains(out, "10.0.0.1") {
+		t.Errorf("alice row missing: %q", out)
+	}
+	// bob has no host -> "-".
+	if !strings.Contains(out, "bob") {
+		t.Errorf("bob row missing: %q", out)
+	}
+}
+
+func TestNoUsers(t *testing.T) {
+	t.Parallel()
+	setup(t, nil, "0.00 0.00 0.00 1/1 1\n", "60.0 1.0\n")
+	out := run(t)
+	if !strings.Contains(out, "0 users") {
+		t.Errorf("expected 0 users, got %q", out)
+	}
+}
+
+func TestFormatUptime(t *testing.T) {
+	t.Parallel()
+	cases := map[time.Duration]string{
+		90 * time.Minute: " 1:30",
+		25 * time.Hour:   "1 day,  1:00",
+		49 * time.Hour:   "2 days,  1:00",
+	}
+	for d, want := range cases {
+		if got := formatUptime(d); got != want {
+			t.Errorf("formatUptime(%v) = %q, want %q", d, got, want)
+		}
+	}
+}

--- a/test/it/console-tools/stty_test.sh
+++ b/test/it/console-tools/stty_test.sh
@@ -1,0 +1,4 @@
+TestSttyNotTty() {
+    echo x | stty 2>&1
+    echo "exit=$?"
+}

--- a/test/it/shellutils/w_test.sh
+++ b/test/it/shellutils/w_test.sh
@@ -1,0 +1,2 @@
+TestWHeader() { w | sed -n '1p'; }
+TestWColumns() { w | sed -n '2p'; }

--- a/test/it/spec/stty_spec.sh
+++ b/test/it/spec/stty_spec.sh
@@ -1,0 +1,10 @@
+Describe 'stty'
+    Include console-tools/stty_test.sh
+
+    It 'reports when standard input is not a terminal'
+        When call TestSttyNotTty
+        The output should equal 'stty: standard input: not a tty
+exit=1'
+        The status should be success
+    End
+End

--- a/test/it/spec/w_spec.sh
+++ b/test/it/spec/w_spec.sh
@@ -1,0 +1,16 @@
+Describe 'w'
+    Include shellutils/w_test.sh
+
+    It 'prints a summary header with the load averages'
+        When call TestWHeader
+        The status should be success
+        The output should include 'load average:'
+        The output should include 'up '
+    End
+    It 'prints the column header'
+        When call TestWColumns
+        The status should be success
+        The output should include 'USER'
+        The output should include 'LOGIN@'
+    End
+End


### PR DESCRIPTION
## Summary

Adds the final two applets of the coreutils batch (#243):

- **`w`** — print a summary header (current time, uptime, user count, and load averages from /proc) followed by one row per active login (USER, TTY, FROM, LOGIN@) read from the utmp database. IDLE/WHAT are placeholders; the utmp/proc paths and clock are injectable for testing.
- **`stty`** — print or change the terminal line settings on standard input. With no setting it prints a summary; `-a` prints all modes; a SETTING toggles a boolean local mode (echo, icanon, isig, ...) or, prefixed with `-`, disables it; `sane`/`raw`/`cooked` are supported. Non-terminal stdin reports `stty: standard input: not a tty` and exits 1.

With these, every command in #243's scope is now implemented (bc, crc32, dc, ed, egrep, factor, fgrep, fsync, less, ls, man, more, nice, sha384sum, sha3sum, stty, sum, time, tree, tsort, users, usleep, uudecode, uuencode, w), delivered across this and the preceding PRs.

## Tests

- `w`: unit tests (injected utmp/loadavg/uptime fixtures and clock) for the header (load averages, user count, uptime formatting), the column header, per-login rows, the no-users case, and `formatUptime`; shellspec for the header and column line.
- `stty`: unit tests with injected termios for the not-a-tty error, `-a` output, disabling echo while keeping icanon, and `applySettings` (set, raw, invalid); shellspec for the not-a-tty path.

## Verification

- `go test ./...` passes; `make test-e2e` passes (524 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stty` applet for viewing and configuring terminal line settings
  * Added `w` applet for displaying currently logged-in users and their active sessions
  * Total available commands increased from 199 to 201

* **Tests**
  * Added comprehensive unit and integration tests for both new applets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->