### PR TITLE
feat(procps): add pmap applet to report a process memory map

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 231 commands. Run `mimixbox --list` to see them on the terminal.
+There are 232 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -151,6 +151,7 @@ There are 231 commands. Run `mimixbox --list` to see them on the terminal.
 | ping | Send ICMP ECHO_REQUEST to network hosts |
 | pipe_progress | Copy stdin to stdout, printing progress dots to stderr |
 | pkill | Signal processes by name |
+| pmap | Report the memory map of a process |
 | posixer | Report which POSIX utilities are installed |
 | poweroff | Power off the system |
 | printenv | Print environment variable |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -78,6 +78,7 @@ import (
 	ap_netutils_whris "github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
+	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
 	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
@@ -220,7 +221,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 231)
+	Applets = make(map[string]Applet, 232)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -310,6 +311,7 @@ func init() {
 	register(ap_pmutils_halt.NewReboot())
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
+	register(ap_procps_pmap.New())
 	register(ap_procps_pwdx.New())
 	register(ap_procps_sysctl.New())
 	register(ap_procps_uptime.New())

--- a/internal/applets/procps/pmap/pmap.go
+++ b/internal/applets/procps/pmap/pmap.go
@@ -1,0 +1,147 @@
+// Package pmap implements the pmap applet: report the memory map of a process,
+// read from /proc/PID/maps.
+package pmap
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the pmap applet.
+type Command struct{}
+
+// New returns a pmap command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "pmap" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report the memory map of a process" }
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+// Run executes pmap.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "PID...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the memory mappings of each process given by PID: one line per mapping " +
+			"(address, size, permissions, and name) and a total, read from /proc/PID/maps.",
+		Examples: []command.Example{
+			{Command: "pmap 1234", Explain: "Show process 1234's memory map."},
+		},
+		ExitStatus: "0  every PID was reported.\n1  a PID was invalid or could not be read.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	pids := fs.Args()
+	if len(pids) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "pmap: a PID is required")
+		return command.SilentFailure()
+	}
+
+	failed := false
+	for _, p := range pids {
+		if _, err := strconv.Atoi(p); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "pmap: %s: invalid process id\n", p)
+			failed = true
+			continue
+		}
+		if err := c.report(stdio, p); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "pmap: %s: %v\n", p, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// report prints one process's map and total.
+func (c *Command) report(stdio command.IO, pid string) error {
+	f, err := os.Open(filepath.Join(procDir, pid, "maps")) //nolint:gosec // /proc path
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	_, _ = fmt.Fprintf(stdio.Out, "%s:   %s\n", pid, cmdline(pid))
+
+	var total int64
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		start, size, perms, name, ok := parseLine(sc.Text())
+		if !ok {
+			continue
+		}
+		total += size
+		_, _ = fmt.Fprintf(stdio.Out, "%016x %7dK %s %s\n", start, size, perms, name)
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdio.Out, " total %12dK\n", total)
+	return nil
+}
+
+// parseLine parses one /proc/PID/maps line into its start address, size in KiB,
+// reformatted permissions, and display name.
+func parseLine(line string) (start uint64, sizeKB int64, perms, name string, ok bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0, 0, "", "", false
+	}
+	lo, hi, found := strings.Cut(fields[0], "-")
+	if !found {
+		return 0, 0, "", "", false
+	}
+	s, err1 := strconv.ParseUint(lo, 16, 64)
+	e, err2 := strconv.ParseUint(hi, 16, 64)
+	if err1 != nil || err2 != nil {
+		return 0, 0, "", "", false
+	}
+	name = "[ anon ]"
+	if len(fields) >= 6 {
+		path := strings.Join(fields[5:], " ")
+		if strings.HasPrefix(path, "[") {
+			name = path
+		} else {
+			name = filepath.Base(path)
+		}
+	}
+	return s, int64(e-s) / 1024, mode(fields[1]), name, true
+}
+
+// mode converts maps permissions ("r-xp") to pmap's "r-x--" form.
+func mode(p string) string {
+	b := []byte("-----")
+	for i := 0; i < 3 && i < len(p); i++ {
+		if p[i] != '-' {
+			b[i] = p[i]
+		}
+	}
+	if len(p) >= 4 && p[3] == 's' {
+		b[3] = 's'
+	}
+	return string(b)
+}
+
+// cmdline returns the process command line, or "[unknown]".
+func cmdline(pid string) string {
+	data, err := os.ReadFile(filepath.Join(procDir, pid, "cmdline")) //nolint:gosec // /proc path
+	if err != nil || len(data) == 0 {
+		return "[unknown]"
+	}
+	return strings.TrimSpace(strings.ReplaceAll(string(data), "\x00", " "))
+}

--- a/internal/applets/procps/pmap/pmap_test.go
+++ b/internal/applets/procps/pmap/pmap_test.go
@@ -1,0 +1,97 @@
+package pmap
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	pdir := filepath.Join(dir, "1234")
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	maps := "00400000-00410000 r-xp 00000000 08:01 123 /usr/bin/cat\n" +
+		"7ffd00000000-7ffd00001000 rw-p 00000000 00:00 0 [stack]\n"
+	if err := os.WriteFile(filepath.Join(pdir, "maps"), []byte(maps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pdir, "cmdline"), []byte("cat\x00file\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestReport(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "1234:   cat file") {
+		t.Errorf("header missing: %q", out)
+	}
+	// 0x10000 = 64K, r-x--, cat
+	if !strings.Contains(out, "0000000000400000      64K r-x-- cat") {
+		t.Errorf("cat mapping wrong: %q", out)
+	}
+	// 0x1000 = 4K stack
+	if !strings.Contains(out, "rw--- [stack]") {
+		t.Errorf("stack mapping wrong: %q", out)
+	}
+	// total 64 + 4 = 68K
+	if !strings.Contains(out, "total           68K") {
+		t.Errorf("total wrong: %q", out)
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	t.Parallel()
+	start, size, perms, name, ok := parseLine("00400000-00410000 r-xp 00000000 08:01 123 /usr/bin/cat")
+	if !ok || start != 0x400000 || size != 64 || perms != "r-x--" || name != "cat" {
+		t.Errorf("parseLine = %x, %d, %q, %q, %v", start, size, perms, name, ok)
+	}
+	if _, _, _, _, ok := parseLine("garbage"); ok {
+		t.Errorf("garbage should not parse")
+	}
+}
+
+func TestMode(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{"r-xp": "r-x--", "rw-p": "rw---", "rwxs": "rwxs-", "---p": "-----"}
+	for in, want := range cases {
+		if got := mode(in); got != want {
+			t.Errorf("mode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "notapid"); err == nil {
+		t.Errorf("invalid PID should fail")
+	}
+	if _, err := run(t, "9999"); err == nil {
+		t.Errorf("missing process should fail")
+	}
+	if _, err := run(t); err == nil {
+		t.Errorf("no PID should fail")
+	}
+}

--- a/test/it/procps/pmap_test.sh
+++ b/test/it/procps/pmap_test.sh
@@ -1,0 +1,2 @@
+TestPmapTotal() { pmap $$ | tail -n 1 | grep -c 'total'; }
+TestPmapInvalid() { pmap notapid 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/pmap_spec.sh
+++ b/test/it/spec/pmap_spec.sh
@@ -1,0 +1,14 @@
+Describe 'pmap'
+    Include procps/pmap_test.sh
+
+    It 'prints a total line for a process map'
+        When call TestPmapTotal
+        The output should equal '1'
+        The status should be success
+    End
+    It 'rejects an invalid PID'
+        When call TestPmapInvalid
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `pmap`, which reports the memory mappings of each PID from /proc/PID/maps: a header (PID and command line), one line per mapping (address, size in KiB, permissions, and name), and a total. Map permissions are reformatted to pmap's `r-x--` style, and anonymous/special regions are labelled. The /proc directory is injectable so parsing is tested against fixtures. The computed total matches host pmap.

## Tests

- Unit (fixture /proc/PID/maps + cmdline): the header, a file-backed mapping (address/size/perms/name), a [stack] mapping, the summed total, the `parseLine` parser, the `mode` permission conversion, and the invalid-PID / missing-process / no-argument errors.
- shellspec: pmap prints a total line for a process map, and rejects an invalid PID.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (572 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245