### PR TITLE
feat(util-linux): add chattr applet to change file attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 252 commands. Run `mimixbox --list` to see them on the terminal.
+There are 253 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -43,6 +43,7 @@ There are 252 commands. Run `mimixbox --list` to see them on the terminal.
 | bzcat | Decompress bz2 data to standard output |
 | cal | Display a calendar |
 | cat | Concatenate files and print on the standard output |
+| chattr | Change ext2/ext4 file attributes |
 | chgrp | Change the group of each FILE to GROUP |
 | chmod | Change file mode bits |
 | chown | Change the owner and/or group of each FILE to OWNER and/or GROUP |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -209,6 +209,7 @@ import (
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
 	ap_util_linux_blkid "github.com/nao1215/mimixbox/internal/applets/util-linux/blkid"
 	ap_util_linux_blockdev "github.com/nao1215/mimixbox/internal/applets/util-linux/blockdev"
+	ap_util_linux_chattr "github.com/nao1215/mimixbox/internal/applets/util-linux/chattr"
 	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
 	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
@@ -241,7 +242,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 252)
+	Applets = make(map[string]Applet, 253)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -463,6 +464,7 @@ func init() {
 	register(ap_textutils_xxd.New())
 	register(ap_util_linux_blkid.New())
 	register(ap_util_linux_blockdev.New())
+	register(ap_util_linux_chattr.New())
 	register(ap_util_linux_chrt.New())
 	register(ap_util_linux_dmesg.New())
 	register(ap_util_linux_fallocate.New())

--- a/internal/applets/util-linux/chattr/chattr.go
+++ b/internal/applets/util-linux/chattr/chattr.go
@@ -1,0 +1,134 @@
+// Package chattr implements the chattr applet: change ext2/ext4 file attributes.
+package chattr
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the chattr applet.
+type Command struct{}
+
+// New returns a chattr command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "chattr" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Change ext2/ext4 file attributes" }
+
+// attrBits maps the chattr attribute letters to their inode flag bits.
+var attrBits = map[byte]uint{
+	's': 0x00000001, 'u': 0x00000002, 'c': 0x00000004, 'S': 0x00000008,
+	'i': 0x00000010, 'a': 0x00000020, 'd': 0x00000040, 'A': 0x00000080,
+	'I': 0x00001000, 'j': 0x00004000, 't': 0x00008000, 'D': 0x00010000,
+	'T': 0x00020000, 'e': 0x00080000, 'C': 0x00800000,
+}
+
+// getFlags and setFlags are indirected so the logic is testable without ioctls.
+var (
+	getFlags = func(path string) (int, error) {
+		f, err := os.Open(path) //nolint:gosec // user-named file
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = f.Close() }()
+		return unix.IoctlGetInt(int(f.Fd()), unix.FS_IOC_GETFLAGS)
+	}
+	setFlags = func(path string, flags int) error {
+		f, err := os.Open(path) //nolint:gosec // user-named file
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		return unix.IoctlSetPointerInt(int(f.Fd()), unix.FS_IOC_SETFLAGS, flags)
+	}
+)
+
+// Run executes chattr.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "{+|-|=}ATTRS FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Change the ext2/ext4 inode attributes of each FILE. The mode is +ATTRS to add, " +
+			"-ATTRS to remove, or =ATTRS to set exactly. Each attribute is a letter such as i " +
+			"(immutable), a (append-only), or A (no atime). Changing immutable/append attributes " +
+			"requires privilege.",
+		Examples: []command.Example{
+			{Command: "chattr +i file", Explain: "Make file immutable."},
+			{Command: "chattr -a file", Explain: "Clear the append-only attribute."},
+		},
+		ExitStatus: "0  all files were updated.\n1  the mode was invalid or a file could not be changed.",
+	})
+	// A "-ATTRS" mode looks like a flag to the parser; protect it with "--".
+	if len(args) > 0 && strings.HasPrefix(args[0], "-") && args[0] != "--help" && args[0] != "--version" {
+		args = append([]string{"--"}, args...)
+	}
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		_, _ = fmt.Fprintln(stdio.Err, "chattr: a mode and at least one file are required")
+		return command.SilentFailure()
+	}
+
+	op := rest[0][0]
+	if op != '+' && op != '-' && op != '=' {
+		return command.Failuref("invalid mode: %q (must start with +, - or =)", rest[0])
+	}
+	bits, err := parseAttrs(rest[0][1:])
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	failed := false
+	for _, path := range rest[1:] {
+		cur, err := getFlags(path)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "chattr: %s: %v\n", path, err)
+			failed = true
+			continue
+		}
+		if err := setFlags(path, apply(op, cur, bits)); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "chattr: %s: %v\n", path, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// parseAttrs turns a string of attribute letters into the combined flag bits.
+func parseAttrs(letters string) (uint, error) {
+	var bits uint
+	for i := 0; i < len(letters); i++ {
+		bit, ok := attrBits[letters[i]]
+		if !ok {
+			return 0, fmt.Errorf("unknown attribute: %q", string(letters[i]))
+		}
+		bits |= bit
+	}
+	return bits, nil
+}
+
+// apply computes the new flags from the operator, current flags, and bits.
+func apply(op byte, cur int, bits uint) int {
+	switch op {
+	case '+':
+		return int(uint(cur) | bits)
+	case '-':
+		return int(uint(cur) &^ bits)
+	default: // '='
+		return int(bits)
+	}
+}

--- a/internal/applets/util-linux/chattr/chattr_test.go
+++ b/internal/applets/util-linux/chattr/chattr_test.go
@@ -1,0 +1,95 @@
+package chattr
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, cur int, getErr error) *int {
+	t.Helper()
+	written := new(int)
+	*written = -1
+	og, os := getFlags, setFlags
+	getFlags = func(string) (int, error) { return cur, getErr }
+	setFlags = func(_ string, flags int) error { *written = flags; return nil }
+	t.Cleanup(func() { getFlags, setFlags = og, os })
+	return written
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestAddRemoveSet(t *testing.T) {
+	w := withStub(t, 0, nil)
+	if err := run(t, "+i", "file"); err != nil {
+		t.Fatal(err)
+	}
+	if *w != 0x10 {
+		t.Errorf("+i wrote %#x, want 0x10", *w)
+	}
+
+	w = withStub(t, 0x20, nil) // append-only set
+	if err := run(t, "-a", "file"); err != nil {
+		t.Fatal(err)
+	}
+	if *w != 0 {
+		t.Errorf("-a wrote %#x, want 0", *w)
+	}
+
+	w = withStub(t, 0xff, nil)
+	if err := run(t, "=e", "file"); err != nil {
+		t.Fatal(err)
+	}
+	if *w != 0x80000 {
+		t.Errorf("=e wrote %#x, want 0x80000", *w)
+	}
+}
+
+func TestApply(t *testing.T) {
+	t.Parallel()
+	if got := apply('+', 0, 0x10); got != 0x10 {
+		t.Errorf("apply(+) = %#x", got)
+	}
+	if got := apply('-', 0x30, 0x20); got != 0x10 {
+		t.Errorf("apply(-) = %#x", got)
+	}
+	if got := apply('=', 0xffff, 0x80000); got != 0x80000 {
+		t.Errorf("apply(=) = %#x", got)
+	}
+}
+
+func TestParseAttrs(t *testing.T) {
+	t.Parallel()
+	bits, err := parseAttrs("ia")
+	if err != nil || bits != 0x10|0x20 {
+		t.Errorf("parseAttrs(ia) = %#x, %v", bits, err)
+	}
+	if _, err := parseAttrs("Z"); err == nil {
+		t.Errorf("unknown attribute should error")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	withStub(t, 0, nil)
+	if err := run(t, "xi", "file"); err == nil {
+		t.Errorf("bad mode should fail")
+	}
+	if err := run(t, "+Z", "file"); err == nil {
+		t.Errorf("bad attribute should fail")
+	}
+	if err := run(t, "+i"); err == nil {
+		t.Errorf("missing file should fail")
+	}
+	withStub(t, 0, errors.New("no such file"))
+	if err := run(t, "+i", "file"); err == nil {
+		t.Errorf("a get failure should fail")
+	}
+}

--- a/test/it/spec/chattr_spec.sh
+++ b/test/it/spec/chattr_spec.sh
@@ -1,0 +1,14 @@
+Describe 'chattr'
+    Include util-linux/chattr_test.sh
+
+    It 'rejects a malformed mode'
+        When call TestChattrBadMode
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects an unknown attribute'
+        When call TestChattrBadAttr
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/chattr_test.sh
+++ b/test/it/util-linux/chattr_test.sh
@@ -1,0 +1,4 @@
+# Setting immutable/append needs privilege and ext2/4; the e2e exercises the
+# deterministic mode-validation path. The flag math is covered by unit tests.
+TestChattrBadMode() { chattr xi /tmp/f 2>/dev/null; echo "rc=$?"; }
+TestChattrBadAttr() { chattr +Z /tmp/f 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `chattr`, the write counterpart to lsattr. It changes the ext2/ext4 inode attributes of each FILE via FS_IOC_SETFLAGS: `+ATTRS` adds, `-ATTRS` removes, and `=ATTRS` sets exactly. A leading `-ATTRS` mode (which looks like a flag) is protected so it parses as the mode. The get/set ioctls are injectable so the flag math is tested without touching a filesystem.

## Tests

- Unit (stubbed ioctls): +i adding, -a removing, =e setting exactly; the `apply` operator math; `parseAttrs` (valid letters and an unknown one); and the bad-mode / unknown-attribute / missing-file / get-failure errors.
- shellspec: a malformed mode and an unknown attribute are both rejected (setting immutable/append needs privilege, so the flag math is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (607 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249