### PR TITLE
feat(util-linux): add lsattr applet to list file attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 251 commands. Run `mimixbox --list` to see them on the terminal.
+There are 252 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -128,6 +128,7 @@ There are 251 commands. Run `mimixbox --list` to see them on the terminal.
 | logname | Print the name of the current user |
 | logread | Show the system log |
 | ls | List directory contents |
+| lsattr | List ext2/ext4 file attributes |
 | lsblk | List information about block devices |
 | lsof | List open files of processes |
 | lspci | List PCI devices |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -221,6 +221,7 @@ import (
 	ap_util_linux_ipcrm "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcrm"
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
+	ap_util_linux_lsattr "github.com/nao1215/mimixbox/internal/applets/util-linux/lsattr"
 	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
@@ -240,7 +241,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 251)
+	Applets = make(map[string]Applet, 252)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -475,6 +476,7 @@ func init() {
 	register(ap_util_linux_ipcrm.New())
 	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
+	register(ap_util_linux_lsattr.New())
 	register(ap_util_linux_lsblk.New())
 	register(ap_util_linux_lspci.New())
 	register(ap_util_linux_lsusb.New())

--- a/internal/applets/util-linux/lsattr/lsattr.go
+++ b/internal/applets/util-linux/lsattr/lsattr.go
@@ -1,0 +1,120 @@
+// Package lsattr implements the lsattr applet: list ext2/ext4 file attributes.
+package lsattr
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the lsattr applet.
+type Command struct{}
+
+// New returns a lsattr command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "lsattr" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List ext2/ext4 file attributes" }
+
+// attrFlags maps the inode flag bits to their lsattr letters, in display order.
+// The bit values are stable across the ext2/ext3/ext4 family.
+var attrFlags = []struct {
+	bit uint
+	ch  byte
+}{
+	{0x00000001, 's'}, // secure deletion
+	{0x00000002, 'u'}, // undelete
+	{0x00000008, 'S'}, // synchronous updates
+	{0x00010000, 'D'}, // synchronous directory updates
+	{0x00000010, 'i'}, // immutable
+	{0x00000020, 'a'}, // append only
+	{0x00000040, 'd'}, // no dump
+	{0x00000080, 'A'}, // no atime updates
+	{0x00000004, 'c'}, // compressed
+	{0x00000800, 'E'}, // encrypted
+	{0x00004000, 'j'}, // data journaling
+	{0x00001000, 'I'}, // hash-indexed directory
+	{0x00008000, 't'}, // no tail-merging
+	{0x00020000, 'T'}, // top of directory hierarchy
+	{0x00080000, 'e'}, // extents
+	{0x00800000, 'C'}, // no copy-on-write
+}
+
+// getFlags is indirected so the decoding can be tested without a real ioctl.
+var getFlags = func(path string) (int, error) {
+	f, err := os.Open(path) //nolint:gosec // user-named file
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+	return unix.IoctlGetInt(int(f.Fd()), unix.FS_IOC_GETFLAGS)
+}
+
+// Run executes lsattr.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[FILE...]", stdio.Err).WithHelp(command.Help{
+		Description: "List the ext2/ext4 inode attributes of each FILE as a string of attribute letters " +
+			"(e.g. i immutable, a append-only, e extents), or '-' where the attribute is unset. With " +
+			"no FILE, the entries of the current directory are listed.",
+		Examples: []command.Example{
+			{Command: "lsattr file.txt", Explain: "Show the attributes of file.txt."},
+		},
+		ExitStatus: "0  all files were read.\n1  a file's attributes could not be read.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	files := fs.Args()
+	if len(files) == 0 {
+		files = dirEntries(".")
+	}
+
+	failed := false
+	for _, path := range files {
+		flags, err := getFlags(path)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "lsattr: %s: %v\n", path, err)
+			failed = true
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%s %s\n", decode(flags), path)
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// decode renders the attribute flags as the lsattr letter string.
+func decode(flags int) string {
+	b := make([]byte, len(attrFlags))
+	for i, f := range attrFlags {
+		if uint(flags)&f.bit != 0 {
+			b[i] = f.ch
+		} else {
+			b[i] = '-'
+		}
+	}
+	return string(b)
+}
+
+// dirEntries returns the names of the entries in dir (non-recursive).
+func dirEntries(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}

--- a/internal/applets/util-linux/lsattr/lsattr_test.go
+++ b/internal/applets/util-linux/lsattr/lsattr_test.go
@@ -1,0 +1,66 @@
+package lsattr
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withFlags(t *testing.T, byPath map[string]int, fail bool) {
+	t.Helper()
+	orig := getFlags
+	getFlags = func(path string) (int, error) {
+		if fail {
+			return 0, errors.New("operation not supported")
+		}
+		return byPath[path], nil
+	}
+	t.Cleanup(func() { getFlags = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestDecode(t *testing.T) {
+	t.Parallel()
+	if got := decode(0); got != "----------------" {
+		t.Errorf("decode(0) = %q", got)
+	}
+	if got := decode(0x10); got != "----i-----------" { // immutable, position 5
+		t.Errorf("decode(immutable) = %q", got)
+	}
+	if got := decode(0x80000); got != "--------------e-" { // extents, position 15
+		t.Errorf("decode(extents) = %q", got)
+	}
+	// immutable + append (0x10 | 0x20).
+	if got := decode(0x30); got != "----ia----------" {
+		t.Errorf("decode(immutable|append) = %q", got)
+	}
+}
+
+func TestRun(t *testing.T) {
+	withFlags(t, map[string]int{"file.txt": 0x10}, false)
+	out, err := run(t, "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "----i----------- file.txt" {
+		t.Errorf("lsattr = %q", out)
+	}
+}
+
+func TestReadFailure(t *testing.T) {
+	withFlags(t, nil, true)
+	if _, err := run(t, "file.txt"); err == nil {
+		t.Errorf("a read failure should fail")
+	}
+}

--- a/test/it/spec/lsattr_spec.sh
+++ b/test/it/spec/lsattr_spec.sh
@@ -1,0 +1,10 @@
+Describe 'lsattr'
+    Include util-linux/lsattr_test.sh
+
+    It 'describes itself with --help'
+        When call TestLsattrHelp
+        The status should be success
+        The output should include 'Usage: lsattr'
+        The output should include 'attribute'
+    End
+End

--- a/test/it/util-linux/lsattr_test.sh
+++ b/test/it/util-linux/lsattr_test.sh
@@ -1,0 +1,3 @@
+# FS_IOC_GETFLAGS support depends on the underlying filesystem (tmpfs lacks it),
+# so the e2e exercises --help; the attribute decoding is covered by unit tests.
+TestLsattrHelp() { lsattr --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `lsattr`, which lists the ext2/ext4 inode attributes of each FILE as a string of attribute letters (i immutable, a append-only, e extents, …) or '-' where unset, read via the FS_IOC_GETFLAGS ioctl. With no FILE it lists the current directory's entries. The ioctl is injectable so the flag decoding is tested without a real filesystem.

This slice covers the common 16 ext2/4 attributes; the field is therefore narrower than e2fsprogs lsattr but the letters and their positions match.

## Tests

- Unit (stubbed ioctl): the `decode` mapping (no flags, immutable, extents, and a combination), the per-file output line, and the read-failure error.
- shellspec: the `--help` path (FS_IOC_GETFLAGS support is filesystem-dependent, so the decoding is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (605 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249