### PR TITLE
feat(procps): add logger applet to write to the system log

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 233 commands. Run `mimixbox --list` to see them on the terminal.
+There are 234 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -118,6 +118,7 @@ There are 233 commands. Run `mimixbox --list` to see them on the terminal.
 | linux64 | Run a program with a 64-bit execution domain |
 | ln | Create hard or symbolic link |
 | log-collect | Gather system log files into one directory |
+| logger | Write a message to the system log |
 | logname | Print the name of the current user |
 | ls | List directory contents |
 | lsblk | List information about block devices |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -77,6 +77,7 @@ import (
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
 	ap_netutils_whris "github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
+	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
 	ap_procps_pstree "github.com/nao1215/mimixbox/internal/applets/procps/pstree"
@@ -222,7 +223,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 233)
+	Applets = make(map[string]Applet, 234)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -310,6 +311,7 @@ func init() {
 	register(ap_pmutils_halt.NewHalt())
 	register(ap_pmutils_halt.NewPoweroff())
 	register(ap_pmutils_halt.NewReboot())
+	register(ap_procps_logger.New())
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pmap.New())

--- a/internal/applets/procps/logger/logger.go
+++ b/internal/applets/procps/logger/logger.go
@@ -1,0 +1,126 @@
+// Package logger implements the logger applet: write a message to the system
+// log via syslog.
+package logger
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/syslog"
+	"os/user"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the logger applet.
+type Command struct{}
+
+// New returns a logger command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "logger" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Write a message to the system log" }
+
+// logFunc is indirected so logging is testable without a running syslogd.
+var logFunc = func(p syslog.Priority, tag, msg string) error {
+	w, err := syslog.New(p, tag)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = w.Close() }()
+	_, err = io.WriteString(w, msg)
+	return err
+}
+
+var facilities = map[string]syslog.Priority{
+	"kern": syslog.LOG_KERN, "user": syslog.LOG_USER, "mail": syslog.LOG_MAIL,
+	"daemon": syslog.LOG_DAEMON, "auth": syslog.LOG_AUTH, "syslog": syslog.LOG_SYSLOG,
+	"lpr": syslog.LOG_LPR, "news": syslog.LOG_NEWS, "uucp": syslog.LOG_UUCP,
+	"cron": syslog.LOG_CRON, "authpriv": syslog.LOG_AUTHPRIV, "ftp": syslog.LOG_FTP,
+	"local0": syslog.LOG_LOCAL0, "local1": syslog.LOG_LOCAL1, "local2": syslog.LOG_LOCAL2,
+	"local3": syslog.LOG_LOCAL3, "local4": syslog.LOG_LOCAL4, "local5": syslog.LOG_LOCAL5,
+	"local6": syslog.LOG_LOCAL6, "local7": syslog.LOG_LOCAL7,
+}
+
+var levels = map[string]syslog.Priority{
+	"emerg": syslog.LOG_EMERG, "alert": syslog.LOG_ALERT, "crit": syslog.LOG_CRIT,
+	"err": syslog.LOG_ERR, "error": syslog.LOG_ERR, "warning": syslog.LOG_WARNING,
+	"warn": syslog.LOG_WARNING, "notice": syslog.LOG_NOTICE, "info": syslog.LOG_INFO,
+	"debug": syslog.LOG_DEBUG,
+}
+
+// Run executes logger.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-p PRIORITY] [-t TAG] [-s] MESSAGE...", stdio.Err).WithHelp(command.Help{
+		Description: "Write MESSAGE (or standard input) to the system log. -p sets the priority as " +
+			"facility.level (default user.notice), -t sets the tag (default the user name), and -s " +
+			"also echoes the message to standard error.",
+		Examples: []command.Example{
+			{Command: "logger -t myapp 'started'", Explain: "Log a tagged message."},
+			{Command: "logger -p auth.warning 'bad login'", Explain: "Log with a priority."},
+		},
+		ExitStatus: "0  the message was logged.\n1  the priority was invalid or syslog was unreachable.",
+	})
+	prio := fs.StringP("priority", "p", "user.notice", "facility.level for the message")
+	tag := fs.StringP("tag", "t", "", "mark the message with this tag")
+	toStderr := fs.BoolP("stderr", "s", false, "also write the message to standard error")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	priority, err := parsePriority(*prio)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	var message string
+	if rest := fs.Args(); len(rest) > 0 {
+		message = strings.Join(rest, " ")
+	} else {
+		data, _ := io.ReadAll(stdio.In)
+		message = strings.TrimRight(string(data), "\n")
+	}
+
+	t := *tag
+	if t == "" {
+		t = defaultTag()
+	}
+
+	if err := logFunc(priority, t, message); err != nil {
+		return command.Failuref("%v", err)
+	}
+	if *toStderr {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: %s\n", t, message)
+	}
+	return nil
+}
+
+// parsePriority converts a "facility.level" spec to a syslog priority.
+func parsePriority(spec string) (syslog.Priority, error) {
+	facName, levName, hasDot := strings.Cut(spec, ".")
+	if !hasDot {
+		facName, levName = "user", spec
+	}
+	fac, ok := facilities[strings.ToLower(facName)]
+	if !ok {
+		return 0, fmt.Errorf("unknown facility: %q", facName)
+	}
+	lev, ok := levels[strings.ToLower(levName)]
+	if !ok {
+		return 0, fmt.Errorf("unknown level: %q", levName)
+	}
+	return fac | lev, nil
+}
+
+func defaultTag() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return "logger"
+}

--- a/internal/applets/procps/logger/logger_test.go
+++ b/internal/applets/procps/logger/logger_test.go
@@ -1,0 +1,89 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"log/syslog"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type logged struct {
+	prio syslog.Priority
+	tag  string
+	msg  string
+}
+
+func withStub(t *testing.T) *logged {
+	t.Helper()
+	captured := &logged{}
+	orig := logFunc
+	logFunc = func(p syslog.Priority, tag, msg string) error {
+		*captured = logged{p, tag, msg}
+		return nil
+	}
+	t.Cleanup(func() { logFunc = orig })
+	return captured
+}
+
+func run(t *testing.T, in string, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(in), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestLogsMessage(t *testing.T) {
+	got := withStub(t)
+	if err := run(t, "", "-t", "myapp", "hello", "world"); err != nil {
+		t.Fatal(err)
+	}
+	if got.tag != "myapp" || got.msg != "hello world" {
+		t.Errorf("logged = %+v", *got)
+	}
+	if got.prio != syslog.LOG_USER|syslog.LOG_NOTICE {
+		t.Errorf("default priority = %d, want user.notice", got.prio)
+	}
+}
+
+func TestPriority(t *testing.T) {
+	got := withStub(t)
+	if err := run(t, "", "-p", "auth.warning", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if got.prio != syslog.LOG_AUTH|syslog.LOG_WARNING {
+		t.Errorf("priority = %d, want auth.warning", got.prio)
+	}
+}
+
+func TestMessageFromStdin(t *testing.T) {
+	got := withStub(t)
+	if err := run(t, "from stdin\n", "-t", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if got.msg != "from stdin" {
+		t.Errorf("stdin msg = %q", got.msg)
+	}
+}
+
+func TestInvalidPriority(t *testing.T) {
+	withStub(t)
+	if err := run(t, "", "-p", "bogus.level", "x"); err == nil {
+		t.Errorf("invalid facility should fail")
+	}
+	if err := run(t, "", "-p", "user.bogus", "x"); err == nil {
+		t.Errorf("invalid level should fail")
+	}
+}
+
+func TestParsePriority(t *testing.T) {
+	t.Parallel()
+	if p, err := parsePriority("daemon.err"); err != nil || p != syslog.LOG_DAEMON|syslog.LOG_ERR {
+		t.Errorf("daemon.err = %d, %v", p, err)
+	}
+	// A bare level defaults to the user facility.
+	if p, err := parsePriority("info"); err != nil || p != syslog.LOG_USER|syslog.LOG_INFO {
+		t.Errorf("info = %d, %v", p, err)
+	}
+}

--- a/test/it/procps/logger_test.sh
+++ b/test/it/procps/logger_test.sh
@@ -1,0 +1,6 @@
+# Delivering to syslog needs a running syslogd, so the e2e exercises the
+# deterministic priority-validation path; logging itself is covered by unit tests.
+TestLoggerBadPriority() {
+    logger -p nosuchfacility.info msg 2>/dev/null
+    echo "rc=$?"
+}

--- a/test/it/spec/logger_spec.sh
+++ b/test/it/spec/logger_spec.sh
@@ -1,0 +1,9 @@
+Describe 'logger'
+    Include procps/logger_test.sh
+
+    It 'rejects an unknown facility'
+        When call TestLoggerBadPriority
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `logger`, which writes a message to the system log via syslog. `-p` sets the priority as `facility.level` (default user.notice), `-t` sets the tag (default the user name), and `-s` also echoes the message to stderr. The message comes from the operands or standard input. The syslog send is injectable so the priority/tag parsing and message handling are tested without a running syslogd.

## Tests

- Unit (stubbed syslog): a tagged message with the default user.notice priority, an explicit `facility.level` priority, a message read from stdin, invalid-facility and invalid-level errors, and the `parsePriority` parser (including a bare level defaulting to the user facility).
- shellspec: logger rejects an unknown facility (delivery needs a running syslogd, so the logging itself is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (574 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245