### PR TITLE
feat(util-linux): add chrt applet for real-time scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 216 commands. Run `mimixbox --list` to see them on the terminal.
+There are 217 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -45,6 +45,7 @@ There are 216 commands. Run `mimixbox --list` to see them on the terminal.
 | chmod | Change file mode bits |
 | chown | Change the owner and/or group of each FILE to OWNER and/or GROUP |
 | chroot | Run command or interactive shell with special root directory |
+| chrt | Get or set a process's real-time scheduling attributes |
 | cksum | Print CRC checksum and byte count of each file |
 | clear | Clear terminal |
 | cmatrix | Show the falling-glyph digital rain effect |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -185,6 +185,7 @@ import (
 	ap_textutils_uucode "github.com/nao1215/mimixbox/internal/applets/textutils/uucode"
 	ap_textutils_wc "github.com/nao1215/mimixbox/internal/applets/textutils/wc"
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
+	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
@@ -206,7 +207,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 216)
+	Applets = make(map[string]Applet, 217)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -403,6 +404,7 @@ func init() {
 	register(ap_textutils_uucode.NewUuencode())
 	register(ap_textutils_wc.New())
 	register(ap_textutils_xxd.New())
+	register(ap_util_linux_chrt.New())
 	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())

--- a/internal/applets/util-linux/chrt/chrt.go
+++ b/internal/applets/util-linux/chrt/chrt.go
@@ -1,0 +1,197 @@
+// Package chrt implements the chrt applet: get or set a process's real-time
+// scheduling policy and priority, or run a command under one.
+package chrt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the chrt applet.
+type Command struct{}
+
+// New returns a chrt command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "chrt" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Get or set a process's real-time scheduling attributes" }
+
+// Linux scheduling policies (not all exported by x/sys/unix here).
+const (
+	schedOther = 0
+	schedFIFO  = 1
+	schedRR    = 2
+	schedBatch = 3
+	schedIdle  = 5
+)
+
+// Indirected so the scheduling changes can be tested without affecting the test
+// process.
+var (
+	getScheduler = func(pid int) (int, error) {
+		r, _, errno := unix.Syscall(unix.SYS_SCHED_GETSCHEDULER, uintptr(pid), 0, 0)
+		if errno != 0 {
+			return 0, errno
+		}
+		return int(r), nil
+	}
+	getParam = func(pid int) (int, error) {
+		var p int32
+		if _, _, errno := unix.Syscall(unix.SYS_SCHED_GETPARAM, uintptr(pid), uintptr(unsafe.Pointer(&p)), 0); errno != 0 {
+			return 0, errno
+		}
+		return int(p), nil
+	}
+	setScheduler = func(pid, policy, priority int) error {
+		p := int32(priority)
+		if _, _, errno := unix.Syscall(unix.SYS_SCHED_SETSCHEDULER, uintptr(pid), uintptr(policy), uintptr(unsafe.Pointer(&p))); errno != 0 {
+			return errno
+		}
+		return nil
+	}
+)
+
+// Run executes chrt.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-f|-r|-o|-b|-i] [-p] PRIORITY {COMMAND|PID}", stdio.Err).WithHelp(command.Help{
+		Description: "Print or change a process's scheduling policy and priority. With -p and a single " +
+			"PID, print them; with a policy flag, set the PID (with -p) or run COMMAND. Policies: " +
+			"-f FIFO, -r round-robin (default), -o other, -b batch, -i idle.",
+		Examples: []command.Example{
+			{Command: "chrt -p 1234", Explain: "Show process 1234's scheduling policy."},
+			{Command: "chrt -f 50 -- server", Explain: "Run server as SCHED_FIFO priority 50."},
+		},
+		ExitStatus: "0  success.\n1  an invalid argument, or the command could not be run.",
+	})
+	fs.SetInterspersed(false)
+	fifo := fs.BoolP("fifo", "f", false, "set SCHED_FIFO")
+	rr := fs.BoolP("rr", "r", false, "set SCHED_RR (the default)")
+	other := fs.BoolP("other", "o", false, "set SCHED_OTHER")
+	batch := fs.BoolP("batch", "b", false, "set SCHED_BATCH")
+	idle := fs.BoolP("idle", "i", false, "set SCHED_IDLE")
+	pidFlag := fs.BoolP("pid", "p", false, "operate on an existing PID")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	policy := schedRR
+	policySet := true
+	switch {
+	case *fifo:
+		policy = schedFIFO
+	case *rr:
+		policy = schedRR
+	case *other:
+		policy = schedOther
+	case *batch:
+		policy = schedBatch
+	case *idle:
+		policy = schedIdle
+	default:
+		policySet = false
+	}
+
+	operands := fs.Args()
+	if len(operands) > 0 && operands[0] == "--" {
+		operands = operands[1:]
+	}
+
+	if *pidFlag && !policySet {
+		// Print mode: chrt -p PID.
+		if len(operands) != 1 {
+			_, _ = fmt.Fprintln(stdio.Err, "chrt: -p without a policy needs exactly one PID")
+			return command.SilentFailure()
+		}
+		pid, perr := strconv.Atoi(operands[0])
+		if perr != nil {
+			return command.Failuref("invalid PID: %q", operands[0])
+		}
+		return c.printPolicy(stdio, pid)
+	}
+
+	// Set mode needs a priority and a target (PID with -p, else COMMAND).
+	if len(operands) < 2 {
+		_, _ = fmt.Fprintln(stdio.Err, "chrt: a priority and a target are required")
+		return command.SilentFailure()
+	}
+	priority, perr := strconv.Atoi(operands[0])
+	if perr != nil {
+		return command.Failuref("invalid priority: %q", operands[0])
+	}
+
+	if *pidFlag {
+		pid, perr := strconv.Atoi(operands[1])
+		if perr != nil {
+			return command.Failuref("invalid PID: %q", operands[1])
+		}
+		if err := setScheduler(pid, policy, priority); err != nil {
+			return command.Failuref("failed to set policy for %d: %v", pid, err)
+		}
+		return nil
+	}
+
+	rest := operands[1:]
+	if len(rest) > 0 && rest[0] == "--" {
+		rest = rest[1:]
+	}
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "chrt: a command is required")
+		return command.SilentFailure()
+	}
+	if err := setScheduler(0, policy, priority); err != nil {
+		return command.Failuref("failed to set policy: %v", err)
+	}
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running the user's command is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	return nil
+}
+
+func (c *Command) printPolicy(stdio command.IO, pid int) error {
+	policy, err := getScheduler(pid)
+	if err != nil {
+		return command.Failuref("failed to get policy for %d: %v", pid, err)
+	}
+	prio, err := getParam(pid)
+	if err != nil {
+		return command.Failuref("failed to get priority for %d: %v", pid, err)
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "pid %d's current scheduling policy: %s\n", pid, policyName(policy))
+	_, _ = fmt.Fprintf(stdio.Out, "pid %d's current scheduling priority: %d\n", pid, prio)
+	return nil
+}
+
+func policyName(p int) string {
+	switch p {
+	case schedOther:
+		return "SCHED_OTHER"
+	case schedFIFO:
+		return "SCHED_FIFO"
+	case schedRR:
+		return "SCHED_RR"
+	case schedBatch:
+		return "SCHED_BATCH"
+	case schedIdle:
+		return "SCHED_IDLE"
+	default:
+		return fmt.Sprintf("UNKNOWN (%d)", p)
+	}
+}

--- a/internal/applets/util-linux/chrt/chrt_test.go
+++ b/internal/applets/util-linux/chrt/chrt_test.go
@@ -1,0 +1,105 @@
+package chrt
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type setCall struct {
+	pid      int
+	policy   int
+	priority int
+}
+
+func withStubs(t *testing.T, policy, prio int) *setCall {
+	t.Helper()
+	captured := &setCall{pid: -999}
+	origGS, origGP, origSS := getScheduler, getParam, setScheduler
+	getScheduler = func(int) (int, error) { return policy, nil }
+	getParam = func(int) (int, error) { return prio, nil }
+	setScheduler = func(pid, p, pr int) error { *captured = setCall{pid, p, pr}; return nil }
+	t.Cleanup(func() { getScheduler, getParam, setScheduler = origGS, origGP, origSS })
+	return captured
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func requireEcho(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skipf("echo not on PATH: %v", err)
+	}
+}
+
+func TestPrintMode(t *testing.T) {
+	withStubs(t, schedFIFO, 50)
+	out, err := run(t, "-p", "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "policy: SCHED_FIFO") || !strings.Contains(out, "priority: 50") {
+		t.Errorf("print = %q", out)
+	}
+}
+
+func TestSetPid(t *testing.T) {
+	captured := withStubs(t, 0, 0)
+	if _, err := run(t, "-r", "-p", "20", "1234"); err != nil {
+		t.Fatal(err)
+	}
+	if *captured != (setCall{1234, schedRR, 20}) {
+		t.Errorf("set call = %+v", *captured)
+	}
+}
+
+func TestRunCommand(t *testing.T) {
+	requireEcho(t)
+	captured := withStubs(t, 0, 0)
+	out, err := run(t, "-f", "30", "--", "echo", "go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *captured != (setCall{0, schedFIFO, 30}) {
+		t.Errorf("set call = %+v", *captured)
+	}
+	if !strings.Contains(out, "go") {
+		t.Errorf("command output = %q", out)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	withStubs(t, 0, 0)
+	if _, err := run(t, "-o", "0"); err == nil {
+		t.Errorf("missing command should fail")
+	}
+	if _, err := run(t, "-p", "notapid"); err == nil {
+		t.Errorf("invalid PID should fail")
+	}
+	if _, err := run(t, "-f", "bad", "echo"); err == nil {
+		t.Errorf("invalid priority should fail")
+	}
+}
+
+func TestPolicyName(t *testing.T) {
+	t.Parallel()
+	cases := map[int]string{
+		schedOther: "SCHED_OTHER", schedFIFO: "SCHED_FIFO", schedRR: "SCHED_RR",
+		schedBatch: "SCHED_BATCH", schedIdle: "SCHED_IDLE",
+	}
+	for in, want := range cases {
+		if got := policyName(in); got != want {
+			t.Errorf("policyName(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/test/it/spec/chrt_spec.sh
+++ b/test/it/spec/chrt_spec.sh
@@ -1,0 +1,14 @@
+Describe 'chrt'
+    Include util-linux/chrt_test.sh
+
+    It 'prints a process scheduling policy'
+        When call TestChrtPrint
+        The output should equal '1'
+        The status should be success
+    End
+    It 'runs a command under a scheduling policy'
+        When call TestChrtRun
+        The output should equal 'scheduled'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/chrt_test.sh
+++ b/test/it/util-linux/chrt_test.sh
@@ -1,0 +1,2 @@
+TestChrtPrint() { chrt -p $$ | grep -c 'scheduling policy'; }
+TestChrtRun() { chrt -o 0 -- echo scheduled; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `chrt`, which prints or changes a process's scheduling policy and priority. `chrt -p PID` prints them (e.g. `SCHED_OTHER`, priority 0); a policy flag (-f FIFO, -r round-robin default, -o other, -b batch, -i idle) sets a PID (with -p) or runs COMMAND under that policy. The sched_getscheduler/getparam/setscheduler syscalls are injectable so the parsing and reporting are tested without changing the test process. `chrt -p` output matches host util-linux byte-for-byte.

## Tests

- Unit (stubbed sched syscalls): print mode, set a PID's policy/priority, run a command under a policy (verifying the exact policy/priority), the missing-command / invalid-PID / invalid-priority errors, and `policyName`.
- shellspec: print a process scheduling policy, and run a command under SCHED_OTHER.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (549 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248