### PR TITLE
feat(util-linux): add lsusb applet to list USB devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 213 commands. Run `mimixbox --list` to see them on the terminal.
+There are 214 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -115,6 +115,7 @@ There are 213 commands. Run `mimixbox --list` to see them on the terminal.
 | ls | List directory contents |
 | lsblk | List information about block devices |
 | lspci | List PCI devices |
+| lsusb | List USB devices |
 | lzcat | Decompress lzma data to standard output |
 | lzma | Compress or decompress files (lzma) |
 | man | Display a manual page |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -192,6 +192,7 @@ import (
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
 	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
+	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
@@ -203,7 +204,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 213)
+	Applets = make(map[string]Applet, 214)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -408,6 +409,7 @@ func init() {
 	register(ap_util_linux_last.New())
 	register(ap_util_linux_lsblk.New())
 	register(ap_util_linux_lspci.New())
+	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())

--- a/internal/applets/util-linux/lsusb/lsusb.go
+++ b/internal/applets/util-linux/lsusb/lsusb.go
@@ -1,0 +1,109 @@
+// Package lsusb implements the lsusb applet: list USB devices read from
+// /sys/bus/usb/devices.
+package lsusb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the lsusb applet.
+type Command struct{}
+
+// New returns an lsusb command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "lsusb" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List USB devices" }
+
+// usbDevices is the sysfs USB directory; tests point it at a fixture.
+var usbDevices = "/sys/bus/usb/devices"
+
+type usbDevice struct {
+	bus    int
+	dev    int
+	vendor string
+	prod   string
+	name   string
+}
+
+// Run executes lsusb.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "List the USB devices under /sys/bus/usb/devices as 'Bus BBB Device DDD: ID " +
+			"vendor:product NAME', sorted by bus and device number. The name is taken from the " +
+			"device's own manufacturer/product strings (no usb.ids database lookup).",
+		Examples: []command.Example{
+			{Command: "lsusb", Explain: "List the USB devices."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	entries, err := os.ReadDir(usbDevices)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "lsusb: %s\n", command.FileError(usbDevices, err))
+		return command.SilentFailure()
+	}
+
+	var devices []usbDevice
+	for _, e := range entries {
+		dir := filepath.Join(usbDevices, e.Name())
+		vendor := field(dir, "idVendor")
+		if vendor == "" {
+			continue // interfaces and other non-device nodes have no idVendor
+		}
+		devices = append(devices, usbDevice{
+			bus:    atoi(field(dir, "busnum")),
+			dev:    atoi(field(dir, "devnum")),
+			vendor: vendor,
+			prod:   field(dir, "idProduct"),
+			name:   strings.TrimSpace(field(dir, "manufacturer") + " " + field(dir, "product")),
+		})
+	}
+	sort.Slice(devices, func(i, j int) bool {
+		if devices[i].bus != devices[j].bus {
+			return devices[i].bus < devices[j].bus
+		}
+		return devices[i].dev < devices[j].dev
+	})
+
+	for _, d := range devices {
+		printDevice(stdio.Out, d)
+	}
+	return nil
+}
+
+func printDevice(out io.Writer, d usbDevice) {
+	line := fmt.Sprintf("Bus %03d Device %03d: ID %s:%s", d.bus, d.dev, d.vendor, d.prod)
+	if d.name != "" {
+		line += " " + d.name
+	}
+	_, _ = fmt.Fprintln(out, line)
+}
+
+func field(dir, name string) string {
+	data, err := os.ReadFile(filepath.Join(dir, name)) //nolint:gosec // a /sys attribute path
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/internal/applets/util-linux/lsusb/lsusb_test.go
+++ b/internal/applets/util-linux/lsusb/lsusb_test.go
@@ -1,0 +1,83 @@
+package lsusb
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func dev(t *testing.T, root, name string, attrs map[string]string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for k, v := range attrs {
+		if err := os.WriteFile(filepath.Join(dir, k), []byte(v+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func runFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	dev(t, root, "usb1", map[string]string{
+		"idVendor": "1d6b", "idProduct": "0002", "busnum": "1", "devnum": "1",
+		"manufacturer": "Linux Foundation", "product": "2.0 root hub",
+	})
+	dev(t, root, "1-1", map[string]string{
+		"idVendor": "046d", "idProduct": "c52b", "busnum": "1", "devnum": "5",
+		"manufacturer": "Logitech", "product": "USB Receiver",
+	})
+	// An interface node without idVendor must be skipped.
+	dev(t, root, "1-1:1.0", map[string]string{"bInterfaceClass": "03"})
+
+	orig := usbDevices
+	usbDevices = root
+	t.Cleanup(func() { usbDevices = orig })
+
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestListing(t *testing.T) {
+	out := runFixture(t)
+	if !strings.Contains(out, "Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub\n") {
+		t.Errorf("root hub line missing: %q", out)
+	}
+	if !strings.Contains(out, "Bus 001 Device 005: ID 046d:c52b Logitech USB Receiver\n") {
+		t.Errorf("device line missing: %q", out)
+	}
+	// Exactly two device lines (the interface node is skipped).
+	if n := strings.Count(out, "\n"); n != 2 {
+		t.Errorf("expected 2 lines, got %d: %q", n, out)
+	}
+}
+
+func TestSortedByBusThenDevice(t *testing.T) {
+	out := runFixture(t)
+	if strings.Index(out, "Device 001") > strings.Index(out, "Device 005") {
+		t.Errorf("devices not sorted: %q", out)
+	}
+}
+
+func TestMissingDir(t *testing.T) {
+	t.Parallel()
+	orig := usbDevices
+	usbDevices = "/no/such/usb/dir"
+	defer func() { usbDevices = orig }()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("missing sysfs dir should fail")
+	}
+}

--- a/test/it/spec/lsusb_spec.sh
+++ b/test/it/spec/lsusb_spec.sh
@@ -1,0 +1,10 @@
+Describe 'lsusb'
+    Include util-linux/lsusb_test.sh
+
+    It 'describes itself with --help'
+        When call TestLsusbHelp
+        The status should be success
+        The output should include 'Usage: lsusb'
+        The output should include 'USB'
+    End
+End

--- a/test/it/util-linux/lsusb_test.sh
+++ b/test/it/util-linux/lsusb_test.sh
@@ -1,0 +1,3 @@
+# /sys/bus/usb/devices may be absent on CI runners, so the e2e exercises the
+# sysfs-independent --help path; the listing itself is covered by unit tests.
+TestLsusbHelp() { lsusb --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `lsusb`, which lists the USB devices under /sys/bus/usb/devices as `Bus BBB Device DDD: ID vendor:product NAME`, sorted by bus and device number. Interface nodes (without an idVendor) are skipped, and the name is taken from the device's own manufacturer/product strings (no usb.ids lookup). The sysfs path is injectable so the listing is tested against fixtures.

## Tests

- Unit (fixture /sys/bus/usb/devices): the formatted root-hub and device lines, skipping an interface node, the exact line count, and sort-by-bus-then-device; plus the missing-directory error.
- shellspec: the sysfs-independent `--help` path (the USB subsystem may be absent on CI runners, so the listing is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (544 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248