### PR TITLE
feat(util-linux): add last applet reading the wtmp database

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 206 commands. Run `mimixbox --list` to see them on the terminal.
+There are 207 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -102,6 +102,7 @@ There are 206 commands. Run `mimixbox --list` to see them on the terminal.
 | ischroot | Detect if running in a chroot |
 | kill | Kill process or send signal to process |
 | killall | Kill processes by name |
+| last | Show a listing of last logged-in users |
 | less | Page through text one screen at a time |
 | lifegame | Life game (Conway's Game of Life) |
 | link | Create a hard link to a file |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -188,6 +188,7 @@ import (
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
+	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
@@ -196,7 +197,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 206)
+	Applets = make(map[string]Applet, 207)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -397,6 +398,7 @@ func init() {
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
+	register(ap_util_linux_last.New())
 	register(ap_util_linux_script.NewScript())
 	register(ap_util_linux_script.NewScriptreplay())
 	register(ap_util_linux_setarch.NewLinux32())

--- a/internal/applets/util-linux/last/last.go
+++ b/internal/applets/util-linux/last/last.go
@@ -1,0 +1,166 @@
+// Package last implements the last applet: show a listing of recent logins and
+// logouts read from the wtmp database, most recent first.
+package last
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the last applet.
+type Command struct{}
+
+// New returns a last command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "last" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show a listing of last logged-in users" }
+
+// wtmpPath is the login-history file; tests point it at a fixture.
+var wtmpPath = "/var/log/wtmp"
+
+// Linux utmp/wtmp layout (x86_64): 384-byte records.
+const (
+	recordSize  = 384
+	typeOffset  = 0
+	lineOffset  = 8
+	userOffset  = 44
+	hostOffset  = 76
+	tvSecOffset = 340
+	fieldLen    = 32
+	hostLen     = 256
+
+	bootTime    = 2
+	userProcess = 7
+	deadProcess = 8
+)
+
+type session struct {
+	user   string
+	line   string
+	host   string
+	login  int64
+	logout int64
+	active bool
+	reboot bool
+}
+
+// Run executes last.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-n COUNT] [FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "List the most recent logins and logouts from the wtmp database (or FILE), newest " +
+			"first. Each line shows the user, terminal, remote host, and the login span; an open " +
+			"session reads 'still logged in'.",
+		Examples: []command.Example{
+			{Command: "last", Explain: "Show the login history."},
+			{Command: "last -n 10", Explain: "Show only the 10 most recent entries."},
+		},
+	})
+	count := fs.IntP("count", "n", 0, "show only the last COUNT entries (0 = all)")
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	path := wtmpPath
+	if rest := fs.Args(); len(rest) > 0 {
+		path = rest[0]
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // the wtmp database (or a user-named override)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "last: %s\n", command.FileError(path, err))
+		return command.SilentFailure()
+	}
+
+	sessions, first := build(data)
+	shown := 0
+	for i := len(sessions) - 1; i >= 0; i-- {
+		if *count > 0 && shown >= *count {
+			break
+		}
+		_, _ = fmt.Fprintln(stdio.Out, format(sessions[i]))
+		shown++
+	}
+	if first > 0 {
+		_, _ = fmt.Fprintf(stdio.Out, "\nwtmp begins %s\n", time.Unix(first, 0).Format("Mon Jan _2 15:04:05 2006"))
+	}
+	return nil
+}
+
+// build pairs login and logout records into sessions, in chronological order,
+// and returns the earliest record time seen.
+func build(data []byte) ([]session, int64) {
+	var sessions []session
+	active := map[string]int{} // line -> index in sessions
+	var first int64
+
+	for off := 0; off+recordSize <= len(data); off += recordSize {
+		rec := data[off : off+recordSize]
+		typ := int16(binary.LittleEndian.Uint16(rec[typeOffset:]))
+		tv := int64(int32(binary.LittleEndian.Uint32(rec[tvSecOffset:])))
+		if tv > 0 && (first == 0 || tv < first) {
+			first = tv
+		}
+		line := cstr(rec[lineOffset : lineOffset+fieldLen])
+
+		switch typ {
+		case bootTime:
+			sessions = append(sessions, session{user: "reboot", line: "system boot", host: cstr(rec[hostOffset : hostOffset+hostLen]), login: tv, reboot: true})
+		case userProcess:
+			sessions = append(sessions, session{
+				user:   cstr(rec[userOffset : userOffset+fieldLen]),
+				line:   line,
+				host:   cstr(rec[hostOffset : hostOffset+hostLen]),
+				login:  tv,
+				active: true,
+			})
+			active[line] = len(sessions) - 1
+		case deadProcess:
+			if idx, ok := active[line]; ok {
+				sessions[idx].logout = tv
+				sessions[idx].active = false
+				delete(active, line)
+			}
+		}
+	}
+	return sessions, first
+}
+
+// format renders one session line.
+func format(s session) string {
+	const layout = "Mon Jan _2 15:04"
+	login := time.Unix(s.login, 0).Format(layout)
+	if s.reboot {
+		return fmt.Sprintf("%-8s %-12s %-16s %s", s.user, s.line, s.host, login)
+	}
+	host := s.host
+	if host == "" {
+		host = "-"
+	}
+	if s.active {
+		return fmt.Sprintf("%-8s %-12s %-16s %s   still logged in", s.user, s.line, host, login)
+	}
+	logout := time.Unix(s.logout, 0).Format("15:04")
+	dur := time.Duration(s.logout-s.login) * time.Second
+	return fmt.Sprintf("%-8s %-12s %-16s %s - %s  (%02d:%02d)",
+		s.user, s.line, host, login, logout, int(dur.Hours()), int(dur.Minutes())%60)
+}
+
+func cstr(b []byte) string {
+	for i, x := range b {
+		if x == 0 {
+			return string(b[:i])
+		}
+	}
+	return strings.TrimRight(string(b), "\x00")
+}

--- a/internal/applets/util-linux/last/last_test.go
+++ b/internal/applets/util-linux/last/last_test.go
@@ -1,0 +1,104 @@
+package last
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func record(typ int16, line, user, host string, tv int32) []byte {
+	b := make([]byte, recordSize)
+	binary.LittleEndian.PutUint16(b[typeOffset:], uint16(typ))
+	copy(b[lineOffset:lineOffset+fieldLen], line)
+	copy(b[userOffset:userOffset+fieldLen], user)
+	copy(b[hostOffset:hostOffset+hostLen], host)
+	binary.LittleEndian.PutUint32(b[tvSecOffset:], uint32(tv))
+	return b
+}
+
+func writeFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "wtmp")
+	var data []byte
+	data = append(data, record(bootTime, "~", "reboot", "5.15", 1699990000)...)
+	data = append(data, record(userProcess, "pts/0", "alice", "10.0.0.1", 1700000000)...)
+	data = append(data, record(deadProcess, "pts/0", "", "", 1700003600)...)
+	data = append(data, record(userProcess, "pts/1", "bob", "10.0.0.2", 1700007200)...)
+	if err := os.WriteFile(f, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func run(t *testing.T, args ...string) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestPairing(t *testing.T) {
+	t.Parallel()
+	out := run(t, writeFixture(t))
+	if !strings.Contains(out, "bob") || !strings.Contains(out, "still logged in") {
+		t.Errorf("bob should still be logged in: %q", out)
+	}
+	if !strings.Contains(out, "alice") || !strings.Contains(out, "(01:00)") {
+		t.Errorf("alice session should be one hour: %q", out)
+	}
+	if !strings.Contains(out, "reboot") || !strings.Contains(out, "system boot") {
+		t.Errorf("reboot entry missing: %q", out)
+	}
+	if !strings.Contains(out, "wtmp begins") {
+		t.Errorf("footer missing: %q", out)
+	}
+}
+
+func TestNewestFirst(t *testing.T) {
+	t.Parallel()
+	out := run(t, writeFixture(t))
+	lines := strings.Split(out, "\n")
+	// bob (newest login) appears before alice (older).
+	bobAt, aliceAt := -1, -1
+	for i, l := range lines {
+		if strings.Contains(l, "bob") {
+			bobAt = i
+		}
+		if strings.Contains(l, "alice") {
+			aliceAt = i
+		}
+	}
+	if bobAt < 0 || aliceAt < 0 || bobAt > aliceAt {
+		t.Errorf("expected bob before alice, got bob@%d alice@%d", bobAt, aliceAt)
+	}
+}
+
+func TestCountLimit(t *testing.T) {
+	t.Parallel()
+	out := run(t, "-n", "1", writeFixture(t))
+	// Only the newest entry (bob) is shown; older ones are omitted.
+	if !strings.Contains(out, "bob") {
+		t.Errorf("-n 1 should show the newest entry (bob): %q", out)
+	}
+	if strings.Contains(out, "alice") || strings.Contains(out, "reboot") {
+		t.Errorf("-n 1 should omit older entries: %q", out)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"/no/such/wtmp"}); err == nil {
+		t.Errorf("missing wtmp should fail")
+	}
+}

--- a/test/it/spec/last_spec.sh
+++ b/test/it/spec/last_spec.sh
@@ -1,0 +1,14 @@
+Describe 'last'
+    Include util-linux/last_test.sh
+
+    It 'treats an empty wtmp as no history and exits 0'
+        When call TestLastRuns
+        The output should equal '[] rc=0'
+        The status should be success
+    End
+    It 'fails on a missing wtmp file'
+        When call TestLastMissing
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/last_test.sh
+++ b/test/it/util-linux/last_test.sh
@@ -1,0 +1,10 @@
+# An empty wtmp (here /dev/null) means no history: last exits 0 with no output.
+TestLastRuns() {
+    out=$(last /dev/null)
+    echo "[$out] rc=$?"
+}
+
+TestLastMissing() {
+    last /no/such/mimixbox/wtmp 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `last`, which lists recent logins and logouts from the wtmp database (or a FILE), newest first. It pairs USER_PROCESS login records with their DEAD_PROCESS logout by terminal line, shows the login span with a duration, marks open sessions as 'still logged in', renders reboot records, and prints a 'wtmp begins ...' footer. `-n COUNT` limits the number of entries. The wtmp path is injectable so the behavior is tested against fixtures rather than the host.

## Tests

- Unit (fixture wtmp): login/logout pairing (a one-hour alice session, bob still logged in, a reboot entry, and the footer), newest-first ordering, the `-n` limit, and the missing-file error.
- shellspec: an empty wtmp (/dev/null) yields no history and exit 0, and a missing wtmp file fails.

## Verification

- `go test ./...` passes; `make test-e2e` passes (532 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248