### PR TITLE
feat(util-linux): add wall applet to broadcast to terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 214 commands. Run `mimixbox --list` to see them on the terminal.
+There are 215 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -222,6 +222,7 @@ There are 214 commands. Run `mimixbox --list` to see them on the terminal.
 | valid-shell | Verify if /etc/shells is valid |
 | vi | A minimal vi-style screen text editor |
 | w | Show who is logged on and a system summary |
+| wall | Write a message to all logged-in users |
 | watch | Execute a program periodically, showing output fullscreen |
 | wc | Print newline, word, and byte counts for each file |
 | wget | The non-interactive network downloader |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -199,12 +199,13 @@ import (
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
+	ap_util_linux_wall "github.com/nao1215/mimixbox/internal/applets/util-linux/wall"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 214)
+	Applets = make(map[string]Applet, 215)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -419,4 +420,5 @@ func init() {
 	register(ap_util_linux_setarch.NewSetarch())
 	register(ap_util_linux_setsid.New())
 	register(ap_util_linux_taskset.New())
+	register(ap_util_linux_wall.New())
 }

--- a/internal/applets/util-linux/wall/wall.go
+++ b/internal/applets/util-linux/wall/wall.go
@@ -1,0 +1,131 @@
+// Package wall implements the wall applet: write a message to all logged-in
+// users' terminals.
+package wall
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the wall applet.
+type Command struct{}
+
+// New returns a wall command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "wall" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Write a message to all logged-in users" }
+
+// Injected so the broadcast can be tested without a terminal or real logins.
+var (
+	utmpPath = "/var/run/utmp"
+	now      = time.Now
+	sender   = defaultSender
+	writeTTY = func(line, text string) error {
+		f, err := os.OpenFile("/dev/"+line, os.O_WRONLY, 0) //nolint:gosec // a terminal device
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		_, err = io.WriteString(f, text)
+		return err
+	}
+)
+
+// Linux utmp layout: 384-byte records; USER_PROCESS is type 7.
+const (
+	recordSize  = 384
+	typeOffset  = 0
+	lineOffset  = 8
+	fieldLen    = 32
+	userProcess = 7
+)
+
+// Run executes wall.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[MESSAGE]", stdio.Err).WithHelp(command.Help{
+		Description: "Write MESSAGE (or standard input when no MESSAGE is given) to the terminals of " +
+			"all logged-in users, prefixed with a 'Broadcast message' banner. Terminals that cannot " +
+			"be written are skipped.",
+		Examples: []command.Example{
+			{Command: "wall 'system going down in 5 minutes'", Explain: "Broadcast a warning."},
+			{Command: "echo done | wall", Explain: "Broadcast a message from standard input."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	var message string
+	if rest := fs.Args(); len(rest) > 0 {
+		message = strings.Join(rest, " ")
+	} else {
+		data, _ := io.ReadAll(stdio.In)
+		message = strings.TrimRight(string(data), "\n")
+	}
+
+	banner := c.banner(message)
+	for _, line := range loggedInLines(utmpPath) {
+		_ = writeTTY(line, banner) // unwritable terminals are silently skipped
+	}
+	return nil
+}
+
+// banner builds the broadcast text.
+func (c *Command) banner(message string) string {
+	who, host := sender()
+	stamp := now().Format("Mon Jan _2 15:04:05 2006")
+	return fmt.Sprintf("\r\nBroadcast message from %s@%s (%s):\r\n\r\n%s\r\n", who, host, stamp, message)
+}
+
+// loggedInLines returns the terminal lines of every USER_PROCESS in utmp.
+func loggedInLines(path string) []string {
+	data, err := os.ReadFile(path) //nolint:gosec // the utmp path
+	if err != nil {
+		return nil
+	}
+	var lines []string
+	for off := 0; off+recordSize <= len(data); off += recordSize {
+		rec := data[off : off+recordSize]
+		if int16(binary.LittleEndian.Uint16(rec[typeOffset:])) != userProcess {
+			continue
+		}
+		if line := cstr(rec[lineOffset : lineOffset+fieldLen]); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func defaultSender() (string, string) {
+	who := "root"
+	if u, err := user.Current(); err == nil {
+		who = u.Username
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		host = "localhost"
+	}
+	return who, host
+}
+
+func cstr(b []byte) string {
+	for i, x := range b {
+		if x == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}

--- a/internal/applets/util-linux/wall/wall_test.go
+++ b/internal/applets/util-linux/wall/wall_test.go
@@ -1,0 +1,90 @@
+package wall
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func record(line string) []byte {
+	b := make([]byte, recordSize)
+	binary.LittleEndian.PutUint16(b[typeOffset:], userProcess)
+	copy(b[lineOffset:lineOffset+fieldLen], line)
+	return b
+}
+
+// setup writes a fixture utmp with the given lines and stubs the injectable
+// hooks; it returns the captured writes.
+func setup(t *testing.T, lines ...string) *map[string]string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "utmp")
+	var data []byte
+	for _, l := range lines {
+		data = append(data, record(l)...)
+	}
+	if err := os.WriteFile(f, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	captured := map[string]string{}
+	origU, origN, origS, origW := utmpPath, now, sender, writeTTY
+	utmpPath = f
+	now = func() time.Time { return time.Date(2026, 6, 9, 21, 0, 0, 0, time.UTC) }
+	sender = func() (string, string) { return "alice", "host1" }
+	writeTTY = func(line, text string) error { captured[line] = text; return nil }
+	t.Cleanup(func() { utmpPath, now, sender, writeTTY = origU, origN, origS, origW })
+	return &captured
+}
+
+func runWall(t *testing.T, in string, args ...string) {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(in), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+}
+
+func TestBroadcastToAllTerminals(t *testing.T) {
+	captured := setup(t, "pts/0", "pts/1")
+	runWall(t, "", "system going down")
+
+	if len(*captured) != 2 {
+		t.Fatalf("expected 2 terminals written, got %d", len(*captured))
+	}
+	for _, line := range []string{"pts/0", "pts/1"} {
+		text := (*captured)[line]
+		if !strings.Contains(text, "Broadcast message from alice@host1") {
+			t.Errorf("%s banner = %q", line, text)
+		}
+		if !strings.Contains(text, "system going down") {
+			t.Errorf("%s missing message: %q", line, text)
+		}
+		if !strings.Contains(text, "2026") {
+			t.Errorf("%s missing timestamp: %q", line, text)
+		}
+	}
+}
+
+func TestMessageFromStdin(t *testing.T) {
+	captured := setup(t, "tty1")
+	runWall(t, "from stdin\n")
+	if !strings.Contains((*captured)["tty1"], "from stdin") {
+		t.Errorf("stdin message not broadcast: %q", (*captured)["tty1"])
+	}
+}
+
+func TestNoTerminals(t *testing.T) {
+	captured := setup(t) // no logins
+	runWall(t, "", "hi")
+	if len(*captured) != 0 {
+		t.Errorf("expected no writes, got %v", *captured)
+	}
+}

--- a/test/it/spec/wall_spec.sh
+++ b/test/it/spec/wall_spec.sh
@@ -1,0 +1,9 @@
+Describe 'wall'
+    Include util-linux/wall_test.sh
+
+    It 'runs and exits successfully'
+        When call TestWallRuns
+        The output should equal 'rc=0'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/wall_test.sh
+++ b/test/it/util-linux/wall_test.sh
@@ -1,0 +1,6 @@
+# With no terminals recorded for the harness, wall writes nothing and exits 0.
+# The banner formatting and targeting are covered by the Go unit tests.
+TestWallRuns() {
+    echo "broadcast" | wall
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `wall`, which writes a message to the terminals of all logged-in users. The message comes from the operands or standard input, and is wrapped in a 'Broadcast message from user@host (time)' banner. Active terminals are taken from the utmp database; terminals that cannot be written are silently skipped. The utmp path, clock, sender, and per-terminal write are injectable so the broadcast is tested without a real terminal or logins.

## Tests

- Unit (fixture utmp + captured writes): the banner is broadcast to every logged-in terminal with the sender, message, and timestamp; a message read from stdin; and no writes when no one is logged in.
- shellspec: wall runs and exits 0 (the banner formatting and targeting are covered by unit tests, since the harness has no writable terminals).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (545 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248