### PR TITLE
feat(procps): add iostat applet for CPU and device I/O statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 240 commands. Run `mimixbox --list` to see them on the terminal.
+There are 241 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -106,6 +106,7 @@ There are 240 commands. Run `mimixbox --list` to see them on the terminal.
 | id | Print User ID and Group ID |
 | install | Copy files and set attributes |
 | ionice | Get or set process I/O scheduling class and priority |
+| iostat | Report CPU and device I/O statistics |
 | ipcrm | Remove System V IPC objects by id |
 | ipcs | Show System V IPC facilities status |
 | ischroot | Detect if running in a chroot |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -78,6 +78,7 @@ import (
 	ap_netutils_whris "github.com/nao1215/mimixbox/internal/applets/netutils/whris"
 	ap_pmutils_halt "github.com/nao1215/mimixbox/internal/applets/pmutils/halt"
 	ap_procps_fuser "github.com/nao1215/mimixbox/internal/applets/procps/fuser"
+	ap_procps_iostat "github.com/nao1215/mimixbox/internal/applets/procps/iostat"
 	ap_procps_killall5 "github.com/nao1215/mimixbox/internal/applets/procps/killall5"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
@@ -229,7 +230,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 240)
+	Applets = make(map[string]Applet, 241)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -318,6 +319,7 @@ func init() {
 	register(ap_pmutils_halt.NewPoweroff())
 	register(ap_pmutils_halt.NewReboot())
 	register(ap_procps_fuser.New())
+	register(ap_procps_iostat.New())
 	register(ap_procps_killall5.New())
 	register(ap_procps_logger.New())
 	register(ap_procps_lsof.New())

--- a/internal/applets/procps/iostat/iostat.go
+++ b/internal/applets/procps/iostat/iostat.go
@@ -1,0 +1,145 @@
+// Package iostat implements the iostat applet: report CPU utilization and
+// per-device I/O statistics read from /proc/stat and /proc/diskstats.
+package iostat
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the iostat applet.
+type Command struct{}
+
+// New returns an iostat command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "iostat" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report CPU and device I/O statistics" }
+
+// Injected so the report is testable.
+var (
+	statPath      = "/proc/stat"
+	diskstatsPath = "/proc/diskstats"
+	uptimePath    = "/proc/uptime"
+)
+
+// Run executes iostat.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the average CPU utilization since boot, then a per-device table of " +
+			"transfers per second and kilobytes read and written, from /proc/stat and " +
+			"/proc/diskstats. Devices with no activity are omitted.",
+		Examples: []command.Example{
+			{Command: "iostat", Explain: "Show CPU and disk I/O statistics."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	up := readUptime()
+	if up < 1 {
+		up = 1
+	}
+
+	user, nice, system, iowait, steal, idle := cpuPercents()
+	_, _ = io.WriteString(stdio.Out, "avg-cpu:  %user   %nice %system %iowait  %steal   %idle\n")
+	_, _ = fmt.Fprintf(stdio.Out, "        %7.2f %7.2f %7.2f %7.2f %7.2f %7.2f\n\n",
+		user, nice, system, iowait, steal, idle)
+
+	_, _ = fmt.Fprintf(stdio.Out, "%-13s %8s %12s %12s %10s %10s\n",
+		"Device", "tps", "kB_read/s", "kB_wrtn/s", "kB_read", "kB_wrtn")
+	for _, d := range readDisks() {
+		if d.reads == 0 && d.writes == 0 {
+			continue // omit inactive devices, like iostat
+		}
+		kbRead := d.sectorsRead / 2
+		kbWrtn := d.sectorsWritten / 2
+		tps := float64(d.reads+d.writes) / float64(up)
+		_, _ = fmt.Fprintf(stdio.Out, "%-13s %8.2f %12.2f %12.2f %10d %10d\n",
+			d.name, tps, float64(kbRead)/float64(up), float64(kbWrtn)/float64(up), kbRead, kbWrtn)
+	}
+	return nil
+}
+
+// cpuPercents returns the avg-cpu breakdown from /proc/stat.
+func cpuPercents() (user, nice, system, iowait, steal, idle float64) {
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		return 0, 0, 0, 0, 0, 100
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) == 0 || f[0] != "cpu" {
+			continue
+		}
+		v := make([]int64, 10)
+		for i := 1; i < len(f) && i <= 10; i++ {
+			v[i-1], _ = strconv.ParseInt(f[i], 10, 64)
+		}
+		total := v[0] + v[1] + v[2] + v[3] + v[4] + v[5] + v[6] + v[7]
+		if total == 0 {
+			return 0, 0, 0, 0, 0, 100
+		}
+		p := func(x int64) float64 { return float64(x) * 100 / float64(total) }
+		return p(v[0] - v[8]), p(v[1] - v[9]), p(v[2] + v[5] + v[6]), p(v[4]), p(v[7]), p(v[3])
+	}
+	return 0, 0, 0, 0, 0, 100
+}
+
+type disk struct {
+	name                        string
+	reads, writes               int64
+	sectorsRead, sectorsWritten int64
+}
+
+// readDisks parses the per-device counters of /proc/diskstats.
+func readDisks() []disk {
+	data, err := os.ReadFile(diskstatsPath)
+	if err != nil {
+		return nil
+	}
+	var disks []disk
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 10 {
+			continue
+		}
+		disks = append(disks, disk{
+			name:           f[2],
+			reads:          atoi(f[3]),
+			sectorsRead:    atoi(f[5]),
+			writes:         atoi(f[7]),
+			sectorsWritten: atoi(f[9]),
+		})
+	}
+	return disks
+}
+
+func atoi(s string) int64 {
+	n, _ := strconv.ParseInt(s, 10, 64)
+	return n
+}
+
+func readUptime() int64 {
+	data, err := os.ReadFile(uptimePath)
+	if err != nil {
+		return 0
+	}
+	f := strings.Fields(string(data))
+	if len(f) == 0 {
+		return 0
+	}
+	secs, _ := strconv.ParseFloat(f[0], 64)
+	return int64(secs)
+}

--- a/internal/applets/procps/iostat/iostat_test.go
+++ b/internal/applets/procps/iostat/iostat_test.go
@@ -1,0 +1,71 @@
+package iostat
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	os1, od, ou := statPath, diskstatsPath, uptimePath
+	statPath = write("stat", "cpu 100 0 50 800 50 0 0 0 0 0\n")
+	// sda: 4 reads, 200 sectors read; 2 writes, 100 sectors written.
+	diskstatsPath = write("diskstats",
+		"   8       0 sda 4 0 200 0 2 0 100 0 0 0 0\n"+
+			"   1       0 ram0 0 0 0 0 0 0 0 0 0 0 0\n")
+	uptimePath = write("uptime", "100.0 0.0\n")
+	t.Cleanup(func() { statPath, diskstatsPath, uptimePath = os1, od, ou })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestReport(t *testing.T) {
+	fixture(t)
+	out := run(t)
+	// avg-cpu: user 10, nice 0, system 5, iowait 5, steal 0, idle 80.
+	if !strings.Contains(out, "avg-cpu:  %user") {
+		t.Errorf("missing avg-cpu header:\n%s", out)
+	}
+	if !strings.Contains(out, "   10.00    0.00    5.00    5.00    0.00   80.00") {
+		t.Errorf("avg-cpu values wrong:\n%s", out)
+	}
+	// sda: kB_read = 200/2 = 100, kB_wrtn = 100/2 = 50; tps = (4+2)/100 = 0.06.
+	if !strings.Contains(out, "sda") || !strings.Contains(out, "       100         50") {
+		t.Errorf("sda totals wrong:\n%s", out)
+	}
+	// ram0 has no activity and must be omitted.
+	if strings.Contains(out, "ram0") {
+		t.Errorf("inactive device should be omitted:\n%s", out)
+	}
+}
+
+func TestCPUPercents(t *testing.T) {
+	t.Parallel()
+	fixture(t)
+	u, n, s, w, st, id := cpuPercents()
+	if u != 10 || n != 0 || s != 5 || w != 5 || st != 0 || id != 80 {
+		t.Errorf("cpuPercents = %v %v %v %v %v %v", u, n, s, w, st, id)
+	}
+}

--- a/test/it/procps/iostat_test.sh
+++ b/test/it/procps/iostat_test.sh
@@ -1,0 +1,2 @@
+TestIostatCpuHeader() { iostat | sed -n '1p'; }
+TestIostatDeviceHeader() { iostat | grep -c 'Device'; }

--- a/test/it/spec/iostat_spec.sh
+++ b/test/it/spec/iostat_spec.sh
@@ -1,0 +1,15 @@
+Describe 'iostat'
+    Include procps/iostat_test.sh
+
+    It 'prints the avg-cpu header'
+        When call TestIostatCpuHeader
+        The output should include 'avg-cpu'
+        The output should include '%idle'
+        The status should be success
+    End
+    It 'prints the device table header'
+        When call TestIostatDeviceHeader
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `iostat`, which prints the average CPU utilization since boot (%user/%nice/%system/%iowait/%steal/%idle from /proc/stat) followed by a per-device I/O table (tps, kB_read/s, kB_wrtn/s, kB_read, kB_wrtn from /proc/diskstats). Inactive devices are omitted, as iostat does. The avg-cpu values and device totals match host iostat. The three /proc paths are injectable so the report is tested deterministically.

The discard (kB_dscd) columns and the Linux/date/arch banner are out of scope for this slice.

## Tests

- Unit (fixtures for stat/diskstats/uptime): the avg-cpu values, the device totals (kB_read/kB_wrtn from sectors), the omission of an inactive device, and the `cpuPercents` calculation.
- shellspec: the avg-cpu header and the device-table header.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (587 examples, 0 failures); `golangci-lint` and `go vet` clean; registry/README in sync.

Part of #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iostat command for reporting CPU and disk I/O statistics. Displays average per-second transfer rates and per-CPU utilization percentages since boot, along with device input/output metrics in a formatted table report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->