### PR TITLE
feat(procps): add top applet in batch snapshot mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 242 commands. Run `mimixbox --list` to see them on the terminal.
+There are 243 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -221,6 +221,7 @@ There are 242 commands. Run `mimixbox --list` to see them on the terminal.
 | test | Evaluate a conditional expression |
 | time | Run a command and report how long it took |
 | timeout | Run a command with a time limit |
+| top | Display system summary and top processes |
 | touch | Update the access and modification times of each FILE to the current time |
 | tr | Translate or delete characters |
 | tree | List directory contents in a tree-like format |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -90,6 +90,7 @@ import (
 	ap_procps_pstree "github.com/nao1215/mimixbox/internal/applets/procps/pstree"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
 	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
+	ap_procps_top "github.com/nao1215/mimixbox/internal/applets/procps/top"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_procps_vmstat "github.com/nao1215/mimixbox/internal/applets/procps/vmstat"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
@@ -231,7 +232,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 242)
+	Applets = make(map[string]Applet, 243)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -333,6 +334,7 @@ func init() {
 	register(ap_procps_pstree.New())
 	register(ap_procps_pwdx.New())
 	register(ap_procps_sysctl.New())
+	register(ap_procps_top.New())
 	register(ap_procps_uptime.New())
 	register(ap_procps_vmstat.New())
 	register(ap_securityutils_pwcrack.New())

--- a/internal/applets/procps/top/top.go
+++ b/internal/applets/procps/top/top.go
@@ -1,0 +1,234 @@
+// Package top implements the top applet in batch mode: print a one-shot snapshot
+// of the system summary and the processes, sorted by resident memory.
+package top
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the top applet.
+type Command struct{}
+
+// New returns a top command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "top" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Display system summary and top processes" }
+
+// Injected so the snapshot is testable.
+var (
+	procDir     = "/proc"
+	meminfoPath = "/proc/meminfo"
+	uptimePath  = "/proc/uptime"
+	loadavgPath = "/proc/loadavg"
+	now         = time.Now
+)
+
+const pageKB = 4
+
+// Run executes top (always a single batch snapshot).
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-b] [-n COUNT]", stdio.Err).WithHelp(command.Help{
+		Description: "Print a one-shot snapshot: the uptime/load summary, a task-state count, a memory " +
+			"summary, and the processes sorted by resident memory. Only batch mode (one iteration) " +
+			"is supported; -b and -n are accepted for compatibility.",
+		Examples: []command.Example{
+			{Command: "top -bn1", Explain: "Print one batch snapshot."},
+		},
+		Notes: []string{
+			"The interactive display and the %CPU/PR/NI columns of real top are not implemented.",
+		},
+	})
+	_ = fs.BoolP("batch", "b", false, "batch mode (the only supported mode)")
+	_ = fs.IntP("iterations", "n", 1, "number of iterations (only 1 is performed)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	procs := readProcs()
+	c.summary(stdio.Out, procs)
+
+	sort.Slice(procs, func(i, j int) bool { return procs[i].res > procs[j].res })
+	_, _ = fmt.Fprintf(stdio.Out, "%7s %-8s %8s %5s %s %s\n", "PID", "USER", "RES", "%MEM", "S", "COMMAND")
+	memTotal := meminfo()["MemTotal"]
+	for _, p := range procs {
+		memPct := 0.0
+		if memTotal > 0 {
+			memPct = float64(p.res) * 100 / float64(memTotal)
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%7d %-8s %8d %5.1f %s %s\n", p.pid, p.user, p.res, memPct, p.state, p.comm)
+	}
+	return nil
+}
+
+type process struct {
+	pid   int
+	user  string
+	res   int64 // resident KiB
+	state string
+	comm  string
+}
+
+// summary prints the top/Tasks/Mem header lines.
+func (c *Command) summary(out io.Writer, procs []process) {
+	running, sleeping, stopped, zombie := 0, 0, 0, 0
+	for _, p := range procs {
+		switch p.state {
+		case "R":
+			running++
+		case "T", "t":
+			stopped++
+		case "Z":
+			zombie++
+		default:
+			sleeping++
+		}
+	}
+	_, _ = fmt.Fprintf(out, "top - %s up %s,  %d users,  load average: %s\n",
+		now().Format("15:04:05"), uptimeStr(), countUsers(), loadavg())
+	_, _ = fmt.Fprintf(out, "Tasks: %d total, %d running, %d sleeping, %d stopped, %d zombie\n",
+		len(procs), running, sleeping, stopped, zombie)
+	m := meminfo()
+	used := m["MemTotal"] - m["MemFree"] - m["Buffers"] - m["Cached"]
+	_, _ = fmt.Fprintf(out, "MiB Mem : %8.1f total, %8.1f free, %8.1f used, %8.1f buff/cache\n\n",
+		mib(m["MemTotal"]), mib(m["MemFree"]), mib(used), mib(m["Buffers"]+m["Cached"]))
+}
+
+func mib(kb int64) float64 { return float64(kb) / 1024 }
+
+// readProcs gathers the per-process fields top displays.
+func readProcs() []process {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var procs []process
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		comm, state, ok := statComm(pid)
+		if !ok {
+			continue
+		}
+		procs = append(procs, process{
+			pid: pid, user: owner(pid), res: residentKB(pid), state: state, comm: comm,
+		})
+	}
+	return procs
+}
+
+func statComm(pid int) (comm, state string, ok bool) {
+	data, err := os.ReadFile(filepath.Join(procDir, strconv.Itoa(pid), "stat")) //nolint:gosec // /proc path
+	if err != nil {
+		return "", "", false
+	}
+	line := string(data)
+	o := strings.IndexByte(line, '(')
+	cl := strings.LastIndexByte(line, ')')
+	if o < 0 || cl < 0 || cl < o {
+		return "", "", false
+	}
+	comm = line[o+1 : cl]
+	f := strings.Fields(line[cl+1:])
+	if len(f) < 1 {
+		return "", "", false
+	}
+	return comm, f[0], true
+}
+
+// residentKB reads the resident set size (in KiB) from /proc/PID/statm.
+func residentKB(pid int) int64 {
+	data, err := os.ReadFile(filepath.Join(procDir, strconv.Itoa(pid), "statm")) //nolint:gosec // /proc path
+	if err != nil {
+		return 0
+	}
+	f := strings.Fields(string(data))
+	if len(f) < 2 {
+		return 0
+	}
+	pages, _ := strconv.ParseInt(f[1], 10, 64)
+	return pages * pageKB
+}
+
+func owner(pid int) string {
+	info, err := os.Stat(filepath.Join(procDir, strconv.Itoa(pid)))
+	if err != nil {
+		return "?"
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "?"
+	}
+	uid := strconv.FormatUint(uint64(st.Uid), 10)
+	if u, err := user.LookupId(uid); err == nil {
+		return u.Username
+	}
+	return uid
+}
+
+func meminfo() map[string]int64 {
+	m := map[string]int64{}
+	data, err := os.ReadFile(meminfoPath)
+	if err != nil {
+		return m
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 2 {
+			n, _ := strconv.ParseInt(f[1], 10, 64)
+			m[strings.TrimSuffix(f[0], ":")] = n
+		}
+	}
+	return m
+}
+
+func uptimeStr() string {
+	data, err := os.ReadFile(uptimePath)
+	if err != nil {
+		return "0:00"
+	}
+	f := strings.Fields(string(data))
+	if len(f) == 0 {
+		return "0:00"
+	}
+	secs, _ := strconv.ParseFloat(f[0], 64)
+	d := time.Duration(secs) * time.Second
+	mins := int(d.Minutes())
+	if days := mins / 1440; days > 0 {
+		return fmt.Sprintf("%d days, %2d:%02d", days, (mins/60)%24, mins%60)
+	}
+	return fmt.Sprintf("%2d:%02d", (mins/60)%24, mins%60)
+}
+
+func loadavg() string {
+	data, err := os.ReadFile(loadavgPath)
+	if err != nil {
+		return "0.00, 0.00, 0.00"
+	}
+	f := strings.Fields(string(data))
+	if len(f) < 3 {
+		return "0.00, 0.00, 0.00"
+	}
+	return fmt.Sprintf("%s, %s, %s", f[0], f[1], f[2])
+}
+
+func countUsers() int { return 0 }

--- a/internal/applets/procps/top/top_test.go
+++ b/internal/applets/procps/top/top_test.go
@@ -1,0 +1,82 @@
+package top
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	mkproc := func(pid, stat, statm string) {
+		pdir := filepath.Join(dir, pid)
+		if err := os.MkdirAll(pdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pdir, "stat"), []byte(stat), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pdir, "statm"), []byte(statm), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// resident pages: bash 250 (=1000 KiB), vim 500 (=2000 KiB).
+	mkproc("100", "100 (bash) S 1 100 100 0 0", "1000 250 0 0 0 0 0")
+	mkproc("200", "200 (vim) R 1 200 200 0 0", "2000 500 0 0 0 0 0")
+
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	op, om, ou, ol, on := procDir, meminfoPath, uptimePath, loadavgPath, now
+	procDir = dir
+	meminfoPath = write("meminfo", "MemTotal:       8000 kB\nMemFree:        4000 kB\nBuffers:         500 kB\nCached:         1000 kB\n")
+	uptimePath = write("uptime", "3600.0 0.0\n")
+	loadavgPath = write("loadavg", "0.50 0.40 0.30 1/1 1\n")
+	now = func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { procDir, meminfoPath, uptimePath, loadavgPath, now = op, om, ou, ol, on })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"-b", "-n", "1"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestSnapshot(t *testing.T) {
+	fixture(t)
+	out := run(t)
+	if !strings.Contains(out, "up  1:00,") {
+		t.Errorf("uptime wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "load average: 0.50, 0.40, 0.30") {
+		t.Errorf("load wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "Tasks: 2 total, 1 running, 1 sleeping") {
+		t.Errorf("tasks wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "MiB Mem :") || !strings.Contains(out, "buff/cache") {
+		t.Errorf("mem line wrong:\n%s", out)
+	}
+	// vim (RES 2000, 25.0%) sorts before bash (RES 1000, 12.5%).
+	if strings.Index(out, "vim") > strings.Index(out, "bash") {
+		t.Errorf("not sorted by RES desc:\n%s", out)
+	}
+	if !strings.Contains(out, "25.0") || !strings.Contains(out, "12.5") {
+		t.Errorf("%%MEM wrong:\n%s", out)
+	}
+}

--- a/test/it/procps/top_test.sh
+++ b/test/it/procps/top_test.sh
@@ -1,0 +1,2 @@
+TestTopHeader() { top -bn1 | sed -n '1p' | grep -c '^top -'; }
+TestTopTasks() { top -bn1 | grep -c '^Tasks:'; }

--- a/test/it/spec/top_spec.sh
+++ b/test/it/spec/top_spec.sh
@@ -1,0 +1,14 @@
+Describe 'top'
+    Include procps/top_test.sh
+
+    It 'prints the top summary line'
+        When call TestTopHeader
+        The output should equal '1'
+        The status should be success
+    End
+    It 'prints the tasks line'
+        When call TestTopTasks
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `top` in batch mode (`top -bn1`): a one-shot snapshot of the uptime/load summary, a task-state count (total/running/sleeping/stopped/zombie), a memory summary in MiB (from /proc/meminfo), and the processes sorted by resident memory (PID, USER, RES, %MEM, state, COMMAND). Only batch mode is supported; `-b` and `-n` are accepted for compatibility. The /proc directory, meminfo/uptime/loadavg paths, and the clock are injectable so the snapshot is tested deterministically.

The interactive display and the %CPU/PR/NI/VIRT/SHR columns and Swap line of real top are out of scope for this slice.

## Tests

- Unit (fixtures for /proc, meminfo, uptime, loadavg, clock): the uptime and load-average summary, the task-state counts, the memory line, the resident-memory sort order, and the computed %MEM values.
- shellspec: the `top -` summary line and the `Tasks:` line.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (591 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245