### PR TITLE
feat(util-linux): add blkid applet for filesystem type detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 219 commands. Run `mimixbox --list` to see them on the terminal.
+There are 220 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -36,6 +36,7 @@ There are 219 commands. Run `mimixbox --list` to see them on the terminal.
 | basename | Print basename (PATH without "/") from file path |
 | bash | Command interpreter (MimixBox mbsh compatibility front-end) |
 | bc | An arbitrary-precision calculator language |
+| blkid | Identify the filesystem type of a device or image |
 | bunzip2 | Decompress bzip2 (.bz2) files |
 | busybox | BusyBox-style multi-call front-end for MimixBox applets |
 | bzcat | Decompress bz2 data to standard output |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -185,6 +185,7 @@ import (
 	ap_textutils_uucode "github.com/nao1215/mimixbox/internal/applets/textutils/uucode"
 	ap_textutils_wc "github.com/nao1215/mimixbox/internal/applets/textutils/wc"
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
+	ap_util_linux_blkid "github.com/nao1215/mimixbox/internal/applets/util-linux/blkid"
 	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
@@ -209,7 +210,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 219)
+	Applets = make(map[string]Applet, 220)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -406,6 +407,7 @@ func init() {
 	register(ap_textutils_uucode.NewUuencode())
 	register(ap_textutils_wc.New())
 	register(ap_textutils_xxd.New())
+	register(ap_util_linux_blkid.New())
 	register(ap_util_linux_chrt.New())
 	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_getopt.New())

--- a/internal/applets/util-linux/blkid/blkid.go
+++ b/internal/applets/util-linux/blkid/blkid.go
@@ -1,0 +1,108 @@
+// Package blkid implements the blkid applet: identify the filesystem type on a
+// device or image file by probing for known superblock signatures.
+package blkid
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the blkid applet.
+type Command struct{}
+
+// New returns a blkid command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "blkid" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Identify the filesystem type of a device or image" }
+
+// signature is a filesystem magic at a fixed offset.
+type signature struct {
+	typ    string
+	offset int64
+	magic  []byte
+}
+
+// signatures are checked in order; the first match wins.
+var signatures = []signature{
+	{"xfs", 0, []byte("XFSB")},
+	{"squashfs", 0, []byte("hsqs")},
+	{"ntfs", 3, []byte("NTFS    ")},
+	{"ext2", 0x438, []byte{0x53, 0xEF}},
+	{"btrfs", 0x10040, []byte("_BHRfS_M")},
+	{"swap", 0xFF6, []byte("SWAPSPACE2")},
+	{"swap", 0xFF6, []byte("SWAP-SPACE")},
+}
+
+// Run executes blkid.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the filesystem TYPE of each FILE (a device or image), detected from its " +
+			"superblock signature. Recognizes ext, xfs, btrfs, ntfs, squashfs, and swap. ext2/3/4 " +
+			"are reported as ext2 (feature-flag version detection is not implemented).",
+		Examples: []command.Example{
+			{Command: "blkid disk.img", Explain: "Identify the filesystem in disk.img."},
+		},
+		ExitStatus: "0  a type was identified.\n2  nothing could be identified.\n1  a file could not be read.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "blkid: a FILE is required")
+		return command.SilentFailure()
+	}
+
+	identified := false
+	readErr := false
+	for _, name := range files {
+		typ, err := probe(name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "blkid: %s\n", command.FileError(name, err))
+			readErr = true
+			continue
+		}
+		if typ != "" {
+			_, _ = fmt.Fprintf(stdio.Out, "%s: TYPE=%q\n", name, typ)
+			identified = true
+		}
+	}
+
+	if readErr {
+		return command.SilentFailure()
+	}
+	if !identified {
+		return &command.ExitError{Code: 2} // nothing identified, like blkid
+	}
+	return nil
+}
+
+// probe reads name and returns the first matching filesystem type, or "".
+func probe(name string) (string, error) {
+	f, err := os.Open(name) //nolint:gosec // user-named device/image
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	for _, s := range signatures {
+		buf := make([]byte, len(s.magic))
+		if _, err := f.ReadAt(buf, s.offset); err != nil {
+			continue // too short to hold this signature
+		}
+		if bytes.Equal(buf, s.magic) {
+			return s.typ, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/applets/util-linux/blkid/blkid_test.go
+++ b/internal/applets/util-linux/blkid/blkid_test.go
@@ -1,0 +1,96 @@
+package blkid
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// image writes a file with magic placed at offset.
+func image(t *testing.T, offset int64, magic []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "img")
+	buf := make([]byte, offset+int64(len(magic))+16)
+	copy(buf[offset:], magic)
+	if err := os.WriteFile(f, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestDetectTypes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		typ    string
+		offset int64
+		magic  []byte
+	}{
+		{"ext2", 0x438, []byte{0x53, 0xEF}},
+		{"xfs", 0, []byte("XFSB")},
+		{"btrfs", 0x10040, []byte("_BHRfS_M")},
+		{"ntfs", 3, []byte("NTFS    ")},
+		{"squashfs", 0, []byte("hsqs")},
+		{"swap", 0xFF6, []byte("SWAPSPACE2")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.typ, func(t *testing.T) {
+			f := image(t, tc.offset, tc.magic)
+			out, err := run(t, f)
+			if err != nil {
+				t.Fatalf("blkid error = %v", err)
+			}
+			want := f + ": TYPE=\"" + tc.typ + "\"\n"
+			if out != want {
+				t.Errorf("blkid = %q, want %q", out, want)
+			}
+		})
+	}
+}
+
+func TestNothingIdentified(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "blank")
+	if err := os.WriteFile(f, make([]byte, 100000), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := run(t, f)
+	if out != "" {
+		t.Errorf("unexpected output: %q", out)
+	}
+	var ee *command.ExitError
+	if e, ok := err.(*command.ExitError); ok {
+		ee = e
+	}
+	if ee == nil || ee.Code != 2 {
+		t.Errorf("err = %v, want exit 2", err)
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	t.Parallel()
+	if _, err := run(t, "/no/such/blkid/file"); err == nil {
+		t.Errorf("missing file should fail")
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	t.Parallel()
+	if _, err := run(t); err == nil {
+		t.Errorf("no file should fail")
+	}
+}

--- a/test/it/spec/blkid_spec.sh
+++ b/test/it/spec/blkid_spec.sh
@@ -1,0 +1,21 @@
+Describe 'blkid'
+    Include util-linux/blkid_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'identifies an ext filesystem'
+        When call TestBlkidExt
+        The output should include 'TYPE="ext2"'
+        The status should be success
+    End
+    It 'identifies an xfs filesystem'
+        When call TestBlkidXfs
+        The output should include 'TYPE="xfs"'
+        The status should be success
+    End
+    It 'exits 2 when nothing is identified'
+        When call TestBlkidNone
+        The output should equal 'rc=2'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/blkid_test.sh
+++ b/test/it/util-linux/blkid_test.sh
@@ -1,0 +1,15 @@
+Setup() {
+    export TEST_DIR=/tmp/mimixbox/it/blkid
+    mkdir -p ${TEST_DIR}
+    # Craft an image with the ext superblock magic (0xEF53 at offset 1080).
+    dd if=/dev/zero of=${TEST_DIR}/ext.img bs=1024 count=2 2>/dev/null
+    printf '\123\357' | dd of=${TEST_DIR}/ext.img bs=1 seek=1080 conv=notrunc 2>/dev/null
+    printf 'XFSB' > ${TEST_DIR}/xfs.img
+    printf 'nothing here' > ${TEST_DIR}/blank.img
+}
+
+CleanUp() { rm -rf /tmp/mimixbox/it/blkid; }
+
+TestBlkidExt() { blkid ${TEST_DIR}/ext.img; }
+TestBlkidXfs() { blkid ${TEST_DIR}/xfs.img; }
+TestBlkidNone() { blkid ${TEST_DIR}/blank.img 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `blkid`, which identifies the filesystem TYPE of each device or image file by probing its superblock signature. It recognizes ext, xfs, btrfs, ntfs, squashfs, and swap, printing `FILE: TYPE="..."`. ext2/3/4 are reported as ext2 (feature-flag version detection and BLOCK_SIZE/UUID extraction are out of scope). Probing a regular image file makes this fully testable without real block devices. The TYPE matches host blkid.

## Tests

- Unit (crafted image fixtures): detection of ext2/xfs/btrfs/ntfs/squashfs/swap at their signature offsets, the exit-2 nothing-identified case, the missing-file error, and the no-arguments error.
- shellspec: identify ext and xfs images, and exit 2 on an unidentifiable image.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (556 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248