### PR TITLE
feat(procps): add mpstat applet for per-processor CPU statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 239 commands. Run `mimixbox --list` to see them on the terminal.
+There are 240 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -139,6 +139,7 @@ There are 239 commands. Run `mimixbox --list` to see them on the terminal.
 | mktemp | Create a temporary file or directory |
 | more | Page through text one screen at a time |
 | mountpoint | See if a directory is a mountpoint |
+| mpstat | Report per-processor CPU statistics |
 | mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY |
 | nc | Read and write data across network connections |
 | nice | Run a command with an adjusted niceness |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -81,6 +81,7 @@ import (
 	ap_procps_killall5 "github.com/nao1215/mimixbox/internal/applets/procps/killall5"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
+	ap_procps_mpstat "github.com/nao1215/mimixbox/internal/applets/procps/mpstat"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
 	ap_procps_ps "github.com/nao1215/mimixbox/internal/applets/procps/ps"
@@ -228,7 +229,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 239)
+	Applets = make(map[string]Applet, 240)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -320,6 +321,7 @@ func init() {
 	register(ap_procps_killall5.New())
 	register(ap_procps_logger.New())
 	register(ap_procps_lsof.New())
+	register(ap_procps_mpstat.New())
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pmap.New())

--- a/internal/applets/procps/mpstat/mpstat.go
+++ b/internal/applets/procps/mpstat/mpstat.go
@@ -1,0 +1,122 @@
+// Package mpstat implements the mpstat applet: report per-processor CPU usage
+// read from /proc/stat.
+package mpstat
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the mpstat applet.
+type Command struct{}
+
+// New returns a mpstat command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mpstat" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report per-processor CPU statistics" }
+
+// statPath is /proc/stat; tests point it at a fixture.
+var statPath = "/proc/stat"
+
+// Run executes mpstat.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the CPU utilisation breakdown for the aggregate ('all') and each individual " +
+			"processor, as the percentage of time spent in user, nice, system, iowait, irq, softirq, " +
+			"steal, guest, and idle. The values are averages since boot.",
+		Examples: []command.Example{
+			{Command: "mpstat", Explain: "Show per-CPU usage."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rows := readCPUs()
+	if len(rows) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "mpstat: cannot read CPU statistics")
+		return command.SilentFailure()
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "%-4s %7s %7s %7s %7s %7s %7s %7s %7s %7s %7s\n",
+		"CPU", "%usr", "%nice", "%sys", "%iowait", "%irq", "%soft", "%steal", "%guest", "%gnice", "%idle")
+	for _, r := range rows {
+		p := percentages(r.values)
+		_, _ = fmt.Fprintf(stdio.Out, "%-4s %7.2f %7.2f %7.2f %7.2f %7.2f %7.2f %7.2f %7.2f %7.2f %7.2f\n",
+			r.label, p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9])
+	}
+	return nil
+}
+
+type cpuRow struct {
+	label  string
+	values []int64
+}
+
+// readCPUs returns the aggregate and per-CPU stat rows in order.
+func readCPUs() []cpuRow {
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		return nil
+	}
+	var rows []cpuRow
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || !strings.HasPrefix(fields[0], "cpu") {
+			continue
+		}
+		label := "all"
+		if fields[0] != "cpu" {
+			label = strings.TrimPrefix(fields[0], "cpu")
+		}
+		var vals []int64
+		for _, f := range fields[1:] {
+			n, _ := strconv.ParseInt(f, 10, 64)
+			vals = append(vals, n)
+		}
+		rows = append(rows, cpuRow{label: label, values: vals})
+	}
+	return rows
+}
+
+// percentages converts the cpu jiffy fields to the ten mpstat percentages:
+// usr, nice, sys, iowait, irq, soft, steal, guest, gnice, idle.
+func percentages(v []int64) [10]float64 {
+	get := func(i int) int64 {
+		if i < len(v) {
+			return v[i]
+		}
+		return 0
+	}
+	user, nice, system, idle := get(0), get(1), get(2), get(3)
+	iowait, irq, softirq, steal := get(4), get(5), get(6), get(7)
+	guest, gnice := get(8), get(9)
+	total := user + nice + system + idle + iowait + irq + softirq + steal
+	var out [10]float64
+	if total == 0 {
+		out[9] = 100
+		return out
+	}
+	pct := func(x int64) float64 { return float64(x) * 100 / float64(total) }
+	out[0] = pct(user - guest) // mpstat counts guest time separately from user
+	out[1] = pct(nice - gnice)
+	out[2] = pct(system)
+	out[3] = pct(iowait)
+	out[4] = pct(irq)
+	out[5] = pct(softirq)
+	out[6] = pct(steal)
+	out[7] = pct(guest)
+	out[8] = pct(gnice)
+	out[9] = pct(idle)
+	return out
+}

--- a/internal/applets/procps/mpstat/mpstat_test.go
+++ b/internal/applets/procps/mpstat/mpstat_test.go
@@ -1,0 +1,81 @@
+package mpstat
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, content string) {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "stat")
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := statPath
+	statPath = f
+	t.Cleanup(func() { statPath = orig })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestRows(t *testing.T) {
+	fixture(t, "cpu 100 0 50 800 50 0 0 0 0 0\ncpu0 50 0 25 400 25 0 0 0 0 0\nintr 1\n")
+	out := run(t)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 { // header, all, cpu0
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), out)
+	}
+	allFields := strings.Fields(lines[1])
+	// all: usr 10.00 nice 0 sys 5 iowait 5 irq 0 soft 0 steal 0 guest 0 gnice 0 idle 80
+	want := []string{"all", "10.00", "0.00", "5.00", "5.00", "0.00", "0.00", "0.00", "0.00", "0.00", "80.00"}
+	for i := range want {
+		if allFields[i] != want[i] {
+			t.Errorf("all column %d = %q, want %q", i, allFields[i], want[i])
+		}
+	}
+	if !strings.HasPrefix(lines[2], "0 ") {
+		t.Errorf("per-cpu row label wrong: %q", lines[2])
+	}
+}
+
+func TestPercentages(t *testing.T) {
+	t.Parallel()
+	p := percentages([]int64{100, 0, 50, 800, 50, 0, 0, 0, 0, 0})
+	if p[0] != 10 || p[2] != 5 || p[3] != 5 || p[9] != 80 {
+		t.Errorf("percentages = %v", p)
+	}
+	// guest time is subtracted from user.
+	g := percentages([]int64{100, 0, 0, 900, 0, 0, 0, 0, 40, 0})
+	if g[0] != 6 || g[7] != 4 { // usr = (100-40)/1000*100 = 6, guest = 40/1000*100 = 4
+		t.Errorf("guest split: usr=%v guest=%v", g[0], g[7])
+	}
+	if percentages(nil)[9] != 100 {
+		t.Errorf("empty should be 100%% idle")
+	}
+}
+
+func TestMissingStat(t *testing.T) {
+	t.Parallel()
+	orig := statPath
+	statPath = "/no/such/stat"
+	defer func() { statPath = orig }()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("missing stat should fail")
+	}
+}

--- a/test/it/procps/mpstat_test.sh
+++ b/test/it/procps/mpstat_test.sh
@@ -1,0 +1,2 @@
+TestMpstatHeader() { mpstat | sed -n '1p'; }
+TestMpstatAll() { mpstat | grep -c '^all '; }

--- a/test/it/spec/mpstat_spec.sh
+++ b/test/it/spec/mpstat_spec.sh
@@ -1,0 +1,15 @@
+Describe 'mpstat'
+    Include procps/mpstat_test.sh
+
+    It 'prints the CPU column header'
+        When call TestMpstatHeader
+        The output should include '%usr'
+        The output should include '%idle'
+        The status should be success
+    End
+    It 'prints the aggregate all row'
+        When call TestMpstatAll
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `mpstat`, which prints the CPU utilization breakdown for the aggregate (`all`) and each individual processor — the percentage of time in user, nice, system, iowait, irq, softirq, steal, guest, gnice, and idle — read from /proc/stat. Guest time is subtracted from user as mpstat does. Values are since-boot averages; the `all` row matches host mpstat byte-for-byte. The stat path is injectable so the computation is tested deterministically.

The Linux/date/arch banner line is omitted in this slice.

## Tests

- Unit (fixture /proc/stat): the aggregate and per-CPU rows computed to exact percentages, the `percentages` calculation including the guest-from-user split and the all-idle fallback, and the missing-stat error.
- shellspec: the CPU column header and the aggregate `all` row.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (585 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245