### PR TITLE
feat(util-linux): add flock applet for advisory file locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 249 commands. Run `mimixbox --list` to see them on the terminal.
+There are 250 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -82,6 +82,7 @@ There are 249 commands. Run `mimixbox --list` to see them on the terminal.
 | false | Do nothing. Return failure(1) |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |
+| flock | Run a command under an advisory file lock |
 | fmt | Simple optimal text formatter |
 | fold | Wrap each input line to fit in specified width |
 | fortune | Print a random, hopefully interesting, adage |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -212,6 +212,7 @@ import (
 	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
 	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
+	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_hwclock "github.com/nao1215/mimixbox/internal/applets/util-linux/hwclock"
@@ -238,7 +239,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 249)
+	Applets = make(map[string]Applet, 250)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -463,6 +464,7 @@ func init() {
 	register(ap_util_linux_chrt.New())
 	register(ap_util_linux_dmesg.New())
 	register(ap_util_linux_fallocate.New())
+	register(ap_util_linux_flock.New())
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())

--- a/internal/applets/util-linux/flock/flock.go
+++ b/internal/applets/util-linux/flock/flock.go
@@ -1,0 +1,124 @@
+// Package flock implements the flock applet: acquire an advisory lock on a file
+// and run a command while holding it.
+package flock
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the flock applet.
+type Command struct{}
+
+// New returns a flock command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "flock" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a command under an advisory file lock" }
+
+// flockFn is indirected so the locking can be observed in tests.
+var flockFn = func(fd int, how int) error { return unix.Flock(fd, how) }
+
+// Run executes flock.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-sxn] [-w SECONDS] FILE COMMAND [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Take an advisory lock on FILE, then run COMMAND while holding it; the lock is " +
+			"released when COMMAND exits. The lock is exclusive by default (-x), or shared with -s. " +
+			"-n fails immediately if the lock is held; -w waits up to SECONDS for it. -c runs the " +
+			"argument with 'sh -c'.",
+		Examples: []command.Example{
+			{Command: "flock /tmp/my.lock echo hi", Explain: "Run echo while holding the lock."},
+			{Command: "flock -n /tmp/my.lock -c 'job'", Explain: "Skip the job if the lock is held."},
+		},
+		ExitStatus: "the command's exit status, or 1 if the lock could not be taken.",
+	})
+	shared := fs.BoolP("shared", "s", false, "take a shared lock")
+	_ = fs.BoolP("exclusive", "x", false, "take an exclusive lock (the default)")
+	nonblock := fs.BoolP("nonblock", "n", false, "fail rather than wait if the lock is held")
+	wait := fs.IntP("wait", "w", 0, "wait at most this many seconds for the lock")
+	cmdStr := fs.StringP("command", "c", "", "run this string with sh -c")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = stdio.Err.Write([]byte("flock: a FILE is required\n"))
+		return command.SilentFailure()
+	}
+	lockPath := rest[0]
+	name, cmdArgs, ok := buildCommand(*cmdStr, rest[1:])
+	if !ok {
+		_, _ = stdio.Err.Write([]byte("flock: a command is required\n"))
+		return command.SilentFailure()
+	}
+
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // user-named lock file
+	if err != nil {
+		return command.Failuref("cannot open %s: %v", lockPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	how := unix.LOCK_EX
+	if *shared {
+		how = unix.LOCK_SH
+	}
+	if err := acquire(int(f.Fd()), how, *nonblock, *wait); err != nil {
+		return command.Failuref("cannot lock %s: %v", lockPath, err)
+	}
+
+	cmd := exec.Command(name, cmdArgs...) //nolint:gosec // user-specified command, as flock is designed to run
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// buildCommand returns the program and arguments to run, from either -c or the
+// remaining operands.
+func buildCommand(cmdStr string, operands []string) (name string, args []string, ok bool) {
+	if cmdStr != "" {
+		return "sh", []string{"-c", cmdStr}, true
+	}
+	if len(operands) == 0 {
+		return "", nil, false
+	}
+	return operands[0], operands[1:], true
+}
+
+// acquire takes the lock, honoring the non-blocking and timeout options.
+func acquire(fd, how int, nonblock bool, wait int) error {
+	if nonblock {
+		return flockFn(fd, how|unix.LOCK_NB)
+	}
+	if wait <= 0 {
+		return flockFn(fd, how)
+	}
+	deadline := time.Now().Add(time.Duration(wait) * time.Second)
+	for {
+		err := flockFn(fd, how|unix.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) || time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/internal/applets/util-linux/flock/flock_test.go
+++ b/internal/applets/util-linux/flock/flock_test.go
@@ -1,0 +1,79 @@
+package flock
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestRunsCommandUnderLock(t *testing.T) {
+	lock := filepath.Join(t.TempDir(), "lock")
+	out, err := run(t, lock, "echo", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hello" {
+		t.Errorf("output = %q, want hello", out)
+	}
+}
+
+func TestRunsViaShell(t *testing.T) {
+	lock := filepath.Join(t.TempDir(), "lock")
+	out, err := run(t, lock, "-c", "echo from-sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "from-sh" {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestNonblockFailsWhenHeld(t *testing.T) {
+	lock := filepath.Join(t.TempDir(), "lock")
+	// Hold an exclusive lock on the file from this test.
+	f, err := os.OpenFile(lock, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run(t, "-n", lock, "echo", "should not run"); err == nil {
+		t.Errorf("flock -n should fail when the lock is held")
+	}
+}
+
+func TestExitCodePropagates(t *testing.T) {
+	lock := filepath.Join(t.TempDir(), "lock")
+	_, err := run(t, lock, "sh", "-c", "exit 3")
+	ee, ok := err.(*command.ExitError)
+	if !ok || ee.Code != 3 {
+		t.Errorf("err = %v, want exit 3", err)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t); err == nil {
+		t.Errorf("no FILE should fail")
+	}
+	lock := filepath.Join(t.TempDir(), "lock")
+	if _, err := run(t, lock); err == nil {
+		t.Errorf("no command should fail")
+	}
+}

--- a/test/it/spec/flock_spec.sh
+++ b/test/it/spec/flock_spec.sh
@@ -1,0 +1,19 @@
+Describe 'flock'
+    Include util-linux/flock_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/flock; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'runs a command while holding the lock'
+        When call TestFlockRuns
+        The output should equal 'locked-run'
+        The status should be success
+    End
+    It 'fails -n when the lock is already held'
+        When call TestFlockNonblock
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/flock_test.sh
+++ b/test/it/util-linux/flock_test.sh
@@ -1,0 +1,11 @@
+TestFlockRuns() {
+    flock "$TEST_DIR/lock" echo "locked-run"
+}
+TestFlockNonblock() {
+    # Hold the lock with a background sleep, then a -n attempt must fail.
+    flock "$TEST_DIR/lock" sleep 1 &
+    sleep 0.2
+    flock -n "$TEST_DIR/lock" echo "nope" 2>/dev/null
+    echo "rc=$?"
+    wait
+}


### PR DESCRIPTION
## Summary

Starts the util-linux filesystem/device batch (#249) with `flock`, the high-value, test-friendly applet the issue calls out first. It takes an advisory lock on FILE (exclusive by default, shared with -s), runs a command while holding it, and releases the lock when the command exits. `-n` fails immediately if the lock is held, `-w SECONDS` waits up to a timeout, and `-c` runs its argument with `sh -c`. The command's exit status is propagated. The lock call is indirected, and the locks are real but hermetic (temp files), so the behavior is tested without touching the host.

## Tests

- Unit: running a command (and `-c` via the shell) while holding the lock, `-n` failing when the lock is already held by the test, exit-code propagation, and the missing-FILE / missing-command errors.
- shellspec: running a command under the lock, and `-n` failing when a background holder owns the lock.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (602 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249