### PR TITLE
feat(procps): add logread applet to show the system log

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 246 commands. Run `mimixbox --list` to see them on the terminal.
+There are 247 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -124,6 +124,7 @@ There are 246 commands. Run `mimixbox --list` to see them on the terminal.
 | log-collect | Gather system log files into one directory |
 | logger | Write a message to the system log |
 | logname | Print the name of the current user |
+| logread | Show the system log |
 | ls | List directory contents |
 | lsblk | List information about block devices |
 | lsof | List open files of processes |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -82,6 +82,7 @@ import (
 	ap_procps_killall5 "github.com/nao1215/mimixbox/internal/applets/procps/killall5"
 	ap_procps_klogd "github.com/nao1215/mimixbox/internal/applets/procps/klogd"
 	ap_procps_logger "github.com/nao1215/mimixbox/internal/applets/procps/logger"
+	ap_procps_logread "github.com/nao1215/mimixbox/internal/applets/procps/logread"
 	ap_procps_lsof "github.com/nao1215/mimixbox/internal/applets/procps/lsof"
 	ap_procps_minips "github.com/nao1215/mimixbox/internal/applets/procps/minips"
 	ap_procps_mpstat "github.com/nao1215/mimixbox/internal/applets/procps/mpstat"
@@ -235,7 +236,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 246)
+	Applets = make(map[string]Applet, 247)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -328,6 +329,7 @@ func init() {
 	register(ap_procps_killall5.New())
 	register(ap_procps_klogd.New())
 	register(ap_procps_logger.New())
+	register(ap_procps_logread.New())
 	register(ap_procps_lsof.New())
 	register(ap_procps_minips.New())
 	register(ap_procps_mpstat.New())

--- a/internal/applets/procps/logread/logread.go
+++ b/internal/applets/procps/logread/logread.go
@@ -1,0 +1,60 @@
+// Package logread implements the logread applet: print the contents of the
+// system log.
+package logread
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the logread applet.
+type Command struct{}
+
+// New returns a logread command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "logread" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show the system log" }
+
+// logCandidates are tried in order; tests point this at a fixture.
+var logCandidates = []string{"/var/log/messages", "/var/log/syslog"}
+
+// Run executes logread.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the system log. With no argument the first readable of /var/log/messages " +
+			"and /var/log/syslog is shown; a FILE argument overrides that. Following the log (-f) is " +
+			"not supported.",
+		Examples: []command.Example{
+			{Command: "logread", Explain: "Print the system log."},
+		},
+		ExitStatus: "0  the log was printed.\n1  no readable log was found.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	candidates := logCandidates
+	if rest := fs.Args(); len(rest) > 0 {
+		candidates = rest
+	}
+
+	for _, path := range candidates {
+		data, err := os.ReadFile(path) //nolint:gosec // user-named or well-known log path
+		if err != nil {
+			continue
+		}
+		_, _ = stdio.Out.Write(data)
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(stdio.Err, "logread: no readable system log was found")
+	return command.SilentFailure()
+}

--- a/internal/applets/procps/logread/logread_test.go
+++ b/internal/applets/procps/logread/logread_test.go
@@ -1,0 +1,63 @@
+package logread
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func writeFile(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "log")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestExplicitFile(t *testing.T) {
+	f := writeFile(t, "alpha\nbeta\n")
+	out, err := run(t, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "alpha\nbeta\n" {
+		t.Errorf("logread FILE = %q", out)
+	}
+}
+
+func TestDefaultCandidate(t *testing.T) {
+	f := writeFile(t, "system log\n")
+	orig := logCandidates
+	logCandidates = []string{"/no/such/log", f}
+	defer func() { logCandidates = orig }()
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "system log\n" {
+		t.Errorf("fallback candidate = %q", out)
+	}
+}
+
+func TestNoLog(t *testing.T) {
+	orig := logCandidates
+	logCandidates = []string{"/no/such/a", "/no/such/b"}
+	defer func() { logCandidates = orig }()
+	if _, err := run(t); err == nil {
+		t.Errorf("no readable log should fail")
+	}
+}

--- a/test/it/procps/logread_test.sh
+++ b/test/it/procps/logread_test.sh
@@ -1,0 +1,8 @@
+TestLogreadFile() {
+    printf 'msg one\nmsg two\n' > "$TEST_DIR/sys.log"
+    logread "$TEST_DIR/sys.log"
+}
+TestLogreadMissing() {
+    logread "$TEST_DIR/nope.log" 2>/dev/null
+    echo "rc=$?"
+}

--- a/test/it/spec/logread_spec.sh
+++ b/test/it/spec/logread_spec.sh
@@ -1,0 +1,20 @@
+Describe 'logread'
+    Include procps/logread_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/logread; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'prints a given log file'
+        When call TestLogreadFile
+        The line 1 of output should equal 'msg one'
+        The line 2 of output should equal 'msg two'
+        The status should be success
+    End
+    It 'fails when no readable log is found'
+        When call TestLogreadMissing
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `logread`, which prints the system log. With no argument it shows the first readable of /var/log/messages and /var/log/syslog; a FILE argument overrides that. It exits non-zero when no readable log is found. The candidate list is injectable so the lookup is tested against fixtures.

mimixbox has no shared-memory syslogd, so logread reads the log file rather than an IPC buffer; following the log (-f) is out of scope for this slice.

## Tests

- Unit: printing an explicit FILE, falling back to the first readable default candidate, and the no-readable-log error.
- shellspec: printing a given log file (line by line) and the missing-log non-zero exit.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (597 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245