### PR TITLE
feat(procps): add pstree applet to display the process tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 232 commands. Run `mimixbox --list` to see them on the terminal.
+There are 233 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -156,6 +156,7 @@ There are 232 commands. Run `mimixbox --list` to see them on the terminal.
 | poweroff | Power off the system |
 | printenv | Print environment variable |
 | printf | Format and print data |
+| pstree | Display the process tree |
 | pwcrack | Audit crypt(3) password hashes against a wordlist |
 | pwd | Print Working Directory |
 | pwdx | Print the working directory of a process |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -79,6 +79,7 @@ import (
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
+	ap_procps_pstree "github.com/nao1215/mimixbox/internal/applets/procps/pstree"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
 	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
@@ -221,7 +222,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 232)
+	Applets = make(map[string]Applet, 233)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -312,6 +313,7 @@ func init() {
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pmap.New())
+	register(ap_procps_pstree.New())
 	register(ap_procps_pwdx.New())
 	register(ap_procps_sysctl.New())
 	register(ap_procps_uptime.New())

--- a/internal/applets/procps/pstree/pstree.go
+++ b/internal/applets/procps/pstree/pstree.go
@@ -1,0 +1,149 @@
+// Package pstree implements the pstree applet: show the running processes as a
+// tree, read from /proc.
+package pstree
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the pstree applet.
+type Command struct{}
+
+// New returns a pstree command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "pstree" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Display the process tree" }
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+type proc struct {
+	pid  int
+	comm string
+	ppid int
+}
+
+// Run executes pstree.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Show the running processes as a tree, each node printed as 'name(pid)' with its " +
+			"children indented beneath it, read from /proc.",
+		Examples: []command.Example{
+			{Command: "pstree", Explain: "Print the process tree."},
+		},
+		Notes: []string{
+			"This is the indented-tree form; the compacted classic pstree layout is not reproduced.",
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	procs := readProcs()
+	children := map[int][]int{}
+	known := map[int]bool{}
+	for _, p := range procs {
+		known[p.pid] = true
+	}
+	byPid := map[int]proc{}
+	for _, p := range procs {
+		byPid[p.pid] = p
+		children[p.ppid] = append(children[p.ppid], p.pid)
+	}
+
+	// Roots: processes whose parent is not itself a known process (pid 1, or
+	// orphans whose ppid is 0).
+	var roots []int
+	for _, p := range procs {
+		if !known[p.ppid] || p.ppid == p.pid {
+			roots = append(roots, p.pid)
+		}
+	}
+	sort.Ints(roots)
+	for _, r := range children {
+		sort.Ints(r)
+	}
+
+	for _, r := range roots {
+		printTree(stdio.Out, byPid, children, r, "", true)
+	}
+	return nil
+}
+
+// printTree prints the subtree rooted at pid.
+func printTree(out io.Writer, byPid map[int]proc, children map[int][]int, pid int, prefix string, root bool) {
+	p := byPid[pid]
+	if root {
+		_, _ = fmt.Fprintf(out, "%s(%d)\n", p.comm, p.pid)
+	}
+	kids := children[pid]
+	for i, kid := range kids {
+		last := i == len(kids)-1
+		connector, childPrefix := "├─", prefix+"│ "
+		if last {
+			connector, childPrefix = "└─", prefix+"  "
+		}
+		kp := byPid[kid]
+		_, _ = fmt.Fprintf(out, "%s%s%s(%d)\n", prefix, connector, kp.comm, kp.pid)
+		printTree(out, byPid, children, kid, childPrefix, false)
+	}
+}
+
+// readProcs reads every process's pid, comm and ppid from /proc/*/stat.
+func readProcs() []proc {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var procs []proc
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(procDir, e.Name(), "stat")) //nolint:gosec // /proc path
+		if err != nil {
+			continue
+		}
+		comm, ppid, ok := parseStat(string(data))
+		if !ok {
+			continue
+		}
+		procs = append(procs, proc{pid: pid, comm: comm, ppid: ppid})
+	}
+	return procs
+}
+
+// parseStat extracts the comm (in parentheses) and the ppid (the field after
+// the state) from a /proc/PID/stat line.
+func parseStat(line string) (comm string, ppid int, ok bool) {
+	open := strings.IndexByte(line, '(')
+	closeP := strings.LastIndexByte(line, ')')
+	if open < 0 || closeP < 0 || closeP < open {
+		return "", 0, false
+	}
+	comm = line[open+1 : closeP]
+	rest := strings.Fields(line[closeP+1:])
+	if len(rest) < 2 { // state, ppid, ...
+		return "", 0, false
+	}
+	ppid, err := strconv.Atoi(rest[1])
+	if err != nil {
+		return "", 0, false
+	}
+	return comm, ppid, true
+}

--- a/internal/applets/procps/pstree/pstree_test.go
+++ b/internal/applets/procps/pstree/pstree_test.go
@@ -1,0 +1,92 @@
+package pstree
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// fixture writes /proc/PID/stat files for the given pid->(comm, ppid) tree.
+func fixture(t *testing.T, procs map[int][2]interface{}) {
+	t.Helper()
+	dir := t.TempDir()
+	for pid, info := range procs {
+		pdir := filepath.Join(dir, fmt.Sprintf("%d", pid))
+		if err := os.MkdirAll(pdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stat := fmt.Sprintf("%d (%s) S %d 0 0", pid, info[0], info[1])
+		if err := os.WriteFile(filepath.Join(pdir, "stat"), []byte(stat), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestTree(t *testing.T) {
+	fixture(t, map[int][2]interface{}{
+		1:   {"init", 0},
+		100: {"sshd", 1},
+		200: {"bash", 100},
+		150: {"cron", 1},
+	})
+	out := run(t)
+	for _, want := range []string{"init(1)", "sshd(100)", "bash(200)", "cron(150)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	// init is the root (printed first, no indentation).
+	if !strings.HasPrefix(out, "init(1)\n") {
+		t.Errorf("init should be the root: %q", out)
+	}
+	// bash appears after sshd (it is sshd's child).
+	if strings.Index(out, "sshd(100)") > strings.Index(out, "bash(200)") {
+		t.Errorf("bash should be under sshd:\n%s", out)
+	}
+}
+
+func TestParseStat(t *testing.T) {
+	t.Parallel()
+	comm, ppid, ok := parseStat("1234 (cat) S 100 1234 1234")
+	if !ok || comm != "cat" || ppid != 100 {
+		t.Errorf("parseStat = %q, %d, %v", comm, ppid, ok)
+	}
+	// A comm containing spaces and parentheses.
+	comm, ppid, ok = parseStat("5 (foo (bar) baz) R 7 0 0")
+	if !ok || comm != "foo (bar) baz" || ppid != 7 {
+		t.Errorf("parseStat with parens = %q, %d, %v", comm, ppid, ok)
+	}
+	if _, _, ok := parseStat("garbage"); ok {
+		t.Errorf("garbage should not parse")
+	}
+}
+
+func TestOrphanRoots(t *testing.T) {
+	// A process whose parent is not in /proc is treated as a root.
+	fixture(t, map[int][2]interface{}{
+		500: {"daemon", 999}, // ppid 999 has no stat file
+	})
+	out := run(t)
+	if !strings.HasPrefix(out, "daemon(500)\n") {
+		t.Errorf("orphan should be a root: %q", out)
+	}
+}

--- a/test/it/procps/pstree_test.sh
+++ b/test/it/procps/pstree_test.sh
@@ -1,0 +1,5 @@
+# The tree connectors are multibyte; grep for an ASCII node label to confirm the
+# tree was built. PID 1 (init/systemd) is always present.
+TestPstreeHasInit() {
+    pstree | grep -c '(1)'
+}

--- a/test/it/spec/pstree_spec.sh
+++ b/test/it/spec/pstree_spec.sh
@@ -1,0 +1,9 @@
+Describe 'pstree'
+    Include procps/pstree_test.sh
+
+    It 'builds a tree containing PID 1'
+        When call TestPstreeHasInit
+        The status should be success
+        The output should not equal '0'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `pstree`, which shows the running processes as a tree read from /proc. Each node is printed as `name(pid)` with its children indented beneath it using `├─`/`└─`/`│` connectors. Process names and parent PIDs come from /proc/PID/stat (the comm-in-parentheses and the field after the state are parsed correctly even when the name contains spaces or parentheses). Orphans whose parent is not a known process become roots. The /proc directory is injectable so the tree is tested against fixtures.

This is the indented-tree form; the compacted classic pstree layout is documented as not reproduced.

## Tests

- Unit (fixture /proc): a four-process tree (root, child, grandchild ordering), the `parseStat` parser including a comm with spaces and nested parentheses, and orphan-as-root handling.
- shellspec: pstree builds a tree containing PID 1 (the connectors are multibyte, so the ASCII node label is asserted).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (573 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245