### PR TITLE
feat(procps): add pgrep and pkill applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 228 commands. Run `mimixbox --list` to see them on the terminal.
+There are 230 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -146,9 +146,11 @@ There are 228 commands. Run `mimixbox --list` to see them on the terminal.
 | paste | Merge lines of files |
 | patch | Apply a diff file to an original |
 | path | Manipulate filename path |
+| pgrep | Find process IDs by name |
 | pidof | Find the process ID of a running program |
 | ping | Send ICMP ECHO_REQUEST to network hosts |
 | pipe_progress | Copy stdin to stdout, printing progress dots to stderr |
+| pkill | Signal processes by name |
 | posixer | Report which POSIX utilities are installed |
 | poweroff | Power off the system |
 | printenv | Print environment variable |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -77,6 +77,7 @@ import (
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
 	ap_netutils_whris "github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
+	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
@@ -218,7 +219,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 228)
+	Applets = make(map[string]Applet, 230)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -306,6 +307,8 @@ func init() {
 	register(ap_pmutils_halt.NewHalt())
 	register(ap_pmutils_halt.NewPoweroff())
 	register(ap_pmutils_halt.NewReboot())
+	register(ap_procps_pgrep.NewPgrep())
+	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pwdx.New())
 	register(ap_procps_uptime.New())
 	register(ap_securityutils_pwcrack.New())

--- a/internal/applets/procps/pgrep/pgrep.go
+++ b/internal/applets/procps/pgrep/pgrep.go
@@ -1,0 +1,154 @@
+// Package pgrep implements the pgrep and pkill applets: find (and, for pkill,
+// signal) processes whose name matches a pattern.
+package pgrep
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"github.com/nao1215/mimixbox/internal/signal"
+)
+
+// Command is the pgrep or pkill applet.
+type Command struct{ kill bool }
+
+// NewPgrep returns the pgrep applet.
+func NewPgrep() *Command { return &Command{} }
+
+// NewPkill returns the pkill applet.
+func NewPkill() *Command { return &Command{kill: true} }
+
+// Name returns the command name.
+func (c *Command) Name() string {
+	if c.kill {
+		return "pkill"
+	}
+	return "pgrep"
+}
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string {
+	if c.kill {
+		return "Signal processes by name"
+	}
+	return "Find process IDs by name"
+}
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+// sendSignal is indirected so signalling is testable.
+var sendSignal = func(pid int, sig syscall.Signal) error { return syscall.Kill(pid, sig) }
+
+// Run executes pgrep/pkill.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	usage := "PATTERN"
+	if c.kill {
+		usage = "[-SIGNAL] PATTERN"
+	}
+	fs := command.NewFlagSet(c.Name(), usage, stdio.Err).WithHelp(c.help())
+	sigSpec := fs.StringP("signal", "s", "TERM", "signal to send (pkill)")
+
+	// Let pkill accept the "-9"/"-KILL" shorthand by rewriting it to --signal.
+	if c.kill && len(args) > 0 && strings.HasPrefix(args[0], "-") && args[0] != "--help" && args[0] != "--version" {
+		if _, err := signal.Number(strings.TrimPrefix(args[0], "-")); err == nil {
+			args = append([]string{"--signal", strings.TrimPrefix(args[0], "-")}, args[1:]...)
+		}
+	}
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: a pattern is required\n", c.Name())
+		return command.SilentFailure()
+	}
+	re, err := regexp.Compile(rest[0])
+	if err != nil {
+		return command.Failuref("invalid pattern: %v", err)
+	}
+
+	pids := match(re)
+	if len(pids) == 0 {
+		return command.SilentFailure() // pgrep/pkill exit 1 when nothing matches
+	}
+
+	if !c.kill {
+		for _, pid := range pids {
+			_, _ = fmt.Fprintln(stdio.Out, pid)
+		}
+		return nil
+	}
+
+	sigNum, err := signal.Number(*sigSpec)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	failed := false
+	for _, pid := range pids {
+		if err := sendSignal(pid, syscall.Signal(sigNum)); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "pkill: signalling %d failed: %v\n", pid, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// match returns the sorted PIDs whose process name matches re.
+func match(re *regexp.Regexp) []int {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(procDir, e.Name(), "comm")) //nolint:gosec // /proc path
+		if err != nil {
+			continue
+		}
+		if re.MatchString(strings.TrimSpace(string(data))) {
+			pids = append(pids, pid)
+		}
+	}
+	sort.Ints(pids)
+	return pids
+}
+
+func (c *Command) help() command.Help {
+	if c.kill {
+		return command.Help{
+			Description: "Send a signal (SIGTERM by default, or -SIGNAL / -s SIGNAL) to every process " +
+				"whose name matches the regular expression PATTERN.",
+			Examples: []command.Example{
+				{Command: "pkill -9 firefox", Explain: "Force-kill processes named like firefox."},
+			},
+			ExitStatus: "0  at least one process was signalled.\n1  nothing matched.",
+		}
+	}
+	return command.Help{
+		Description: "Print the process IDs of every process whose name matches the regular expression " +
+			"PATTERN, one per line in ascending order.",
+		Examples: []command.Example{
+			{Command: "pgrep sshd", Explain: "List the PIDs of sshd processes."},
+		},
+		ExitStatus: "0  at least one process matched.\n1  nothing matched.",
+	}
+}

--- a/internal/applets/procps/pgrep/pgrep_test.go
+++ b/internal/applets/procps/pgrep/pgrep_test.go
@@ -1,0 +1,106 @@
+package pgrep
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, procs map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	for pid, comm := range procs {
+		pdir := filepath.Join(dir, pid)
+		if err := os.MkdirAll(pdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pdir, "comm"), []byte(comm+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A non-numeric entry must be ignored.
+	_ = os.MkdirAll(filepath.Join(dir, "self"), 0o755)
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+type sig struct {
+	pid int
+	num syscall.Signal
+}
+
+func stubSignal(t *testing.T) *[]sig {
+	t.Helper()
+	var calls []sig
+	orig := sendSignal
+	sendSignal = func(pid int, s syscall.Signal) error { calls = append(calls, sig{pid, s}); return nil }
+	t.Cleanup(func() { sendSignal = orig })
+	return &calls
+}
+
+func run(t *testing.T, c *Command, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := c.Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestPgrepMatches(t *testing.T) {
+	fixture(t, map[string]string{"10": "sshd", "20": "bash", "30": "sshd"})
+	out, err := run(t, NewPgrep(), "sshd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "10\n30" {
+		t.Errorf("pgrep = %q, want \"10\\n30\"", out)
+	}
+}
+
+func TestPgrepNoMatch(t *testing.T) {
+	fixture(t, map[string]string{"10": "bash"})
+	if _, err := run(t, NewPgrep(), "nope"); err == nil {
+		t.Errorf("no match should exit non-zero")
+	}
+}
+
+func TestPkillSignals(t *testing.T) {
+	fixture(t, map[string]string{"10": "vim", "20": "vim", "30": "less"})
+	calls := stubSignal(t)
+	if _, err := run(t, NewPkill(), "vim"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("signalled %d processes, want 2", len(*calls))
+	}
+	for _, c := range *calls {
+		if c.num != syscall.SIGTERM {
+			t.Errorf("default signal = %v, want SIGTERM", c.num)
+		}
+	}
+}
+
+func TestPkillSignalShorthand(t *testing.T) {
+	fixture(t, map[string]string{"10": "vim"})
+	calls := stubSignal(t)
+	if _, err := run(t, NewPkill(), "-9", "vim"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 1 || (*calls)[0].num != syscall.SIGKILL {
+		t.Errorf("pkill -9 calls = %v, want SIGKILL", *calls)
+	}
+}
+
+func TestNoPattern(t *testing.T) {
+	fixture(t, map[string]string{"10": "x"})
+	if _, err := run(t, NewPgrep()); err == nil {
+		t.Errorf("no pattern should fail")
+	}
+}

--- a/test/it/procps/pgrep_test.sh
+++ b/test/it/procps/pgrep_test.sh
@@ -1,0 +1,13 @@
+# pgrep for a long-running helper started by the test.
+TestPgrepFindsSleep() {
+    sleep 30 &
+    p=$!
+    found=$(pgrep sleep | grep -c "^${p}$")
+    kill $p 2>/dev/null
+    echo "$found"
+}
+
+TestPgrepNoMatch() {
+    pgrep zzz_no_such_proc_zzz
+    echo "rc=$?"
+}

--- a/test/it/spec/pgrep_spec.sh
+++ b/test/it/spec/pgrep_spec.sh
@@ -1,0 +1,14 @@
+Describe 'pgrep / pkill'
+    Include procps/pgrep_test.sh
+
+    It 'finds a running process by name'
+        When call TestPgrepFindsSleep
+        The output should equal '1'
+        The status should be success
+    End
+    It 'exits non-zero when nothing matches'
+        When call TestPgrepNoMatch
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with the process-matching pair:

- **`pgrep PATTERN`** — print, in ascending order, the PIDs of every process whose name (from /proc/PID/comm) matches the regular expression PATTERN.
- **`pkill [-SIGNAL] PATTERN`** — send a signal (SIGTERM by default, or the `-9`/`-KILL` shorthand or `-s SIGNAL`) to every matching process. The signal is resolved through the shared signal table (the single source of truth from #264).

Both exit non-zero when nothing matches, per the procps convention. The /proc directory and the signal call are injectable so matching and signalling are tested without real processes.

## Tests

- Unit (fixture /proc + stubbed signal): pgrep matches and sorts PIDs and ignores non-numeric entries, the no-match non-zero exit, pkill signalling matched PIDs with SIGTERM by default and SIGKILL via `-9`, and the no-pattern error.
- shellspec: pgrep finds a backgrounded sleep by name, and exits non-zero when nothing matches.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (568 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245