### PR TITLE
feat(util-linux): add hwclock applet to read the RTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 222 commands. Run `mimixbox --list` to see them on the terminal.
+There are 223 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -100,6 +100,7 @@ There are 222 commands. Run `mimixbox --list` to see them on the terminal.
 | hostname | Show the system's host name |
 | http-status-code | Explain HTTP status codes and their RFC references |
 | hush | Command interpreter (MimixBox mbsh compatibility front-end) |
+| hwclock | Read the hardware (RTC) clock |
 | id | Print User ID and Group ID |
 | install | Copy files and set attributes |
 | ionice | Get or set process I/O scheduling class and priority |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -191,6 +191,7 @@ import (
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
+	ap_util_linux_hwclock "github.com/nao1215/mimixbox/internal/applets/util-linux/hwclock"
 	ap_util_linux_ionice "github.com/nao1215/mimixbox/internal/applets/util-linux/ionice"
 	ap_util_linux_ipcrm "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcrm"
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
@@ -212,7 +213,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 222)
+	Applets = make(map[string]Applet, 223)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -416,6 +417,7 @@ func init() {
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())
+	register(ap_util_linux_hwclock.New())
 	register(ap_util_linux_ionice.New())
 	register(ap_util_linux_ipcrm.New())
 	register(ap_util_linux_ipcs.New())

--- a/internal/applets/util-linux/hwclock/hwclock.go
+++ b/internal/applets/util-linux/hwclock/hwclock.go
@@ -1,0 +1,76 @@
+// Package hwclock implements the hwclock applet: read the hardware (RTC) clock.
+package hwclock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the hwclock applet.
+type Command struct{}
+
+// New returns a hwclock command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "hwclock" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Read the hardware (RTC) clock" }
+
+// readRTC is indirected so the formatting can be tested without a real RTC. It
+// returns the RTC time, which the kernel keeps in UTC.
+var readRTC = func() (time.Time, error) {
+	f, err := os.OpenFile("/dev/rtc0", os.O_RDONLY, 0)
+	if err != nil {
+		f, err = os.OpenFile("/dev/rtc", os.O_RDONLY, 0)
+		if err != nil {
+			return time.Time{}, err
+		}
+	}
+	defer func() { _ = f.Close() }()
+
+	rt, err := unix.IoctlGetRTCTime(int(f.Fd()))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Date(int(rt.Year)+1900, time.Month(rt.Mon+1), int(rt.Mday),
+		int(rt.Hour), int(rt.Min), int(rt.Sec), 0, time.UTC), nil
+}
+
+// Run executes hwclock.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-r] [-u]", stdio.Err).WithHelp(command.Help{
+		Description: "Read the hardware real-time clock and print it. With -u, print it in UTC; " +
+			"otherwise in local time. Setting the clock is not implemented in this slice.",
+		Examples: []command.Example{
+			{Command: "hwclock", Explain: "Print the RTC time in local time."},
+			{Command: "hwclock -u", Explain: "Print it in UTC."},
+		},
+		ExitStatus: "0  success.\n1  the RTC could not be read.",
+	})
+	_ = fs.BoolP("show", "r", false, "read and print the RTC (the default)")
+	utc := fs.BoolP("utc", "u", false, "print the time in UTC")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	t, err := readRTC()
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "hwclock: cannot read the RTC: %v\n", err)
+		return command.SilentFailure()
+	}
+
+	if !*utc {
+		t = t.Local()
+	}
+	_, _ = fmt.Fprintln(stdio.Out, t.Format("2006-01-02 15:04:05"))
+	return nil
+}

--- a/internal/applets/util-linux/hwclock/hwclock_test.go
+++ b/internal/applets/util-linux/hwclock/hwclock_test.go
@@ -1,0 +1,59 @@
+package hwclock
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withRTC(t *testing.T, when time.Time, err error) {
+	t.Helper()
+	orig := readRTC
+	readRTC = func() (time.Time, error) { return when, err }
+	t.Cleanup(func() { readRTC = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestShowLocal(t *testing.T) {
+	rtc := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	withRTC(t, rtc, nil)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := rtc.Local().Format("2006-01-02 15:04:05")
+	if out != want {
+		t.Errorf("hwclock = %q, want %q", out, want)
+	}
+}
+
+func TestShowUTC(t *testing.T) {
+	rtc := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	withRTC(t, rtc, nil)
+	out, err := run(t, "-u")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "2026-06-10 12:00:00" {
+		t.Errorf("hwclock -u = %q, want 2026-06-10 12:00:00", out)
+	}
+}
+
+func TestReadFailure(t *testing.T) {
+	withRTC(t, time.Time{}, errors.New("permission denied"))
+	if _, err := run(t); err == nil {
+		t.Errorf("an RTC read failure should fail")
+	}
+}

--- a/test/it/spec/hwclock_spec.sh
+++ b/test/it/spec/hwclock_spec.sh
@@ -1,0 +1,10 @@
+Describe 'hwclock'
+    Include util-linux/hwclock_test.sh
+
+    It 'describes itself with --help'
+        When call TestHwclockHelp
+        The status should be success
+        The output should include 'Usage: hwclock'
+        The output should include 'RTC'
+    End
+End

--- a/test/it/util-linux/hwclock_test.sh
+++ b/test/it/util-linux/hwclock_test.sh
@@ -1,0 +1,3 @@
+# Reading /dev/rtc requires privilege, so the e2e exercises the --help path; the
+# RTC read and time formatting are covered by Go unit tests.
+TestHwclockHelp() { hwclock --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `hwclock`, which reads the hardware real-time clock (via the RTC_RD_TIME ioctl on /dev/rtc0) and prints it — in local time by default, or in UTC with `-u`. The RTC read is injectable so the formatting is tested without a real clock (reading the RTC requires privilege). Setting the clock is out of scope for this slice.

## Tests

- Unit (injected RTC): print in local time and in UTC (`-u`) from a fixed RTC time, and a read-failure surfacing a non-zero exit.
- shellspec: the privilege-independent `--help` path (reading /dev/rtc requires privilege, so the read/format is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (560 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248