### PR TITLE
fix(mesg): address CodeRabbit feedback

### DIFF
--- a/internal/applets/util-linux/mesg/mesg.go
+++ b/internal/applets/util-linux/mesg/mesg.go
@@ -78,16 +78,22 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		_, _ = fmt.Fprintln(stdio.Out, "is n")
 		return &command.ExitError{Code: 1}
 	}
+	if len(operands) > 1 {
+		_, _ = fmt.Fprintln(stdio.Err, "mesg: too many arguments")
+		return &command.ExitError{Code: 2}
+	}
 
 	switch operands[0] {
 	case "y":
 		if err := os.Chmod(path, info.Mode()|groupWrite); err != nil {
-			return command.Failuref("%v", err)
+			_, _ = fmt.Fprintf(stdio.Err, "mesg: %v\n", err)
+			return &command.ExitError{Code: 2}
 		}
 		return nil
 	case "n":
 		if err := os.Chmod(path, info.Mode()&^groupWrite); err != nil {
-			return command.Failuref("%v", err)
+			_, _ = fmt.Fprintf(stdio.Err, "mesg: %v\n", err)
+			return &command.ExitError{Code: 2}
 		}
 		return &command.ExitError{Code: 1}
 	default:

--- a/internal/applets/util-linux/mesg/mesg_test.go
+++ b/internal/applets/util-linux/mesg/mesg_test.go
@@ -95,6 +95,13 @@ func TestInvalidArg(t *testing.T) {
 	}
 }
 
+func TestTooManyArgs(t *testing.T) {
+	withTTYFile(t, 0o620)
+	if _, code := run(t, "y", "extra"); code != 2 {
+		t.Errorf("extra operand code = %d, want 2", code)
+	}
+}
+
 func TestNotATTY(t *testing.T) {
 	// The real resolveTTY rejects a non-*os.File reader.
 	out := &bytes.Buffer{}


### PR DESCRIPTION
## Summary

Follow-up to #325 addressing two CodeRabbit Major findings:

- `mesg` now rejects extra operands: `mesg y extra` reports 'too many arguments' and exits 2 (invalid usage) instead of silently ignoring the extra argument.
- chmod failures from `mesg y`/`mesg n` now exit 2 (error), matching the documented exit contract, rather than 1.

## Verification

- `go test ./...` passes (added a too-many-arguments test); `golangci-lint` clean. Verified on a pty that `mesg y extra` reports the error and exits 2.

Part of #248