### PR TITLE
feat(procps): add syslogd applet (minimal logging daemon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 247 commands. Run `mimixbox --list` to see them on the terminal.
+There are 248 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -217,6 +217,7 @@ There are 247 commands. Run `mimixbox --list` to see them on the terminal.
 | sum | Checksum and count the blocks in a file (BSD) |
 | sync | Synchronize cached writes to persistent storage |
 | sysctl | Read and write kernel parameters at runtime |
+| syslogd | Minimal system logging daemon |
 | tac | Print the file contents from the end to the beginning |
 | tail | Print the last NUMBER(default=10) lines |
 | tar | Archive files (create, list, extract) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -94,6 +94,7 @@ import (
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
 	ap_procps_smemcap "github.com/nao1215/mimixbox/internal/applets/procps/smemcap"
 	ap_procps_sysctl "github.com/nao1215/mimixbox/internal/applets/procps/sysctl"
+	ap_procps_syslogd "github.com/nao1215/mimixbox/internal/applets/procps/syslogd"
 	ap_procps_top "github.com/nao1215/mimixbox/internal/applets/procps/top"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_procps_vmstat "github.com/nao1215/mimixbox/internal/applets/procps/vmstat"
@@ -236,7 +237,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 247)
+	Applets = make(map[string]Applet, 248)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -342,6 +343,7 @@ func init() {
 	register(ap_procps_pwdx.New())
 	register(ap_procps_smemcap.New())
 	register(ap_procps_sysctl.New())
+	register(ap_procps_syslogd.New())
 	register(ap_procps_top.New())
 	register(ap_procps_uptime.New())
 	register(ap_procps_vmstat.New())

--- a/internal/applets/procps/syslogd/syslogd.go
+++ b/internal/applets/procps/syslogd/syslogd.go
@@ -1,0 +1,97 @@
+// Package syslogd implements the syslogd applet: a minimal system-log daemon
+// that receives messages on a Unix datagram socket and appends them to a file.
+package syslogd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the syslogd applet.
+type Command struct{}
+
+// New returns a syslogd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "syslogd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Minimal system logging daemon" }
+
+// Run executes syslogd in the foreground until the context is cancelled.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-l SOCKET] [-O LOGFILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Receive log messages on a Unix datagram socket and append them to a log file, " +
+			"running in the foreground until interrupted. -l sets the socket (default /dev/log) and " +
+			"-O the log file (default /var/log/messages). The priority prefix is stripped from each " +
+			"message. Background daemonisation and the shared-memory buffer are not implemented.",
+		Examples: []command.Example{
+			{Command: "syslogd -l /tmp/log -O /tmp/messages", Explain: "Log to a custom socket and file."},
+		},
+		ExitStatus: "0  the daemon stopped cleanly.\n1  the socket or log file could not be opened.",
+	})
+	socket := fs.StringP("socket", "l", "/dev/log", "datagram socket to listen on")
+	logfile := fs.StringP("output", "O", "/var/log/messages", "file to append messages to")
+	_ = fs.BoolP("foreground", "n", false, "run in the foreground (the only supported mode)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	_ = os.Remove(*socket) // a stale socket would block ListenUnixgram
+	conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: *socket, Net: "unixgram"})
+	if err != nil {
+		return command.Failuref("cannot listen on %s: %v", *socket, err)
+	}
+	defer func() { _ = conn.Close() }()
+	defer func() { _ = os.Remove(*socket) }()
+
+	out, err := os.OpenFile(*logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) //nolint:gosec // user-named log
+	if err != nil {
+		return command.Failuref("cannot open %s: %v", *logfile, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	// Closing the connection when the context is cancelled unblocks Read.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	buf := make([]byte, 16*1024)
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			return nil // connection closed via context cancellation
+		}
+		if _, err := fmt.Fprintln(out, stripPriority(string(buf[:n]))); err != nil {
+			return command.Failuref("cannot write to %s: %v", *logfile, err)
+		}
+	}
+}
+
+// stripPriority removes a leading "<N>" syslog priority prefix (N numeric).
+func stripPriority(msg string) string {
+	if strings.HasPrefix(msg, "<") {
+		if end := strings.IndexByte(msg, '>'); end > 1 && isDigits(msg[1:end]) {
+			return strings.TrimRight(msg[end+1:], "\n")
+		}
+	}
+	return strings.TrimRight(msg, "\n")
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
+}

--- a/internal/applets/procps/syslogd/syslogd_test.go
+++ b/internal/applets/procps/syslogd/syslogd_test.go
@@ -1,0 +1,101 @@
+package syslogd
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// waitFor polls cond until it is true or the deadline passes.
+func waitFor(cond func() bool) bool {
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+func TestReceivesAndLogs(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "log.sock")
+	logfile := filepath.Join(dir, "messages")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		done <- New().Run(ctx, io, []string{"-l", sock, "-O", logfile})
+	}()
+
+	if !waitFor(func() bool { _, err := os.Stat(sock); return err == nil }) {
+		cancel()
+		t.Fatal("syslogd never created its socket")
+	}
+
+	conn, err := net.Dial("unixgram", sock)
+	if err != nil {
+		cancel()
+		t.Fatalf("dial: %v", err)
+	}
+	if _, err := conn.Write([]byte("<13>hello world")); err != nil {
+		cancel()
+		t.Fatalf("write: %v", err)
+	}
+	_ = conn.Close()
+
+	logged := waitFor(func() bool {
+		data, _ := os.ReadFile(logfile)
+		return strings.Contains(string(data), "hello world")
+	})
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("syslogd did not stop after cancellation")
+	}
+
+	if !logged {
+		data, _ := os.ReadFile(logfile)
+		t.Fatalf("message not logged; file = %q", data)
+	}
+	// The priority prefix must be stripped.
+	data, _ := os.ReadFile(logfile)
+	if strings.Contains(string(data), "<13>") {
+		t.Errorf("priority prefix not stripped: %q", data)
+	}
+}
+
+func TestStripPriority(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"<13>message":    "message",
+		"no prefix":      "no prefix",
+		"<7>trailing\n":  "trailing",
+		"<not a number>": "<not a number>",
+	}
+	for in, want := range cases {
+		if got := stripPriority(in); got != want {
+			t.Errorf("stripPriority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBadSocketFails(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, []string{"-l", "/no/such/dir/log.sock", "-O", "/tmp/x"})
+	if err == nil {
+		t.Errorf("an unbindable socket should fail")
+	}
+}

--- a/test/it/procps/syslogd_test.sh
+++ b/test/it/procps/syslogd_test.sh
@@ -1,0 +1,3 @@
+# syslogd runs until interrupted, so the e2e exercises --help; the socket-to-log
+# behavior is covered by a Go integration-style unit test.
+TestSyslogdHelp() { syslogd --help; }

--- a/test/it/spec/syslogd_spec.sh
+++ b/test/it/spec/syslogd_spec.sh
@@ -1,0 +1,10 @@
+Describe 'syslogd'
+    Include procps/syslogd_test.sh
+
+    It 'describes itself with --help'
+        When call TestSyslogdHelp
+        The status should be success
+        The output should include 'Usage: syslogd'
+        The output should include 'log'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the procps batch (#245) with `syslogd`, a minimal system-log daemon: it receives log messages on a Unix datagram socket (`-l`, default /dev/log) and appends them to a log file (`-O`, default /var/log/messages), running in the foreground until the context is cancelled (e.g. SIGINT). The syslog priority prefix is stripped from each message. It pairs with the logread applet.

Background daemonization and the shared-memory buffer of BusyBox syslogd are out of scope for this slice; `-n` (foreground) is accepted and is the implemented mode.

## Tests

- Unit (integration-style): start the daemon on a temp socket/log with a cancellable context, send a datagram, verify the message lands in the log file with its priority prefix stripped, and that the daemon stops cleanly on cancellation; the `stripPriority` parser (numeric prefix only); and the unbindable-socket error.
- shellspec: the `--help` path (the daemon blocks until interrupted, so its behavior is covered by the unit test).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (598 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `syslogd`—a minimal system logging daemon that listens on a Unix datagram socket for syslog messages and writes them to a log file. Supports configurable socket path (default `/dev/log`) and log file location (default `/var/log/messages`). Automatically strips syslog priority prefixes from messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->