### PR TITLE
feat(procps): add vmstat applet for virtual memory statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 238 commands. Run `mimixbox --list` to see them on the terminal.
+There are 239 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -244,6 +244,7 @@ There are 238 commands. Run `mimixbox --list` to see them on the terminal.
 | uuidgen | Print UUID (Universally Unique IDentifier) |
 | valid-shell | Verify if /etc/shells is valid |
 | vi | A minimal vi-style screen text editor |
+| vmstat | Report virtual memory statistics |
 | w | Show who is logged on and a system summary |
 | wall | Write a message to all logged-in users |
 | watch | Execute a program periodically, showing output fullscreen |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -88,6 +88,7 @@ import (
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
 	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
+	ap_procps_vmstat "github.com/nao1215/mimixbox/internal/applets/procps/vmstat"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
 	ap_securityutils_pwscore "github.com/nao1215/mimixbox/internal/applets/securityutils/pwscore"
@@ -227,7 +228,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 238)
+	Applets = make(map[string]Applet, 239)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -327,6 +328,7 @@ func init() {
 	register(ap_procps_pwdx.New())
 	register(ap_procps_sysctl.New())
 	register(ap_procps_uptime.New())
+	register(ap_procps_vmstat.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())
 	register(ap_securityutils_pwscore.New())

--- a/internal/applets/procps/vmstat/vmstat.go
+++ b/internal/applets/procps/vmstat/vmstat.go
@@ -1,0 +1,171 @@
+// Package vmstat implements the vmstat applet: report virtual-memory, process,
+// I/O, and CPU statistics in a single snapshot read from /proc.
+package vmstat
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the vmstat applet.
+type Command struct{}
+
+// New returns a vmstat command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "vmstat" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report virtual memory statistics" }
+
+// Injected so the snapshot is testable.
+var (
+	statPath    = "/proc/stat"
+	meminfoPath = "/proc/meminfo"
+	vmPath      = "/proc/vmstat"
+	uptimePath  = "/proc/uptime"
+)
+
+// pageKB is the page size in KiB used to convert swap-page counters.
+const pageKB = 4
+
+// Run executes vmstat.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print a single line of system statistics: runnable/blocked processes, memory " +
+			"(swap used, free, buffers, cache), swap and block I/O, interrupts and context switches, " +
+			"and the CPU time breakdown. The I/O and system columns are averages since boot.",
+		Examples: []command.Example{
+			{Command: "vmstat", Explain: "Show one snapshot of system statistics."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	mem := readKeyed(meminfoPath)
+	vm := readKeyed(vmPath)
+	stat := readStat()
+	up := readUptime()
+	if up < 1 {
+		up = 1
+	}
+
+	swpd := mem["SwapTotal"] - mem["SwapFree"]
+	us, sy, id, wa, st := cpuPercents(stat.cpu)
+
+	_, _ = fmt.Fprintln(stdio.Out, "procs -----------memory---------- ---swap-- -----io---- -system-- ------cpu-----")
+	_, _ = fmt.Fprintln(stdio.Out, " r  b   swpd   free   buff  cache   si   so    bi    bo   in   cs us sy id wa st")
+	_, _ = fmt.Fprintf(stdio.Out, "%2d %2d %6d %6d %6d %6d %4d %4d %5d %5d %4d %4d %2d %2d %2d %2d %2d\n",
+		stat.running, stat.blocked,
+		swpd, mem["MemFree"], mem["Buffers"], mem["Cached"],
+		vm["pswpin"]*pageKB/up, vm["pswpout"]*pageKB/up,
+		vm["pgpgin"]/up, vm["pgpgout"]/up,
+		stat.intr/up, stat.ctxt/up,
+		us, sy, id, wa, st)
+	return nil
+}
+
+type statData struct {
+	cpu              []int64
+	intr, ctxt       int64
+	running, blocked int64
+}
+
+// readStat parses the cpu, intr, ctxt and procs lines of /proc/stat.
+func readStat() statData {
+	var s statData
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		return s
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		switch fields[0] {
+		case "cpu":
+			for _, f := range fields[1:] {
+				n, _ := strconv.ParseInt(f, 10, 64)
+				s.cpu = append(s.cpu, n)
+			}
+		case "intr":
+			s.intr = atoi64(fields)
+		case "ctxt":
+			s.ctxt = atoi64(fields)
+		case "procs_running":
+			s.running = atoi64(fields)
+		case "procs_blocked":
+			s.blocked = atoi64(fields)
+		}
+	}
+	return s
+}
+
+func atoi64(fields []string) int64 {
+	if len(fields) < 2 {
+		return 0
+	}
+	n, _ := strconv.ParseInt(fields[1], 10, 64)
+	return n
+}
+
+// cpuPercents converts the cumulative cpu jiffies to integer percentages.
+func cpuPercents(cpu []int64) (us, sy, id, wa, st int64) {
+	get := func(i int) int64 {
+		if i < len(cpu) {
+			return cpu[i]
+		}
+		return 0
+	}
+	user, nice, system, idle := get(0), get(1), get(2), get(3)
+	iowait, irq, softirq, steal := get(4), get(5), get(6), get(7)
+	total := user + nice + system + idle + iowait + irq + softirq + steal
+	if total == 0 {
+		return 0, 0, 100, 0, 0
+	}
+	pct := func(v int64) int64 { return v * 100 / total }
+	return pct(user + nice), pct(system + irq + softirq), pct(idle), pct(iowait), pct(steal)
+}
+
+// readKeyed reads a "Key: value kB" or "key value" file into a map of int64.
+func readKeyed(path string) map[string]int64 {
+	m := map[string]int64{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return m
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSuffix(fields[0], ":")
+		n, err := strconv.ParseInt(fields[1], 10, 64)
+		if err == nil {
+			m[key] = n
+		}
+	}
+	return m
+}
+
+func readUptime() int64 {
+	data, err := os.ReadFile(uptimePath)
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0
+	}
+	secs, _ := strconv.ParseFloat(fields[0], 64)
+	return int64(secs)
+}

--- a/internal/applets/procps/vmstat/vmstat_test.go
+++ b/internal/applets/procps/vmstat/vmstat_test.go
@@ -1,0 +1,72 @@
+package vmstat
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	os, om, ov, ou := statPath, meminfoPath, vmPath, uptimePath
+	meminfoPath = write("meminfo", "MemFree:        1000 kB\nBuffers:         200 kB\nCached:          300 kB\nSwapTotal:       500 kB\nSwapFree:        400 kB\n")
+	statPath = write("stat", "cpu 100 0 50 800 50 0 0 0\nintr 2000 1 2 3\nctxt 4000\nprocs_running 3\nprocs_blocked 1\n")
+	vmPath = write("vmstat", "pswpin 10\npswpout 20\npgpgin 400\npgpgout 200\n")
+	uptimePath = write("uptime", "100.0 50.0\n")
+	t.Cleanup(func() { statPath, meminfoPath, vmPath, uptimePath = os, om, ov, ou })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestSnapshot(t *testing.T) {
+	fixture(t)
+	out := run(t)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), out)
+	}
+	// r=3 b=1 swpd=100 free=1000 buff=200 cache=300 si=0 so=0 bi=4 bo=2 in=20 cs=40 us=10 sy=5 id=80 wa=5 st=0
+	fields := strings.Fields(lines[2])
+	want := []string{"3", "1", "100", "1000", "200", "300", "0", "0", "4", "2", "20", "40", "10", "5", "80", "5", "0"}
+	if len(fields) != len(want) {
+		t.Fatalf("got %d columns: %q", len(fields), lines[2])
+	}
+	for i := range want {
+		if fields[i] != want[i] {
+			t.Errorf("column %d = %q, want %q (line: %q)", i, fields[i], want[i], lines[2])
+		}
+	}
+}
+
+func TestCPUPercents(t *testing.T) {
+	t.Parallel()
+	us, sy, id, wa, st := cpuPercents([]int64{100, 0, 50, 800, 50, 0, 0, 0})
+	if us != 10 || sy != 5 || id != 80 || wa != 5 || st != 0 {
+		t.Errorf("cpuPercents = %d %d %d %d %d, want 10 5 80 5 0", us, sy, id, wa, st)
+	}
+	// All-idle fallback when total is zero.
+	if _, _, id, _, _ := cpuPercents(nil); id != 100 {
+		t.Errorf("empty cpu idle = %d, want 100", id)
+	}
+}

--- a/test/it/procps/vmstat_test.sh
+++ b/test/it/procps/vmstat_test.sh
@@ -1,0 +1,2 @@
+TestVmstatHeader() { vmstat | sed -n '2p'; }
+TestVmstatData() { vmstat | sed -n '3p' | grep -cE '^[ 0-9]+$'; }

--- a/test/it/spec/vmstat_spec.sh
+++ b/test/it/spec/vmstat_spec.sh
@@ -1,0 +1,15 @@
+Describe 'vmstat'
+    Include procps/vmstat_test.sh
+
+    It 'prints the column header'
+        When call TestVmstatHeader
+        The output should include 'swpd'
+        The output should include 'free'
+        The status should be success
+    End
+    It 'prints a numeric data row'
+        When call TestVmstatData
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `vmstat`, which prints a single snapshot of system statistics read from /proc: runnable/blocked processes (/proc/stat), memory (swap used, free, buffers, cache from /proc/meminfo), swap and block I/O (/proc/vmstat), interrupts and context switches (/proc/stat), and the CPU time breakdown (us/sy/id/wa/st). The I/O and system columns are since-boot averages (cumulative / uptime). The header and memory/procs/CPU columns match host vmstat. The four /proc paths are injectable so the snapshot is tested deterministically.

## Tests

- Unit (fixtures for stat/meminfo/vmstat/uptime): the full data row computed to exact values (procs, swap-used, free/buffers/cache, the I/O and system rates, and the CPU percentages), and the `cpuPercents` calculation including the all-idle fallback.
- shellspec: the column header and a numeric data row.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (583 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245