### PR TITLE
feat(procps): add fuser applet to identify processes using a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 234 commands. Run `mimixbox --list` to see them on the terminal.
+There are 235 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -87,6 +87,7 @@ There are 234 commands. Run `mimixbox --list` to see them on the terminal.
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
 | fsync | Flush a file's data to storage with fsync(2) |
+| fuser | Identify processes using a file |
 | getopt | Parse command options (enhanced, like util-linux getopt) |
 | ghrdc | GitHub Release Download Counter |
 | grep | Print lines that match patterns |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -77,6 +77,7 @@ import (
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
 	ap_netutils_whris "github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
+	ap_procps_fuser "github.com/nao1215/mimixbox/internal/applets/procps/fuser"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
@@ -223,7 +224,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 234)
+	Applets = make(map[string]Applet, 235)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -311,6 +312,7 @@ func init() {
 	register(ap_pmutils_halt.NewHalt())
 	register(ap_pmutils_halt.NewPoweroff())
 	register(ap_pmutils_halt.NewReboot())
+	register(ap_procps_fuser.New())
 	register(ap_procps_logger.New())
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())

--- a/internal/applets/procps/fuser/fuser.go
+++ b/internal/applets/procps/fuser/fuser.go
@@ -1,0 +1,136 @@
+// Package fuser implements the fuser applet: identify the processes using a file
+// (or directory) by scanning their /proc entries.
+package fuser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fuser applet.
+type Command struct{}
+
+// New returns a fuser command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fuser" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Identify processes using a file" }
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+// Run executes fuser.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the IDs of the processes that have FILE open, or use it as their working " +
+			"directory, executable, or root, found by scanning /proc. The 'FILE:' header is written " +
+			"to standard error and the PIDs to standard output.",
+		Examples: []command.Example{
+			{Command: "fuser /var/log/syslog", Explain: "List the processes using the log file."},
+		},
+		ExitStatus: "0  at least one process was found for some FILE.\n1  none were found.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "fuser: a FILE is required")
+		return command.SilentFailure()
+	}
+
+	anyFound := false
+	for _, name := range files {
+		target := resolve(name)
+		pids := usersOf(target)
+		_, _ = fmt.Fprintf(stdio.Err, "%s:", name)
+		var parts []string
+		for _, pid := range pids {
+			parts = append(parts, strconv.Itoa(pid))
+		}
+		if len(parts) > 0 {
+			anyFound = true
+			_, _ = fmt.Fprintln(stdio.Out, strings.Join(parts, " "))
+		}
+	}
+
+	if !anyFound {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// resolve returns the canonical absolute path of name for comparison.
+func resolve(name string) string {
+	if abs, err := filepath.Abs(name); err == nil {
+		name = abs
+	}
+	if real, err := filepath.EvalSymlinks(name); err == nil {
+		return real
+	}
+	return name
+}
+
+// usersOf returns the sorted PIDs whose fd/cwd/exe/root point at target.
+func usersOf(target string) []int {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		if processUses(filepath.Join(procDir, e.Name()), target) {
+			pids = append(pids, pid)
+		}
+	}
+	sort.Ints(pids)
+	return pids
+}
+
+// processUses reports whether the process at procPath references target through
+// its cwd, exe, root, or any open file descriptor.
+func processUses(procPath, target string) bool {
+	for _, link := range []string{"cwd", "exe", "root"} {
+		if linkEquals(filepath.Join(procPath, link), target) {
+			return true
+		}
+	}
+	fds, err := os.ReadDir(filepath.Join(procPath, "fd"))
+	if err != nil {
+		return false
+	}
+	for _, fd := range fds {
+		if linkEquals(filepath.Join(procPath, "fd", fd.Name()), target) {
+			return true
+		}
+	}
+	return false
+}
+
+// linkEquals reports whether the symlink at path resolves to target.
+func linkEquals(path, target string) bool {
+	dest, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	if real, err := filepath.EvalSymlinks(dest); err == nil {
+		dest = real
+	}
+	return dest == target
+}

--- a/internal/applets/procps/fuser/fuser_test.go
+++ b/internal/applets/procps/fuser/fuser_test.go
@@ -1,0 +1,92 @@
+package fuser
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// setup builds a fixture /proc and a target file, with one process holding the
+// target as an open fd and another using it as its cwd.
+func setup(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	proc := filepath.Join(base, "proc")
+	mklink := func(pid, rel, dest string) {
+		p := filepath.Join(proc, pid, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(dest, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mklink("100", "fd/3", target)  // process 100 has the file open
+	mklink("200", "cwd", base)     // process 200's cwd is the directory
+	mklink("300", "fd/4", "/etc/hosts") // process 300 uses something else
+
+	orig := procDir
+	procDir = proc
+	t.Cleanup(func() { procDir = orig })
+	return target
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestFindsOpenFile(t *testing.T) {
+	target := setup(t)
+	out, err := run(t, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "100" {
+		t.Errorf("fuser = %q, want 100", out)
+	}
+}
+
+func TestFindsByCwd(t *testing.T) {
+	target := setup(t)
+	dir := filepath.Dir(target)
+	out, err := run(t, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "200" {
+		t.Errorf("fuser dir = %q, want 200", out)
+	}
+}
+
+func TestNoUsers(t *testing.T) {
+	setup(t)
+	dir := t.TempDir()
+	unused := filepath.Join(dir, "lonely")
+	if err := os.WriteFile(unused, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, unused); err == nil {
+		t.Errorf("a file with no users should exit non-zero")
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	setup(t)
+	if _, err := run(t); err == nil {
+		t.Errorf("no file should fail")
+	}
+}

--- a/test/it/procps/fuser_test.sh
+++ b/test/it/procps/fuser_test.sh
@@ -1,0 +1,9 @@
+# The test's own process has its cwd here, so fuser . finds at least one PID.
+TestFuserCwd() {
+    fuser . 2>/dev/null | grep -cE '[0-9]'
+}
+
+TestFuserNone() {
+    fuser /no/such/fuser/file 2>/dev/null
+    echo "rc=$?"
+}

--- a/test/it/spec/fuser_spec.sh
+++ b/test/it/spec/fuser_spec.sh
@@ -1,0 +1,14 @@
+Describe 'fuser'
+    Include procps/fuser_test.sh
+
+    It 'finds processes using the current directory'
+        When call TestFuserCwd
+        The status should be success
+        The output should equal '1'
+    End
+    It 'exits non-zero when nothing uses the file'
+        When call TestFuserNone
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `fuser`, which prints the IDs of the processes using each FILE — found by scanning /proc for processes that have it open (an fd) or use it as their working directory, executable, or root. The `FILE:` header goes to standard error and the PIDs to standard output, matching host fuser. It exits non-zero when nothing uses any FILE. The /proc directory is injectable so the scan is tested against fixtures.

mmap-based usage is out of scope for this slice.

## Tests

- Unit (fixture /proc with fd/cwd symlinks): finding a process by an open fd, finding one by its cwd (a directory), the no-users non-zero exit, and the no-argument error.
- shellspec: fuser finds processes using the current directory, and exits non-zero when nothing uses the file.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (576 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fuser` command to identify which processes are using a specified file or directory.

* **Documentation**
  * Updated command reference with the new `fuser` command; total command count increased to 235.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->