### PR TITLE
feat(util-linux): add rdate applet for RFC 868 remote time

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 217 commands. Run `mimixbox --list` to see them on the terminal.
+There are 218 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -152,6 +152,7 @@ There are 217 commands. Run `mimixbox --list` to see them on the terminal.
 | pwd | Print Working Directory |
 | pwgen | Generate random passwords for authorized testing |
 | pwscore | Estimate the strength of a password |
+| rdate | Get the time from a remote host (RFC 868) |
 | readlink | Print resolved symbolic links or canonical file names |
 | realpath | Print the resolved absolute file name |
 | reboot | Reboot the system |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -196,6 +196,7 @@ import (
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
+	ap_util_linux_rdate "github.com/nao1215/mimixbox/internal/applets/util-linux/rdate"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
@@ -207,7 +208,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 217)
+	Applets = make(map[string]Applet, 218)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -416,6 +417,7 @@ func init() {
 	register(ap_util_linux_lspci.New())
 	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mesg.New())
+	register(ap_util_linux_rdate.New())
 	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())
 	register(ap_util_linux_script.NewScriptreplay())

--- a/internal/applets/util-linux/rdate/rdate.go
+++ b/internal/applets/util-linux/rdate/rdate.go
@@ -1,0 +1,109 @@
+// Package rdate implements the rdate applet: get (and optionally set) the time
+// from a remote host using the RFC 868 Time Protocol.
+package rdate
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the rdate applet.
+type Command struct{}
+
+// New returns an rdate command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "rdate" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Get the time from a remote host (RFC 868)" }
+
+// epochOffset is the seconds between the RFC 868 epoch (1900-01-01) and the Unix
+// epoch (1970-01-01).
+const epochOffset = 2208988800
+
+// Injected so the network and clock are controllable in tests.
+var (
+	port    = "37"
+	timeout = 10 * time.Second
+	setTime = func(t time.Time) error {
+		tv := unixTimeval(t)
+		return setSystemTime(&tv)
+	}
+)
+
+// Run executes rdate.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-p] [-s] HOST", stdio.Err).WithHelp(command.Help{
+		Description: "Connect to HOST's RFC 868 time service (TCP port 37) and read the current time. " +
+			"With -p (the default) print it; with -s also set the system clock (which requires " +
+			"privilege).",
+		Examples: []command.Example{
+			{Command: "rdate time.example.com", Explain: "Print the remote time."},
+			{Command: "rdate -s time.example.com", Explain: "Set the local clock from the remote time."},
+		},
+		ExitStatus: "0  success.\n1  the host could not be reached or the time could not be set.",
+	})
+	printIt := fs.BoolP("print", "p", false, "print the remote time (the default)")
+	setIt := fs.BoolP("set", "s", false, "set the system clock from the remote time")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	hosts := fs.Args()
+	if len(hosts) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "rdate: a host is required")
+		return command.SilentFailure()
+	}
+
+	remote, err := fetch(hosts[0])
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "rdate: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	if *setIt {
+		if err := setTime(remote); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "rdate: cannot set the system clock: %v\n", err)
+			return command.SilentFailure()
+		}
+	}
+	if *printIt || !*setIt {
+		_, _ = fmt.Fprintln(stdio.Out, remote.Format("Mon Jan _2 15:04:05 2006"))
+	}
+	return nil
+}
+
+// fetch reads the time from host's RFC 868 service.
+func fetch(host string) (time.Time, error) {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
+
+	var buf [4]byte
+	if _, err := io.ReadFull(conn, buf[:]); err != nil {
+		return time.Time{}, err
+	}
+	secs := binary.BigEndian.Uint32(buf[:])
+	return time.Unix(int64(secs)-epochOffset, 0), nil
+}
+
+// unixTimeval converts a time to a unix.Timeval for settimeofday(2).
+func unixTimeval(t time.Time) unix.Timeval {
+	return unix.Timeval{Sec: t.Unix(), Usec: int64(t.Nanosecond() / 1000)}
+}
+
+// setSystemTime sets the system clock (requires privilege).
+func setSystemTime(tv *unix.Timeval) error { return unix.Settimeofday(tv) }

--- a/internal/applets/util-linux/rdate/rdate_test.go
+++ b/internal/applets/util-linux/rdate/rdate_test.go
@@ -1,0 +1,95 @@
+package rdate
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// serveTime starts a one-shot RFC 868 server returning the given Unix time and
+// points the package port at it.
+func serveTime(t *testing.T, unixSecs int64) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, p, _ := net.SplitHostPort(ln.Addr().String())
+	orig := port
+	port = p
+	t.Cleanup(func() { port = orig; _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		var buf [4]byte
+		binary.BigEndian.PutUint32(buf[:], uint32(unixSecs+epochOffset))
+		_, _ = conn.Write(buf[:])
+	}()
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestPrintRemoteTime(t *testing.T) {
+	const secs = 1700000000
+	serveTime(t, secs)
+	out, err := run(t, "127.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Unix(secs, 0).Format("Mon Jan _2 15:04:05 2006") + "\n"
+	if out != want {
+		t.Errorf("rdate = %q, want %q", out, want)
+	}
+}
+
+func TestSetClock(t *testing.T) {
+	const secs = 1600000000
+	serveTime(t, secs)
+	var got time.Time
+	orig := setTime
+	setTime = func(tm time.Time) error { got = tm; return nil }
+	defer func() { setTime = orig }()
+
+	if _, err := run(t, "-s", "127.0.0.1"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Unix() != secs {
+		t.Errorf("set clock to %d, want %d", got.Unix(), secs)
+	}
+}
+
+func TestMissingHost(t *testing.T) {
+	t.Parallel()
+	if _, err := run(t); err == nil {
+		t.Errorf("missing host should fail")
+	}
+}
+
+func TestUnreachable(t *testing.T) {
+	t.Parallel()
+	orig := port
+	port = "1" // nothing listens here
+	defer func() { port = orig }()
+	origTO := timeout
+	timeout = 500 * time.Millisecond
+	defer func() { timeout = origTO }()
+	if _, err := run(t, "127.0.0.1"); err == nil {
+		t.Errorf("an unreachable host should fail")
+	}
+}

--- a/test/it/spec/rdate_spec.sh
+++ b/test/it/spec/rdate_spec.sh
@@ -1,0 +1,14 @@
+Describe 'rdate'
+    Include util-linux/rdate_test.sh
+
+    It 'fails when no host is given'
+        When call TestRdateNoHost
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'fails when the host has no time service'
+        When call TestRdateUnreachable
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/rdate_test.sh
+++ b/test/it/util-linux/rdate_test.sh
@@ -1,0 +1,11 @@
+# Fetching from a live RFC 868 server is non-deterministic, so the e2e exercises
+# the error paths; the fetch/print/set logic is covered by Go unit tests.
+TestRdateNoHost() {
+    rdate 2>/dev/null
+    echo "rc=$?"
+}
+
+TestRdateUnreachable() {
+    rdate 127.0.0.1 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `rdate`, which gets (and optionally sets) the time from a remote host using the RFC 868 Time Protocol (TCP port 37). It connects, reads the 4-byte seconds-since-1900 value, converts to local time, and prints it; `-s` also sets the system clock (which requires privilege). The port, timeout, and clock-set call are injectable so the network and clock logic are tested deterministically.

## Tests

- Unit (local one-shot RFC 868 server): fetch and print a known remote time, `-s` sets the clock to the fetched time (via an injected setter), the missing-host error, and a connection failure to a port with no service.
- shellspec: rdate fails when no host is given and when the host has no time service.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (551 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rdate` command to retrieve remote system time from RFC 868 time servers. Supports `--print` flag to display remote time (default) and `--set` flag to synchronize the local system clock (requires elevated privileges).

* **Tests**
  * Added comprehensive unit and integration test coverage for the new `rdate` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->