### PR TITLE
feat(util-linux): add setarch, linux32, and linux64 applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 203 commands. Run `mimixbox --list` to see them on the terminal.
+There are 206 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -105,6 +105,8 @@ There are 203 commands. Run `mimixbox --list` to see them on the terminal.
 | less | Page through text one screen at a time |
 | lifegame | Life game (Conway's Game of Life) |
 | link | Create a hard link to a file |
+| linux32 | Run a program with a 32-bit execution domain |
+| linux64 | Run a program with a 64-bit execution domain |
 | ln | Create hard or symbolic link |
 | log-collect | Gather system log files into one directory |
 | logname | Print the name of the current user |
@@ -159,6 +161,7 @@ There are 203 commands. Run `mimixbox --list` to see them on the terminal.
 | sed | Stream editor for filtering and transforming text |
 | seq | Print a column of numbers |
 | serial | Rename the file to the name with a serial number |
+| setarch | Run a program with a changed architecture personality |
 | setsid | Run a program in a new session |
 | sh | Command interpreter (MimixBox mbsh compatibility front-end) |
 | sha1sum | Calculate or Check secure hash 1 algorithm |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -189,13 +189,14 @@ import (
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
+	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 203)
+	Applets = make(map[string]Applet, 206)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -398,5 +399,8 @@ func init() {
 	register(ap_util_linux_hexdump.NewHexdump())
 	register(ap_util_linux_script.NewScript())
 	register(ap_util_linux_script.NewScriptreplay())
+	register(ap_util_linux_setarch.NewLinux32())
+	register(ap_util_linux_setarch.NewLinux64())
+	register(ap_util_linux_setarch.NewSetarch())
 	register(ap_util_linux_setsid.New())
 }

--- a/internal/applets/util-linux/setarch/setarch.go
+++ b/internal/applets/util-linux/setarch/setarch.go
@@ -1,0 +1,124 @@
+// Package setarch implements the setarch, linux32, and linux64 applets: run a
+// program with a changed execution domain (personality), most usefully so that
+// uname reports a 32-bit machine on a 64-bit kernel.
+package setarch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Linux execution-domain personalities (not exported by x/sys/unix here).
+const (
+	perLinux   uintptr = 0x0000
+	perLinux32 uintptr = 0x0008
+)
+
+// setPersonality is indirected so tests do not change the test process's domain.
+var setPersonality = func(p uintptr) error {
+	if _, _, errno := unix.Syscall(unix.SYS_PERSONALITY, p, 0, 0); errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Command is the setarch/linux32/linux64 applet.
+type Command struct{ name string }
+
+// NewSetarch returns the setarch applet.
+func NewSetarch() *Command { return &Command{name: "setarch"} }
+
+// NewLinux32 returns the linux32 applet.
+func NewLinux32() *Command { return &Command{name: "linux32"} }
+
+// NewLinux64 returns the linux64 applet.
+func NewLinux64() *Command { return &Command{name: "linux64"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	switch c.name {
+	case "linux32":
+		return "Run a program with a 32-bit execution domain"
+	case "linux64":
+		return "Run a program with a 64-bit execution domain"
+	default:
+		return "Run a program with a changed architecture personality"
+	}
+}
+
+// Run executes the applet.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	usage := "[-c] COMMAND [ARG]..."
+	if c.name == "setarch" {
+		usage = "ARCH [-c] COMMAND [ARG]..."
+	}
+	fs := command.NewFlagSet(c.Name(), usage, stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND with a changed execution-domain personality. linux32 selects a " +
+			"32-bit domain (so uname reports a 32-bit machine), linux64 a 64-bit one, and setarch " +
+			"selects it from the leading ARCH name (e.g. i686, x86_64).",
+		Examples: []command.Example{
+			{Command: "linux32 uname -m", Explain: "Report the 32-bit machine name."},
+			{Command: "setarch i686 ./configure", Explain: "Configure as if on a 32-bit host."},
+		},
+		ExitStatus: "The exit status of COMMAND (127 if it could not be run).",
+	})
+	fs.SetInterspersed(false)
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	persona := perLinux32
+	if c.name == "linux64" {
+		persona = perLinux
+	}
+	if c.name == "setarch" {
+		if len(rest) == 0 {
+			_, _ = fmt.Fprintln(stdio.Err, "setarch: missing ARCH operand")
+			return command.SilentFailure()
+		}
+		persona = personaForArch(rest[0])
+		rest = rest[1:]
+	}
+
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: missing command\n", c.Name())
+		return command.SilentFailure()
+	}
+
+	if err := setPersonality(persona); err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: cannot set personality: %v\n", c.Name(), err)
+		return command.SilentFailure()
+	}
+
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running the user's command is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		_, _ = fmt.Fprintf(stdio.Err, "%s: %s: %v\n", c.Name(), rest[0], err)
+		return &command.ExitError{Code: 127}
+	}
+	return nil
+}
+
+// personaForArch maps an architecture name to its personality.
+func personaForArch(arch string) uintptr {
+	switch arch {
+	case "linux32", "i386", "i486", "i586", "i686", "x86":
+		return perLinux32
+	default:
+		return perLinux
+	}
+}

--- a/internal/applets/util-linux/setarch/setarch_test.go
+++ b/internal/applets/util-linux/setarch/setarch_test.go
@@ -1,0 +1,108 @@
+package setarch
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// withStub captures the personality passed to setPersonality without touching
+// the test process's execution domain.
+func withStub(t *testing.T) *uintptr {
+	t.Helper()
+	var got uintptr = 0xffff
+	orig := setPersonality
+	setPersonality = func(p uintptr) error { got = p; return nil }
+	t.Cleanup(func() { setPersonality = orig })
+	return &got
+}
+
+func run(t *testing.T, c *Command, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := c.Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func requireEcho(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skipf("echo not on PATH: %v", err)
+	}
+}
+
+func TestLinux32Personality(t *testing.T) {
+	requireEcho(t)
+	got := withStub(t)
+	out, err := run(t, NewLinux32(), "echo", "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *got != perLinux32 {
+		t.Errorf("persona = %#x, want perLinux32", *got)
+	}
+	if !strings.Contains(out, "ok") {
+		t.Errorf("command output = %q", out)
+	}
+}
+
+func TestLinux64Personality(t *testing.T) {
+	requireEcho(t)
+	got := withStub(t)
+	if _, err := run(t, NewLinux64(), "echo", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != perLinux {
+		t.Errorf("persona = %#x, want perLinux", *got)
+	}
+}
+
+func TestSetarchArch(t *testing.T) {
+	requireEcho(t)
+	got := withStub(t)
+	if _, err := run(t, NewSetarch(), "i686", "echo", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != perLinux32 {
+		t.Errorf("setarch i686 persona = %#x, want perLinux32", *got)
+	}
+	if _, err := run(t, NewSetarch(), "x86_64", "echo", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != perLinux {
+		t.Errorf("setarch x86_64 persona = %#x, want perLinux", *got)
+	}
+}
+
+func TestMissingCommand(t *testing.T) {
+	withStub(t)
+	if _, err := run(t, NewLinux32()); err == nil {
+		t.Errorf("missing command should fail")
+	}
+}
+
+func TestSetarchMissingArch(t *testing.T) {
+	withStub(t)
+	if _, err := run(t, NewSetarch()); err == nil {
+		t.Errorf("setarch with no arch should fail")
+	}
+}
+
+func TestPersonaForArch(t *testing.T) {
+	t.Parallel()
+	for _, a := range []string{"i686", "i386", "linux32", "x86"} {
+		if personaForArch(a) != perLinux32 {
+			t.Errorf("personaForArch(%q) != perLinux32", a)
+		}
+	}
+	for _, a := range []string{"x86_64", "linux64", "amd64"} {
+		if personaForArch(a) != perLinux {
+			t.Errorf("personaForArch(%q) != perLinux", a)
+		}
+	}
+}

--- a/test/it/spec/setarch_spec.sh
+++ b/test/it/spec/setarch_spec.sh
@@ -1,0 +1,24 @@
+Describe 'setarch / linux32 / linux64'
+    Include util-linux/setarch_test.sh
+
+    It 'linux32 makes uname report a 32-bit machine'
+        When call TestLinux32Uname
+        The output should equal 'i686'
+        The status should be success
+    End
+    It 'linux64 reports the native machine'
+        When call TestLinux64Uname
+        The output should equal 'x86_64'
+        The status should be success
+    End
+    It 'linux32 passes the command output through'
+        When call TestLinux32Passthrough
+        The output should equal 'passed'
+        The status should be success
+    End
+    It 'setarch selects the personality from ARCH'
+        When call TestSetarchArch
+        The output should equal 'i686'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/setarch_test.sh
+++ b/test/it/util-linux/setarch_test.sh
@@ -1,0 +1,4 @@
+TestLinux32Uname() { linux32 uname -m; }
+TestLinux64Uname() { linux64 uname -m; }
+TestLinux32Passthrough() { linux32 echo passed; }
+TestSetarchArch() { setarch i686 uname -m; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with the architecture-personality wrappers:

- **`linux32`** — run a command with a 32-bit execution domain, so uname reports a 32-bit machine (e.g. i686 on an x86_64 kernel).
- **`linux64`** — run a command with the native 64-bit domain.
- **`setarch ARCH COMMAND`** — pick the domain from the leading ARCH name (i686/i386/... → 32-bit; x86_64/... → 64-bit).

They set the process personality(2) and then exec the command, propagating its exit status (127 if it cannot be run). Option parsing stops at the command so its own flags pass through. The PER_LINUX32/PER_LINUX constants are defined locally since this x/sys/unix version does not export them.

## Tests

- Unit: `linux32`/`linux64`/`setarch` select the correct personality (the personality call is stubbed so the test process is untouched), command output passes through, and missing-command / missing-arch errors; plus `personaForArch`.
- shellspec: `linux32 uname -m` reports i686, `linux64 uname -m` reports x86_64, `setarch i686 uname -m` reports i686, and `linux32` passes command output through.

## Verification

- `go test ./...` passes; `make test-e2e` passes (530 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248