### PR TITLE
feat(util-linux): add lsblk applet to list block devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 211 commands. Run `mimixbox --list` to see them on the terminal.
+There are 212 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -113,6 +113,7 @@ There are 211 commands. Run `mimixbox --list` to see them on the terminal.
 | log-collect | Gather system log files into one directory |
 | logname | Print the name of the current user |
 | ls | List directory contents |
+| lsblk | List information about block devices |
 | lzcat | Decompress lzma data to standard output |
 | lzma | Compress or decompress files (lzma) |
 | man | Display a manual page |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -190,6 +190,7 @@ import (
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
+	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
@@ -201,7 +202,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 211)
+	Applets = make(map[string]Applet, 212)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -404,6 +405,7 @@ func init() {
 	register(ap_util_linux_hexdump.NewHexdump())
 	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
+	register(ap_util_linux_lsblk.New())
 	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())

--- a/internal/applets/util-linux/lsblk/lsblk.go
+++ b/internal/applets/util-linux/lsblk/lsblk.go
@@ -1,0 +1,196 @@
+// Package lsblk implements the lsblk applet: list block devices and their
+// partitions, read from /sys/block, with mount points from /proc/mounts.
+package lsblk
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the lsblk applet.
+type Command struct{}
+
+// New returns an lsblk command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "lsblk" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List information about block devices" }
+
+// These are injectable so the listing can be tested against fixtures.
+var (
+	sysBlock   = "/sys/block"
+	procMounts = "/proc/mounts"
+)
+
+type device struct {
+	name   string
+	majMin string
+	rm     string
+	size   int64
+	ro     string
+	typ    string
+	mount  string
+}
+
+// Run executes lsblk.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-a]", stdio.Err).WithHelp(command.Help{
+		Description: "List the block devices under /sys/block and their partitions as a tree, with " +
+			"each device's MAJ:MIN, removable flag, size, read-only flag, type, and mount point. " +
+			"Empty devices (size 0) are hidden unless -a is given.",
+		Examples: []command.Example{
+			{Command: "lsblk", Explain: "List the block devices."},
+			{Command: "lsblk -a", Explain: "Include empty devices."},
+		},
+	})
+	all := fs.BoolP("all", "a", false, "also list empty devices")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	mounts := readMounts(procMounts)
+	names, err := os.ReadDir(sysBlock)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "lsblk: %s\n", command.FileError(sysBlock, err))
+		return command.SilentFailure()
+	}
+
+	var disks []string
+	for _, n := range names {
+		disks = append(disks, n.Name())
+	}
+	sort.Strings(disks)
+
+	_, _ = fmt.Fprintf(stdio.Out, "%-12s %-7s %2s %6s %2s %-4s %s\n", "NAME", "MAJ:MIN", "RM", "SIZE", "RO", "TYPE", "MOUNTPOINTS")
+	for _, name := range disks {
+		d := readDevice(name, "disk", mounts)
+		// Hide empty devices and RAM disks by default, as lsblk does.
+		if (d.size == 0 || strings.HasPrefix(name, "ram")) && !*all {
+			continue
+		}
+		printDevice(stdio.Out, d, "")
+
+		parts := partitions(name)
+		for i, p := range parts {
+			pd := readDevice(filepath.Join(name, p), "part", mounts)
+			pd.name = p
+			prefix := "├─"
+			if i == len(parts)-1 {
+				prefix = "└─"
+			}
+			printDevice(stdio.Out, pd, prefix)
+		}
+	}
+	return nil
+}
+
+// readDevice reads one device's attributes from /sys/block/<rel>.
+func readDevice(rel, typ string, mounts map[string]string) device {
+	dir := filepath.Join(sysBlock, rel)
+	name := filepath.Base(rel)
+	d := device{
+		name:   name,
+		majMin: readField(filepath.Join(dir, "dev")),
+		rm:     readField(filepath.Join(dir, "removable")),
+		size:   readInt(filepath.Join(dir, "size")) * 512,
+		ro:     readField(filepath.Join(dir, "ro")),
+		typ:    typ,
+		mount:  mounts["/dev/"+name],
+	}
+	if d.rm == "" {
+		d.rm = "0"
+	}
+	if d.ro == "" {
+		d.ro = "0"
+	}
+	return d
+}
+
+// partitions returns the partition sub-device names of a disk, sorted.
+func partitions(disk string) []string {
+	entries, err := os.ReadDir(filepath.Join(sysBlock, disk))
+	if err != nil {
+		return nil
+	}
+	var parts []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(sysBlock, disk, e.Name(), "partition")); err == nil {
+			parts = append(parts, e.Name())
+		}
+	}
+	sort.Strings(parts)
+	return parts
+}
+
+func printDevice(out io.Writer, d device, prefix string) {
+	_, _ = fmt.Fprintf(out, "%-12s %-7s %2s %6s %2s %-4s %s\n",
+		prefix+d.name, d.majMin, d.rm, humanSize(d.size), d.ro, d.typ, d.mount)
+}
+
+// readMounts maps a device path to its mount point from /proc/mounts.
+func readMounts(path string) map[string]string {
+	m := map[string]string{}
+	f, err := os.Open(path) //nolint:gosec // the mounts path
+	if err != nil {
+		return m
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) >= 2 {
+			if _, ok := m[fields[0]]; !ok {
+				m[fields[0]] = fields[1]
+			}
+		}
+	}
+	return m
+}
+
+func readField(path string) string {
+	data, err := os.ReadFile(path) //nolint:gosec // a /sys attribute path
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func readInt(path string) int64 {
+	n, _ := strconv.ParseInt(readField(path), 10, 64)
+	return n
+}
+
+// humanSize renders a byte count the way lsblk does: 1024-based with a single
+// decimal that is dropped when it is whole (2G, 256G, 364.8M).
+func humanSize(bytes int64) string {
+	if bytes == 0 {
+		return "0B"
+	}
+	const units = "BKMGTP"
+	val := float64(bytes)
+	i := 0
+	for val >= 1024 && i < len(units)-1 {
+		val /= 1024
+		i++
+	}
+	// Format to one decimal, then drop a trailing ".0" as lsblk does (2G, not 2.0G).
+	s := strings.TrimSuffix(fmt.Sprintf("%.1f", val), ".0")
+	return s + string(units[i])
+}

--- a/internal/applets/util-linux/lsblk/lsblk_test.go
+++ b/internal/applets/util-linux/lsblk/lsblk_test.go
@@ -1,0 +1,115 @@
+package lsblk
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func writeAttr(t *testing.T, dir, name, val string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(val+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fixture(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	block := filepath.Join(root, "block")
+
+	// sda: 1 GiB disk with one 512 MiB partition.
+	sda := filepath.Join(block, "sda")
+	writeAttr(t, sda, "size", "2097152") // *512 = 1 GiB
+	writeAttr(t, sda, "ro", "0")
+	writeAttr(t, sda, "removable", "0")
+	writeAttr(t, sda, "dev", "8:0")
+	sda1 := filepath.Join(sda, "sda1")
+	writeAttr(t, sda1, "partition", "1")
+	writeAttr(t, sda1, "size", "1048576") // *512 = 512 MiB
+	writeAttr(t, sda1, "ro", "0")
+	writeAttr(t, sda1, "dev", "8:1")
+
+	// ram0 and an empty loop, both hidden by default.
+	ram := filepath.Join(block, "ram0")
+	writeAttr(t, ram, "size", "8192")
+	writeAttr(t, ram, "dev", "1:0")
+	loop := filepath.Join(block, "loop0")
+	writeAttr(t, loop, "size", "0")
+	writeAttr(t, loop, "dev", "7:0")
+
+	mounts := filepath.Join(root, "mounts")
+	if err := os.WriteFile(mounts, []byte("/dev/sda1 /mnt ext4 rw 0 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origB, origM := sysBlock, procMounts
+	sysBlock, procMounts = block, mounts
+	t.Cleanup(func() { sysBlock, procMounts = origB, origM })
+}
+
+func run(t *testing.T, args ...string) string {
+	t.Helper()
+	fixture(t)
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestDiskAndPartition(t *testing.T) {
+	out := run(t)
+	if !strings.Contains(out, "sda") || !strings.Contains(out, "1G") || !strings.Contains(out, "disk") {
+		t.Errorf("disk row = %q", out)
+	}
+	if !strings.Contains(out, "sda1") || !strings.Contains(out, "512M") || !strings.Contains(out, "part") {
+		t.Errorf("partition row = %q", out)
+	}
+	if !strings.Contains(out, "/mnt") {
+		t.Errorf("mountpoint missing: %q", out)
+	}
+	// The partition is drawn as a tree child.
+	if !strings.Contains(out, "─sda1") {
+		t.Errorf("tree prefix missing: %q", out)
+	}
+}
+
+func TestHidesRamAndEmptyByDefault(t *testing.T) {
+	out := run(t)
+	if strings.Contains(out, "ram0") || strings.Contains(out, "loop0") {
+		t.Errorf("ram/empty devices should be hidden: %q", out)
+	}
+}
+
+func TestAllShowsEverything(t *testing.T) {
+	out := run(t, "-a")
+	if !strings.Contains(out, "ram0") || !strings.Contains(out, "loop0") {
+		t.Errorf("-a should show all devices: %q", out)
+	}
+}
+
+func TestHumanSize(t *testing.T) {
+	t.Parallel()
+	cases := map[int64]string{
+		0:                  "0B",
+		512:                "512B",
+		1024:               "1K",
+		1073741824:         "1G",
+		382867200: "365.1M",
+	}
+	for in, want := range cases {
+		if got := humanSize(in); got != want {
+			t.Errorf("humanSize(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/test/it/spec/lsblk_spec.sh
+++ b/test/it/spec/lsblk_spec.sh
@@ -1,0 +1,16 @@
+Describe 'lsblk'
+    Include util-linux/lsblk_test.sh
+
+    It 'prints the column header'
+        When call TestLsblkHeader
+        The status should be success
+        The output should include 'NAME'
+        The output should include 'SIZE'
+        The output should include 'TYPE'
+    End
+    It 'runs and exits successfully'
+        When call TestLsblkRuns
+        The output should equal '0'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/lsblk_test.sh
+++ b/test/it/util-linux/lsblk_test.sh
@@ -1,0 +1,2 @@
+TestLsblkHeader() { lsblk | sed -n '1p'; }
+TestLsblkRuns() { lsblk >/dev/null 2>&1; echo $?; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `lsblk`, which lists block devices and their partitions as a tree, read from /sys/block with mount points from /proc/mounts. Each row shows NAME, MAJ:MIN, RM (removable), SIZE (1024-based, e.g. 364.8M/2G/256G), RO, TYPE (disk/part), and the mount point. Empty devices and RAM disks are hidden unless `-a` is given. Sizes match host `lsblk` byte-for-byte; the /sys and /proc paths are injectable so the listing is tested against fixtures.

Per-process accounting like the `[SWAP]` marker and multiple mount points per device are out of scope for this slice.

## Tests

- Unit (fixture /sys/block + /proc/mounts): a disk with a partition (size, type, tree prefix, and mount point), RAM/empty devices hidden by default and shown with -a, and the `humanSize` formatter.
- shellspec: the column header and that lsblk runs and exits 0.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (542 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248