### PR TITLE
feat(procps): add lsof applet to list open files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 235 commands. Run `mimixbox --list` to see them on the terminal.
+There are 236 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -123,6 +123,7 @@ There are 235 commands. Run `mimixbox --list` to see them on the terminal.
 | logname | Print the name of the current user |
 | ls | List directory contents |
 | lsblk | List information about block devices |
+| lsof | List open files of processes |
 | lspci | List PCI devices |
 | lsusb | List USB devices |
 | lzcat | Decompress lzma data to standard output |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -79,6 +79,7 @@ import (
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
 	ap_procps_fuser "github.com/nao1215/mimixbox/internal/applets/procps/fuser"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
+	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
 	ap_procps_pstree "github.com/nao1215/mimixbox/internal/applets/procps/pstree"
@@ -224,7 +225,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 235)
+	Applets = make(map[string]Applet, 236)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -314,6 +315,7 @@ func init() {
 	register(ap_pmutils_halt.NewReboot())
 	register(ap_procps_fuser.New())
 	register(ap_procps_logger.New())
+	register(ap_procps_lsof.New())
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pmap.New())

--- a/internal/applets/procps/lsof/lsof.go
+++ b/internal/applets/procps/lsof/lsof.go
@@ -1,0 +1,157 @@
+// Package lsof implements the lsof applet: list open files of processes, read
+// from /proc.
+package lsof
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the lsof applet.
+type Command struct{}
+
+// New returns a lsof command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "lsof" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List open files of processes" }
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+// Run executes lsof.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-p PID]", stdio.Err).WithHelp(command.Help{
+		Description: "List the open files of processes, one row per file, with the command, PID, owner, " +
+			"the file descriptor (cwd/rtd/txt or a number), and the path. With -p, restrict the " +
+			"listing to one process.",
+		Examples: []command.Example{
+			{Command: "lsof -p 1234", Explain: "List process 1234's open files."},
+		},
+		ExitStatus: "0  success.\n1  the requested PID could not be read.",
+	})
+	pid := fs.IntP("pid", "p", 0, "list only this PID's open files")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	var pids []int
+	if fs.Changed("pid") {
+		pids = []int{*pid}
+	} else {
+		pids = allPids()
+	}
+
+	tw := tabwriter.NewWriter(stdio.Out, 0, 0, 1, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "COMMAND\tPID\tUSER\tFD\tNAME")
+	found := false
+	for _, p := range pids {
+		if listProcess(tw, p) {
+			found = true
+		}
+	}
+	_ = tw.Flush()
+
+	if fs.Changed("pid") && !found {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// listProcess writes one process's open files; it reports whether the process
+// could be read.
+func listProcess(tw *tabwriter.Writer, pid int) bool {
+	dir := filepath.Join(procDir, strconv.Itoa(pid))
+	comm := field(dir, "comm")
+	if comm == "" {
+		return false
+	}
+	owner := ownerOf(dir)
+
+	row := func(fd, name string) {
+		if name != "" {
+			_, _ = fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\n", comm, pid, owner, fd, name)
+		}
+	}
+	row("cwd", readlink(filepath.Join(dir, "cwd")))
+	row("rtd", readlink(filepath.Join(dir, "root")))
+	row("txt", readlink(filepath.Join(dir, "exe")))
+
+	fds, err := os.ReadDir(filepath.Join(dir, "fd"))
+	if err == nil {
+		var nums []int
+		for _, e := range fds {
+			if n, err := strconv.Atoi(e.Name()); err == nil {
+				nums = append(nums, n)
+			}
+		}
+		sort.Ints(nums)
+		for _, n := range nums {
+			row(strconv.Itoa(n), readlink(filepath.Join(dir, "fd", strconv.Itoa(n))))
+		}
+	}
+	return true
+}
+
+func allPids() []int {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, e := range entries {
+		if n, err := strconv.Atoi(e.Name()); err == nil {
+			pids = append(pids, n)
+		}
+	}
+	sort.Ints(pids)
+	return pids
+}
+
+func field(dir, name string) string {
+	data, err := os.ReadFile(filepath.Join(dir, name)) //nolint:gosec // /proc path
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func readlink(path string) string {
+	dest, err := os.Readlink(path)
+	if err != nil {
+		return ""
+	}
+	return dest
+}
+
+// ownerOf returns the user name owning the process directory.
+func ownerOf(dir string) string {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "?"
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "?"
+	}
+	uid := strconv.FormatUint(uint64(st.Uid), 10)
+	if u, err := user.LookupId(uid); err == nil {
+		return u.Username
+	}
+	return uid
+}

--- a/internal/applets/procps/lsof/lsof_test.go
+++ b/internal/applets/procps/lsof/lsof_test.go
@@ -1,0 +1,80 @@
+package lsof
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	pdir := filepath.Join(dir, "1234")
+	if err := os.MkdirAll(filepath.Join(pdir, "fd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pdir, "comm"), []byte("myproc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mklink := func(rel, dest string) {
+		if err := os.Symlink(dest, filepath.Join(pdir, rel)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mklink("cwd", "/work/dir")
+	mklink("exe", "/usr/bin/myproc")
+	mklink("fd/0", "/dev/null")
+	mklink("fd/3", "/var/log/app.log")
+
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestListProcess(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "-p", "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"COMMAND", "myproc", "1234",
+		"cwd /work/dir", "txt /usr/bin/myproc",
+		"0   /dev/null", "3   /var/log/app.log",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestListAll(t *testing.T) {
+	fixture(t)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "myproc") {
+		t.Errorf("all-processes listing missing myproc:\n%s", out)
+	}
+}
+
+func TestMissingPid(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "-p", "9999"); err == nil {
+		t.Errorf("a missing PID should fail")
+	}
+}

--- a/test/it/procps/lsof_test.sh
+++ b/test/it/procps/lsof_test.sh
@@ -1,0 +1,2 @@
+TestLsofSelf() { lsof -p $$ | grep -c 'cwd'; }
+TestLsofHeader() { lsof -p $$ | sed -n '1p'; }

--- a/test/it/spec/lsof_spec.sh
+++ b/test/it/spec/lsof_spec.sh
@@ -1,0 +1,15 @@
+Describe 'lsof'
+    Include procps/lsof_test.sh
+
+    It 'lists the working directory of a process'
+        When call TestLsofSelf
+        The status should be success
+        The output should equal '1'
+    End
+    It 'prints the column header'
+        When call TestLsofHeader
+        The status should be success
+        The output should include 'COMMAND'
+        The output should include 'NAME'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `lsof`, which lists the open files of processes read from /proc: one row per file with the command, PID, owner, the descriptor (cwd/rtd/txt or a number), and the path. With `-p PID` it restricts the listing to one process (and exits non-zero if that PID cannot be read); otherwise it lists every process. The /proc directory is injectable so the listing is tested against fixtures.

The full lsof column set (TYPE/DEVICE/SIZE/NODE) and mmap entries are out of scope for this slice.

## Tests

- Unit (fixture /proc with comm + cwd/exe/fd symlinks): the per-process rows (cwd, txt, and numbered fds with their paths), the all-processes listing, and the missing-PID error.
- shellspec: lsof lists a process's working directory and prints the column header.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (578 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245