### PR TITLE
feat(util-linux): add blockdev applet to report device properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 223 commands. Run `mimixbox --list` to see them on the terminal.
+There are 224 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -37,6 +37,7 @@ There are 223 commands. Run `mimixbox --list` to see them on the terminal.
 | bash | Command interpreter (MimixBox mbsh compatibility front-end) |
 | bc | An arbitrary-precision calculator language |
 | blkid | Identify the filesystem type of a device or image |
+| blockdev | Report block device properties |
 | bunzip2 | Decompress bzip2 (.bz2) files |
 | busybox | BusyBox-style multi-call front-end for MimixBox applets |
 | bzcat | Decompress bz2 data to standard output |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -186,6 +186,7 @@ import (
 	ap_textutils_wc "github.com/nao1215/mimixbox/internal/applets/textutils/wc"
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
 	ap_util_linux_blkid "github.com/nao1215/mimixbox/internal/applets/util-linux/blkid"
+	ap_util_linux_blockdev "github.com/nao1215/mimixbox/internal/applets/util-linux/blockdev"
 	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
 	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
@@ -213,7 +214,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 223)
+	Applets = make(map[string]Applet, 224)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -411,6 +412,7 @@ func init() {
 	register(ap_textutils_wc.New())
 	register(ap_textutils_xxd.New())
 	register(ap_util_linux_blkid.New())
+	register(ap_util_linux_blockdev.New())
 	register(ap_util_linux_chrt.New())
 	register(ap_util_linux_dmesg.New())
 	register(ap_util_linux_fallocate.New())

--- a/internal/applets/util-linux/blockdev/blockdev.go
+++ b/internal/applets/util-linux/blockdev/blockdev.go
@@ -1,0 +1,114 @@
+// Package blockdev implements the blockdev applet: report block-device
+// properties (size, sector size, block size, read-only flag) via ioctls.
+package blockdev
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the blockdev applet.
+type Command struct{}
+
+// New returns a blockdev command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "blockdev" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report block device properties" }
+
+// blockQuery is indirected so the flag dispatch can be tested without a device.
+var blockQuery = func(path, name string) (uint64, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0) //nolint:gosec // user-named device
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+	fd := int(f.Fd())
+
+	switch name {
+	case "getsize64":
+		var sz uint64
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(unix.BLKGETSIZE64), uintptr(unsafe.Pointer(&sz))); errno != 0 {
+			return 0, errno
+		}
+		return sz, nil
+	case "getss":
+		v, err := unix.IoctlGetInt(fd, unix.BLKSSZGET)
+		return uint64(v), err
+	case "getbsz":
+		v, err := unix.IoctlGetInt(fd, unix.BLKBSZGET)
+		return uint64(v), err
+	case "getro":
+		v, err := unix.IoctlGetInt(fd, unix.BLKROGET)
+		return uint64(v), err
+	default:
+		return 0, fmt.Errorf("unknown query %q", name)
+	}
+}
+
+// queries lists the supported flags in display order.
+var queries = []struct {
+	flag, name, help string
+}{
+	{"getsize64", "getsize64", "print the device size in bytes"},
+	{"getsz", "getsize64", "print the device size in bytes (alias of --getsize64)"},
+	{"getss", "getss", "print the logical sector size in bytes"},
+	{"getbsz", "getbsz", "print the block size in bytes"},
+	{"getro", "getro", "print 1 if read-only, 0 otherwise"},
+}
+
+// Run executes blockdev.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[--getsize64] [--getss] [--getbsz] [--getro] DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Report properties of a block DEVICE. Each query flag prints one value: the " +
+			"size in bytes, the logical sector size, the block size, or the read-only flag. Reading " +
+			"a device usually requires privilege.",
+		Examples: []command.Example{
+			{Command: "blockdev --getsize64 /dev/sda", Explain: "Print the device size in bytes."},
+		},
+		ExitStatus: "0  success.\n1  no query was given, or the device could not be read.",
+	})
+	flags := map[string]*bool{}
+	for _, q := range queries {
+		flags[q.flag] = fs.Bool(q.flag, false, q.help)
+	}
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "blockdev: a device is required")
+		return command.SilentFailure()
+	}
+	device := rest[0]
+
+	any := false
+	for _, q := range queries {
+		if !*flags[q.flag] {
+			continue
+		}
+		any = true
+		v, err := blockQuery(device, q.name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "blockdev: cannot read %s: %v\n", device, err)
+			return command.SilentFailure()
+		}
+		_, _ = fmt.Fprintln(stdio.Out, v)
+	}
+	if !any {
+		_, _ = fmt.Fprintln(stdio.Err, "blockdev: a query flag is required")
+		return command.SilentFailure()
+	}
+	return nil
+}

--- a/internal/applets/util-linux/blockdev/blockdev_test.go
+++ b/internal/applets/util-linux/blockdev/blockdev_test.go
@@ -1,0 +1,94 @@
+package blockdev
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, values map[string]uint64, fail bool) *[]string {
+	t.Helper()
+	var asked []string
+	orig := blockQuery
+	blockQuery = func(_, name string) (uint64, error) {
+		asked = append(asked, name)
+		if fail {
+			return 0, errors.New("permission denied")
+		}
+		return values[name], nil
+	}
+	t.Cleanup(func() { blockQuery = orig })
+	return &asked
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestGetSize64(t *testing.T) {
+	withStub(t, map[string]uint64{"getsize64": 1073741824}, false)
+	out, err := run(t, "--getsize64", "/dev/sda")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "1073741824" {
+		t.Errorf("--getsize64 = %q", out)
+	}
+}
+
+func TestSectorSize(t *testing.T) {
+	asked := withStub(t, map[string]uint64{"getss": 512}, false)
+	out, err := run(t, "--getss", "/dev/sda")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "512" {
+		t.Errorf("--getss = %q", out)
+	}
+	if len(*asked) != 1 || (*asked)[0] != "getss" {
+		t.Errorf("asked = %v", *asked)
+	}
+}
+
+func TestMultipleQueries(t *testing.T) {
+	withStub(t, map[string]uint64{"getss": 512, "getro": 1}, false)
+	out, err := run(t, "--getss", "--getro", "/dev/sda")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "512\n1" {
+		t.Errorf("multiple = %q, want \"512\\n1\"", out)
+	}
+}
+
+func TestGetszAliasesGetsize64(t *testing.T) {
+	asked := withStub(t, map[string]uint64{"getsize64": 999}, false)
+	if _, err := run(t, "--getsz", "/dev/sda"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*asked) != 1 || (*asked)[0] != "getsize64" {
+		t.Errorf("--getsz should query getsize64, asked = %v", *asked)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	withStub(t, nil, false)
+	if _, err := run(t, "/dev/sda"); err == nil {
+		t.Errorf("no query flag should fail")
+	}
+	if _, err := run(t, "--getro"); err == nil {
+		t.Errorf("no device should fail")
+	}
+	withStub(t, nil, true)
+	if _, err := run(t, "--getss", "/dev/sda"); err == nil {
+		t.Errorf("a query failure should fail")
+	}
+}

--- a/test/it/spec/blockdev_spec.sh
+++ b/test/it/spec/blockdev_spec.sh
@@ -1,0 +1,15 @@
+Describe 'blockdev'
+    Include util-linux/blockdev_test.sh
+
+    It 'describes itself with --help'
+        When call TestBlockdevHelp
+        The status should be success
+        The output should include 'Usage: blockdev'
+        The output should include 'DEVICE'
+    End
+    It 'fails when no query flag is given'
+        When call TestBlockdevNoQuery
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/blockdev_test.sh
+++ b/test/it/util-linux/blockdev_test.sh
@@ -1,0 +1,4 @@
+# Reading a block device requires privilege, so the e2e exercises the --help
+# path and the no-query error; the ioctl dispatch is covered by Go unit tests.
+TestBlockdevHelp() { blockdev --help; }
+TestBlockdevNoQuery() { blockdev /dev/null 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#248) with `blockdev`, which reports block-device properties via ioctls: `--getsize64` (size in bytes), `--getsz` (alias of --getsize64), `--getss` (logical sector size), `--getbsz` (block size), and `--getro` (read-only flag). Each query flag prints one value, in display order. Reading a device usually requires privilege, so the ioctl query is injectable and the flag dispatch is tested without a real device.

## Tests

- Unit (stubbed query): `--getsize64`, `--getss`, multiple queries in order, `--getsz` aliasing getsize64, and the no-query / no-device / query-failure errors.
- shellspec: the privilege-independent `--help` path and the no-query error.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (562 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `blockdev` command to report block device properties. Supports queries for device size, sector size, block size, and read-only status via command-line flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->