### PR TITLE
fix(ionice): address CodeRabbit feedback

### DIFF
--- a/internal/applets/util-linux/ionice/ionice.go
+++ b/internal/applets/util-linux/ionice/ionice.go
@@ -73,6 +73,22 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		return err
 	}
 
+	// Reject out-of-range class/priority rather than silently coercing them.
+	if *class < classNone || *class > classIdle {
+		return command.Failuref("invalid class: %d (expected 1 realtime, 2 best-effort, 3 idle)", *class)
+	}
+	if *data < 0 || *data > 7 {
+		return command.Failuref("invalid priority data: %d (expected 0-7)", *data)
+	}
+
+	rest := fs.Args()
+	if len(rest) > 0 && rest[0] == "--" {
+		rest = rest[1:]
+	}
+	if fs.Changed("pid") && len(rest) > 0 {
+		return command.Failuref("cannot run a command together with -p")
+	}
+
 	// Print mode: -p without -c.
 	if fs.Changed("pid") && !fs.Changed("class") {
 		v, gerr := ioprioGet(*pid)
@@ -83,7 +99,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		return nil
 	}
 
-	ioprio := (*class << ioprioClassShift) | (*data & 0x7)
+	ioprio := (*class << ioprioClassShift) | *data
 	if *class == classIdle || *class == classNone {
 		ioprio = *class << ioprioClassShift
 	}
@@ -95,10 +111,6 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		return nil
 	}
 
-	rest := fs.Args()
-	if len(rest) > 0 && rest[0] == "--" {
-		rest = rest[1:]
-	}
 	if len(rest) == 0 {
 		// No command and no PID: report this process's own class.
 		v, gerr := ioprioGet(0)

--- a/internal/applets/util-linux/ionice/ionice_test.go
+++ b/internal/applets/util-linux/ionice/ionice_test.go
@@ -87,6 +87,19 @@ func TestSelfReport(t *testing.T) {
 	}
 }
 
+func TestValidation(t *testing.T) {
+	withStubs(t, 0)
+	if _, err := run(t, "-c", "2", "-n", "15", "echo"); err == nil {
+		t.Errorf("out-of-range -n should fail")
+	}
+	if _, err := run(t, "-c", "9", "echo"); err == nil {
+		t.Errorf("out-of-range -c should fail")
+	}
+	if _, err := run(t, "-c", "3", "-p", "1234", "--", "echo"); err == nil {
+		t.Errorf("-p with a command should fail")
+	}
+}
+
 func TestDescribe(t *testing.T) {
 	t.Parallel()
 	cases := map[int]string{


### PR DESCRIPTION
## Summary

Follow-up to #331 addressing two CodeRabbit Major findings:

- `ionice` now validates `-c`/`-n` bounds instead of silently coercing them: an out-of-range class (not 0-3) or priority data (not 0-7) is rejected with an error rather than masked (so `-n 15` no longer becomes 7).
- `ionice -p PID` combined with a trailing COMMAND is now rejected ('cannot run a command together with -p') instead of silently dropping the command.

## Verification

- `go test ./...` passes (added validation tests); `golangci-lint` clean. Verified that `-n 15`, `-c 9`, and `-c 3 -p PID -- echo` all fail with exit 1, while valid invocations still work.

Part of #248