### PR TITLE
feat(util-linux): add ipcrm applet to remove System V IPC objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 220 commands. Run `mimixbox --list` to see them on the terminal.
+There are 221 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -102,6 +102,7 @@ There are 220 commands. Run `mimixbox --list` to see them on the terminal.
 | id | Print User ID and Group ID |
 | install | Copy files and set attributes |
 | ionice | Get or set process I/O scheduling class and priority |
+| ipcrm | Remove System V IPC objects by id |
 | ipcs | Show System V IPC facilities status |
 | ischroot | Detect if running in a chroot |
 | kill | Kill process or send signal to process |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -191,6 +191,7 @@ import (
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_ionice "github.com/nao1215/mimixbox/internal/applets/util-linux/ionice"
+	ap_util_linux_ipcrm "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcrm"
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
 	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
@@ -210,7 +211,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 220)
+	Applets = make(map[string]Applet, 221)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -414,6 +415,7 @@ func init() {
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
 	register(ap_util_linux_ionice.New())
+	register(ap_util_linux_ipcrm.New())
 	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
 	register(ap_util_linux_lsblk.New())

--- a/internal/applets/util-linux/ipcrm/ipcrm.go
+++ b/internal/applets/util-linux/ipcrm/ipcrm.go
@@ -1,0 +1,84 @@
+// Package ipcrm implements the ipcrm applet: remove System V IPC objects
+// (message queues, shared memory segments, and semaphore arrays) by id.
+package ipcrm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the ipcrm applet.
+type Command struct{}
+
+// New returns an ipcrm command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ipcrm" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Remove System V IPC objects by id" }
+
+// removeIPC is indirected so removal can be tested without real IPC objects.
+var removeIPC = func(kind string, id int) error {
+	var errno unix.Errno
+	switch kind {
+	case "msg":
+		_, _, errno = unix.Syscall(unix.SYS_MSGCTL, uintptr(id), uintptr(unix.IPC_RMID), 0)
+	case "shm":
+		_, _, errno = unix.Syscall(unix.SYS_SHMCTL, uintptr(id), uintptr(unix.IPC_RMID), 0)
+	case "sem":
+		_, _, errno = unix.Syscall(unix.SYS_SEMCTL, uintptr(id), 0, uintptr(unix.IPC_RMID))
+	}
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes ipcrm.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-q msqid] [-m shmid] [-s semid]...", stdio.Err).WithHelp(command.Help{
+		Description: "Remove the System V IPC objects with the given ids: -q a message queue, -m a " +
+			"shared memory segment, -s a semaphore array. Each option may be given more than once. " +
+			"Removal by key (-Q/-M/-S) is not supported.",
+		Examples: []command.Example{
+			{Command: "ipcrm -q 0 -m 32769", Explain: "Remove a message queue and a shared memory segment."},
+		},
+		ExitStatus: "0  every object was removed.\n1  an id was invalid or could not be removed.",
+	})
+	queues := fs.IntSliceP("queue-id", "q", nil, "remove the message queue with this id")
+	shmems := fs.IntSliceP("shmem-id", "m", nil, "remove the shared memory segment with this id")
+	sems := fs.IntSliceP("semaphore-id", "s", nil, "remove the semaphore array with this id")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if len(*queues)+len(*shmems)+len(*sems) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "ipcrm: nothing to remove (use -q, -m, or -s)")
+		return command.SilentFailure()
+	}
+
+	failed := false
+	remove := func(kind, label string, ids []int) {
+		for _, id := range ids {
+			if err := removeIPC(kind, id); err != nil {
+				_, _ = fmt.Fprintf(stdio.Err, "ipcrm: removing %s %d failed: %v\n", label, id, err)
+				failed = true
+			}
+		}
+	}
+	remove("msg", "queue", *queues)
+	remove("shm", "shared memory segment", *shmems)
+	remove("sem", "semaphore", *sems)
+
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}

--- a/internal/applets/util-linux/ipcrm/ipcrm_test.go
+++ b/internal/applets/util-linux/ipcrm/ipcrm_test.go
@@ -1,0 +1,77 @@
+package ipcrm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type removal struct {
+	kind string
+	id   int
+}
+
+func withStub(t *testing.T, failKind string) *[]removal {
+	t.Helper()
+	var calls []removal
+	orig := removeIPC
+	removeIPC = func(kind string, id int) error {
+		calls = append(calls, removal{kind, id})
+		if kind == failKind {
+			return errors.New("boom")
+		}
+		return nil
+	}
+	t.Cleanup(func() { removeIPC = orig })
+	return &calls
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestRemovesEachKind(t *testing.T) {
+	calls := withStub(t, "")
+	if err := run(t, "-q", "1", "-m", "2", "-s", "3"); err != nil {
+		t.Fatal(err)
+	}
+	want := []removal{{"msg", 1}, {"shm", 2}, {"sem", 3}}
+	if len(*calls) != 3 {
+		t.Fatalf("calls = %v", *calls)
+	}
+	for i, w := range want {
+		if (*calls)[i] != w {
+			t.Errorf("call %d = %v, want %v", i, (*calls)[i], w)
+		}
+	}
+}
+
+func TestMultipleIds(t *testing.T) {
+	calls := withStub(t, "")
+	if err := run(t, "-q", "10", "-q", "20"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 2 || (*calls)[0].id != 10 || (*calls)[1].id != 20 {
+		t.Errorf("calls = %v", *calls)
+	}
+}
+
+func TestNothingToRemove(t *testing.T) {
+	withStub(t, "")
+	if err := run(t); err == nil {
+		t.Errorf("no ids should fail")
+	}
+}
+
+func TestRemovalFailure(t *testing.T) {
+	withStub(t, "shm")
+	if err := run(t, "-m", "5"); err == nil {
+		t.Errorf("a failed removal should fail")
+	}
+}

--- a/test/it/spec/ipcrm_spec.sh
+++ b/test/it/spec/ipcrm_spec.sh
@@ -1,0 +1,14 @@
+Describe 'ipcrm'
+    Include util-linux/ipcrm_test.sh
+
+    It 'fails when nothing is requested'
+        When call TestIpcrmNothing
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'fails to remove a non-existent id'
+        When call TestIpcrmBadId
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/ipcrm_test.sh
+++ b/test/it/util-linux/ipcrm_test.sh
@@ -1,0 +1,9 @@
+TestIpcrmNothing() {
+    ipcrm 2>/dev/null
+    echo "rc=$?"
+}
+
+TestIpcrmBadId() {
+    ipcrm -q 2147483647 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `ipcrm` (the companion to ipcs), which removes System V IPC objects by id: `-q` a message queue, `-m` a shared memory segment, `-s` a semaphore array. Each option may be repeated to remove several objects. Removal by key (-Q/-M/-S) is documented as not supported. The removal call is injectable so the dispatch is tested without real IPC objects.

## Tests

- Unit (stubbed removal): each kind dispatches to the right msg/shm/sem removal with the right id, multiple ids per flag, the nothing-to-remove error, and a removal failure surfacing a non-zero exit.
- shellspec: ipcrm fails when nothing is requested and when removing a non-existent id.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (558 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248