### PR TITLE
feat(util-linux): add renice applet to change process priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 207 commands. Run `mimixbox --list` to see them on the terminal.
+There are 208 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -149,6 +149,7 @@ There are 207 commands. Run `mimixbox --list` to see them on the terminal.
 | realpath | Print the resolved absolute file name |
 | reboot | Reboot the system |
 | remove-shell | Remove shell name from /etc/shells |
+| renice | Alter the priority of running processes |
 | reset | Reset terminal |
 | resize | Print commands to set the terminal size |
 | rev | Reverse the order of characters in every line |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -189,6 +189,7 @@ import (
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
+	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
@@ -197,7 +198,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 207)
+	Applets = make(map[string]Applet, 208)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -399,6 +400,7 @@ func init() {
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
 	register(ap_util_linux_last.New())
+	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())
 	register(ap_util_linux_script.NewScriptreplay())
 	register(ap_util_linux_setarch.NewLinux32())

--- a/internal/applets/shellutils/users/users_test.go
+++ b/internal/applets/shellutils/users/users_test.go
@@ -67,7 +67,7 @@ func TestRunMissingFile(t *testing.T) {
 }
 
 func TestRunDefaultPath(t *testing.T) {
-	t.Parallel()
+	// Not parallel: it mutates the package-level utmpPath.
 	dir := t.TempDir()
 	f := filepath.Join(dir, "utmp")
 	if err := os.WriteFile(f, record(userProcess, "dave"), 0o644); err != nil {

--- a/internal/applets/shellutils/w/w_test.go
+++ b/internal/applets/shellutils/w/w_test.go
@@ -60,7 +60,7 @@ func run(t *testing.T) string {
 }
 
 func TestHeaderAndRows(t *testing.T) {
-	t.Parallel()
+	// Not parallel: setup() mutates package-level paths and the clock.
 	recs := append(record("alice", "pts/0", "10.0.0.1", 0), record("bob", "tty1", "", 0)...)
 	setup(t, recs, "0.50 0.40 0.30 1/100 999\n", "90000.0 1.0\n")
 
@@ -89,7 +89,7 @@ func TestHeaderAndRows(t *testing.T) {
 }
 
 func TestNoUsers(t *testing.T) {
-	t.Parallel()
+	// Not parallel: setup() mutates package-level paths and the clock.
 	setup(t, nil, "0.00 0.00 0.00 1/1 1\n", "60.0 1.0\n")
 	out := run(t)
 	if !strings.Contains(out, "0 users") {

--- a/internal/applets/util-linux/renice/renice.go
+++ b/internal/applets/util-linux/renice/renice.go
@@ -1,0 +1,103 @@
+// Package renice implements the renice applet: change the scheduling priority
+// (niceness) of one or more running processes.
+package renice
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the renice applet.
+type Command struct{}
+
+// New returns a renice command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "renice" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Alter the priority of running processes" }
+
+// Indirected so the priority changes can be tested without touching real
+// processes. getNice returns the actual niceness (-20..19).
+var (
+	getNice = func(pid int) (int, error) {
+		raw, err := unix.Getpriority(unix.PRIO_PROCESS, pid)
+		return 20 - raw, err
+	}
+	setNice = func(pid, nice int) error {
+		return unix.Setpriority(unix.PRIO_PROCESS, pid, nice)
+	}
+)
+
+// Run executes renice.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-n] PRIORITY [-p] PID...", stdio.Err).WithHelp(command.Help{
+		Description: "Change the niceness (scheduling priority) of the given PIDs to PRIORITY (-20 " +
+			"highest .. 19 lowest). Only the owner or the superuser may lower a process's niceness.",
+		Examples: []command.Example{
+			{Command: "renice 10 -p 1234", Explain: "Make process 1234 lower priority."},
+			{Command: "renice -n 5 1234 5678", Explain: "Renice two processes."},
+		},
+		ExitStatus: "0  every process was reniced.\n1  a priority or PID was invalid, or a change was denied.",
+	})
+	nicePtr := fs.IntP("priority", "n", 0, "the new niceness")
+	pidFlag := fs.BoolP("pid", "p", false, "interpret the operands as process IDs (the default)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	_ = pidFlag
+
+	operands := fs.Args()
+	priority := *nicePtr
+	if !fs.Changed("priority") {
+		// The first operand is the priority when -n was not given.
+		if len(operands) == 0 {
+			_, _ = fmt.Fprintln(stdio.Err, "renice: missing priority")
+			return command.SilentFailure()
+		}
+		priority, err = strconv.Atoi(operands[0])
+		if err != nil {
+			return command.Failuref("invalid priority: %q", operands[0])
+		}
+		operands = operands[1:]
+	}
+
+	if len(operands) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "renice: no PID given")
+		return command.SilentFailure()
+	}
+
+	var failed bool
+	for _, p := range operands {
+		pid, err := strconv.Atoi(p)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "renice: invalid PID: %q\n", p)
+			failed = true
+			continue
+		}
+		old, gerr := getNice(pid)
+		if gerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "renice: failed to get priority for %d: %v\n", pid, gerr)
+			failed = true
+			continue
+		}
+		if serr := setNice(pid, priority); serr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "renice: failed to set priority for %d: %v\n", pid, serr)
+			failed = true
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%d (process ID) old priority %d, new priority %d\n", pid, old, priority)
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}

--- a/internal/applets/util-linux/renice/renice_test.go
+++ b/internal/applets/util-linux/renice/renice_test.go
@@ -1,0 +1,78 @@
+package renice
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type call struct {
+	pid  int
+	nice int
+}
+
+func withStubs(t *testing.T, old int) *[]call {
+	t.Helper()
+	var calls []call
+	origGet, origSet := getNice, setNice
+	getNice = func(int) (int, error) { return old, nil }
+	setNice = func(pid, nice int) error { calls = append(calls, call{pid, nice}); return nil }
+	t.Cleanup(func() { getNice, setNice = origGet, origSet })
+	return &calls
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestPositionalPriority(t *testing.T) {
+	calls := withStubs(t, 0)
+	out, err := run(t, "5", "-p", "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 1 || (*calls)[0] != (call{1234, 5}) {
+		t.Errorf("calls = %v, want [{1234 5}]", *calls)
+	}
+	if !strings.Contains(out, "1234 (process ID) old priority 0, new priority 5") {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestDashNPriority(t *testing.T) {
+	calls := withStubs(t, 2)
+	if _, err := run(t, "-n", "10", "1234", "5678"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 2 || (*calls)[0] != (call{1234, 10}) || (*calls)[1] != (call{5678, 10}) {
+		t.Errorf("calls = %v", *calls)
+	}
+}
+
+func TestInvalidPid(t *testing.T) {
+	withStubs(t, 0)
+	if _, err := run(t, "5", "notapid"); err == nil {
+		t.Errorf("invalid PID should fail")
+	}
+}
+
+func TestMissingPriority(t *testing.T) {
+	withStubs(t, 0)
+	if _, err := run(t); err == nil {
+		t.Errorf("missing priority should fail")
+	}
+}
+
+func TestMissingPid(t *testing.T) {
+	withStubs(t, 0)
+	if _, err := run(t, "5"); err == nil {
+		t.Errorf("missing PID should fail")
+	}
+}

--- a/test/it/spec/renice_spec.sh
+++ b/test/it/spec/renice_spec.sh
@@ -1,0 +1,14 @@
+Describe 'renice'
+    Include util-linux/renice_test.sh
+
+    It 'reports the priority change'
+        When call TestRenice
+        The output should equal '1'
+        The status should be success
+    End
+    It 'rejects a non-numeric PID'
+        When call TestReniceInvalid
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/renice_test.sh
+++ b/test/it/util-linux/renice_test.sh
@@ -1,0 +1,10 @@
+# Renice this shell to its current niceness (a no-op change that needs no extra
+# privilege), and confirm the GNU-style report line.
+TestRenice() {
+    renice -n 0 -p $$ | grep -c 'process ID'
+}
+
+TestReniceInvalid() {
+    renice 5 notapid 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `renice`, which changes the niceness (scheduling priority) of running processes. It accepts the priority as the first operand or via `-n`, then one or more PIDs (with `-p`), and prints the GNU-style `PID (process ID) old priority X, new priority Y` report. The priority syscalls are injectable so the parsing and reporting are tested without touching real processes.

## Tests

- Unit (stubbed priority calls): positional priority with `-p`, `-n` priority across multiple PIDs (verifying the exact pid/nice calls and the report line), and the invalid-PID / missing-priority / missing-PID errors.
- shellspec: renice the test shell to its own niceness (a no-op needing no privilege) and confirm the report line, plus the non-numeric-PID failure.

## Verification

- `go test ./...` passes; `make test-e2e` passes (534 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248