### PR TITLE
feat(util-linux): add findfs applet to find a device by label or UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 250 commands. Run `mimixbox --list` to see them on the terminal.
+There are 251 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -82,6 +82,7 @@ There are 250 commands. Run `mimixbox --list` to see them on the terminal.
 | false | Do nothing. Return failure(1) |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |
+| findfs | Find a filesystem by label or UUID |
 | flock | Run a command under an advisory file lock |
 | fmt | Simple optimal text formatter |
 | fold | Wrap each input line to fit in specified width |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -212,6 +212,7 @@ import (
 	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
 	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
+	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
@@ -239,7 +240,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 250)
+	Applets = make(map[string]Applet, 251)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -464,6 +465,7 @@ func init() {
 	register(ap_util_linux_chrt.New())
 	register(ap_util_linux_dmesg.New())
 	register(ap_util_linux_fallocate.New())
+	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())

--- a/internal/applets/util-linux/findfs/findfs.go
+++ b/internal/applets/util-linux/findfs/findfs.go
@@ -1,0 +1,94 @@
+// Package findfs implements the findfs applet: find a block device by its
+// filesystem LABEL or UUID.
+package findfs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the findfs applet.
+type Command struct{}
+
+// New returns a findfs command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "findfs" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Find a filesystem by label or UUID" }
+
+// The udev symlink directories; tests point these at fixtures.
+var (
+	byLabelDir = "/dev/disk/by-label"
+	byUUIDDir  = "/dev/disk/by-uuid"
+)
+
+// Run executes findfs.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "LABEL=<label>|UUID=<uuid>", stdio.Err).WithHelp(command.Help{
+		Description: "Print the block device whose filesystem has the given LABEL or UUID, resolved " +
+			"through /dev/disk/by-label and /dev/disk/by-uuid.",
+		Examples: []command.Example{
+			{Command: "findfs LABEL=rootfs", Explain: "Print the device labelled rootfs."},
+			{Command: "findfs UUID=1234-5678", Explain: "Print the device with that UUID."},
+		},
+		ExitStatus: "0  the device was found.\n1  the tag could not be resolved.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "findfs: a LABEL=<label> or UUID=<uuid> tag is required")
+		return command.SilentFailure()
+	}
+	spec := rest[0]
+
+	kind, value, ok := strings.Cut(spec, "=")
+	if !ok {
+		return c.unresolved(stdio, spec)
+	}
+
+	var dir string
+	switch strings.ToUpper(kind) {
+	case "LABEL":
+		dir = byLabelDir
+	case "UUID":
+		dir = byUUIDDir
+	default:
+		return c.unresolved(stdio, spec)
+	}
+
+	device, err := resolve(filepath.Join(dir, value))
+	if err != nil {
+		return c.unresolved(stdio, spec)
+	}
+	_, _ = fmt.Fprintln(stdio.Out, device)
+	return nil
+}
+
+func (c *Command) unresolved(stdio command.IO, spec string) error {
+	_, _ = fmt.Fprintf(stdio.Err, "findfs: unable to resolve '%s'\n", spec)
+	return command.SilentFailure()
+}
+
+// resolve reads the udev symlink and returns the absolute device path.
+func resolve(link string) (string, error) {
+	target, err := os.Readlink(link)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(target) {
+		return filepath.Clean(target), nil
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(link), target)), nil
+}

--- a/internal/applets/util-linux/findfs/findfs_test.go
+++ b/internal/applets/util-linux/findfs/findfs_test.go
@@ -1,0 +1,87 @@
+package findfs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	label := filepath.Join(dir, "by-label")
+	uuid := filepath.Join(dir, "by-uuid")
+	for _, d := range []string{label, uuid} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("/dev/sda1", filepath.Join(label, "rootfs")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../sdb2", filepath.Join(uuid, "1234-5678")); err != nil {
+		t.Fatal(err)
+	}
+	ol, ou := byLabelDir, byUUIDDir
+	byLabelDir, byUUIDDir = label, uuid
+	t.Cleanup(func() { byLabelDir, byUUIDDir = ol, ou })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestLabel(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "LABEL=rootfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "/dev/sda1" {
+		t.Errorf("findfs LABEL = %q, want /dev/sda1", out)
+	}
+}
+
+func TestUUIDRelative(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "UUID=1234-5678")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Clean(filepath.Join(byUUIDDir, "../../sdb2"))
+	if out != want {
+		t.Errorf("findfs UUID = %q, want %q", out, want)
+	}
+}
+
+func TestCaseInsensitiveTag(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "label=rootfs"); err != nil {
+		t.Errorf("lowercase tag should resolve: %v", err)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "LABEL=missing"); err == nil {
+		t.Errorf("missing label should fail")
+	}
+	if _, err := run(t, "BOGUS=x"); err == nil {
+		t.Errorf("unknown tag kind should fail")
+	}
+	if _, err := run(t, "noequals"); err == nil {
+		t.Errorf("malformed spec should fail")
+	}
+	if _, err := run(t); err == nil {
+		t.Errorf("no argument should fail")
+	}
+}

--- a/test/it/spec/findfs_spec.sh
+++ b/test/it/spec/findfs_spec.sh
@@ -1,0 +1,14 @@
+Describe 'findfs'
+    Include util-linux/findfs_test.sh
+
+    It 'fails for an unknown label'
+        When call TestFindfsMissing
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects a malformed tag'
+        When call TestFindfsBadSpec
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/findfs_test.sh
+++ b/test/it/util-linux/findfs_test.sh
@@ -1,0 +1,2 @@
+TestFindfsMissing() { findfs LABEL=no_such_label_xyz 2>/dev/null; echo "rc=$?"; }
+TestFindfsBadSpec() { findfs notatag 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `findfs`, which prints the block device whose filesystem has a given `LABEL=<label>` or `UUID=<uuid>`, resolved through /dev/disk/by-label and /dev/disk/by-uuid. The tag kind is case-insensitive, relative udev symlinks are resolved to absolute device paths, and an unresolvable tag fails with the same message as host findfs. The two udev directories are injectable so resolution is tested against fixtures.

## Tests

- Unit (fixture udev symlink dirs): resolving a LABEL to an absolute device, a UUID via a relative symlink, a case-insensitive tag, and the missing-label / unknown-kind / malformed-spec / no-argument errors.
- shellspec: an unknown label and a malformed tag both fail.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (604 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249