### PR TITLE
feat(util-linux): add lspci applet to list PCI devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 212 commands. Run `mimixbox --list` to see them on the terminal.
+There are 213 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -114,6 +114,7 @@ There are 212 commands. Run `mimixbox --list` to see them on the terminal.
 | logname | Print the name of the current user |
 | ls | List directory contents |
 | lsblk | List information about block devices |
+| lspci | List PCI devices |
 | lzcat | Decompress lzma data to standard output |
 | lzma | Compress or decompress files (lzma) |
 | man | Display a manual page |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -191,6 +191,7 @@ import (
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
 	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
+	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
@@ -202,7 +203,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 212)
+	Applets = make(map[string]Applet, 213)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -406,6 +407,7 @@ func init() {
 	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
 	register(ap_util_linux_lsblk.New())
+	register(ap_util_linux_lspci.New())
 	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())

--- a/internal/applets/util-linux/lspci/lspci.go
+++ b/internal/applets/util-linux/lspci/lspci.go
@@ -1,0 +1,100 @@
+// Package lspci implements the lspci applet: list PCI devices read from
+// /sys/bus/pci/devices, in the numeric class/vendor:device form.
+package lspci
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the lspci applet.
+type Command struct{}
+
+// New returns an lspci command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "lspci" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List PCI devices" }
+
+// pciDevices is the sysfs PCI directory; tests point it at a fixture.
+var pciDevices = "/sys/bus/pci/devices"
+
+// Run executes lspci.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-n]", stdio.Err).WithHelp(command.Help{
+		Description: "List the PCI devices under /sys/bus/pci/devices as 'SLOT CLASS: VENDOR:DEVICE', " +
+			"with a revision when non-zero. Vendor/device names from a pci.ids database are not " +
+			"resolved, so the output is always numeric.",
+		Examples: []command.Example{
+			{Command: "lspci", Explain: "List the PCI devices."},
+		},
+	})
+	_ = fs.BoolP("numeric", "n", false, "show numeric IDs (always on in this implementation)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	entries, err := os.ReadDir(pciDevices)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "lspci: %s\n", command.FileError(pciDevices, err))
+		return command.SilentFailure()
+	}
+
+	var slots []string
+	for _, e := range entries {
+		slots = append(slots, e.Name())
+	}
+	sort.Strings(slots)
+
+	for _, slot := range slots {
+		c.printDevice(stdio.Out, slot)
+	}
+	return nil
+}
+
+func (c *Command) printDevice(out io.Writer, slot string) {
+	dir := filepath.Join(pciDevices, slot)
+	class := hexField(dir, "class")
+	vendor := hexField(dir, "vendor")
+	device := hexField(dir, "device")
+	rev := hexField(dir, "revision")
+
+	// The class field is 6 hex digits (class, subclass, prog-if); lspci shows
+	// the first four (class + subclass).
+	if len(class) > 4 {
+		class = class[:4]
+	}
+
+	line := fmt.Sprintf("%s %s: %s:%s", displaySlot(slot), class, vendor, device)
+	if rev != "" && rev != "00" {
+		line += fmt.Sprintf(" (rev %s)", rev)
+	}
+	_, _ = fmt.Fprintln(out, line)
+}
+
+// displaySlot drops the default "0000:" PCI domain, as lspci does.
+func displaySlot(slot string) string {
+	return strings.TrimPrefix(slot, "0000:")
+}
+
+// hexField reads a "0x..." sysfs attribute and returns its digits without the
+// prefix.
+func hexField(dir, name string) string {
+	data, err := os.ReadFile(filepath.Join(dir, name)) //nolint:gosec // a /sys attribute path
+	if err != nil {
+		return ""
+	}
+	return strings.TrimPrefix(strings.TrimSpace(string(data)), "0x")
+}

--- a/internal/applets/util-linux/lspci/lspci_test.go
+++ b/internal/applets/util-linux/lspci/lspci_test.go
@@ -1,0 +1,88 @@
+package lspci
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func dev(t *testing.T, root, slot string, attrs map[string]string) {
+	t.Helper()
+	dir := filepath.Join(root, slot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for k, v := range attrs {
+		if err := os.WriteFile(filepath.Join(dir, k), []byte(v+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func runFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	dev(t, root, "0000:00:1f.2", map[string]string{
+		"class": "0x010601", "vendor": "0x8086", "device": "0x1234", "revision": "0x00",
+	})
+	dev(t, root, "0001:02:00.0", map[string]string{
+		"class": "0x030000", "vendor": "0x10de", "device": "0x1c82", "revision": "0x05",
+	})
+	orig := pciDevices
+	pciDevices = root
+	t.Cleanup(func() { pciDevices = orig })
+
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestNumericListing(t *testing.T) {
+	out := runFixture(t)
+	// Domain 0000 is dropped; class trimmed to 4 digits; no rev when 00.
+	if !strings.Contains(out, "00:1f.2 0106: 8086:1234\n") {
+		t.Errorf("first device line missing: %q", out)
+	}
+	// Non-default domain kept; revision shown.
+	if !strings.Contains(out, "0001:02:00.0 0300: 10de:1c82 (rev 05)\n") {
+		t.Errorf("second device line missing: %q", out)
+	}
+}
+
+func TestSorted(t *testing.T) {
+	out := runFixture(t)
+	a := strings.Index(out, "00:1f.2")
+	b := strings.Index(out, "0001:02:00.0")
+	if a < 0 || b < 0 || a > b {
+		t.Errorf("devices not sorted by slot: %q", out)
+	}
+}
+
+func TestMissingDir(t *testing.T) {
+	t.Parallel()
+	orig := pciDevices
+	pciDevices = "/no/such/pci/dir"
+	defer func() { pciDevices = orig }()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("missing sysfs dir should fail")
+	}
+}
+
+func TestDisplaySlot(t *testing.T) {
+	t.Parallel()
+	if got := displaySlot("0000:00:00.0"); got != "00:00.0" {
+		t.Errorf("displaySlot = %q", got)
+	}
+	if got := displaySlot("0001:00:00.0"); got != "0001:00:00.0" {
+		t.Errorf("non-zero domain should be kept: %q", got)
+	}
+}

--- a/test/it/spec/lspci_spec.sh
+++ b/test/it/spec/lspci_spec.sh
@@ -1,0 +1,9 @@
+Describe 'lspci'
+    Include util-linux/lspci_test.sh
+
+    It 'lists PCI devices and exits successfully'
+        When call TestLspciRuns
+        The output should equal '0'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/lspci_test.sh
+++ b/test/it/util-linux/lspci_test.sh
@@ -1,0 +1,1 @@
+TestLspciRuns() { lspci >/dev/null 2>&1; echo $?; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `lspci`, which lists the PCI devices under /sys/bus/pci/devices as `SLOT CLASS: VENDOR:DEVICE`, with a revision when non-zero, sorted by slot. The default `0000:` PCI domain is dropped and the class is trimmed to its class+subclass nibbles, matching host `lspci -n` byte-for-byte. Vendor/device name resolution from a pci.ids database is out of scope, so the output is always numeric. The sysfs path is injectable so the listing is tested against fixtures.

## Tests

- Unit (fixture /sys/bus/pci/devices): the numeric listing (domain dropped, class trimmed, revision shown only when non-zero), slot sorting, the missing-directory error, and the `displaySlot` helper.
- shellspec: lspci runs and exits 0.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (543 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248