### PR TITLE
style(pgrep): use American spelling

### DIFF
--- a/internal/applets/procps/pgrep/pgrep.go
+++ b/internal/applets/procps/pgrep/pgrep.go
@@ -45,7 +45,7 @@ func (c *Command) Synopsis() string {
 // procDir is the /proc mount; tests point it at a fixture.
 var procDir = "/proc"
 
-// sendSignal is indirected so signalling is testable.
+// sendSignal is indirected so signaling is testable.
 var sendSignal = func(pid int, sig syscall.Signal) error { return syscall.Kill(pid, sig) }
 
 // Run executes pgrep/pkill.
@@ -98,7 +98,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	failed := false
 	for _, pid := range pids {
 		if err := sendSignal(pid, syscall.Signal(sigNum)); err != nil {
-			_, _ = fmt.Fprintf(stdio.Err, "pkill: signalling %d failed: %v\n", pid, err)
+			_, _ = fmt.Fprintf(stdio.Err, "pkill: signaling %d failed: %v\n", pid, err)
 			failed = true
 		}
 	}
@@ -140,7 +140,7 @@ func (c *Command) help() command.Help {
 			Examples: []command.Example{
 				{Command: "pkill -9 firefox", Explain: "Force-kill processes named like firefox."},
 			},
-			ExitStatus: "0  at least one process was signalled.\n1  nothing matched.",
+			ExitStatus: "0  at least one process was signaled.\n1  nothing matched.",
 		}
 	}
 	return command.Help{

--- a/internal/applets/procps/pgrep/pgrep_test.go
+++ b/internal/applets/procps/pgrep/pgrep_test.go
@@ -78,7 +78,7 @@ func TestPkillSignals(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(*calls) != 2 {
-		t.Fatalf("signalled %d processes, want 2", len(*calls))
+		t.Fatalf("signaled %d processes, want 2", len(*calls))
 	}
 	for _, c := range *calls {
 		if c.num != syscall.SIGTERM {


### PR DESCRIPTION
Follow-up to #344 addressing CodeRabbit's spelling nitpicks: 'signalling'/'signalled' → 'signaling'/'signaled', for consistency with the rest of the codebase.

`go test ./internal/applets/procps/pgrep/` passes; golangci-lint clean.

Part of #245