### PR TITLE
feat(procps): add powertop applet, completing the procps batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 248 commands. Run `mimixbox --list` to see them on the terminal.
+There are 249 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -164,6 +164,7 @@ There are 248 commands. Run `mimixbox --list` to see them on the terminal.
 | pmap | Report the memory map of a process |
 | posixer | Report which POSIX utilities are installed |
 | poweroff | Power off the system |
+| powertop | Report the system power supplies |
 | printenv | Print environment variable |
 | printf | Format and print data |
 | ps | Report a snapshot of the current processes |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -89,6 +89,7 @@ import (
 	ap_procps_nmeter "github.com/nao1215/mimixbox/internal/applets/procps/nmeter"
 	ap_procps_pgrep "github.com/nao1215/mimixbox/internal/applets/procps/pgrep"
 	ap_procps_pmap "github.com/nao1215/mimixbox/internal/applets/procps/pmap"
+	ap_procps_powertop "github.com/nao1215/mimixbox/internal/applets/procps/powertop"
 	ap_procps_ps "github.com/nao1215/mimixbox/internal/applets/procps/ps"
 	ap_procps_pstree "github.com/nao1215/mimixbox/internal/applets/procps/pstree"
 	ap_procps_pwdx "github.com/nao1215/mimixbox/internal/applets/procps/pwdx"
@@ -237,7 +238,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 248)
+	Applets = make(map[string]Applet, 249)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -338,6 +339,7 @@ func init() {
 	register(ap_procps_pgrep.NewPgrep())
 	register(ap_procps_pgrep.NewPkill())
 	register(ap_procps_pmap.New())
+	register(ap_procps_powertop.New())
 	register(ap_procps_ps.New())
 	register(ap_procps_pstree.New())
 	register(ap_procps_pwdx.New())

--- a/internal/applets/procps/powertop/powertop.go
+++ b/internal/applets/procps/powertop/powertop.go
@@ -1,0 +1,112 @@
+// Package powertop implements the powertop applet: a one-shot report of the
+// system's power supplies read from /sys/class/power_supply.
+package powertop
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the powertop applet.
+type Command struct{}
+
+// New returns a powertop command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "powertop" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report the system power supplies" }
+
+// powerSupplyDir is the sysfs power-supply class; tests point it at a fixture.
+var powerSupplyDir = "/sys/class/power_supply"
+
+// Run executes powertop in one-shot report mode.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print a one-shot report of the system's power supplies (AC adapters and " +
+			"batteries) read from /sys/class/power_supply: the AC online state and each battery's " +
+			"charge and status.",
+		Examples: []command.Example{
+			{Command: "powertop", Explain: "Report the power supplies."},
+		},
+		Notes: []string{
+			"The interactive power analysis and tunables of real powertop are not implemented.",
+		},
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	supplies := readSupplies()
+	if len(supplies) == 0 {
+		_, _ = fmt.Fprintln(stdio.Out, "powertop: no power supplies found")
+		return nil
+	}
+
+	_, _ = fmt.Fprintln(stdio.Out, "Power supplies:")
+	for _, s := range supplies {
+		_, _ = fmt.Fprintf(stdio.Out, "  %s\n", s)
+	}
+	return nil
+}
+
+// readSupplies returns one formatted line per power-supply device, sorted by
+// name.
+func readSupplies() []string {
+	entries, err := os.ReadDir(powerSupplyDir)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	var lines []string
+	for _, name := range names {
+		dir := filepath.Join(powerSupplyDir, name)
+		switch readAttr(dir, "type") {
+		case "Battery":
+			cap := readAttr(dir, "capacity")
+			status := readAttr(dir, "status")
+			lines = append(lines, fmt.Sprintf("%s (Battery): %s%% (%s)", name, orUnknown(cap), orUnknown(status)))
+		case "Mains":
+			state := "offline"
+			if readAttr(dir, "online") == "1" {
+				state = "online"
+			}
+			lines = append(lines, fmt.Sprintf("%s (AC): %s", name, state))
+		case "":
+			// Not a recognizable power supply; skip it.
+		default:
+			lines = append(lines, fmt.Sprintf("%s (%s)", name, readAttr(dir, "type")))
+		}
+	}
+	return lines
+}
+
+// readAttr reads a single sysfs attribute file, trimming whitespace.
+func readAttr(dir, name string) string {
+	data, err := os.ReadFile(filepath.Join(dir, name)) //nolint:gosec // sysfs attribute path
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "?"
+	}
+	return s
+}

--- a/internal/applets/procps/powertop/powertop_test.go
+++ b/internal/applets/procps/powertop/powertop_test.go
@@ -1,0 +1,78 @@
+package powertop
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, devices map[string]map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, attrs := range devices {
+		ddir := filepath.Join(dir, name)
+		if err := os.MkdirAll(ddir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for k, v := range attrs {
+			if err := os.WriteFile(filepath.Join(ddir, k), []byte(v+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	orig := powerSupplyDir
+	powerSupplyDir = dir
+	t.Cleanup(func() { powerSupplyDir = orig })
+}
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	return out.String()
+}
+
+func TestReport(t *testing.T) {
+	fixture(t, map[string]map[string]string{
+		"AC":   {"type": "Mains", "online": "1"},
+		"BAT0": {"type": "Battery", "capacity": "85", "status": "Discharging"},
+	})
+	out := run(t)
+	if !strings.Contains(out, "AC (AC): online") {
+		t.Errorf("AC line wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "BAT0 (Battery): 85% (Discharging)") {
+		t.Errorf("battery line wrong:\n%s", out)
+	}
+}
+
+func TestOfflineAC(t *testing.T) {
+	fixture(t, map[string]map[string]string{"AC": {"type": "Mains", "online": "0"}})
+	if out := run(t); !strings.Contains(out, "AC (AC): offline") {
+		t.Errorf("offline AC wrong:\n%s", out)
+	}
+}
+
+func TestNoSupplies(t *testing.T) {
+	fixture(t, map[string]map[string]string{})
+	if out := run(t); !strings.Contains(out, "no power supplies found") {
+		t.Errorf("empty report wrong:\n%s", out)
+	}
+}
+
+func TestMissingDir(t *testing.T) {
+	orig := powerSupplyDir
+	powerSupplyDir = "/no/such/power"
+	defer func() { powerSupplyDir = orig }()
+	if out := run(t); !strings.Contains(out, "no power supplies found") {
+		t.Errorf("missing dir should report none:\n%s", out)
+	}
+}

--- a/test/it/procps/powertop_test.sh
+++ b/test/it/procps/powertop_test.sh
@@ -1,0 +1,4 @@
+# Power-supply hardware is absent on CI/WSL, so the report path is covered by Go
+# unit tests with fixtures; the e2e confirms powertop runs and exits 0.
+TestPowertopRuns() { powertop >/dev/null; echo "rc=$?"; }
+TestPowertopHelp() { powertop --help; }

--- a/test/it/spec/powertop_spec.sh
+++ b/test/it/spec/powertop_spec.sh
@@ -1,0 +1,15 @@
+Describe 'powertop'
+    Include procps/powertop_test.sh
+
+    It 'runs and exits zero'
+        When call TestPowertopRuns
+        The output should equal 'rc=0'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestPowertopHelp
+        The status should be success
+        The output should include 'Usage: powertop'
+        The output should include 'power'
+    End
+End


### PR DESCRIPTION
## Summary

Adds the final applet of the procps batch (#245): `powertop` in one-shot report mode. It reads /sys/class/power_supply and prints the AC adapters' online state and each battery's charge and status. When no power supplies are present (servers, WSL, CI), it reports that and exits 0. The sysfs path is injectable so the report is tested against fixtures.

With this, every command in #245's scope is now implemented (uptime, pwdx, pgrep, pkill, sysctl, pmap, pstree, logger, fuser, lsof, ps, killall5, vmstat, mpstat, iostat, minips, top, smemcap, klogd, nmeter, logread, syslogd, powertop), delivered across this and the preceding PRs.

The interactive power analysis and tunables of real powertop are out of scope for this slice.

## Tests

- Unit (fixture /sys/class/power_supply): the AC-online and battery (charge + status) lines, an offline AC, the empty-report path, and a missing sysfs directory reporting none.
- shellspec: powertop runs and exits zero, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (600 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Closes #245