### PR TITLE
feat(procps): add killall5 applet to signal all processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 237 commands. Run `mimixbox --list` to see them on the terminal.
+There are 238 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -111,6 +111,7 @@ There are 237 commands. Run `mimixbox --list` to see them on the terminal.
 | ischroot | Detect if running in a chroot |
 | kill | Kill process or send signal to process |
 | killall | Kill processes by name |
+| killall5 | Send a signal to all processes |
 | last | Show a listing of last logged-in users |
 | less | Page through text one screen at a time |
 | lifegame | Life game (Conway's Game of Life) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -78,6 +78,7 @@ import (
 	ap_netutils_whris "github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
 	ap_procps_fuser "github.com/nao1215/mimixbox/internal/applets/procps/fuser"
+	ap_procps_killall5 "github.com/nao1215/mimixbox/internal/applets/procps/killall5"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
@@ -226,7 +227,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 237)
+	Applets = make(map[string]Applet, 238)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -315,6 +316,7 @@ func init() {
 	register(ap_pmutils_halt.NewPoweroff())
 	register(ap_pmutils_halt.NewReboot())
 	register(ap_procps_fuser.New())
+	register(ap_procps_killall5.New())
 	register(ap_procps_logger.New())
 	register(ap_procps_lsof.New())
 	register(ap_procps_pgrep.NewPgrep())

--- a/internal/applets/procps/killall5/killall5.go
+++ b/internal/applets/procps/killall5/killall5.go
@@ -1,0 +1,114 @@
+// Package killall5 implements the killall5 applet: send a signal to all
+// processes except kernel threads, PID 1, and the caller itself.
+package killall5
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"github.com/nao1215/mimixbox/internal/signal"
+)
+
+// Command is the killall5 applet.
+type Command struct{}
+
+// New returns a killall5 command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "killall5" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Send a signal to all processes" }
+
+// Injected so the destructive behavior is testable.
+var (
+	procDir    = "/proc"
+	selfPid    = os.Getpid
+	sendSignal = func(pid int, sig syscall.Signal) error { return syscall.Kill(pid, sig) }
+)
+
+// Run executes killall5.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-SIGNAL] [-o PID]...", stdio.Err).WithHelp(command.Help{
+		Description: "Send a signal (SIGTERM by default, or -SIGNAL) to every process except kernel " +
+			"threads, PID 1, the killall5 process itself, and any PID excluded with -o. This is the " +
+			"SysV-init tool used during shutdown.",
+		Examples: []command.Example{
+			{Command: "killall5 -15", Explain: "Send SIGTERM to all processes."},
+			{Command: "killall5 -9 -o 1234", Explain: "SIGKILL all but PID 1234."},
+		},
+		ExitStatus: "0  a signal was sent.\n2  no processes were found to signal.",
+	})
+	var omit []int
+	fs.IntSliceVarP(&omit, "omit", "o", nil, "do not signal this PID")
+
+	// Accept the "-15"/"-TERM" shorthand by rewriting it to --signal.
+	sigSpec := "TERM"
+	var passthrough []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") && a != "--help" && a != "--version" {
+			if _, err := signal.Number(strings.TrimPrefix(a, "-")); err == nil {
+				sigSpec = strings.TrimPrefix(a, "-")
+				continue
+			}
+		}
+		passthrough = append(passthrough, a)
+	}
+
+	proceed, err := fs.Parse(stdio, passthrough)
+	if err != nil || !proceed {
+		return err
+	}
+
+	sigNum, err := signal.Number(sigSpec)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	excluded := map[int]bool{1: true, c.self(): true}
+	for _, p := range omit {
+		excluded[p] = true
+	}
+
+	targets := c.targets(excluded)
+	if len(targets) == 0 {
+		return &command.ExitError{Code: 2}
+	}
+	for _, pid := range targets {
+		_ = sendSignal(pid, syscall.Signal(sigNum)) // a process may exit before we reach it
+	}
+	return nil
+}
+
+func (c *Command) self() int { return selfPid() }
+
+// targets returns the sorted PIDs to signal: every process with a command line
+// (i.e. not a kernel thread) that is not excluded.
+func (c *Command) targets(excluded map[int]bool) []int {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || excluded[pid] {
+			continue
+		}
+		// Kernel threads have an empty cmdline; skip them.
+		data, err := os.ReadFile(filepath.Join(procDir, e.Name(), "cmdline")) //nolint:gosec // /proc path
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids)
+	return pids
+}

--- a/internal/applets/procps/killall5/killall5_test.go
+++ b/internal/applets/procps/killall5/killall5_test.go
@@ -1,0 +1,102 @@
+package killall5
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, self int, cmdlines map[int]string) *map[int]syscall.Signal {
+	t.Helper()
+	dir := t.TempDir()
+	for pid, cmd := range cmdlines {
+		pdir := filepath.Join(dir, fmtInt(pid))
+		if err := os.MkdirAll(pdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pdir, "cmdline"), []byte(cmd), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	signalled := map[int]syscall.Signal{}
+	origP, origS, origSig := procDir, selfPid, sendSignal
+	procDir = dir
+	selfPid = func() int { return self }
+	sendSignal = func(pid int, sig syscall.Signal) error { signalled[pid] = sig; return nil }
+	t.Cleanup(func() { procDir, selfPid, sendSignal = origP, origS, origSig })
+	return &signalled
+}
+
+func fmtInt(n int) string { return strconv.Itoa(n) }
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: bytes.NewReader(nil), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func keys(m map[int]syscall.Signal) []int {
+	var out []int
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func TestSignalsAllButExcluded(t *testing.T) {
+	// PID 1 excluded, 2 is a kernel thread (empty cmdline), self is 100.
+	sig := fixture(t, 100, map[int]string{1: "init", 2: "", 100: "test", 200: "bash", 300: "vim"})
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	got := keys(*sig)
+	if len(got) != 2 || got[0] != 200 || got[1] != 300 {
+		t.Errorf("signalled = %v, want [200 300]", got)
+	}
+	if (*sig)[200] != syscall.SIGTERM {
+		t.Errorf("default signal = %v, want SIGTERM", (*sig)[200])
+	}
+}
+
+func TestSignalShorthand(t *testing.T) {
+	sig := fixture(t, 100, map[int]string{200: "bash"})
+	if err := run(t, "-9"); err != nil {
+		t.Fatal(err)
+	}
+	if (*sig)[200] != syscall.SIGKILL {
+		t.Errorf("killall5 -9 -> %v, want SIGKILL", (*sig)[200])
+	}
+}
+
+func TestOmit(t *testing.T) {
+	sig := fixture(t, 100, map[int]string{200: "bash", 300: "vim"})
+	if err := run(t, "-o", "200"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := (*sig)[200]; ok {
+		t.Errorf("PID 200 should be omitted")
+	}
+	if _, ok := (*sig)[300]; !ok {
+		t.Errorf("PID 300 should be signalled")
+	}
+}
+
+func TestNoTargets(t *testing.T) {
+	fixture(t, 100, map[int]string{1: "init", 100: "self"})
+	err := run(t)
+	var ee *command.ExitError
+	if e, ok := err.(*command.ExitError); ok {
+		ee = e
+	}
+	if ee == nil || ee.Code != 2 {
+		t.Errorf("err = %v, want exit 2", err)
+	}
+}

--- a/test/it/procps/killall5_test.sh
+++ b/test/it/procps/killall5_test.sh
@@ -1,0 +1,3 @@
+# killall5 signals every process, so the e2e only exercises the non-destructive
+# --help path; the signal dispatch is covered by Go unit tests.
+TestKillall5Help() { killall5 --help; }

--- a/test/it/spec/killall5_spec.sh
+++ b/test/it/spec/killall5_spec.sh
@@ -1,0 +1,10 @@
+Describe 'killall5'
+    Include procps/killall5_test.sh
+
+    It 'describes itself with --help'
+        When call TestKillall5Help
+        The status should be success
+        The output should include 'Usage: killall5'
+        The output should include 'signal'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `killall5`, the SysV-init tool that sends a signal (SIGTERM by default, or the `-SIGNAL` shorthand resolved via the shared signal table) to every process except kernel threads, PID 1, the killall5 process itself, and any PID excluded with `-o`. Kernel threads are identified by their empty cmdline. It exits 2 when there is nothing to signal. The /proc directory, the self-PID, and the signal call are injectable so the (destructive) behavior is tested safely.

## Tests

- Unit (fixture /proc + stubbed signal): signalling every eligible process while skipping PID 1, the kernel thread, and self; the `-9` shorthand sending SIGKILL; `-o` excluding a PID; and the exit-2 no-targets case.
- shellspec: the non-destructive `--help` path (signalling every process can't run in CI, so the dispatch is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (581 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245