### PR TITLE
feat(util-linux): add rdev and readprofile, completing the util-linux batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 224 commands. Run `mimixbox --list` to see them on the terminal.
+There are 226 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -158,7 +158,9 @@ There are 224 commands. Run `mimixbox --list` to see them on the terminal.
 | pwgen | Generate random passwords for authorized testing |
 | pwscore | Estimate the strength of a password |
 | rdate | Get the time from a remote host (RFC 868) |
+| rdev | Print the root filesystem device |
 | readlink | Print resolved symbolic links or canonical file names |
+| readprofile | Summarize the kernel profiling buffer |
 | realpath | Print the resolved absolute file name |
 | reboot | Reboot the system |
 | remove-shell | Remove shell name from /etc/shells |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -202,6 +202,8 @@ import (
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_rdate "github.com/nao1215/mimixbox/internal/applets/util-linux/rdate"
+	ap_util_linux_rdev "github.com/nao1215/mimixbox/internal/applets/util-linux/rdev"
+	ap_util_linux_readprofile "github.com/nao1215/mimixbox/internal/applets/util-linux/readprofile"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
@@ -214,7 +216,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 224)
+	Applets = make(map[string]Applet, 226)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -429,6 +431,8 @@ func init() {
 	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_rdate.New())
+	register(ap_util_linux_rdev.New())
+	register(ap_util_linux_readprofile.New())
 	register(ap_util_linux_renice.New())
 	register(ap_util_linux_script.NewScript())
 	register(ap_util_linux_script.NewScriptreplay())

--- a/internal/applets/util-linux/rdev/rdev.go
+++ b/internal/applets/util-linux/rdev/rdev.go
@@ -1,0 +1,74 @@
+// Package rdev implements the rdev applet: print the device of the root
+// filesystem.
+package rdev
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the rdev applet.
+type Command struct{}
+
+// New returns an rdev command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "rdev" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the root filesystem device" }
+
+// procMounts is the mount table; tests point it at a fixture.
+var procMounts = "/proc/mounts"
+
+// Run executes rdev.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the device mounted as the root filesystem (/), in the historical " +
+			"'DEVICE /' form. Setting the root device, which old rdev did by patching a kernel " +
+			"image, is not supported.",
+		Examples: []command.Example{
+			{Command: "rdev", Explain: "Print the root device, e.g. '/dev/sda1 /'."},
+		},
+		ExitStatus: "0  the root device was found.\n1  it could not be determined.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	device, err := rootDevice(procMounts)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "rdev: %v\n", err)
+		return command.SilentFailure()
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "%s /\n", device)
+	return nil
+}
+
+// rootDevice returns the device mounted at "/" from the mount table.
+func rootDevice(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // the mount table path
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) >= 2 && fields[1] == "/" {
+			return fields[0], nil
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("could not determine the root device")
+}

--- a/internal/applets/util-linux/rdev/rdev_test.go
+++ b/internal/applets/util-linux/rdev/rdev_test.go
@@ -1,0 +1,59 @@
+package rdev
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withMounts(t *testing.T, content string) {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "mounts")
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := procMounts
+	procMounts = f
+	t.Cleanup(func() { procMounts = orig })
+}
+
+func run(t *testing.T) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, nil)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestRootDevice(t *testing.T) {
+	withMounts(t, "proc /proc proc rw 0 0\n/dev/sda1 / ext4 rw 0 0\ntmpfs /tmp tmpfs rw 0 0\n")
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "/dev/sda1 /" {
+		t.Errorf("rdev = %q, want %q", out, "/dev/sda1 /")
+	}
+}
+
+func TestNoRoot(t *testing.T) {
+	withMounts(t, "proc /proc proc rw 0 0\n")
+	if _, err := run(t); err == nil {
+		t.Errorf("missing root mount should fail")
+	}
+}
+
+func TestMissingMounts(t *testing.T) {
+	orig := procMounts
+	procMounts = "/no/such/mounts"
+	defer func() { procMounts = orig }()
+	if _, err := run(t); err == nil {
+		t.Errorf("missing mounts file should fail")
+	}
+}

--- a/internal/applets/util-linux/readprofile/readprofile.go
+++ b/internal/applets/util-linux/readprofile/readprofile.go
@@ -1,0 +1,70 @@
+// Package readprofile implements the readprofile applet: report a summary of the
+// kernel profiling buffer (/proc/profile).
+package readprofile
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the readprofile applet.
+type Command struct{}
+
+// New returns a readprofile command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "readprofile" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Summarize the kernel profiling buffer" }
+
+// profilePath is the kernel profiling buffer; tests point it at a fixture.
+var profilePath = "/proc/profile"
+
+// Run executes readprofile.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Read the kernel profiling buffer (/proc/profile) and report its profiling step " +
+			"and the total number of samples. Per-symbol attribution (which needs the kernel symbol " +
+			"map) is not implemented, and the buffer is empty unless the kernel was booted with " +
+			"profiling enabled.",
+		Examples: []command.Example{
+			{Command: "readprofile", Explain: "Show the profiling step and total samples."},
+		},
+		ExitStatus: "0  success.\n1  the profiling buffer could not be read or is empty.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	data, err := os.ReadFile(profilePath) //nolint:gosec // the profiling buffer path
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "readprofile: %s\n", command.FileError(profilePath, err))
+		return command.SilentFailure()
+	}
+	if len(data) < 4 {
+		_, _ = fmt.Fprintln(stdio.Err, "readprofile: profiling is not enabled (buffer is empty)")
+		return command.SilentFailure()
+	}
+
+	step, total := summarize(data)
+	_, _ = fmt.Fprintf(stdio.Out, "profiling step: %d\n", step)
+	_, _ = fmt.Fprintf(stdio.Out, "total samples: %d\n", total)
+	return nil
+}
+
+// summarize reads /proc/profile as a uint32 array: the first word is the
+// profiling step and the rest are per-bucket sample counts.
+func summarize(data []byte) (step uint32, total uint64) {
+	step = binary.LittleEndian.Uint32(data[:4])
+	for off := 4; off+4 <= len(data); off += 4 {
+		total += uint64(binary.LittleEndian.Uint32(data[off : off+4]))
+	}
+	return step, total
+}

--- a/internal/applets/util-linux/readprofile/readprofile_test.go
+++ b/internal/applets/util-linux/readprofile/readprofile_test.go
@@ -1,0 +1,77 @@
+package readprofile
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withProfile(t *testing.T, words []uint32) {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "profile")
+	buf := make([]byte, len(words)*4)
+	for i, w := range words {
+		binary.LittleEndian.PutUint32(buf[i*4:], w)
+	}
+	if err := os.WriteFile(f, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := profilePath
+	profilePath = f
+	t.Cleanup(func() { profilePath = orig })
+}
+
+func run(t *testing.T) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, nil)
+	return out.String(), err
+}
+
+func TestSummary(t *testing.T) {
+	withProfile(t, []uint32{4, 0, 5, 0, 3}) // step 4, samples 0+5+0+3 = 8
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "profiling step: 4\ntotal samples: 8\n" {
+		t.Errorf("readprofile = %q", out)
+	}
+}
+
+func TestEmptyBuffer(t *testing.T) {
+	withProfile(t, nil)
+	if _, err := run(t); err == nil {
+		t.Errorf("an empty buffer should fail")
+	}
+}
+
+func TestMissingFile(t *testing.T) {
+	orig := profilePath
+	profilePath = "/no/such/profile"
+	defer func() { profilePath = orig }()
+	if _, err := run(t); err == nil {
+		t.Errorf("a missing profile should fail")
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	t.Parallel()
+	buf := make([]byte, 16)
+	binary.LittleEndian.PutUint32(buf[0:], 2)
+	binary.LittleEndian.PutUint32(buf[4:], 10)
+	binary.LittleEndian.PutUint32(buf[8:], 20)
+	binary.LittleEndian.PutUint32(buf[12:], 30)
+	step, total := summarize(buf)
+	if step != 2 || total != 60 {
+		t.Errorf("summarize = %d, %d; want 2, 60", step, total)
+	}
+}

--- a/test/it/spec/rdev_spec.sh
+++ b/test/it/spec/rdev_spec.sh
@@ -1,0 +1,9 @@
+Describe 'rdev'
+    Include util-linux/rdev_test.sh
+
+    It 'prints the root device with the / mountpoint'
+        When call TestRdev
+        The status should be success
+        The output should include ' /'
+    End
+End

--- a/test/it/spec/readprofile_spec.sh
+++ b/test/it/spec/readprofile_spec.sh
@@ -1,0 +1,10 @@
+Describe 'readprofile'
+    Include util-linux/readprofile_test.sh
+
+    It 'describes itself with --help'
+        When call TestReadprofileHelp
+        The status should be success
+        The output should include 'Usage: readprofile'
+        The output should include 'profiling'
+    End
+End

--- a/test/it/util-linux/rdev_test.sh
+++ b/test/it/util-linux/rdev_test.sh
@@ -1,0 +1,1 @@
+TestRdev() { rdev; }

--- a/test/it/util-linux/readprofile_test.sh
+++ b/test/it/util-linux/readprofile_test.sh
@@ -1,0 +1,3 @@
+# /proc/profile is absent unless the kernel booted with profiling, so the e2e
+# exercises --help; the buffer summary is covered by Go unit tests.
+TestReadprofileHelp() { readprofile --help; }


### PR DESCRIPTION
## Summary

Adds the final two applets of the util-linux inspection/session batch (#248):

- **`rdev`** — print the device mounted as the root filesystem (`/`), in the historical `DEVICE /` form, read from /proc/mounts. Setting the root device (which old rdev did by patching a kernel image) is not supported.
- **`readprofile`** — read the kernel profiling buffer (/proc/profile) and report its profiling step and total sample count. Per-symbol attribution (needs the kernel symbol map) is out of scope, and the buffer is empty unless the kernel booted with profiling.

With these, every command in #248's scope is now implemented (blkid, blockdev, chrt, dmesg, fallocate, getopt, hd, hexdump, hwclock, ionice, ipcrm, ipcs, last, linux32, linux64, lsblk, lspci, lsusb, mesg, rdate, rdev, readprofile, renice, script, scriptreplay, setarch, setpriv, setsid, taskset, wall), delivered across this and the preceding PRs.

## Tests

- `rdev`: unit tests (fixture /proc/mounts) for the root-device extraction, the no-root and missing-file errors; shellspec for the `DEVICE /` output.
- `readprofile`: unit tests (fixture /proc/profile) for the step/total summary, the empty-buffer and missing-file errors, and the `summarize` helper; shellspec for the `--help` path (the buffer is absent unless profiling is enabled).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (564 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Closes #248