### PR TITLE
feat(util-linux): add mesg applet to control terminal write access

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 210 commands. Run `mimixbox --list` to see them on the terminal.
+There are 211 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -118,6 +118,7 @@ There are 210 commands. Run `mimixbox --list` to see them on the terminal.
 | man | Display a manual page |
 | mbsh | Mimix Box Shell |
 | md5sum | Calculate or Check md5sum message digest |
+| mesg | Display or control write access to your terminal |
 | mkdir | Make directories |
 | mkfifo | Make FIFO (named pipe) |
 | mknod | Make block or character special files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -190,6 +190,7 @@ import (
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
+	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
@@ -200,7 +201,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 210)
+	Applets = make(map[string]Applet, 211)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -403,6 +404,7 @@ func init() {
 	register(ap_util_linux_hexdump.NewHexdump())
 	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
+	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())
 	register(ap_util_linux_script.NewScriptreplay())

--- a/internal/applets/util-linux/mesg/mesg.go
+++ b/internal/applets/util-linux/mesg/mesg.go
@@ -1,0 +1,97 @@
+// Package mesg implements the mesg applet: display or control write access to
+// the controlling terminal (whether other users may send it messages with
+// write/wall).
+package mesg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the mesg applet.
+type Command struct{}
+
+// New returns a mesg command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mesg" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Display or control write access to your terminal" }
+
+// resolveTTY returns the path of the terminal on r; tests replace it.
+var resolveTTY = func(r io.Reader) (string, error) {
+	f, ok := r.(*os.File)
+	if !ok {
+		return "", os.ErrInvalid
+	}
+	if _, err := unix.IoctlGetTermios(int(f.Fd()), unix.TCGETS); err != nil {
+		return "", err
+	}
+	return os.Readlink(fmt.Sprintf("/proc/self/fd/%d", f.Fd()))
+}
+
+// groupWrite is the terminal's group-write permission bit.
+const groupWrite = 0o020
+
+// Run executes mesg.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[y|n]", stdio.Err).WithHelp(command.Help{
+		Description: "With no argument, report whether other users may write to your terminal " +
+			"('is y' or 'is n'). 'mesg y' grants access and 'mesg n' revokes it by toggling the " +
+			"terminal's group-write permission.",
+		Examples: []command.Example{
+			{Command: "mesg", Explain: "Report the current state."},
+			{Command: "mesg n", Explain: "Disallow messages to your terminal."},
+		},
+		ExitStatus: "0  access is allowed.\n1  access is denied.\n2  an error occurred (e.g. not a terminal).",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	path, err := resolveTTY(stdio.In)
+	if err != nil {
+		_, _ = fmt.Fprintln(stdio.Err, "mesg: cannot get terminal name")
+		return &command.ExitError{Code: 2}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "mesg: %s\n", command.FileError(path, err))
+		return &command.ExitError{Code: 2}
+	}
+	allowed := info.Mode()&groupWrite != 0
+
+	operands := fs.Args()
+	if len(operands) == 0 {
+		if allowed {
+			_, _ = fmt.Fprintln(stdio.Out, "is y")
+			return nil
+		}
+		_, _ = fmt.Fprintln(stdio.Out, "is n")
+		return &command.ExitError{Code: 1}
+	}
+
+	switch operands[0] {
+	case "y":
+		if err := os.Chmod(path, info.Mode()|groupWrite); err != nil {
+			return command.Failuref("%v", err)
+		}
+		return nil
+	case "n":
+		if err := os.Chmod(path, info.Mode()&^groupWrite); err != nil {
+			return command.Failuref("%v", err)
+		}
+		return &command.ExitError{Code: 1}
+	default:
+		_, _ = fmt.Fprintf(stdio.Err, "mesg: invalid argument: %q\n", operands[0])
+		return &command.ExitError{Code: 2}
+	}
+}

--- a/internal/applets/util-linux/mesg/mesg_test.go
+++ b/internal/applets/util-linux/mesg/mesg_test.go
@@ -1,0 +1,110 @@
+package mesg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee *command.ExitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+	return 1
+}
+
+// withTTYFile makes resolveTTY return a temp file with the given mode, so the
+// permission logic can be exercised without a real terminal.
+func withTTYFile(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "tty")
+	if err := os.WriteFile(f, nil, mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(f, mode); err != nil {
+		t.Fatal(err)
+	}
+	orig := resolveTTY
+	resolveTTY = func(io.Reader) (string, error) { return f, nil }
+	t.Cleanup(func() { resolveTTY = orig })
+	return f
+}
+
+func run(t *testing.T, args ...string) (string, int) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), exitCode(err)
+}
+
+func TestReportAllowed(t *testing.T) {
+	withTTYFile(t, 0o620) // group-writable
+	out, code := run(t)
+	if out != "is y" || code != 0 {
+		t.Errorf("got %q code %d, want 'is y' 0", out, code)
+	}
+}
+
+func TestReportDenied(t *testing.T) {
+	withTTYFile(t, 0o600) // not group-writable
+	out, code := run(t)
+	if out != "is n" || code != 1 {
+		t.Errorf("got %q code %d, want 'is n' 1", out, code)
+	}
+}
+
+func TestEnable(t *testing.T) {
+	f := withTTYFile(t, 0o600)
+	if _, code := run(t, "y"); code != 0 {
+		t.Errorf("mesg y code = %d, want 0", code)
+	}
+	info, _ := os.Stat(f)
+	if info.Mode()&groupWrite == 0 {
+		t.Errorf("group-write bit should be set, mode = %o", info.Mode())
+	}
+}
+
+func TestDisable(t *testing.T) {
+	f := withTTYFile(t, 0o620)
+	if _, code := run(t, "n"); code != 1 {
+		t.Errorf("mesg n code = %d, want 1", code)
+	}
+	info, _ := os.Stat(f)
+	if info.Mode()&groupWrite != 0 {
+		t.Errorf("group-write bit should be cleared, mode = %o", info.Mode())
+	}
+}
+
+func TestInvalidArg(t *testing.T) {
+	withTTYFile(t, 0o620)
+	if _, code := run(t, "maybe"); code != 2 {
+		t.Errorf("invalid arg code = %d, want 2", code)
+	}
+}
+
+func TestNotATTY(t *testing.T) {
+	// The real resolveTTY rejects a non-*os.File reader.
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, nil)
+	if exitCode(err) != 2 {
+		t.Errorf("not-a-tty code = %d, want 2", exitCode(err))
+	}
+	if !strings.Contains(errBuf.String(), "terminal name") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}

--- a/test/it/spec/mesg_spec.sh
+++ b/test/it/spec/mesg_spec.sh
@@ -1,0 +1,10 @@
+Describe 'mesg'
+    Include util-linux/mesg_test.sh
+
+    It 'reports an error when stdin is not a terminal'
+        When call TestMesgNotTty
+        The output should equal 'mesg: cannot get terminal name
+rc=2'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/mesg_test.sh
+++ b/test/it/util-linux/mesg_test.sh
@@ -1,0 +1,6 @@
+# Under the e2e harness stdin is not a terminal, so mesg reports the error and
+# exits 2. The terminal permission logic is covered by the Go unit tests.
+TestMesgNotTty() {
+    echo x | mesg 2>&1
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `mesg`, which displays or controls whether other users may write to your terminal. With no argument it reports `is y`/`is n` (and exits 0/1 per the GNU contract); `mesg y` and `mesg n` grant or revoke access by toggling the terminal's group-write permission. A non-terminal stdin reports `mesg: cannot get terminal name` and exits 2. The terminal-path resolution is injectable so the permission logic is tested without a real tty.

## Tests

- Unit (injected tty file): report allowed/denied with the matching exit codes, enable/disable toggling the group-write bit, the invalid-argument exit 2, and the not-a-terminal exit 2 via the real resolver.
- shellspec: stdin is not a terminal under the harness, so mesg reports the error and exits 2.

## Verification

- `go test ./...` passes; `make test-e2e` passes (540 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mesg` command to display or control write access to your terminal. The command reports whether terminal write access is enabled or disabled, and allows toggling permissions as needed.
  * Added comprehensive test coverage including unit and integration tests for all command behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->