### PR TITLE
feat(procps): add nmeter applet to print system stats from a format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 245 commands. Run `mimixbox --list` to see them on the terminal.
+There are 246 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -147,6 +147,7 @@ There are 245 commands. Run `mimixbox --list` to see them on the terminal.
 | nc | Read and write data across network connections |
 | nice | Run a command with an adjusted niceness |
 | nl | Write each FILE to standard output with line numbers added |
+| nmeter | Print system statistics from a format string |
 | nohup | Run a command immune to hangups, with output to a non-tty |
 | nproc | Print the number of processing units available |
 | nyancat | Animate the rainbow-trailing Nyan Cat |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -85,6 +85,7 @@ import (
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
 	ap_procps_minips "github.com/nao1215/mimixbox/internal/applets/procps/minips"
 	ap_procps_mpstat "github.com/nao1215/mimixbox/internal/applets/procps/mpstat"
+	ap_procps_nmeter "github.com/nao1215/mimixbox/internal/applets/procps/nmeter"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
 	ap_procps_ps "github.com/nao1215/mimixbox/internal/applets/procps/ps"
@@ -234,7 +235,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 245)
+	Applets = make(map[string]Applet, 246)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -330,6 +331,7 @@ func init() {
 	register(ap_procps_lsof.New())
 	register(ap_procps_minips.New())
 	register(ap_procps_mpstat.New())
+	register(ap_procps_nmeter.New())
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pmap.New())

--- a/internal/applets/procps/nmeter/nmeter.go
+++ b/internal/applets/procps/nmeter/nmeter.go
@@ -1,0 +1,133 @@
+// Package nmeter implements the nmeter applet: print a one-shot line of system
+// statistics expanded from a format string.
+package nmeter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the nmeter applet.
+type Command struct{}
+
+// New returns a nmeter command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "nmeter" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print system statistics from a format string" }
+
+// Injected so the snapshot is testable.
+var (
+	statPath    = "/proc/stat"
+	meminfoPath = "/proc/meminfo"
+	now         = time.Now
+)
+
+// Run executes nmeter (a single snapshot of the format).
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "FORMAT", stdio.Err).WithHelp(command.Help{
+		Description: "Expand FORMAT once and print the result. Supported directives: %t (time), " +
+			"%c (CPU busy percent since boot), %m (used memory in MiB), %M (total memory in MiB), " +
+			"and %% (a literal percent). Other text is copied verbatim.",
+		Examples: []command.Example{
+			{Command: "nmeter '%t cpu:%c mem:%m'", Explain: "Print time, CPU, and used memory."},
+		},
+		Notes: []string{
+			"Only a single snapshot is printed; the continuous live display of real nmeter is not implemented.",
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "nmeter: a format string is required")
+		return command.SilentFailure()
+	}
+
+	_, _ = fmt.Fprintln(stdio.Out, expand(rest[0]))
+	return nil
+}
+
+// expand replaces the supported directives in format with current values.
+func expand(format string) string {
+	var b strings.Builder
+	for i := 0; i < len(format); i++ {
+		if format[i] != '%' || i+1 >= len(format) {
+			b.WriteByte(format[i])
+			continue
+		}
+		i++
+		switch format[i] {
+		case 't':
+			b.WriteString(now().Format("15:04:05"))
+		case 'c':
+			fmt.Fprintf(&b, "%.0f%%", cpuBusy())
+		case 'm':
+			m := meminfo()
+			fmt.Fprintf(&b, "%dM", (m["MemTotal"]-m["MemAvailable"])/1024)
+		case 'M':
+			fmt.Fprintf(&b, "%dM", meminfo()["MemTotal"]/1024)
+		case '%':
+			b.WriteByte('%')
+		default:
+			b.WriteByte('%')
+			b.WriteByte(format[i])
+		}
+	}
+	return b.String()
+}
+
+// cpuBusy returns the non-idle CPU percentage since boot.
+func cpuBusy() float64 {
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) == 0 || f[0] != "cpu" {
+			continue
+		}
+		var total, idle int64
+		for i := 1; i < len(f); i++ {
+			n, _ := strconv.ParseInt(f[i], 10, 64)
+			total += n
+			if i == 4 { // idle is the 4th value
+				idle = n
+			}
+		}
+		if total == 0 {
+			return 0
+		}
+		return float64(total-idle) * 100 / float64(total)
+	}
+	return 0
+}
+
+func meminfo() map[string]int64 {
+	m := map[string]int64{}
+	data, err := os.ReadFile(meminfoPath)
+	if err != nil {
+		return m
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 2 {
+			n, _ := strconv.ParseInt(f[1], 10, 64)
+			m[strings.TrimSuffix(f[0], ":")] = n
+		}
+	}
+	return m
+}

--- a/internal/applets/procps/nmeter/nmeter_test.go
+++ b/internal/applets/procps/nmeter/nmeter_test.go
@@ -1,0 +1,70 @@
+package nmeter
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	os1, om, on := statPath, meminfoPath, now
+	// cpu: total = 100+0+50+800+50 = 1000, idle = 800 -> busy 200/1000 = 20%.
+	statPath = write("stat", "cpu 100 0 50 800 50 0 0 0\n")
+	// MemTotal 8192 MiB-ish: 8388608 kB; MemAvailable 4194304 kB -> used 4194304 kB = 4096 MiB.
+	meminfoPath = write("meminfo", "MemTotal:       8388608 kB\nMemAvailable:   4194304 kB\n")
+	now = func() time.Time { return time.Date(2026, 6, 10, 9, 8, 7, 0, time.UTC) }
+	t.Cleanup(func() { statPath, meminfoPath, now = os1, om, on })
+}
+
+func run(t *testing.T, format string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, []string{format})
+	return strings.TrimRight(out.String(), "\n"), err
+}
+
+func TestExpand(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "%t cpu:%c mem:%m/%M %%done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "09:08:07 cpu:20% mem:4096M/8192M %done" {
+		t.Errorf("nmeter = %q", out)
+	}
+}
+
+func TestUnknownDirectivePassesThrough(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "a%zb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "a%zb" {
+		t.Errorf("unknown directive = %q, want a%%zb", out)
+	}
+}
+
+func TestNoFormat(t *testing.T) {
+	fixture(t)
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("missing format should fail")
+	}
+}

--- a/test/it/procps/nmeter_test.sh
+++ b/test/it/procps/nmeter_test.sh
@@ -1,0 +1,2 @@
+TestNmeterLiteral() { nmeter 'hello %% world'; }
+TestNmeterMem() { nmeter 'mem:%M' | grep -cE 'mem:[0-9]+M'; }

--- a/test/it/spec/nmeter_spec.sh
+++ b/test/it/spec/nmeter_spec.sh
@@ -1,0 +1,14 @@
+Describe 'nmeter'
+    Include procps/nmeter_test.sh
+
+    It 'expands a literal percent and copies text'
+        When call TestNmeterLiteral
+        The output should equal 'hello % world'
+        The status should be success
+    End
+    It 'expands the total-memory directive'
+        When call TestNmeterMem
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `nmeter`, which expands a FORMAT string once and prints the result. Supported directives: %t (time), %c (CPU busy percent since boot, from /proc/stat), %m (used memory in MiB) and %M (total memory in MiB, from /proc/meminfo), and %% (a literal percent); other text is copied verbatim, and an unknown %X is passed through unchanged. The /proc paths and the clock are injectable so the expansion is tested deterministically.

Only a single snapshot is printed; the continuous live display of real nmeter is out of scope for this slice.

## Tests

- Unit (fixtures for stat/meminfo/clock): the full directive expansion (time, CPU 20%, used/total memory, literal percent), an unknown directive passing through, and the missing-format error.
- shellspec: a literal-percent expansion and the total-memory directive.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (595 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245