### PR TITLE
feat(util-linux): add ionice applet for I/O scheduling priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 215 commands. Run `mimixbox --list` to see them on the terminal.
+There are 216 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -99,6 +99,7 @@ There are 215 commands. Run `mimixbox --list` to see them on the terminal.
 | hush | Command interpreter (MimixBox mbsh compatibility front-end) |
 | id | Print User ID and Group ID |
 | install | Copy files and set attributes |
+| ionice | Get or set process I/O scheduling class and priority |
 | ipcs | Show System V IPC facilities status |
 | ischroot | Detect if running in a chroot |
 | kill | Kill process or send signal to process |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -188,6 +188,7 @@ import (
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
+	ap_util_linux_ionice "github.com/nao1215/mimixbox/internal/applets/util-linux/ionice"
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
 	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
@@ -205,7 +206,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 215)
+	Applets = make(map[string]Applet, 216)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -406,6 +407,7 @@ func init() {
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
+	register(ap_util_linux_ionice.New())
 	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
 	register(ap_util_linux_lsblk.New())

--- a/internal/applets/util-linux/ionice/ionice.go
+++ b/internal/applets/util-linux/ionice/ionice.go
@@ -1,0 +1,141 @@
+// Package ionice implements the ionice applet: get or set the I/O scheduling
+// class and priority of a process, or run a command with a given I/O priority.
+package ionice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the ionice applet.
+type Command struct{}
+
+// New returns an ionice command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ionice" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Get or set process I/O scheduling class and priority" }
+
+// I/O priority encoding (see Documentation/block/ioprio).
+const (
+	ioprioWhoProcess = 1
+	ioprioClassShift = 13
+	classNone        = 0
+	classRealtime    = 1
+	classBestEffort  = 2
+	classIdle        = 3
+)
+
+// Indirected so the priority changes can be tested without real I/O scheduling.
+var (
+	ioprioGet = func(pid int) (int, error) {
+		r, _, errno := unix.Syscall(unix.SYS_IOPRIO_GET, ioprioWhoProcess, uintptr(pid), 0)
+		if errno != 0 {
+			return 0, errno
+		}
+		return int(r), nil
+	}
+	ioprioSet = func(pid, ioprio int) error {
+		if _, _, errno := unix.Syscall(unix.SYS_IOPRIO_SET, ioprioWhoProcess, uintptr(pid), uintptr(ioprio)); errno != 0 {
+			return errno
+		}
+		return nil
+	}
+)
+
+// Run executes ionice.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-c CLASS] [-n DATA] [-p PID | COMMAND]", stdio.Err).WithHelp(command.Help{
+		Description: "Get or set a process's I/O scheduling class (1 realtime, 2 best-effort, 3 idle) " +
+			"and priority data (0-7, lower is higher priority). With -p PID and no -c, print the " +
+			"current class; with -c, set the PID or run COMMAND with that class.",
+		Examples: []command.Example{
+			{Command: "ionice -p 1234", Explain: "Show process 1234's I/O class."},
+			{Command: "ionice -c 3 -- backup.sh", Explain: "Run backup.sh at idle I/O priority."},
+		},
+		ExitStatus: "0  success.\n1  an invalid class/PID, or the command could not be run.",
+	})
+	fs.SetInterspersed(false)
+	class := fs.IntP("class", "c", classBestEffort, "scheduling class (1 rt, 2 be, 3 idle)")
+	data := fs.IntP("classdata", "n", 4, "priority data within the class (0-7)")
+	pid := fs.IntP("pid", "p", 0, "act on an existing PID")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	// Print mode: -p without -c.
+	if fs.Changed("pid") && !fs.Changed("class") {
+		v, gerr := ioprioGet(*pid)
+		if gerr != nil {
+			return command.Failuref("failed to get priority for %d: %v", *pid, gerr)
+		}
+		_, _ = fmt.Fprintln(stdio.Out, describe(v))
+		return nil
+	}
+
+	ioprio := (*class << ioprioClassShift) | (*data & 0x7)
+	if *class == classIdle || *class == classNone {
+		ioprio = *class << ioprioClassShift
+	}
+
+	if fs.Changed("pid") {
+		if err := ioprioSet(*pid, ioprio); err != nil {
+			return command.Failuref("failed to set priority for %d: %v", *pid, err)
+		}
+		return nil
+	}
+
+	rest := fs.Args()
+	if len(rest) > 0 && rest[0] == "--" {
+		rest = rest[1:]
+	}
+	if len(rest) == 0 {
+		// No command and no PID: report this process's own class.
+		v, gerr := ioprioGet(0)
+		if gerr != nil {
+			return command.Failuref("failed to get priority: %v", gerr)
+		}
+		_, _ = fmt.Fprintln(stdio.Out, describe(v))
+		return nil
+	}
+
+	if err := ioprioSet(0, ioprio); err != nil {
+		return command.Failuref("failed to set priority: %v", err)
+	}
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running the user's command is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	return nil
+}
+
+// describe renders an ioprio value the way ionice prints it.
+func describe(ioprio int) string {
+	class := ioprio >> ioprioClassShift
+	data := ioprio & 0x7
+	switch class {
+	case classRealtime:
+		return fmt.Sprintf("realtime: prio %d", data)
+	case classBestEffort:
+		return fmt.Sprintf("best-effort: prio %d", data)
+	case classIdle:
+		return "idle"
+	default:
+		return fmt.Sprintf("none: prio %d", data)
+	}
+}

--- a/internal/applets/util-linux/ionice/ionice_test.go
+++ b/internal/applets/util-linux/ionice/ionice_test.go
@@ -1,0 +1,103 @@
+package ionice
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type setCall struct {
+	pid    int
+	ioprio int
+}
+
+func withStubs(t *testing.T, have int) *setCall {
+	t.Helper()
+	captured := &setCall{pid: -999}
+	origGet, origSet := ioprioGet, ioprioSet
+	ioprioGet = func(int) (int, error) { return have, nil }
+	ioprioSet = func(pid, ioprio int) error { captured.pid, captured.ioprio = pid, ioprio; return nil }
+	t.Cleanup(func() { ioprioGet, ioprioSet = origGet, origSet })
+	return captured
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func requireEcho(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skipf("echo not on PATH: %v", err)
+	}
+}
+
+func TestPrintMode(t *testing.T) {
+	withStubs(t, (classBestEffort<<ioprioClassShift)|4)
+	out, err := run(t, "-p", "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "best-effort: prio 4" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func TestSetPid(t *testing.T) {
+	captured := withStubs(t, 0)
+	if _, err := run(t, "-c", "3", "-p", "1234"); err != nil {
+		t.Fatal(err)
+	}
+	if captured.pid != 1234 || captured.ioprio != classIdle<<ioprioClassShift {
+		t.Errorf("set call = %+v", *captured)
+	}
+}
+
+func TestRunCommand(t *testing.T) {
+	requireEcho(t)
+	captured := withStubs(t, 0)
+	out, err := run(t, "-c", "2", "-n", "5", "echo", "ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured.pid != 0 || captured.ioprio != (classBestEffort<<ioprioClassShift)|5 {
+		t.Errorf("set call = %+v", *captured)
+	}
+	if !strings.Contains(out, "ok") {
+		t.Errorf("command output = %q", out)
+	}
+}
+
+func TestSelfReport(t *testing.T) {
+	withStubs(t, classIdle<<ioprioClassShift)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "idle" {
+		t.Errorf("self report = %q", out)
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	t.Parallel()
+	cases := map[int]string{
+		(classRealtime << ioprioClassShift) | 2: "realtime: prio 2",
+		classBestEffort << ioprioClassShift:     "best-effort: prio 0",
+		classIdle << ioprioClassShift:           "idle",
+		classNone << ioprioClassShift:           "none: prio 0",
+	}
+	for in, want := range cases {
+		if got := describe(in); got != want {
+			t.Errorf("describe(%#x) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/test/it/spec/ionice_spec.sh
+++ b/test/it/spec/ionice_spec.sh
@@ -1,0 +1,14 @@
+Describe 'ionice'
+    Include util-linux/ionice_test.sh
+
+    It 'prints a process I/O class'
+        When call TestIonicePrint
+        The output should equal '1'
+        The status should be success
+    End
+    It 'runs a command at a given I/O class'
+        When call TestIoniceRun
+        The output should equal 'idled'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/ionice_test.sh
+++ b/test/it/util-linux/ionice_test.sh
@@ -1,0 +1,2 @@
+TestIonicePrint() { ionice -p $$ | grep -cE 'prio|idle'; }
+TestIoniceRun() { ionice -c 3 -- echo idled; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `ionice`, which gets or sets a process's I/O scheduling class and priority, or runs a command at a given I/O priority. `ionice -p PID` (without -c) prints the class (e.g. `best-effort: prio 4`, `idle`); `-c CLASS [-n DATA]` sets the PID (with -p) or runs COMMAND. Classes are 1 realtime, 2 best-effort, 3 idle; DATA is 0-7. The ioprio_get/ioprio_set syscalls are injectable so the encoding/decoding is tested without changing real I/O scheduling. `ionice -p` output matches host util-linux.

## Tests

- Unit (stubbed ioprio syscalls): print mode, set a PID's class, run a command at a class+priority (verifying the exact encoded ioprio), the self-report path, and the `describe` decoder for every class.
- shellspec: print a process I/O class, and run a command at the idle class.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (547 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ionice` command for viewing and managing process I/O scheduling class and priority. Supports querying current I/O priorities, modifying process I/O scheduling, and running commands with specified I/O parameters.

* **Tests**
  * Added comprehensive unit and integration tests for the ionice command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->