### PR TITLE
feat(procps): add sysctl applet to read/write kernel parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 230 commands. Run `mimixbox --list` to see them on the terminal.
+There are 231 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -202,6 +202,7 @@ There are 230 commands. Run `mimixbox --list` to see them on the terminal.
 | stty | Print or change terminal line settings |
 | sum | Checksum and count the blocks in a file (BSD) |
 | sync | Synchronize cached writes to persistent storage |
+| sysctl | Read and write kernel parameters at runtime |
 | tac | Print the file contents from the end to the beginning |
 | tail | Print the last NUMBER(default=10) lines |
 | tar | Archive files (create, list, extract) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -79,6 +79,7 @@ import (
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
+	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
@@ -219,7 +220,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 230)
+	Applets = make(map[string]Applet, 231)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -310,6 +311,7 @@ func init() {
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pwdx.New())
+	register(ap_procps_sysctl.New())
 	register(ap_procps_uptime.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())

--- a/internal/applets/procps/sysctl/sysctl.go
+++ b/internal/applets/procps/sysctl/sysctl.go
@@ -1,0 +1,120 @@
+// Package sysctl implements the sysctl applet: read and write kernel parameters
+// through /proc/sys.
+package sysctl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the sysctl applet.
+type Command struct{}
+
+// New returns a sysctl command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "sysctl" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Read and write kernel parameters at runtime" }
+
+// sysDir is the sysctl tree; tests point it at a fixture.
+var sysDir = "/proc/sys"
+
+// Run executes sysctl.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-a] [-w] NAME[=VALUE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Read or write kernel parameters under /proc/sys. Names use dots (kernel.ostype). " +
+			"With -a, list every parameter; NAME=VALUE (or -w) writes a value.",
+		Examples: []command.Example{
+			{Command: "sysctl kernel.ostype", Explain: "Print one parameter."},
+			{Command: "sysctl -w net.ipv4.ip_forward=1", Explain: "Set a parameter."},
+		},
+		ExitStatus: "0  success.\n1  a parameter was missing or could not be set.",
+	})
+	all := fs.BoolP("all", "a", false, "list all parameters")
+	_ = fs.BoolP("write", "w", false, "write a NAME=VALUE setting")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if *all {
+		c.listAll(stdio.Out)
+		return nil
+	}
+
+	names := fs.Args()
+	if len(names) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "sysctl: a parameter name is required")
+		return command.SilentFailure()
+	}
+
+	failed := false
+	for _, arg := range names {
+		if name, value, isSet := strings.Cut(arg, "="); isSet {
+			if err := c.write(stdio.Out, name, value); err != nil {
+				_, _ = fmt.Fprintf(stdio.Err, "sysctl: %v\n", err)
+				failed = true
+			}
+			continue
+		}
+		if err := c.read(stdio.Out, arg); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sysctl: %v\n", err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// read prints one parameter as "name = value".
+func (c *Command) read(out io.Writer, name string) error {
+	data, err := os.ReadFile(pathFor(name)) //nolint:gosec // sysctl path
+	if err != nil {
+		return fmt.Errorf("cannot read %s: %w", name, err)
+	}
+	_, _ = fmt.Fprintf(out, "%s = %s\n", name, strings.TrimRight(string(data), "\n"))
+	return nil
+}
+
+// pathFor maps a dotted sysctl name to its file path.
+func pathFor(name string) string {
+	return filepath.Join(sysDir, filepath.FromSlash(strings.ReplaceAll(name, ".", "/")))
+}
+
+func (c *Command) write(out io.Writer, name, value string) error {
+	if err := os.WriteFile(pathFor(name), []byte(value), 0o644); err != nil { //nolint:gosec // sysctl path
+		return fmt.Errorf("cannot set %s: %w", name, err)
+	}
+	_, _ = fmt.Fprintf(out, "%s = %s\n", name, value)
+	return nil
+}
+
+// listAll walks the sysctl tree and prints every readable parameter.
+func (c *Command) listAll(out io.Writer) {
+	_ = filepath.WalkDir(sysDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		data, rerr := os.ReadFile(path) //nolint:gosec // sysctl path
+		if rerr != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(sysDir, path)
+		name := strings.ReplaceAll(filepath.ToSlash(rel), "/", ".")
+		_, _ = fmt.Fprintf(out, "%s = %s\n", name, strings.TrimRight(string(data), "\n"))
+		return nil
+	})
+}

--- a/internal/applets/procps/sysctl/sysctl_test.go
+++ b/internal/applets/procps/sysctl/sysctl_test.go
@@ -1,0 +1,91 @@
+package sysctl
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(rel, val string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(val+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("kernel/ostype", "Linux")
+	write("net/ipv4/ip_forward", "0")
+
+	orig := sysDir
+	sysDir = dir
+	t.Cleanup(func() { sysDir = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestRead(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "kernel.ostype")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "kernel.ostype = Linux\n" {
+		t.Errorf("read = %q", out)
+	}
+}
+
+func TestListAll(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "kernel.ostype = Linux") || !strings.Contains(out, "net.ipv4.ip_forward = 0") {
+		t.Errorf("-a = %q", out)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "net.ipv4.ip_forward=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "net.ipv4.ip_forward = 1\n" {
+		t.Errorf("write output = %q", out)
+	}
+	data, _ := os.ReadFile(filepath.Join(sysDir, "net/ipv4/ip_forward"))
+	if string(data) != "1" {
+		t.Errorf("file = %q, want 1", data)
+	}
+}
+
+func TestReadMissing(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "no.such.param"); err == nil {
+		t.Errorf("missing parameter should fail")
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	fixture(t)
+	if _, err := run(t); err == nil {
+		t.Errorf("no arguments should fail")
+	}
+}

--- a/test/it/procps/sysctl_test.sh
+++ b/test/it/procps/sysctl_test.sh
@@ -1,0 +1,2 @@
+TestSysctlRead() { sysctl kernel.ostype; }
+TestSysctlAll() { sysctl -a 2>/dev/null | grep -c ' = '; }

--- a/test/it/spec/sysctl_spec.sh
+++ b/test/it/spec/sysctl_spec.sh
@@ -1,0 +1,14 @@
+Describe 'sysctl'
+    Include procps/sysctl_test.sh
+
+    It 'reads a kernel parameter'
+        When call TestSysctlRead
+        The output should equal 'kernel.ostype = Linux'
+        The status should be success
+    End
+    It 'lists parameters with -a'
+        When call TestSysctlAll
+        The status should be success
+        The output should not equal '0'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `sysctl`, which reads and writes kernel parameters through /proc/sys. Dotted names map to paths (`kernel.ostype` → kernel/ostype): `sysctl NAME` prints `NAME = value`, `sysctl -a` lists every parameter, and `sysctl NAME=VALUE` (or `-w`) writes one. The sysctl tree is injectable so reads and writes are tested against a fixture. Output matches host sysctl.

## Tests

- Unit (fixture /proc/sys): read a parameter, `-a` listing, write NAME=VALUE (verifying both the output and the file), and the missing-parameter / no-argument errors.
- shellspec: read `kernel.ostype` and that `-a` lists parameters.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (570 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245