### PR TITLE
feat(util-linux): add ipcs applet for System V IPC status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 209 commands. Run `mimixbox --list` to see them on the terminal.
+There are 210 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -99,6 +99,7 @@ There are 209 commands. Run `mimixbox --list` to see them on the terminal.
 | hush | Command interpreter (MimixBox mbsh compatibility front-end) |
 | id | Print User ID and Group ID |
 | install | Copy files and set attributes |
+| ipcs | Show System V IPC facilities status |
 | ischroot | Detect if running in a chroot |
 | kill | Kill process or send signal to process |
 | killall | Kill processes by name |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -188,6 +188,7 @@ import (
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
+	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
@@ -199,7 +200,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 209)
+	Applets = make(map[string]Applet, 210)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -400,6 +401,7 @@ func init() {
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
+	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
 	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())

--- a/internal/applets/util-linux/ipcs/ipcs.go
+++ b/internal/applets/util-linux/ipcs/ipcs.go
@@ -1,0 +1,151 @@
+// Package ipcs implements the ipcs applet: report status of System V
+// inter-process communication facilities (message queues, shared memory, and
+// semaphore arrays), read from /proc/sysvipc.
+package ipcs
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the ipcs applet.
+type Command struct{}
+
+// New returns an ipcs command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ipcs" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show System V IPC facilities status" }
+
+// procDir is the sysvipc directory; tests point it at a fixture.
+var procDir = "/proc/sysvipc"
+
+// Run executes ipcs.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-q] [-m] [-s]", stdio.Err).WithHelp(command.Help{
+		Description: "Show information about the active System V IPC objects. With no option all three " +
+			"facilities are shown; -q limits to message queues, -m to shared memory, and -s to " +
+			"semaphore arrays.",
+		Examples: []command.Example{
+			{Command: "ipcs", Explain: "Show all IPC objects."},
+			{Command: "ipcs -m", Explain: "Show only shared memory segments."},
+		},
+	})
+	queues := fs.BoolP("queues", "q", false, "message queues")
+	shmem := fs.BoolP("shmems", "m", false, "shared memory segments")
+	sems := fs.BoolP("semaphores", "s", false, "semaphore arrays")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	all := !*queues && !*shmem && !*sems
+	if all || *queues {
+		c.messageQueues(stdio.Out)
+	}
+	if all || *shmem {
+		c.sharedMemory(stdio.Out)
+	}
+	if all || *sems {
+		c.semaphores(stdio.Out)
+	}
+	return nil
+}
+
+func (c *Command) messageQueues(out io.Writer) {
+	_, _ = fmt.Fprintln(out, "\n------ Message Queues --------")
+	_, _ = fmt.Fprintf(out, "%-12s %-10s %-10s %-6s %-12s %-10s\n", "key", "msqid", "owner", "perms", "used-bytes", "messages")
+	for _, f := range records(filepath.Join(procDir, "msg")) {
+		if len(f) < 8 {
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "%-12s %-10s %-10s %-6s %-12s %-10s\n",
+			key(f[0]), f[1], owner(f[7]), f[2], f[3], f[4])
+	}
+}
+
+func (c *Command) sharedMemory(out io.Writer) {
+	_, _ = fmt.Fprintln(out, "\n------ Shared Memory Segments --------")
+	_, _ = fmt.Fprintf(out, "%-12s %-10s %-10s %-6s %-12s %-8s\n", "key", "shmid", "owner", "perms", "bytes", "nattch")
+	for _, f := range records(filepath.Join(procDir, "shm")) {
+		if len(f) < 8 {
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "%-12s %-10s %-10s %-6s %-12s %-8s\n",
+			key(f[0]), f[1], owner(f[7]), f[2], f[3], f[6])
+	}
+}
+
+func (c *Command) semaphores(out io.Writer) {
+	_, _ = fmt.Fprintln(out, "\n------ Semaphore Arrays --------")
+	_, _ = fmt.Fprintf(out, "%-12s %-10s %-10s %-6s %-8s\n", "key", "semid", "owner", "perms", "nsems")
+	for _, f := range records(filepath.Join(procDir, "sem")) {
+		if len(f) < 5 {
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "%-12s %-10s %-10s %-6s %-8s\n",
+			key(f[0]), f[1], owner(f[4]), f[2], f[3])
+	}
+}
+
+// records reads a /proc/sysvipc file, skips its header line, and returns the
+// whitespace-split fields of each remaining line.
+func records(path string) [][]string {
+	f, err := os.Open(path) //nolint:gosec // the sysvipc path
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	var out [][]string
+	sc := bufio.NewScanner(f)
+	first := true
+	for sc.Scan() {
+		if first { // header row
+			first = false
+			continue
+		}
+		fields := strings.Fields(sc.Text())
+		if len(fields) > 0 {
+			out = append(out, fields)
+		}
+	}
+	return out
+}
+
+// key formats a decimal key field as ipcs does (0x%08x).
+func key(s string) string {
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return s
+	}
+	return fmt.Sprintf("0x%08x", uint32(n))
+}
+
+var userCache = map[string]string{}
+
+// owner resolves a uid string to a user name.
+func owner(uid string) string {
+	if name, ok := userCache[uid]; ok {
+		return name
+	}
+	name := uid
+	if u, err := user.LookupId(uid); err == nil {
+		name = u.Username
+	}
+	userCache[uid] = name
+	return name
+}

--- a/internal/applets/util-linux/ipcs/ipcs_test.go
+++ b/internal/applets/util-linux/ipcs/ipcs_test.go
@@ -1,0 +1,90 @@
+package ipcs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// header line + one record, matching /proc/sysvipc field order.
+	write("msg", "key msqid perms cbytes qnum lspid lrpid uid gid cuid cgid stime rtime ctime\n"+
+		"12345 7 600 10 2 100 101 1000 1000 1000 1000 0 0 0\n")
+	write("shm", "key shmid perms size cpid lpid nattch uid gid cuid cgid atime dtime ctime rss swap\n"+
+		"54321 8 644 4096 200 201 3 1000 1000 1000 1000 0 0 0 0 0\n")
+	write("sem", "key semid perms nsems uid gid cuid cgid otime ctime\n"+
+		"99 9 666 5 1000 1000 1000 1000 0 0\n")
+
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+func run(t *testing.T, args ...string) string {
+	t.Helper()
+	fixture(t)
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestAllSections(t *testing.T) {
+	out := run(t)
+	for _, want := range []string{"Message Queues", "Shared Memory Segments", "Semaphore Arrays"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing section %q", want)
+		}
+	}
+}
+
+func TestMessageQueueRecord(t *testing.T) {
+	out := run(t, "-q")
+	// 12345 == 0x3039; used-bytes 10; messages 2; perms 600.
+	if !strings.Contains(out, "0x00003039") || !strings.Contains(out, "600") {
+		t.Errorf("msg record = %q", out)
+	}
+	if strings.Contains(out, "Shared Memory") {
+		t.Errorf("-q should not show shared memory")
+	}
+}
+
+func TestSharedMemoryRecord(t *testing.T) {
+	out := run(t, "-m")
+	// 54321 == 0xd431; bytes 4096; nattch 3.
+	if !strings.Contains(out, "0x0000d431") || !strings.Contains(out, "4096") || !strings.Contains(out, "644") {
+		t.Errorf("shm record = %q", out)
+	}
+}
+
+func TestSemaphoreRecord(t *testing.T) {
+	out := run(t, "-s")
+	// 99 == 0x63; nsems 5; perms 666.
+	if !strings.Contains(out, "0x00000063") || !strings.Contains(out, "666") {
+		t.Errorf("sem record = %q", out)
+	}
+}
+
+func TestKeyFormat(t *testing.T) {
+	t.Parallel()
+	if got := key("12345"); got != "0x00003039" {
+		t.Errorf("key = %q", got)
+	}
+	if got := key("0"); got != "0x00000000" {
+		t.Errorf("key(0) = %q", got)
+	}
+}

--- a/test/it/spec/ipcs_spec.sh
+++ b/test/it/spec/ipcs_spec.sh
@@ -1,0 +1,15 @@
+Describe 'ipcs'
+    Include util-linux/ipcs_test.sh
+
+    It 'shows the IPC facility sections'
+        When call TestIpcsAll
+        The output should equal '1'
+        The status should be success
+    End
+    It 'limits to shared memory with -m'
+        When call TestIpcsShm
+        The status should be success
+        The output should include 'Shared Memory Segments'
+        The output should not include 'Message Queues'
+    End
+End

--- a/test/it/util-linux/ipcs_test.sh
+++ b/test/it/util-linux/ipcs_test.sh
@@ -1,0 +1,2 @@
+TestIpcsAll() { ipcs | grep -c 'Message Queues'; }
+TestIpcsShm() { ipcs -m; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `ipcs`, which reports the status of System V IPC facilities read from /proc/sysvipc. With no option it shows all three sections (message queues, shared memory segments, semaphore arrays); -q, -m, and -s limit the output to one. Each record shows the key (as 0x%08x), the IPC id, the owner (resolved from uid), the perms, and the resource-specific columns. The sysvipc directory is injectable so parsing is tested against fixtures.

## Tests

- Unit (fixture /proc/sysvipc): all three sections appear; the message-queue, shared-memory, and semaphore records parse to the right key/id/perms/columns; -q/-m/-s limit the sections; and the `key` 0x-formatting helper.
- shellspec: `ipcs` shows the facility sections, and `-m` limits to shared memory.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (539 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248