### PR TITLE
feat(util-linux): add dmesg applet to print the kernel ring buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 221 commands. Run `mimixbox --list` to see them on the terminal.
+There are 222 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -66,6 +66,7 @@ There are 221 commands. Run `mimixbox --list` to see them on the terminal.
 | df | Report file system disk space usage |
 | diff | Compare files line by line |
 | dirname | Print only directory path |
+| dmesg | Print or control the kernel ring buffer |
 | dos2unix | Change CRLF to LF |
 | du | Estimate file space usage |
 | echo | Display a line of text |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -187,6 +187,7 @@ import (
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
 	ap_util_linux_blkid "github.com/nao1215/mimixbox/internal/applets/util-linux/blkid"
 	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
+	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
@@ -211,7 +212,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 221)
+	Applets = make(map[string]Applet, 222)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -410,6 +411,7 @@ func init() {
 	register(ap_textutils_xxd.New())
 	register(ap_util_linux_blkid.New())
 	register(ap_util_linux_chrt.New())
+	register(ap_util_linux_dmesg.New())
 	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())

--- a/internal/applets/util-linux/dmesg/dmesg.go
+++ b/internal/applets/util-linux/dmesg/dmesg.go
@@ -1,0 +1,92 @@
+// Package dmesg implements the dmesg applet: print the kernel ring buffer.
+package dmesg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the dmesg applet.
+type Command struct{}
+
+// New returns a dmesg command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "dmesg" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print or control the kernel ring buffer" }
+
+// syslog actions (klogctl).
+const (
+	syslogActionReadAll = 3
+)
+
+// readKernelLog is indirected so the parser can be tested with a fixture.
+var readKernelLog = func() ([]byte, error) {
+	buf := make([]byte, 1<<20)
+	n, err := unix.Klogctl(syslogActionReadAll, buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+// Run executes dmesg.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-r]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the messages in the kernel ring buffer. Each line's syslog priority prefix " +
+			"(<N>) is stripped unless -r (raw) is given. Reading the buffer may require privilege.",
+		Examples: []command.Example{
+			{Command: "dmesg", Explain: "Show the kernel messages."},
+			{Command: "dmesg -r", Explain: "Show them with the raw priority prefixes."},
+		},
+		ExitStatus: "0  success.\n1  the kernel buffer could not be read.",
+	})
+	raw := fs.BoolP("raw", "r", false, "print the raw buffer, keeping priority prefixes")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	data, err := readKernelLog()
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "dmesg: read kernel buffer failed: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	_, _ = fmt.Fprint(stdio.Out, format(string(data), *raw))
+	return nil
+}
+
+// format strips the syslog priority prefix from each non-empty line unless raw.
+func format(s string, raw bool) string {
+	if raw {
+		return s
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if line == "" {
+			continue
+		}
+		b.WriteString(stripPriority(line))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// stripPriority removes a leading "<N>" syslog priority marker.
+func stripPriority(line string) string {
+	if strings.HasPrefix(line, "<") {
+		if i := strings.IndexByte(line, '>'); i >= 0 {
+			return line[i+1:]
+		}
+	}
+	return line
+}

--- a/internal/applets/util-linux/dmesg/dmesg_test.go
+++ b/internal/applets/util-linux/dmesg/dmesg_test.go
@@ -1,0 +1,72 @@
+package dmesg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withLog(t *testing.T, data string, err error) {
+	t.Helper()
+	orig := readKernelLog
+	readKernelLog = func() ([]byte, error) {
+		if err != nil {
+			return nil, err
+		}
+		return []byte(data), nil
+	}
+	t.Cleanup(func() { readKernelLog = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestStripsPriority(t *testing.T) {
+	withLog(t, "<6>[    0.000000] boot\n<4>[    1.234567] warning\n", nil)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "[    0.000000] boot\n[    1.234567] warning\n"
+	if out != want {
+		t.Errorf("dmesg = %q, want %q", out, want)
+	}
+}
+
+func TestRawKeepsPrefix(t *testing.T) {
+	raw := "<6>[    0.000000] boot\n"
+	withLog(t, raw, nil)
+	out, err := run(t, "-r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != raw {
+		t.Errorf("dmesg -r = %q, want %q", out, raw)
+	}
+}
+
+func TestReadFailure(t *testing.T) {
+	withLog(t, "", errors.New("operation not permitted"))
+	if _, err := run(t); err == nil {
+		t.Errorf("a read failure should fail")
+	}
+}
+
+func TestStripPriority(t *testing.T) {
+	t.Parallel()
+	if got := stripPriority("<6>[ 0.0] hi"); got != "[ 0.0] hi" {
+		t.Errorf("stripPriority = %q", got)
+	}
+	if got := stripPriority("no prefix"); got != "no prefix" {
+		t.Errorf("stripPriority(no prefix) = %q", got)
+	}
+}

--- a/test/it/spec/dmesg_spec.sh
+++ b/test/it/spec/dmesg_spec.sh
@@ -1,0 +1,10 @@
+Describe 'dmesg'
+    Include util-linux/dmesg_test.sh
+
+    It 'describes itself with --help'
+        When call TestDmesgHelp
+        The status should be success
+        The output should include 'Usage: dmesg'
+        The output should include 'kernel ring buffer'
+    End
+End

--- a/test/it/util-linux/dmesg_test.sh
+++ b/test/it/util-linux/dmesg_test.sh
@@ -1,0 +1,4 @@
+# Reading the kernel ring buffer can require privilege depending on the host's
+# dmesg_restrict, so the e2e exercises the sysfs-independent --help path; the
+# read and priority-stripping are covered by Go unit tests.
+TestDmesgHelp() { dmesg --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `dmesg`, which prints the kernel ring buffer (via klogctl SYSLOG_ACTION_READ_ALL). Each line's syslog priority prefix (`<N>`) is stripped unless `-r` (raw) is given. Reading the buffer may require privilege depending on the host's dmesg_restrict. The log reader is injectable so the parsing is tested with fixtures.

## Tests

- Unit (injected kernel log): priority-prefix stripping, `-r` keeping the raw prefixes, a read-failure surfacing a non-zero exit, and the `stripPriority` helper.
- shellspec: the sysfs/permission-independent `--help` path (reading the buffer can be restricted on CI runners, so the read/parse is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (559 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248