### PR TITLE
fix(rdate): address CodeRabbit feedback

### DIFF
--- a/internal/applets/util-linux/rdate/rdate.go
+++ b/internal/applets/util-linux/rdate/rdate.go
@@ -77,9 +77,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			return command.SilentFailure()
 		}
 	}
-	if *printIt || !*setIt {
-		_, _ = fmt.Fprintln(stdio.Out, remote.Format("Mon Jan _2 15:04:05 2006"))
-	}
+	// rdate prints the remote time by default; -p makes that explicit and -s
+	// additionally sets the clock, so the time is always printed here.
+	_ = printIt
+	_, _ = fmt.Fprintln(stdio.Out, remote.Format("Mon Jan _2 15:04:05 2006"))
 	return nil
 }
 

--- a/internal/applets/util-linux/rdate/rdate_test.go
+++ b/internal/applets/util-linux/rdate/rdate_test.go
@@ -82,9 +82,17 @@ func TestMissingHost(t *testing.T) {
 }
 
 func TestUnreachable(t *testing.T) {
-	t.Parallel()
+	// Bind an ephemeral port and immediately close it, so the port is known to
+	// be closed rather than assuming a fixed port is free.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, p, _ := net.SplitHostPort(ln.Addr().String())
+	_ = ln.Close()
+
 	orig := port
-	port = "1" // nothing listens here
+	port = p
 	defer func() { port = orig }()
 	origTO := timeout
 	timeout = 500 * time.Millisecond


### PR DESCRIPTION
## Summary

Follow-up to #334 addressing two CodeRabbit Major findings:

- `rdate -s HOST` now prints the remote time as well as setting the clock, matching the help text (printing is the default action and -s additionally sets the clock). Previously -s suppressed the print.
- The unreachable-host test no longer assumes `127.0.0.1:1` is free: it binds an ephemeral port, closes it, and points `port` at that known-closed port, so the failure path is exercised deterministically.

## Verification

- `go test ./...` passes (race-clean); `golangci-lint` clean.

Part of #248