### PR TITLE
feat(procps): add smemcap applet to capture /proc data for smem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 243 commands. Run `mimixbox --list` to see them on the terminal.
+There are 244 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -204,6 +204,7 @@ There are 243 commands. Run `mimixbox --list` to see them on the terminal.
 | shuf | Generate a random permutation of input lines |
 | sl | Cure your bad habit of mistyping |
 | sleep | Pause for NUMBER seconds(minutes, hours, days) |
+| smemcap | Capture /proc memory data into a tar for smem |
 | sort | Sort lines of text files |
 | speaker | Read text aloud using an installed TTS engine |
 | split | Split a file into pieces |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -89,6 +89,7 @@ import (
 	ap_procps_ps "github.com/nao1215/mimixbox/internal/applets/procps/ps"
 	ap_procps_pstree "github.com/nao1215/mimixbox/internal/applets/procps/pstree"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
+	ap_procps_smemcap "github.com/nao1215/mimixbox/internal/applets/procps/smemcap"
 	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
 	ap_procps_top "github.com/nao1215/mimixbox/internal/applets/procps/top"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
@@ -232,7 +233,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 243)
+	Applets = make(map[string]Applet, 244)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -333,6 +334,7 @@ func init() {
 	register(ap_procps_ps.New())
 	register(ap_procps_pstree.New())
 	register(ap_procps_pwdx.New())
+	register(ap_procps_smemcap.New())
 	register(ap_procps_sysctl.New())
 	register(ap_procps_top.New())
 	register(ap_procps_uptime.New())

--- a/internal/applets/procps/smemcap/smemcap.go
+++ b/internal/applets/procps/smemcap/smemcap.go
@@ -1,0 +1,96 @@
+// Package smemcap implements the smemcap applet: capture the /proc data that
+// smem needs into a tar archive written to standard output.
+package smemcap
+
+import (
+	"archive/tar"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the smemcap applet.
+type Command struct{}
+
+// New returns a smemcap command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "smemcap" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Capture /proc memory data into a tar for smem" }
+
+// Injected so the capture is testable.
+var (
+	procDir     = "/proc"
+	meminfoPath = "/proc/meminfo"
+	versionPath = "/proc/version"
+)
+
+// Run executes smemcap.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Write a tar archive to standard output containing the system's memory-usage data " +
+			"(/proc/meminfo and /proc/version) and, for each process, its smaps, stat, and cmdline. " +
+			"The archive is meant to be read later by 'smem -S'.",
+		Examples: []command.Example{
+			{Command: "smemcap > capture.tar", Explain: "Capture the current memory state."},
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	tw := tar.NewWriter(stdio.Out)
+	add(tw, "meminfo", meminfoPath)
+	add(tw, "version", versionPath)
+	for _, pid := range pids() {
+		dir := filepath.Join(procDir, pid)
+		add(tw, pid+"/smaps", filepath.Join(dir, "smaps"))
+		add(tw, pid+"/stat", filepath.Join(dir, "stat"))
+		add(tw, pid+"/cmdline", filepath.Join(dir, "cmdline"))
+	}
+	if err := tw.Close(); err != nil {
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// add writes one file into the archive, skipping it if it cannot be read.
+func add(tw *tar.Writer, name, srcPath string) {
+	data, err := os.ReadFile(srcPath) //nolint:gosec // /proc path
+	if err != nil {
+		return
+	}
+	hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(data))}
+	if tw.WriteHeader(hdr) != nil {
+		return
+	}
+	_, _ = tw.Write(data)
+}
+
+// pids returns the numeric /proc entries in sorted order.
+func pids() []string {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil
+	}
+	var nums []int
+	for _, e := range entries {
+		if n, err := strconv.Atoi(e.Name()); err == nil {
+			nums = append(nums, n)
+		}
+	}
+	sort.Ints(nums)
+	out := make([]string, len(nums))
+	for i, n := range nums {
+		out[i] = strconv.Itoa(n)
+	}
+	return out
+}

--- a/internal/applets/procps/smemcap/smemcap_test.go
+++ b/internal/applets/procps/smemcap/smemcap_test.go
@@ -1,0 +1,106 @@
+package smemcap
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	pdir := filepath.Join(dir, "100")
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"smaps":   "00400000-00410000 r-xp ...\n",
+		"stat":    "100 (bash) S 1 100\n",
+		"cmdline": "bash\x00",
+	} {
+		if err := os.WriteFile(filepath.Join(pdir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	op, om, ov := procDir, meminfoPath, versionPath
+	procDir = dir
+	meminfoPath = write("meminfo", "MemTotal: 8000 kB\n")
+	versionPath = write("version", "Linux version 6.0\n")
+	t.Cleanup(func() { procDir, meminfoPath, versionPath = op, om, ov })
+}
+
+func capture(t *testing.T) map[string]string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io2 := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io2, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	files := map[string]string{}
+	tr := tar.NewReader(out)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, _ := io.ReadAll(tr)
+		files[hdr.Name] = string(data)
+	}
+	return files
+}
+
+func TestCapture(t *testing.T) {
+	fixture(t)
+	files := capture(t)
+	for _, name := range []string{"meminfo", "version", "100/smaps", "100/stat", "100/cmdline"} {
+		if _, ok := files[name]; !ok {
+			t.Errorf("archive missing %q (have %v)", name, keys(files))
+		}
+	}
+	if files["meminfo"] != "MemTotal: 8000 kB\n" {
+		t.Errorf("meminfo content = %q", files["meminfo"])
+	}
+	if files["100/stat"] != "100 (bash) S 1 100\n" {
+		t.Errorf("stat content = %q", files["100/stat"])
+	}
+}
+
+func TestMissingFilesSkipped(t *testing.T) {
+	fixture(t)
+	// Remove the process smaps; the capture should still succeed without it.
+	if err := os.Remove(filepath.Join(procDir, "100", "smaps")); err != nil {
+		t.Fatal(err)
+	}
+	files := capture(t)
+	if _, ok := files["100/smaps"]; ok {
+		t.Errorf("missing smaps should be skipped")
+	}
+	if _, ok := files["100/stat"]; !ok {
+		t.Errorf("stat should still be captured")
+	}
+}
+
+func keys(m map[string]string) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/test/it/procps/smemcap_test.sh
+++ b/test/it/procps/smemcap_test.sh
@@ -1,0 +1,5 @@
+# Capture to a tar and confirm the meminfo entry is present.
+TestSmemcap() {
+    smemcap > "$TEST_DIR/cap.tar"
+    tar -tf "$TEST_DIR/cap.tar" | grep -c '^meminfo$'
+}

--- a/test/it/spec/smemcap_spec.sh
+++ b/test/it/spec/smemcap_spec.sh
@@ -1,0 +1,14 @@
+Describe 'smemcap'
+    Include procps/smemcap_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/smemcap; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'captures a tar containing meminfo'
+        When call TestSmemcap
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `smemcap`, which writes a tar archive to standard output containing the system's memory data (/proc/meminfo and /proc/version) and, for each process, its smaps, stat, and cmdline — the input format read later by `smem -S`. Files that cannot be read (e.g. a privileged smaps) are skipped gracefully. The /proc directory and the meminfo/version paths are injectable so the capture is tested by reading the produced tar back.

## Tests

- Unit (fixture /proc + tar round-trip): the archive contains meminfo, version, and the per-process smaps/stat/cmdline with correct content, and a removed smaps is skipped while the rest is still captured.
- shellspec: smemcap produces a tar that contains the meminfo entry.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (592 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245