### PR TITLE
feat(procps): add ps applet to report current processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 236 commands. Run `mimixbox --list` to see them on the terminal.
+There are 237 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -159,6 +159,7 @@ There are 236 commands. Run `mimixbox --list` to see them on the terminal.
 | poweroff | Power off the system |
 | printenv | Print environment variable |
 | printf | Format and print data |
+| ps | Report a snapshot of the current processes |
 | pstree | Display the process tree |
 | pwcrack | Audit crypt(3) password hashes against a wordlist |
 | pwd | Print Working Directory |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -82,6 +82,7 @@ import (
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
+	ap_procps_ps "github.com/nao1215/mimixbox/internal/applets/procps/ps"
 	ap_procps_pstree "github.com/nao1215/mimixbox/internal/applets/procps/pstree"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
 	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
@@ -225,7 +226,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 236)
+	Applets = make(map[string]Applet, 237)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -319,6 +320,7 @@ func init() {
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pmap.New())
+	register(ap_procps_ps.New())
 	register(ap_procps_pstree.New())
 	register(ap_procps_pwdx.New())
 	register(ap_procps_sysctl.New())

--- a/internal/applets/procps/ps/ps.go
+++ b/internal/applets/procps/ps/ps.go
@@ -1,0 +1,122 @@
+// Package ps implements the ps applet: report a snapshot of the current
+// processes, read from /proc.
+package ps
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the ps applet.
+type Command struct{}
+
+// New returns a ps command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ps" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report a snapshot of the current processes" }
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+// clockTicks is the kernel USER_HZ (jiffies per second).
+const clockTicks = 100
+
+// Run executes ps.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "List every process with its PID, controlling terminal, accumulated CPU time, and " +
+			"command name, read from /proc and sorted by PID (like ps -e).",
+		Examples: []command.Example{
+			{Command: "ps", Explain: "List the running processes."},
+		},
+		Notes: []string{
+			"All processes are listed; the BSD/Unix option syntax (aux, -ef) is not parsed.",
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(stdio.Out, "    PID TTY          TIME CMD")
+	for _, pid := range pids() {
+		comm, ttyNr, jiffies, ok := readStat(pid)
+		if !ok {
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%7d %-8s %s %s\n", pid, ttyName(ttyNr), cpuTime(jiffies), comm)
+	}
+	return nil
+}
+
+func pids() []int {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var out []int
+	for _, e := range entries {
+		if n, err := strconv.Atoi(e.Name()); err == nil {
+			out = append(out, n)
+		}
+	}
+	sort.Ints(out)
+	return out
+}
+
+// readStat returns a process's comm, tty number, and total CPU jiffies.
+func readStat(pid int) (comm string, ttyNr int, jiffies int64, ok bool) {
+	data, err := os.ReadFile(filepath.Join(procDir, strconv.Itoa(pid), "stat")) //nolint:gosec // /proc path
+	if err != nil {
+		return "", 0, 0, false
+	}
+	line := string(data)
+	open := strings.IndexByte(line, '(')
+	closeP := strings.LastIndexByte(line, ')')
+	if open < 0 || closeP < 0 || closeP < open {
+		return "", 0, 0, false
+	}
+	comm = line[open+1 : closeP]
+	f := strings.Fields(line[closeP+1:]) // state ppid pgrp session tty_nr ... utime(11) stime(12)
+	if len(f) < 13 {
+		return "", 0, 0, false
+	}
+	ttyNr, _ = strconv.Atoi(f[4])
+	utime, _ := strconv.ParseInt(f[11], 10, 64)
+	stime, _ := strconv.ParseInt(f[12], 10, 64)
+	return comm, ttyNr, utime + stime, true
+}
+
+// ttyName decodes a tty device number to a name, or "?" when there is none.
+func ttyName(dev int) string {
+	if dev == 0 {
+		return "?"
+	}
+	major := (dev >> 8) & 0xfff
+	minor := (dev & 0xff) | ((dev >> 12) & 0xfff00)
+	switch major {
+	case 136:
+		return "pts/" + strconv.Itoa(minor)
+	case 4:
+		return "tty" + strconv.Itoa(minor)
+	default:
+		return "?"
+	}
+}
+
+// cpuTime formats accumulated jiffies as HH:MM:SS.
+func cpuTime(jiffies int64) string {
+	secs := jiffies / clockTicks
+	return fmt.Sprintf("%02d:%02d:%02d", secs/3600, (secs%3600)/60, secs%60)
+}

--- a/internal/applets/procps/ps/ps_test.go
+++ b/internal/applets/procps/ps/ps_test.go
@@ -1,0 +1,81 @@
+package ps
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, stats map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	for pid, stat := range stats {
+		pdir := filepath.Join(dir, pid)
+		if err := os.MkdirAll(pdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pdir, "stat"), []byte(stat), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestListing(t *testing.T) {
+	fixture(t, map[string]string{
+		// tty_nr 34816 = pts/0; utime 150 + stime 50 = 200 jiffies = 2s.
+		"100": "100 (bash) S 1 100 100 34816 100 0 0 0 0 0 150 50",
+		"1":   "1 (init) S 0 1 1 0 0 0 0 0 0 0 0 0",
+	})
+	out := run(t)
+	if !strings.HasPrefix(out, "    PID TTY          TIME CMD\n") {
+		t.Errorf("header wrong: %q", out)
+	}
+	if !strings.Contains(out, "    100 pts/0    00:00:02 bash") {
+		t.Errorf("bash row wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "      1 ?        00:00:00 init") {
+		t.Errorf("init row wrong:\n%s", out)
+	}
+	// Sorted by PID: 1 before 100.
+	if strings.Index(out, " init") > strings.Index(out, " bash") {
+		t.Errorf("not sorted by PID:\n%s", out)
+	}
+}
+
+func TestTTYName(t *testing.T) {
+	t.Parallel()
+	cases := map[int]string{0: "?", 34816: "pts/0", 34817: "pts/1", 1024: "tty0"}
+	for in, want := range cases {
+		if got := ttyName(in); got != want {
+			t.Errorf("ttyName(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCPUTime(t *testing.T) {
+	t.Parallel()
+	cases := map[int64]string{0: "00:00:00", 200: "00:00:02", 100 * 65: "00:01:05", 100 * 3661: "01:01:01"}
+	for in, want := range cases {
+		if got := cpuTime(in); got != want {
+			t.Errorf("cpuTime(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/test/it/procps/ps_test.sh
+++ b/test/it/procps/ps_test.sh
@@ -1,0 +1,2 @@
+TestPsHeader() { ps | sed -n '1p'; }
+TestPsHasInit() { ps | grep -c ' init'; }

--- a/test/it/procps/ps_test.sh
+++ b/test/it/procps/ps_test.sh
@@ -1,2 +1,2 @@
 TestPsHeader() { ps | sed -n '1p'; }
-TestPsHasInit() { ps | grep -c ' init'; }
+TestPsHasProcesses() { ps | grep -cE '^ *[0-9]+ '; }

--- a/test/it/spec/ps_spec.sh
+++ b/test/it/spec/ps_spec.sh
@@ -7,7 +7,7 @@ Describe 'ps'
         The status should be success
     End
     It 'lists running processes'
-        When call TestPsHasInit
+        When call TestPsHasProcesses
         The status should be success
         The output should not equal '0'
     End

--- a/test/it/spec/ps_spec.sh
+++ b/test/it/spec/ps_spec.sh
@@ -1,0 +1,14 @@
+Describe 'ps'
+    Include procps/ps_test.sh
+
+    It 'prints the standard header'
+        When call TestPsHeader
+        The output should equal '    PID TTY          TIME CMD'
+        The status should be success
+    End
+    It 'lists running processes'
+        When call TestPsHasInit
+        The status should be success
+        The output should not equal '0'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `ps`, which lists every process with its PID, controlling terminal, accumulated CPU time, and command name, read from /proc and sorted by PID (like `ps -e`). The TTY is decoded from the stat device number (pts/N, ttyN), the time from utime+stime jiffies. The output header and columns match host ps. The /proc directory is injectable so the listing is tested against fixtures.

All processes are listed; the BSD/Unix option syntax (aux, -ef) is not parsed in this slice, and uncommon TTY device families show '?'.

## Tests

- Unit (fixture /proc/PID/stat): the header and a process row (PID/TTY/TIME/CMD, with pts decoding and a 2-second CPU time), an init row, PID sorting, the `ttyName` decoder, and `cpuTime` formatting.
- shellspec: the standard header and that running processes are listed.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (580 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245