### PR TITLE
feat(procps): add klogd applet to forward kernel messages to syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 244 commands. Run `mimixbox --list` to see them on the terminal.
+There are 245 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -113,6 +113,7 @@ There are 244 commands. Run `mimixbox --list` to see them on the terminal.
 | kill | Kill process or send signal to process |
 | killall | Kill processes by name |
 | killall5 | Send a signal to all processes |
+| klogd | Forward kernel messages to the system log |
 | last | Show a listing of last logged-in users |
 | less | Page through text one screen at a time |
 | lifegame | Life game (Conway's Game of Life) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -80,6 +80,7 @@ import (
 	ap_procps_fuser "github.com/nao1215/mimixbox/internal/applets/procps/fuser"
 	ap_procps_iostat "github.com/nao1215/mimixbox/internal/applets/procps/iostat"
 	ap_procps_killall5 "github.com/nao1215/mimixbox/internal/applets/procps/killall5"
+	ap_procps_klogd "github.com/nao1215/mimixbox/internal/applets/procps/klogd"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
 	ap_procps_minips "github.com/nao1215/mimixbox/internal/applets/procps/minips"
@@ -233,7 +234,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 244)
+	Applets = make(map[string]Applet, 245)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -324,6 +325,7 @@ func init() {
 	register(ap_procps_fuser.New())
 	register(ap_procps_iostat.New())
 	register(ap_procps_killall5.New())
+	register(ap_procps_klogd.New())
 	register(ap_procps_logger.New())
 	register(ap_procps_lsof.New())
 	register(ap_procps_minips.New())

--- a/internal/applets/procps/klogd/klogd.go
+++ b/internal/applets/procps/klogd/klogd.go
@@ -1,0 +1,100 @@
+// Package klogd implements the klogd applet: read the kernel ring buffer and
+// forward each message to the system log (one-shot mode).
+package klogd
+
+import (
+	"context"
+	"log/syslog"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the klogd applet.
+type Command struct{}
+
+// New returns a klogd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "klogd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Forward kernel messages to the system log" }
+
+// syslogActionReadAll is SYSLOG_ACTION_READ_ALL for klogctl(2).
+const syslogActionReadAll = 3
+
+// readKernelLog is indirected so the forwarding can be tested without root.
+var readKernelLog = func() ([]byte, error) {
+	buf := make([]byte, 1<<20)
+	n, err := unix.Klogctl(syslogActionReadAll, buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+// logFunc is indirected so it is testable without a running syslogd.
+var logFunc = func(p syslog.Priority, msg string) error {
+	w, err := syslog.New(p, "kernel")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = w.Close() }()
+	_, err = w.Write([]byte(msg))
+	return err
+}
+
+// Run executes klogd in one-shot mode.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-o]", stdio.Err).WithHelp(command.Help{
+		Description: "Read the kernel ring buffer once and forward each message to the system log " +
+			"with the LOG_KERN facility, preserving each message's priority. Only one-shot mode is " +
+			"implemented; the continuously-following daemon is not.",
+		Examples: []command.Example{
+			{Command: "klogd -o", Explain: "Forward the current kernel messages and exit."},
+		},
+		ExitStatus: "0  the messages were forwarded.\n1  the kernel buffer or syslog was unreachable.",
+	})
+	_ = fs.BoolP("once", "o", false, "read the buffer once and exit (the only supported mode)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	data, err := readKernelLog()
+	if err != nil {
+		return command.Failuref("cannot read the kernel buffer: %v", err)
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		prio, text := splitPriority(line)
+		if err := logFunc(prio, text); err != nil {
+			return command.Failuref("cannot forward to syslog: %v", err)
+		}
+	}
+	return nil
+}
+
+// splitPriority parses a leading "<N>" kernel priority prefix, returning the
+// LOG_KERN-facility priority and the message text. Without a prefix it defaults
+// to LOG_KERN|LOG_INFO.
+func splitPriority(line string) (syslog.Priority, string) {
+	prio := syslog.LOG_KERN | syslog.LOG_INFO
+	if strings.HasPrefix(line, "<") {
+		if end := strings.IndexByte(line, '>'); end > 1 {
+			if n, err := strconv.Atoi(line[1:end]); err == nil {
+				prio = syslog.LOG_KERN | syslog.Priority(n&0x7)
+				return prio, line[end+1:]
+			}
+		}
+	}
+	return prio, line
+}

--- a/internal/applets/procps/klogd/klogd_test.go
+++ b/internal/applets/procps/klogd/klogd_test.go
@@ -1,0 +1,84 @@
+package klogd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/syslog"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type forwarded struct {
+	prio syslog.Priority
+	msg  string
+}
+
+func stub(t *testing.T, log string, readErr, sendErr error) *[]forwarded {
+	t.Helper()
+	var sent []forwarded
+	or, ol := readKernelLog, logFunc
+	readKernelLog = func() ([]byte, error) {
+		if readErr != nil {
+			return nil, readErr
+		}
+		return []byte(log), nil
+	}
+	logFunc = func(p syslog.Priority, msg string) error {
+		if sendErr != nil {
+			return sendErr
+		}
+		sent = append(sent, forwarded{p, msg})
+		return nil
+	}
+	t.Cleanup(func() { readKernelLog, logFunc = or, ol })
+	return &sent
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestForwards(t *testing.T) {
+	sent := stub(t, "<6>kernel up\n<3>disk error\n\n", nil, nil)
+	if err := run(t, "-o"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*sent) != 2 {
+		t.Fatalf("forwarded %d, want 2: %+v", len(*sent), *sent)
+	}
+	if (*sent)[0].msg != "kernel up" || (*sent)[0].prio != syslog.LOG_KERN|syslog.LOG_INFO {
+		t.Errorf("first = %+v", (*sent)[0])
+	}
+	if (*sent)[1].msg != "disk error" || (*sent)[1].prio != syslog.LOG_KERN|syslog.LOG_ERR {
+		t.Errorf("second = %+v", (*sent)[1])
+	}
+}
+
+func TestSplitPriority(t *testing.T) {
+	t.Parallel()
+	if p, m := splitPriority("<4>warn msg"); p != syslog.LOG_KERN|syslog.LOG_WARNING || m != "warn msg" {
+		t.Errorf("split = %d, %q", p, m)
+	}
+	if p, m := splitPriority("no prefix"); p != syslog.LOG_KERN|syslog.LOG_INFO || m != "no prefix" {
+		t.Errorf("split default = %d, %q", p, m)
+	}
+}
+
+func TestReadFailure(t *testing.T) {
+	stub(t, "", errors.New("permission denied"), nil)
+	if err := run(t, "-o"); err == nil {
+		t.Errorf("a read failure should fail")
+	}
+}
+
+func TestForwardFailure(t *testing.T) {
+	stub(t, "<6>line\n", nil, errors.New("no syslogd"))
+	if err := run(t, "-o"); err == nil {
+		t.Errorf("a forward failure should fail")
+	}
+}

--- a/test/it/procps/klogd_test.sh
+++ b/test/it/procps/klogd_test.sh
@@ -1,0 +1,3 @@
+# Forwarding to syslog needs a running syslogd and kernel-buffer access, so the
+# e2e exercises --help; the parsing and forwarding are covered by unit tests.
+TestKlogdHelp() { klogd --help; }

--- a/test/it/spec/klogd_spec.sh
+++ b/test/it/spec/klogd_spec.sh
@@ -1,0 +1,10 @@
+Describe 'klogd'
+    Include procps/klogd_test.sh
+
+    It 'describes itself with --help'
+        When call TestKlogdHelp
+        The status should be success
+        The output should include 'Usage: klogd'
+        The output should include 'kernel'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `klogd` in one-shot mode: it reads the kernel ring buffer (via klogctl) once and forwards each message to the system log with the LOG_KERN facility, preserving each message's priority parsed from its `<N>` prefix. The kernel read and the syslog send are injectable so the parsing and forwarding are tested without root or a running syslogd.

The continuously-following daemon mode is out of scope for this slice; `-o` is accepted and is the implemented behavior.

## Tests

- Unit (stubbed kernel read + syslog): forwarding each non-empty line with the correct kern-facility priority and stripped text, the `splitPriority` parser (explicit `<N>` and the default), and the read-failure and forward-failure errors.
- shellspec: the `--help` path (forwarding needs a running syslogd and kernel access, so it is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (593 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245