### PR TITLE
feat(util-linux): add script and scriptreplay applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 201 commands. Run `mimixbox --list` to see them on the terminal.
+There are 203 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -153,6 +153,8 @@ There are 201 commands. Run `mimixbox --list` to see them on the terminal.
 | rmdir | Remove directory |
 | rpm | Query an RPM package file |
 | rpm2cpio | Extract the cpio payload from an RPM package |
+| script | Record a command's output to a typescript |
+| scriptreplay | Replay a typescript using its timing file |
 | sddf | Search & Delete Duplicated File |
 | sed | Stream editor for filtering and transforming text |
 | seq | Print a column of numbers |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -188,13 +188,14 @@ import (
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
+	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 201)
+	Applets = make(map[string]Applet, 203)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -395,5 +396,7 @@ func init() {
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
+	register(ap_util_linux_script.NewScript())
+	register(ap_util_linux_script.NewScriptreplay())
 	register(ap_util_linux_setsid.New())
 }

--- a/internal/applets/util-linux/script/script.go
+++ b/internal/applets/util-linux/script/script.go
@@ -1,0 +1,230 @@
+// Package script implements the script and scriptreplay applets: record a
+// command's output (with a timing file) to a typescript, and replay it with the
+// original pacing.
+package script
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// clock is indirected so recorded timing is deterministic under test.
+var clock = time.Now
+
+// sleep is indirected so replay does not actually wait under test.
+var sleep = time.Sleep
+
+// Command is the script or scriptreplay applet.
+type Command struct{ replay bool }
+
+// NewScript returns a script command.
+func NewScript() *Command { return &Command{} }
+
+// NewScriptreplay returns a scriptreplay command.
+func NewScriptreplay() *Command { return &Command{replay: true} }
+
+// Name returns the command name.
+func (c *Command) Name() string {
+	if c.replay {
+		return "scriptreplay"
+	}
+	return "script"
+}
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	if c.replay {
+		return "Replay a typescript using its timing file"
+	}
+	return "Record a command's output to a typescript"
+}
+
+// Run dispatches to the recorder or the player.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	if c.replay {
+		return c.runReplay(ctx, stdio, args)
+	}
+	return c.runScript(ctx, stdio, args)
+}
+
+type entry struct {
+	delay float64
+	bytes int
+}
+
+// recorder tees writes into a buffer while recording per-write timing.
+type recorder struct {
+	buf    bytes.Buffer
+	timing []entry
+	last   time.Time
+	mirror io.Writer
+}
+
+func (r *recorder) Write(p []byte) (int, error) {
+	t := clock()
+	delay := 0.0
+	if !r.last.IsZero() {
+		delay = t.Sub(r.last).Seconds()
+	}
+	r.last = t
+	r.timing = append(r.timing, entry{delay: delay, bytes: len(p)})
+	if r.mirror != nil {
+		_, _ = r.mirror.Write(p)
+	}
+	return r.buf.Write(p)
+}
+
+// runScript records a command session.
+func (c *Command) runScript(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-c COMMAND] [-T TIMINGFILE] [TYPESCRIPT]", stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND (with -c) and write everything it prints to TYPESCRIPT (default " +
+			"'typescript'), wrapped in 'Script started/done' lines. With -T, also write a timing " +
+			"file of 'delay bytes' records that scriptreplay can use.",
+		Examples: []command.Example{
+			{Command: "script -c 'make' -T timing build.log", Explain: "Record make's output and timing."},
+		},
+		ExitStatus: "The exit status of COMMAND.",
+	})
+	cmdStr := fs.StringP("command", "c", "", "run COMMAND rather than an interactive shell")
+	timingFile := fs.StringP("timing", "T", "", "write timing data to this file")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *cmdStr == "" {
+		_, _ = fmt.Fprintln(stdio.Err, "script: -c COMMAND is required in this implementation")
+		return command.SilentFailure()
+	}
+
+	typescript := "typescript"
+	if rest := fs.Args(); len(rest) > 0 {
+		typescript = rest[0]
+	}
+
+	rec := &recorder{mirror: stdio.Out}
+	cmd := exec.CommandContext(ctx, "sh", "-c", *cmdStr) //nolint:gosec // running the user's command is the point
+	cmd.Stdin = stdio.In
+	cmd.Stdout = rec
+	cmd.Stderr = rec
+	runErr := cmd.Run()
+	exitCode := 0
+	if ee, ok := runErr.(*exec.ExitError); ok {
+		exitCode = ee.ExitCode()
+	}
+
+	started := clock().Format("2006-01-02 15:04:05-07:00")
+	var b strings.Builder
+	fmt.Fprintf(&b, "Script started on %s [COMMAND=%q]\n", started, *cmdStr)
+	b.Write(rec.buf.Bytes())
+	fmt.Fprintf(&b, "\nScript done on %s [COMMAND_EXIT_CODE=%q]\n", started, strconv.Itoa(exitCode))
+	if err := os.WriteFile(typescript, []byte(b.String()), 0o644); err != nil { //nolint:gosec // user-named file
+		_, _ = fmt.Fprintf(stdio.Err, "script: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	if *timingFile != "" {
+		var tb strings.Builder
+		for _, e := range rec.timing {
+			fmt.Fprintf(&tb, "%.6f %d\n", e.delay, e.bytes)
+		}
+		if err := os.WriteFile(*timingFile, []byte(tb.String()), 0o644); err != nil { //nolint:gosec // user-named file
+			_, _ = fmt.Fprintf(stdio.Err, "script: %v\n", err)
+			return command.SilentFailure()
+		}
+	}
+
+	if exitCode != 0 {
+		return &command.ExitError{Code: exitCode}
+	}
+	return nil
+}
+
+// runReplay plays back a recorded session.
+func (c *Command) runReplay(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "TIMINGFILE [TYPESCRIPT]", stdio.Err).WithHelp(command.Help{
+		Description: "Replay the captured output in TYPESCRIPT (default 'typescript') to standard " +
+			"output, pausing between chunks by the delays recorded in TIMINGFILE.",
+		Examples: []command.Example{
+			{Command: "scriptreplay timing build.log", Explain: "Replay the recorded session."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "scriptreplay: a timing file is required")
+		return command.SilentFailure()
+	}
+	timingPath := rest[0]
+	typescript := "typescript"
+	if len(rest) > 1 {
+		typescript = rest[1]
+	}
+
+	timing, err := readTiming(timingPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "scriptreplay: %s\n", command.FileError(timingPath, err))
+		return command.SilentFailure()
+	}
+	data, err := os.ReadFile(typescript) //nolint:gosec // user-named file
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "scriptreplay: %s\n", command.FileError(typescript, err))
+		return command.SilentFailure()
+	}
+
+	// Skip the "Script started" header line; the timing covers the bytes after it.
+	body := data
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		body = data[i+1:]
+	}
+
+	pos := 0
+	for _, e := range timing {
+		sleep(time.Duration(e.delay * float64(time.Second)))
+		end := pos + e.bytes
+		if end > len(body) {
+			end = len(body)
+		}
+		if pos < end {
+			_, _ = stdio.Out.Write(body[pos:end])
+		}
+		pos = end
+	}
+	return nil
+}
+
+// readTiming parses a "delay bytes" timing file.
+func readTiming(path string) ([]entry, error) {
+	f, err := os.Open(path) //nolint:gosec // user-named file
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []entry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		delay, _ := strconv.ParseFloat(fields[0], 64)
+		n, _ := strconv.Atoi(fields[1])
+		out = append(out, entry{delay: delay, bytes: n})
+	}
+	return out, sc.Err()
+}

--- a/internal/applets/util-linux/script/script_test.go
+++ b/internal/applets/util-linux/script/script_test.go
@@ -1,0 +1,94 @@
+package script
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func requireSh(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not on PATH: %v", err)
+	}
+}
+
+func TestScriptRecords(t *testing.T) {
+	requireSh(t)
+	// Freeze the clock so timing is deterministic.
+	orig := clock
+	clock = func() time.Time { return time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC) }
+	defer func() { clock = orig }()
+
+	dir := t.TempDir()
+	ts := filepath.Join(dir, "out.txt")
+	tm := filepath.Join(dir, "timing")
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := NewScript().Run(context.Background(), io, []string{"-c", "printf hello", "-T", tm, ts}); err != nil {
+		t.Fatalf("script error = %v", err)
+	}
+
+	data, _ := os.ReadFile(ts)
+	s := string(data)
+	if !strings.Contains(s, "Script started on") || !strings.Contains(s, "hello") || !strings.Contains(s, "Script done on") {
+		t.Errorf("typescript = %q", s)
+	}
+	timing, _ := os.ReadFile(tm)
+	if !strings.Contains(string(timing), "5") { // "hello" is 5 bytes
+		t.Errorf("timing = %q", timing)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	requireSh(t)
+	origSleep := sleep
+	sleep = func(time.Duration) {} // do not actually wait
+	defer func() { sleep = origSleep }()
+
+	dir := t.TempDir()
+	ts := filepath.Join(dir, "out.txt")
+	tm := filepath.Join(dir, "timing")
+
+	rec := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := NewScript().Run(context.Background(), rec, []string{"-c", "printf 'one\\ntwo\\n'", "-T", tm, ts}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := &bytes.Buffer{}
+	play := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := NewScriptreplay().Run(context.Background(), play, []string{tm, ts}); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "one\ntwo\n" {
+		t.Errorf("replay = %q, want %q", out.String(), "one\ntwo\n")
+	}
+}
+
+func TestScriptPropagatesExit(t *testing.T) {
+	requireSh(t)
+	dir := t.TempDir()
+	ts := filepath.Join(dir, "out.txt")
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := NewScript().Run(context.Background(), io, []string{"-c", "exit 3", ts})
+	var ee *command.ExitError
+	if e, ok := err.(*command.ExitError); ok {
+		ee = e
+	}
+	if ee == nil || ee.Code != 3 {
+		t.Errorf("err = %v, want exit 3", err)
+	}
+}
+
+func TestReplayMissingTiming(t *testing.T) {
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := NewScriptreplay().Run(context.Background(), io, []string{"/no/such/timing", "/no/such/ts"}); err == nil {
+		t.Errorf("missing timing should fail")
+	}
+}

--- a/test/it/spec/script_spec.sh
+++ b/test/it/spec/script_spec.sh
@@ -1,0 +1,16 @@
+Describe 'script / scriptreplay'
+    Include util-linux/script_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'records command output to a typescript'
+        When call TestScriptRecords
+        The output should equal '1'
+        The status should be success
+    End
+    It 'replays a recorded typescript'
+        When call TestScriptReplay
+        The output should equal 'replayed'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/script_test.sh
+++ b/test/it/util-linux/script_test.sh
@@ -1,0 +1,16 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/script
+    mkdir -p ${TEST_DIR}
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/script; }
+
+TestScriptRecords() {
+    script -c 'printf recorded' -T ${TEST_DIR}/timing ${TEST_DIR}/out.txt >/dev/null 2>&1
+    grep -c 'Script started' ${TEST_DIR}/out.txt
+}
+
+TestScriptReplay() {
+    script -c 'printf replayed' -T ${TEST_DIR}/timing ${TEST_DIR}/out.txt >/dev/null 2>&1
+    scriptreplay ${TEST_DIR}/timing ${TEST_DIR}/out.txt
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with the session recorder and player:

- **`script`** — run `-c COMMAND` and write everything it prints to a typescript (default `typescript`), wrapped in `Script started/done` lines. With `-T`, it also writes a `delay bytes` timing file. The command's output is mirrored live to stdout and its exit status is propagated.
- **`scriptreplay`** — replay a typescript to stdout, pausing between chunks by the delays in the timing file (skipping the header line, as the timing covers the captured bytes).

The clock and the replay sleep are injectable so recording and playback are deterministic in tests. Interactive (no -c) capture would require a pty and is out of scope for this slice; `script` reports that -c is required.

## Tests

- Unit: `script` records the started/output/done content and a timing entry (frozen clock); a record-then-replay round trip reproduces the output exactly (no-op sleep); exit-code propagation; and the missing-timing-file error.
- shellspec: `script` produces a typescript with the started marker, and a record-then-`scriptreplay` round trip reproduces the output.

## Verification

- `go test ./...` passes; `make test-e2e` passes (526 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248