### PR TITLE
feat(procps): add minips applet (minimal process lister)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 241 commands. Run `mimixbox --list` to see them on the terminal.
+There are 242 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -134,6 +134,7 @@ There are 241 commands. Run `mimixbox --list` to see them on the terminal.
 | mbsh | Mimix Box Shell |
 | md5sum | Calculate or Check md5sum message digest |
 | mesg | Display or control write access to your terminal |
+| minips | Minimal process lister (PID, user, command) |
 | mkdir | Make directories |
 | mkfifo | Make FIFO (named pipe) |
 | mknod | Make block or character special files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -82,6 +82,7 @@ import (
 	ap_procps_killall5 "github.com/nao1215/mimixbox/internal/applets/procps/killall5"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
+	ap_procps_minips "github.com/nao1215/mimixbox/internal/applets/procps/minips"
 	ap_procps_mpstat "github.com/nao1215/mimixbox/internal/applets/procps/mpstat"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
@@ -230,7 +231,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 241)
+	Applets = make(map[string]Applet, 242)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -323,6 +324,7 @@ func init() {
 	register(ap_procps_killall5.New())
 	register(ap_procps_logger.New())
 	register(ap_procps_lsof.New())
+	register(ap_procps_minips.New())
 	register(ap_procps_mpstat.New())
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())

--- a/internal/applets/procps/minips/minips.go
+++ b/internal/applets/procps/minips/minips.go
@@ -1,0 +1,101 @@
+// Package minips implements the minips applet: a minimal process lister showing
+// the PID, owning user, and command, read from /proc.
+package minips
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the minips applet.
+type Command struct{}
+
+// New returns a minips command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "minips" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Minimal process lister (PID, user, command)" }
+
+// procDir is the /proc mount; tests point it at a fixture.
+var procDir = "/proc"
+
+// Run executes minips.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "List every process with its PID, owning user, and command name, read from /proc " +
+			"and sorted by PID. This is a minimal subset of ps.",
+		Examples: []command.Example{
+			{Command: "minips", Explain: "List processes minimally."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(stdio.Out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "PID\tUSER\tCOMMAND")
+	for _, pid := range pids() {
+		comm, ok := comm(pid)
+		if !ok {
+			continue
+		}
+		_, _ = fmt.Fprintf(tw, "%d\t%s\t%s\n", pid, owner(pid), comm)
+	}
+	_ = tw.Flush()
+	return nil
+}
+
+func pids() []int {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var out []int
+	for _, e := range entries {
+		if n, err := strconv.Atoi(e.Name()); err == nil {
+			out = append(out, n)
+		}
+	}
+	sort.Ints(out)
+	return out
+}
+
+// comm reads a process's command name from /proc/PID/comm.
+func comm(pid int) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(procDir, strconv.Itoa(pid), "comm")) //nolint:gosec // /proc path
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(data)), true
+}
+
+// owner returns the user name owning the process.
+func owner(pid int) string {
+	info, err := os.Stat(filepath.Join(procDir, strconv.Itoa(pid)))
+	if err != nil {
+		return "?"
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "?"
+	}
+	uid := strconv.FormatUint(uint64(st.Uid), 10)
+	if u, err := user.LookupId(uid); err == nil {
+		return u.Username
+	}
+	return uid
+}

--- a/internal/applets/procps/minips/minips_test.go
+++ b/internal/applets/procps/minips/minips_test.go
@@ -1,0 +1,61 @@
+package minips
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, procs map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	for pid, c := range procs {
+		pdir := filepath.Join(dir, pid)
+		if err := os.MkdirAll(pdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pdir, "comm"), []byte(c+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = os.MkdirAll(filepath.Join(dir, "notapid"), 0o755) // ignored
+	orig := procDir
+	procDir = dir
+	t.Cleanup(func() { procDir = orig })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestListing(t *testing.T) {
+	fixture(t, map[string]string{"1": "init", "100": "bash", "50": "sshd"})
+	out := run(t)
+	if !strings.HasPrefix(out, "PID") || !strings.Contains(out, "USER") || !strings.Contains(out, "COMMAND") {
+		t.Errorf("header wrong: %q", out)
+	}
+	for _, want := range []string{"init", "bash", "sshd"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	// Sorted: 1 before 50 before 100.
+	if !(strings.Index(out, "init") < strings.Index(out, "sshd") && strings.Index(out, "sshd") < strings.Index(out, "bash")) {
+		t.Errorf("not sorted by PID:\n%s", out)
+	}
+	// The non-numeric directory is ignored (4 lines: header + 3 procs).
+	if n := strings.Count(strings.TrimRight(out, "\n"), "\n"); n != 3 {
+		t.Errorf("expected 3 process rows, got %d:\n%s", n, out)
+	}
+}

--- a/test/it/procps/minips_test.sh
+++ b/test/it/procps/minips_test.sh
@@ -1,0 +1,2 @@
+TestMinipsHeader() { minips | sed -n '1p' | grep -c 'COMMAND'; }
+TestMinipsRows() { minips | grep -cE '^[0-9]+'; }

--- a/test/it/spec/minips_spec.sh
+++ b/test/it/spec/minips_spec.sh
@@ -1,0 +1,14 @@
+Describe 'minips'
+    Include procps/minips_test.sh
+
+    It 'prints the PID/USER/COMMAND header'
+        When call TestMinipsHeader
+        The output should equal '1'
+        The status should be success
+    End
+    It 'lists processes'
+        When call TestMinipsRows
+        The status should be success
+        The output should not equal '0'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `minips`, a minimal process lister: every process's PID, owning user, and command name, read from /proc and sorted by PID. It is the small subset of ps (no TTY/TIME/state columns). The /proc directory is injectable so the listing is tested against fixtures.

## Tests

- Unit (fixture /proc): the PID/USER/COMMAND header, the listed commands, PID sorting, and that non-numeric directories are ignored.
- shellspec: the header and that processes are listed.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (589 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245