### PR TITLE
feat(procps): add uptime and pwdx applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 226 commands. Run `mimixbox --list` to see them on the terminal.
+There are 228 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -155,6 +155,7 @@ There are 226 commands. Run `mimixbox --list` to see them on the terminal.
 | printf | Format and print data |
 | pwcrack | Audit crypt(3) password hashes against a wordlist |
 | pwd | Print Working Directory |
+| pwdx | Print the working directory of a process |
 | pwgen | Generate random passwords for authorized testing |
 | pwscore | Estimate the strength of a password |
 | rdate | Get the time from a remote host (RFC 868) |
@@ -225,6 +226,7 @@ There are 226 commands. Run `mimixbox --list` to see them on the terminal.
 | unshadow | Combine passwd and shadow files for password auditing |
 | unxz | Decompress xz files |
 | unzip | Extract files from a ZIP archive |
+| uptime | Tell how long the system has been running |
 | users | Print the user names of those currently logged in |
 | usleep | Pause for N microseconds |
 | uudecode | Decode a uuencoded (or base64) file |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -77,6 +77,8 @@ import (
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
 	ap_netutils_whris "github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
+	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
+	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
 	ap_securityutils_pwscore "github.com/nao1215/mimixbox/internal/applets/securityutils/pwscore"
@@ -216,7 +218,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 226)
+	Applets = make(map[string]Applet, 228)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -304,6 +306,8 @@ func init() {
 	register(ap_pmutils_halt.NewHalt())
 	register(ap_pmutils_halt.NewPoweroff())
 	register(ap_pmutils_halt.NewReboot())
+	register(ap_procps_pwdx.New())
+	register(ap_procps_uptime.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())
 	register(ap_securityutils_pwscore.New())

--- a/internal/applets/procps/pwdx/pwdx.go
+++ b/internal/applets/procps/pwdx/pwdx.go
@@ -1,0 +1,70 @@
+// Package pwdx implements the pwdx applet: print the current working directory
+// of one or more processes.
+package pwdx
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the pwdx applet.
+type Command struct{}
+
+// New returns a pwdx command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "pwdx" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the working directory of a process" }
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+// Run executes pwdx.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "PID...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the current working directory of each process given by PID, read from " +
+			"/proc/PID/cwd.",
+		Examples: []command.Example{
+			{Command: "pwdx 1234", Explain: "Print process 1234's working directory."},
+		},
+		ExitStatus: "0  every PID was resolved.\n1  a PID was invalid or could not be read.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	pids := fs.Args()
+	if len(pids) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "pwdx: a PID is required")
+		return command.SilentFailure()
+	}
+
+	failed := false
+	for _, p := range pids {
+		if _, err := strconv.Atoi(p); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "pwdx: %s: invalid process id\n", p)
+			failed = true
+			continue
+		}
+		cwd, err := os.Readlink(filepath.Join(procDir, p, "cwd"))
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "pwdx: %s: %v\n", p, err)
+			failed = true
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%s: %s\n", p, cwd)
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}

--- a/internal/applets/procps/pwdx/pwdx_test.go
+++ b/internal/applets/procps/pwdx/pwdx_test.go
@@ -1,0 +1,66 @@
+package pwdx
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withProc(t *testing.T, pid, cwd string) {
+	t.Helper()
+	dir := t.TempDir()
+	pdir := filepath.Join(dir, pid)
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(cwd, filepath.Join(pdir, "cwd")); err != nil {
+		t.Fatal(err)
+	}
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestPrintCwd(t *testing.T) {
+	withProc(t, "1234", "/home/alice/work")
+	out, err := run(t, "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "1234: /home/alice/work" {
+		t.Errorf("pwdx = %q", out)
+	}
+}
+
+func TestInvalidPid(t *testing.T) {
+	withProc(t, "1", "/")
+	if _, err := run(t, "notapid"); err == nil {
+		t.Errorf("invalid PID should fail")
+	}
+}
+
+func TestMissingProcess(t *testing.T) {
+	withProc(t, "1", "/")
+	if _, err := run(t, "9999"); err == nil {
+		t.Errorf("a missing process should fail")
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	if _, err := run(t); err == nil {
+		t.Errorf("no PID should fail")
+	}
+}

--- a/internal/applets/procps/uptime/uptime.go
+++ b/internal/applets/procps/uptime/uptime.go
@@ -1,0 +1,124 @@
+// Package uptime implements the uptime applet: show how long the system has been
+// running, the number of logged-in users, and the load averages.
+package uptime
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the uptime applet.
+type Command struct{}
+
+// New returns an uptime command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "uptime" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Tell how long the system has been running" }
+
+// Injected so the output can be tested deterministically.
+var (
+	uptimePath  = "/proc/uptime"
+	loadavgPath = "/proc/loadavg"
+	utmpPath    = "/var/run/utmp"
+	now         = time.Now
+)
+
+// utmp layout: 384-byte records; USER_PROCESS is type 7.
+const (
+	recordSize  = 384
+	userProcess = 7
+)
+
+// Run executes uptime.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the current time, how long the system has been up, the number of users " +
+			"currently logged in, and the load averages for the past 1, 5, and 15 minutes.",
+		Examples: []command.Example{
+			{Command: "uptime", Explain: "Show the uptime summary."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(stdio.Out, line(now(), readUptime(), readLoadavg(), countUsers()))
+	return nil
+}
+
+// line builds the uptime summary, matching the procps layout.
+func line(t time.Time, up time.Duration, load string, users int) string {
+	word := "users"
+	if users == 1 {
+		word = "user"
+	}
+	return fmt.Sprintf(" %s up %s,  %d %s,  load average: %s",
+		t.Format("15:04:05"), formatUptime(up), users, word, load)
+}
+
+// formatUptime renders the uptime like procps does.
+func formatUptime(d time.Duration) string {
+	totalMin := int(d.Minutes())
+	days := totalMin / (60 * 24)
+	hours := (totalMin / 60) % 24
+	mins := totalMin % 60
+	switch {
+	case days > 1:
+		return fmt.Sprintf("%d days, %2d:%02d", days, hours, mins)
+	case days == 1:
+		return fmt.Sprintf("1 day, %2d:%02d", hours, mins)
+	default:
+		return fmt.Sprintf("%2d:%02d", hours, mins)
+	}
+}
+
+func readUptime() time.Duration {
+	data, err := os.ReadFile(uptimePath)
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0
+	}
+	secs, _ := strconv.ParseFloat(fields[0], 64)
+	return time.Duration(secs) * time.Second
+}
+
+func readLoadavg() string {
+	data, err := os.ReadFile(loadavgPath)
+	if err != nil {
+		return "0.00, 0.00, 0.00"
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 3 {
+		return "0.00, 0.00, 0.00"
+	}
+	return fmt.Sprintf("%s, %s, %s", fields[0], fields[1], fields[2])
+}
+
+func countUsers() int {
+	data, err := os.ReadFile(utmpPath)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for off := 0; off+recordSize <= len(data); off += recordSize {
+		if int16(binary.LittleEndian.Uint16(data[off:])) == userProcess {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/applets/procps/uptime/uptime_test.go
+++ b/internal/applets/procps/uptime/uptime_test.go
@@ -1,0 +1,79 @@
+package uptime
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T, up, load string, users int) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	utmp := make([]byte, recordSize*users)
+	for i := 0; i < users; i++ {
+		binary.LittleEndian.PutUint16(utmp[i*recordSize:], userProcess)
+	}
+	uf := filepath.Join(dir, "utmp")
+	if err := os.WriteFile(uf, utmp, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ou, ol, oum, on := uptimePath, loadavgPath, utmpPath, now
+	uptimePath = write("uptime", up)
+	loadavgPath = write("loadavg", load)
+	utmpPath = uf
+	now = func() time.Time { return time.Date(2026, 6, 10, 21, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { uptimePath, loadavgPath, utmpPath, now = ou, ol, oum, on })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return strings.TrimRight(out.String(), "\n")
+}
+
+func TestUptimeLine(t *testing.T) {
+	setup(t, "90000.0 1.0\n", "0.50 0.40 0.30 1/1 1\n", 2)
+	out := run(t)
+	if !strings.Contains(out, "load average: 0.50, 0.40, 0.30") {
+		t.Errorf("load = %q", out)
+	}
+	if !strings.Contains(out, "2 users") {
+		t.Errorf("users = %q", out)
+	}
+	if !strings.Contains(out, "up 1 day,  1:00") { // 90000s = 1 day 1:00
+		t.Errorf("uptime = %q", out)
+	}
+}
+
+func TestFormatUptime(t *testing.T) {
+	t.Parallel()
+	cases := map[time.Duration]string{
+		90 * time.Minute: " 1:30",
+		25 * time.Hour:   "1 day,  1:00",
+		49 * time.Hour:   "2 days,  1:00",
+	}
+	for d, want := range cases {
+		if got := formatUptime(d); got != want {
+			t.Errorf("formatUptime(%v) = %q, want %q", d, got, want)
+		}
+	}
+}

--- a/test/it/procps/uptime_pwdx_test.sh
+++ b/test/it/procps/uptime_pwdx_test.sh
@@ -1,0 +1,5 @@
+TestUptime() { uptime | grep -c 'load average'; }
+TestPwdx() {
+    cd /tmp
+    pwdx $$ | grep -c '/'
+}

--- a/test/it/spec/uptime_pwdx_spec.sh
+++ b/test/it/spec/uptime_pwdx_spec.sh
@@ -1,0 +1,14 @@
+Describe 'uptime / pwdx'
+    Include procps/uptime_pwdx_test.sh
+
+    It 'uptime shows the load averages'
+        When call TestUptime
+        The output should equal '1'
+        The status should be success
+    End
+    It 'pwdx prints a process working directory'
+        When call TestPwdx
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Starts the procps batch (#245) with two /proc-reading applets:

- **`uptime`** — print the current time, how long the system has been up, the number of logged-in users, and the 1/5/15-minute load averages (from /proc/uptime, /proc/loadavg, and utmp). The output matches the procps layout.
- **`pwdx`** — print the current working directory of each PID (from /proc/PID/cwd), matching host pwdx.

The /proc paths, clock, and utmp are injectable so both are tested deterministically.

## Tests

- Unit (fixtures): uptime's load averages, user count, and day/hour formatting (plus formatUptime); pwdx's cwd output, invalid-PID, missing-process, and no-argument errors.
- shellspec: uptime shows the load averages, and pwdx prints a process working directory.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (566 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245