### PR TITLE
feat(util-linux): add setpriv applet to run with changed privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 218 commands. Run `mimixbox --list` to see them on the terminal.
+There are 219 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -172,6 +172,7 @@ There are 218 commands. Run `mimixbox --list` to see them on the terminal.
 | seq | Print a column of numbers |
 | serial | Rename the file to the name with a serial number |
 | setarch | Run a program with a changed architecture personality |
+| setpriv | Run a program with different privilege settings |
 | setsid | Run a program in a new session |
 | sh | Command interpreter (MimixBox mbsh compatibility front-end) |
 | sha1sum | Calculate or Check secure hash 1 algorithm |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -200,6 +200,7 @@ import (
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
+	ap_util_linux_setpriv "github.com/nao1215/mimixbox/internal/applets/util-linux/setpriv"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
 	ap_util_linux_wall "github.com/nao1215/mimixbox/internal/applets/util-linux/wall"
@@ -208,7 +209,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 218)
+	Applets = make(map[string]Applet, 219)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -424,6 +425,7 @@ func init() {
 	register(ap_util_linux_setarch.NewLinux32())
 	register(ap_util_linux_setarch.NewLinux64())
 	register(ap_util_linux_setarch.NewSetarch())
+	register(ap_util_linux_setpriv.New())
 	register(ap_util_linux_setsid.New())
 	register(ap_util_linux_taskset.New())
 	register(ap_util_linux_wall.New())

--- a/internal/applets/util-linux/setpriv/setpriv.go
+++ b/internal/applets/util-linux/setpriv/setpriv.go
@@ -1,0 +1,135 @@
+// Package setpriv implements the setpriv applet: run a program with changed
+// privilege settings, or dump the current ones.
+package setpriv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the setpriv applet.
+type Command struct{}
+
+// New returns a setpriv command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "setpriv" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program with different privilege settings" }
+
+const prSetNoNewPrivs = 38
+
+// Injected so the credential queries are controllable in tests.
+var (
+	getuid     = os.Getuid
+	geteuid    = os.Geteuid
+	getgid     = os.Getgid
+	getegid    = os.Getegid
+	getgroups  = os.Getgroups
+	noNewPrivs = func() int {
+		v, err := unix.PrctlRetInt(unix.PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0)
+		if err != nil {
+			return 0
+		}
+		return v
+	}
+)
+
+// Run executes setpriv.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[--dump | OPTIONS COMMAND [ARG]...]", stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND with changed privileges, or with --dump print the current ones. " +
+			"Options: --reuid UID and --regid GID change the credentials (needs privilege), and " +
+			"--no-new-privs prevents the program from gaining new privileges.",
+		Examples: []command.Example{
+			{Command: "setpriv --dump", Explain: "Show the current uid/gid and privileges."},
+			{Command: "setpriv --reuid 1000 --regid 1000 -- id", Explain: "Run id as another user."},
+		},
+		ExitStatus: "0  success.\n1  an invalid option, or the command could not be run.",
+	})
+	dump := fs.BoolP("dump", "d", false, "show the current privileges and exit")
+	reuid := fs.Int("reuid", -1, "set the real and effective user ID")
+	regid := fs.Int("regid", -1, "set the real and effective group ID")
+	nnp := fs.Bool("no-new-privs", false, "disallow gaining new privileges")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if *dump {
+		c.dump(stdio.Out)
+		return nil
+	}
+
+	rest := fs.Args()
+	if len(rest) > 0 && rest[0] == "--" {
+		rest = rest[1:]
+	}
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "setpriv: a command is required")
+		return command.SilentFailure()
+	}
+
+	if *nnp {
+		if _, err := unix.PrctlRetInt(prSetNoNewPrivs, 1, 0, 0, 0); err != nil {
+			return command.Failuref("cannot set no_new_privs: %v", err)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running the user's command is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if *reuid >= 0 || *regid >= 0 {
+		cred := &syscall.Credential{Uid: uint32(getuid()), Gid: uint32(getgid())}
+		if *reuid >= 0 {
+			cred.Uid = uint32(*reuid)
+		}
+		if *regid >= 0 {
+			cred.Gid = uint32(*regid)
+		}
+		cmd.SysProcAttr = &syscall.SysProcAttr{Credential: cred}
+	}
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &command.ExitError{Code: exitErr.ExitCode()}
+		}
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	return nil
+}
+
+// dump prints the current credentials, mirroring setpriv --dump.
+func (c *Command) dump(out io.Writer) {
+	_, _ = fmt.Fprintf(out, "uid: %d\n", getuid())
+	_, _ = fmt.Fprintf(out, "euid: %d\n", geteuid())
+	_, _ = fmt.Fprintf(out, "gid: %d\n", getgid())
+	_, _ = fmt.Fprintf(out, "egid: %d\n", getegid())
+	groups, _ := getgroups()
+	_, _ = fmt.Fprintf(out, "Supplementary groups: %s\n", joinInts(groups))
+	_, _ = fmt.Fprintf(out, "no_new_privs: %d\n", noNewPrivs())
+}
+
+func joinInts(ns []int) string {
+	if len(ns) == 0 {
+		return "[none]"
+	}
+	parts := make([]string, len(ns))
+	for i, n := range ns {
+		parts[i] = strconv.Itoa(n)
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/applets/util-linux/setpriv/setpriv_test.go
+++ b/internal/applets/util-linux/setpriv/setpriv_test.go
@@ -1,0 +1,76 @@
+package setpriv
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStubs(t *testing.T) {
+	t.Helper()
+	og, oeg, ogg, oeg2, oggr, onnp := getuid, geteuid, getgid, getegid, getgroups, noNewPrivs
+	getuid = func() int { return 1000 }
+	geteuid = func() int { return 1000 }
+	getgid = func() int { return 1000 }
+	getegid = func() int { return 1000 }
+	getgroups = func() ([]int, error) { return []int{4, 1000}, nil }
+	noNewPrivs = func() int { return 0 }
+	t.Cleanup(func() {
+		getuid, geteuid, getgid, getegid, getgroups, noNewPrivs = og, oeg, ogg, oeg2, oggr, onnp
+	})
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestDump(t *testing.T) {
+	withStubs(t)
+	out, err := run(t, "--dump")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "uid: 1000\neuid: 1000\ngid: 1000\negid: 1000\nSupplementary groups: 4,1000\nno_new_privs: 0\n"
+	if out != want {
+		t.Errorf("dump =\n%q\nwant\n%q", out, want)
+	}
+}
+
+func TestRunCommand(t *testing.T) {
+	if _, err := exec.LookPath("echo"); err != nil {
+		t.Skipf("echo not on PATH: %v", err)
+	}
+	withStubs(t)
+	out, err := run(t, "--no-new-privs", "--", "echo", "hi")
+	if err != nil {
+		t.Fatalf("run error = %v", err)
+	}
+	if !strings.Contains(out, "hi") {
+		t.Errorf("command output = %q", out)
+	}
+}
+
+func TestMissingCommand(t *testing.T) {
+	withStubs(t)
+	if _, err := run(t); err == nil {
+		t.Errorf("missing command should fail")
+	}
+}
+
+func TestJoinInts(t *testing.T) {
+	t.Parallel()
+	if got := joinInts([]int{1, 2, 3}); got != "1,2,3" {
+		t.Errorf("joinInts = %q", got)
+	}
+	if got := joinInts(nil); got != "[none]" {
+		t.Errorf("joinInts(nil) = %q", got)
+	}
+}

--- a/test/it/spec/setpriv_spec.sh
+++ b/test/it/spec/setpriv_spec.sh
@@ -1,0 +1,14 @@
+Describe 'setpriv'
+    Include util-linux/setpriv_test.sh
+
+    It 'dumps the current privileges'
+        When call TestSetprivDump
+        The status should be success
+        The output should not equal '0'
+    End
+    It 'runs a command with --no-new-privs'
+        When call TestSetprivRun
+        The output should equal 'ran'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/setpriv_test.sh
+++ b/test/it/util-linux/setpriv_test.sh
@@ -1,0 +1,2 @@
+TestSetprivDump() { setpriv --dump | grep -cE 'uid:|no_new_privs:'; }
+TestSetprivRun() { setpriv --no-new-privs -- echo ran; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `setpriv`. With `--dump` it prints the current credentials (uid, euid, gid, egid, supplementary groups, no_new_privs), matching host setpriv. Otherwise it runs COMMAND with the requested changes: `--reuid`/`--regid` set the credentials (via the child's SysProcAttr, needs privilege) and `--no-new-privs` prevents the program from gaining new privileges (prctl). The credential queries are injectable so --dump is tested deterministically.

Capability manipulation (inheritable/ambient/bounding sets) is out of scope for this slice.

## Tests

- Unit (stubbed credential getters): the exact `--dump` output, running a command with --no-new-privs, the missing-command error, and the `joinInts` helper.
- shellspec: `--dump` lists uid/no_new_privs, and a command runs with --no-new-privs.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (553 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248