### PR TITLE
feat(util-linux): add taskset applet for CPU affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 208 commands. Run `mimixbox --list` to see them on the terminal.
+There are 209 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -186,6 +186,7 @@ There are 208 commands. Run `mimixbox --list` to see them on the terminal.
 | tac | Print the file contents from the end to the beginning |
 | tail | Print the last NUMBER(default=10) lines |
 | tar | Archive files (create, list, extract) |
+| taskset | Set or get a process's CPU affinity |
 | tee | Read from standard input and write to standard output and files |
 | test | Evaluate a conditional expression |
 | time | Run a command and report how long it took |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -193,12 +193,13 @@ import (
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
+	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 208)
+	Applets = make(map[string]Applet, 209)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -407,4 +408,5 @@ func init() {
 	register(ap_util_linux_setarch.NewLinux64())
 	register(ap_util_linux_setarch.NewSetarch())
 	register(ap_util_linux_setsid.New())
+	register(ap_util_linux_taskset.New())
 }

--- a/internal/applets/util-linux/taskset/taskset.go
+++ b/internal/applets/util-linux/taskset/taskset.go
@@ -1,0 +1,185 @@
+// Package taskset implements the taskset applet: retrieve or set the CPU
+// affinity of a process, or launch a command bound to a set of CPUs.
+package taskset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the taskset applet.
+type Command struct{}
+
+// New returns a taskset command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "taskset" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Set or get a process's CPU affinity" }
+
+// Indirected so affinity changes can be tested without touching real processes.
+var (
+	getAffinity = func(pid int, set *unix.CPUSet) error { return unix.SchedGetaffinity(pid, set) }
+	setAffinity = func(pid int, set *unix.CPUSet) error { return unix.SchedSetaffinity(pid, set) }
+)
+
+// Run executes taskset.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-c] [-p] MASK|CPU-LIST [COMMAND|PID]...", stdio.Err).WithHelp(command.Help{
+		Description: "Without -p, run COMMAND bound to the given CPUs and pass its flags through. " +
+			"With -p, print a PID's current affinity, or set it when a mask is given first. The CPUs " +
+			"are a hexadecimal MASK, or a CPU-LIST like '0,2-4' when -c is used.",
+		Examples: []command.Example{
+			{Command: "taskset -c 0,1 -- make", Explain: "Run make on CPUs 0 and 1."},
+			{Command: "taskset -p 1234", Explain: "Print process 1234's affinity mask."},
+		},
+		ExitStatus: "0  success.\n1  an invalid mask/PID, or the command could not be run.",
+	})
+	fs.SetInterspersed(false)
+	pidMode := fs.BoolP("pid", "p", false, "operate on an existing PID")
+	cpuList := fs.BoolP("cpu-list", "c", false, "interpret the operand as a CPU list, not a hex mask")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	operands := fs.Args()
+
+	if *pidMode {
+		return c.pidMode(stdio, operands, *cpuList)
+	}
+	return c.runMode(ctx, stdio, operands, *cpuList)
+}
+
+// pidMode handles "-p PID" (print) and "-p MASK PID" (set).
+func (c *Command) pidMode(stdio command.IO, operands []string, cpuList bool) error {
+	switch len(operands) {
+	case 1:
+		pid, err := strconv.Atoi(operands[0])
+		if err != nil {
+			return command.Failuref("invalid PID: %q", operands[0])
+		}
+		var set unix.CPUSet
+		if err := getAffinity(pid, &set); err != nil {
+			return command.Failuref("failed to get affinity for %d: %v", pid, err)
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "pid %d's current affinity mask: %s\n", pid, maskHex(&set))
+		return nil
+	case 2:
+		set, err := parseSet(operands[0], cpuList)
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
+		pid, err := strconv.Atoi(operands[1])
+		if err != nil {
+			return command.Failuref("invalid PID: %q", operands[1])
+		}
+		if err := setAffinity(pid, set); err != nil {
+			return command.Failuref("failed to set affinity for %d: %v", pid, err)
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "pid %d's new affinity mask: %s\n", pid, maskHex(set))
+		return nil
+	default:
+		_, _ = fmt.Fprintln(stdio.Err, "taskset: -p needs a PID (optionally preceded by a mask)")
+		return command.SilentFailure()
+	}
+}
+
+// runMode handles "MASK COMMAND" / "-c CPU-LIST COMMAND".
+func (c *Command) runMode(ctx context.Context, stdio command.IO, operands []string, cpuList bool) error {
+	if len(operands) < 2 {
+		_, _ = fmt.Fprintln(stdio.Err, "taskset: a mask and a command are required")
+		return command.SilentFailure()
+	}
+	set, err := parseSet(operands[0], cpuList)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	rest := operands[1:]
+	if rest[0] == "--" {
+		rest = rest[1:]
+	}
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "taskset: a command is required")
+		return command.SilentFailure()
+	}
+	if err := setAffinity(0, set); err != nil {
+		return command.Failuref("failed to set affinity: %v", err)
+	}
+
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running the user's command is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	return nil
+}
+
+// parseSet builds a CPUSet from a hex mask or a CPU list ("0,2-4").
+func parseSet(s string, cpuList bool) (*unix.CPUSet, error) {
+	var set unix.CPUSet
+	if cpuList {
+		for _, part := range strings.Split(s, ",") {
+			if part == "" {
+				continue
+			}
+			if lo, hi, ok := strings.Cut(part, "-"); ok {
+				a, err1 := strconv.Atoi(lo)
+				b, err2 := strconv.Atoi(hi)
+				if err1 != nil || err2 != nil || a > b {
+					return nil, fmt.Errorf("invalid CPU list: %q", s)
+				}
+				for i := a; i <= b; i++ {
+					set.Set(i)
+				}
+			} else {
+				n, err := strconv.Atoi(part)
+				if err != nil {
+					return nil, fmt.Errorf("invalid CPU list: %q", s)
+				}
+				set.Set(n)
+			}
+		}
+		return &set, nil
+	}
+
+	v := new(big.Int)
+	hex := strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
+	if _, ok := v.SetString(hex, 16); !ok {
+		return nil, fmt.Errorf("invalid mask: %q", s)
+	}
+	for i := 0; i < v.BitLen(); i++ {
+		if v.Bit(i) == 1 {
+			set.Set(i)
+		}
+	}
+	return &set, nil
+}
+
+// maskHex renders a CPUSet as the lowercase hex bitmask taskset prints.
+func maskHex(set *unix.CPUSet) string {
+	v := new(big.Int)
+	for i := 0; i < 1024; i++ {
+		if set.IsSet(i) {
+			v.SetBit(v, i, 1)
+		}
+	}
+	if v.Sign() == 0 {
+		return "0"
+	}
+	return v.Text(16)
+}

--- a/internal/applets/util-linux/taskset/taskset_test.go
+++ b/internal/applets/util-linux/taskset/taskset_test.go
@@ -1,0 +1,142 @@
+package taskset
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+func requireEcho(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skipf("echo not on PATH: %v", err)
+	}
+}
+
+// withStubs makes getAffinity report `have` and captures whatever setAffinity is
+// given.
+func withStubs(t *testing.T, have *unix.CPUSet) **unix.CPUSet {
+	t.Helper()
+	var captured *unix.CPUSet
+	origGet, origSet := getAffinity, setAffinity
+	getAffinity = func(_ int, set *unix.CPUSet) error {
+		if have != nil {
+			*set = *have
+		}
+		return nil
+	}
+	setAffinity = func(_ int, set *unix.CPUSet) error { cp := *set; captured = &cp; return nil }
+	t.Cleanup(func() { getAffinity, setAffinity = origGet, origSet })
+	return &captured
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func cpuSet(cpus ...int) *unix.CPUSet {
+	var s unix.CPUSet
+	for _, c := range cpus {
+		s.Set(c)
+	}
+	return &s
+}
+
+func TestPrintAffinity(t *testing.T) {
+	withStubs(t, cpuSet(0, 1, 2, 3)) // mask 0xf
+	out, err := run(t, "-p", "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "pid 1234's current affinity mask: f\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestRunWithCPUList(t *testing.T) {
+	requireEcho(t)
+	captured := withStubs(t, nil)
+	if _, err := run(t, "-c", "0,2-3", "echo", "ok"); err != nil {
+		t.Fatal(err)
+	}
+	got := *captured
+	if got == nil {
+		t.Fatal("setAffinity not called")
+	}
+	for _, c := range []int{0, 2, 3} {
+		if !got.IsSet(c) {
+			t.Errorf("CPU %d should be set", c)
+		}
+	}
+	if got.IsSet(1) {
+		t.Errorf("CPU 1 should not be set")
+	}
+}
+
+func TestRunWithHexMask(t *testing.T) {
+	requireEcho(t)
+	captured := withStubs(t, nil)
+	if _, err := run(t, "0x5", "echo", "x"); err != nil { // bits 0 and 2
+		t.Fatal(err)
+	}
+	got := *captured
+	if !got.IsSet(0) || !got.IsSet(2) || got.IsSet(1) {
+		t.Errorf("0x5 -> wrong CPUs")
+	}
+}
+
+func TestSetPidAffinity(t *testing.T) {
+	captured := withStubs(t, nil)
+	out, err := run(t, "-p", "0x3", "999")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := *captured
+	if !got.IsSet(0) || !got.IsSet(1) {
+		t.Errorf("set affinity wrong")
+	}
+	if !strings.Contains(out, "new affinity mask: 3") {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	withStubs(t, nil)
+	if _, err := run(t, "zzz", "echo"); err == nil {
+		t.Errorf("invalid mask should fail")
+	}
+	if _, err := run(t, "-p", "notapid"); err == nil {
+		t.Errorf("invalid PID should fail")
+	}
+	if _, err := run(t, "0x1"); err == nil {
+		t.Errorf("missing command should fail")
+	}
+}
+
+func TestParseSet(t *testing.T) {
+	t.Parallel()
+	s, err := parseSet("0,2-4", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []int{0, 2, 3, 4} {
+		if !s.IsSet(c) {
+			t.Errorf("CPU %d missing", c)
+		}
+	}
+	if _, err := parseSet("1-0", true); err == nil {
+		t.Errorf("reversed range should fail")
+	}
+	if _, err := parseSet("xy", false); err == nil {
+		t.Errorf("bad hex should fail")
+	}
+}

--- a/test/it/spec/taskset_spec.sh
+++ b/test/it/spec/taskset_spec.sh
@@ -1,0 +1,19 @@
+Describe 'taskset'
+    Include util-linux/taskset_test.sh
+
+    It 'prints a process affinity mask'
+        When call TestTasksetPrint
+        The output should equal '1'
+        The status should be success
+    End
+    It 'runs a command bound to a CPU'
+        When call TestTasksetRun
+        The output should equal 'affined'
+        The status should be success
+    End
+    It 'rejects an invalid mask'
+        When call TestTasksetInvalid
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/taskset_test.sh
+++ b/test/it/util-linux/taskset_test.sh
@@ -1,0 +1,12 @@
+TestTasksetPrint() {
+    taskset -p $$ | grep -c 'affinity mask'
+}
+
+TestTasksetRun() {
+    taskset -c 0 echo affined
+}
+
+TestTasksetInvalid() {
+    taskset zzz echo x 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `taskset`, which retrieves or sets a process's CPU affinity, or launches a command bound to a set of CPUs:

- `taskset -p PID` prints the affinity mask (e.g. `pid 1234's current affinity mask: f`); `taskset -p MASK PID` sets it.
- `taskset MASK COMMAND` / `taskset -c CPU-LIST COMMAND` runs COMMAND bound to those CPUs, with the command's own flags passed through (a leading `--` is accepted). CPUs are a hex MASK or, with -c, a list like `0,2-4`.

The affinity syscalls are injectable so the parsing/reporting is tested without changing real processes. `taskset -p` output matches host util-linux byte-for-byte.

## Tests

- Unit (stubbed affinity): print affinity, run with a CPU list and with a hex mask (verifying the exact CPUs set), set a PID's affinity, the invalid-mask / invalid-PID / missing-command errors, and `parseSet` (lists, ranges, reversed range, bad hex).
- shellspec: print a process mask, run a command bound to CPU 0, and reject an invalid mask.

## Verification

- `go test ./...` passes; `make test-e2e` passes (537 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248