### PR TITLE
feat(util-linux): add mount applet to list mounted filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 253 commands. Run `mimixbox --list` to see them on the terminal.
+There are 254 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -146,6 +146,7 @@ There are 253 commands. Run `mimixbox --list` to see them on the terminal.
 | mknod | Make block or character special files |
 | mktemp | Create a temporary file or directory |
 | more | Page through text one screen at a time |
+| mount | List the mounted filesystems |
 | mountpoint | See if a directory is a mountpoint |
 | mpstat | Report per-processor CPU statistics |
 | mv | Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -227,6 +227,7 @@ import (
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
+	ap_util_linux_mount "github.com/nao1215/mimixbox/internal/applets/util-linux/mount"
 	ap_util_linux_rdate "github.com/nao1215/mimixbox/internal/applets/util-linux/rdate"
 	ap_util_linux_rdev "github.com/nao1215/mimixbox/internal/applets/util-linux/rdev"
 	ap_util_linux_readprofile "github.com/nao1215/mimixbox/internal/applets/util-linux/readprofile"
@@ -242,7 +243,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 253)
+	Applets = make(map[string]Applet, 254)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -483,6 +484,7 @@ func init() {
 	register(ap_util_linux_lspci.New())
 	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mesg.New())
+	register(ap_util_linux_mount.New())
 	register(ap_util_linux_rdate.New())
 	register(ap_util_linux_rdev.New())
 	register(ap_util_linux_readprofile.New())

--- a/internal/applets/util-linux/mount/mount.go
+++ b/internal/applets/util-linux/mount/mount.go
@@ -1,0 +1,130 @@
+// Package mount implements the mount applet: list the mounted filesystems.
+// Mounting itself is privileged and is not performed by this slice.
+package mount
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the mount applet.
+type Command struct{}
+
+// New returns a mount command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mount" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List the mounted filesystems" }
+
+// mountsPath is the kernel mount table; tests point it at a fixture.
+var mountsPath = "/proc/mounts"
+
+// Run executes mount.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-t TYPE]", stdio.Err).WithHelp(command.Help{
+		Description: "List the mounted filesystems, one per line as 'DEVICE on MOUNTPOINT type FSTYPE " +
+			"(OPTIONS)', read from /proc/mounts. With -t, show only mounts of the given filesystem " +
+			"type. Performing a mount is privileged and is not done by this build.",
+		Examples: []command.Example{
+			{Command: "mount", Explain: "List every mounted filesystem."},
+			{Command: "mount -t ext4", Explain: "List only ext4 mounts."},
+		},
+		ExitStatus: "0  the table was listed.\n1  the mount table could not be read, or a mount was requested.",
+	})
+	typeFilter := fs.StringP("types", "t", "", "only show mounts of this filesystem type")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if len(fs.Args()) > 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "mount: performing a mount is not supported by this build; "+
+			"run with no operands to list the mounted filesystems")
+		return command.SilentFailure()
+	}
+
+	mounts, err := readMounts()
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "mount: %v\n", err)
+		return command.SilentFailure()
+	}
+	for _, m := range mounts {
+		if *typeFilter != "" && m.fstype != *typeFilter {
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%s on %s type %s (%s)\n", m.device, m.mountpoint, m.fstype, m.options)
+	}
+	return nil
+}
+
+type mountEntry struct {
+	device, mountpoint, fstype, options string
+}
+
+// readMounts parses the kernel mount table.
+func readMounts() ([]mountEntry, error) {
+	f, err := os.Open(mountsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var entries []mountEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 4 {
+			continue
+		}
+		entries = append(entries, mountEntry{
+			device:     unescape(fields[0]),
+			mountpoint: unescape(fields[1]),
+			fstype:     fields[2],
+			options:    fields[3],
+		})
+	}
+	return entries, sc.Err()
+}
+
+// unescape decodes the octal escapes (\040 space, \011 tab, …) used in
+// /proc/mounts device and mount-point fields.
+func unescape(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+4 <= len(s) && isOctal(s[i+1:i+4]) {
+			b.WriteByte(octalByte(s[i+1 : i+4]))
+			i += 3
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func isOctal(s string) bool {
+	if len(s) != 3 {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		if s[i] < '0' || s[i] > '7' {
+			return false
+		}
+	}
+	return true
+}
+
+func octalByte(s string) byte {
+	return byte((s[0]-'0')<<6 | (s[1]-'0')<<3 | (s[2] - '0'))
+}

--- a/internal/applets/util-linux/mount/mount_test.go
+++ b/internal/applets/util-linux/mount/mount_test.go
@@ -1,0 +1,93 @@
+package mount
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "mounts")
+	content := "/dev/sda1 / ext4 rw,relatime 0 0\n" +
+		"proc /proc proc rw,nosuid 0 0\n" +
+		"tmpfs /my\\040mount tmpfs rw 0 0\n"
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := mountsPath
+	mountsPath = f
+	t.Cleanup(func() { mountsPath = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestList(t *testing.T) {
+	fixture(t)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "/dev/sda1 on / type ext4 (rw,relatime)") {
+		t.Errorf("ext4 line wrong:\n%s", out)
+	}
+	// The octal-escaped space must be decoded.
+	if !strings.Contains(out, "tmpfs on /my mount type tmpfs (rw)") {
+		t.Errorf("escape decoding wrong:\n%s", out)
+	}
+}
+
+func TestTypeFilter(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "-t", "ext4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "ext4") || strings.Contains(out, "proc") || strings.Contains(out, "tmpfs") {
+		t.Errorf("-t ext4 wrong:\n%s", out)
+	}
+}
+
+func TestMountOperandUnsupported(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "/dev/sda1", "/mnt"); err == nil {
+		t.Errorf("requesting a mount should fail deterministically")
+	}
+}
+
+func TestMissingTable(t *testing.T) {
+	orig := mountsPath
+	mountsPath = "/no/such/mounts"
+	defer func() { mountsPath = orig }()
+	if _, err := run(t); err == nil {
+		t.Errorf("a missing mount table should fail")
+	}
+}
+
+func TestUnescape(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		`/my\040mount`:   "/my mount",
+		`/tab\011here`:   "/tab\there",
+		`/plain`:         "/plain",
+		`/back\134slash`: `/back\slash`,  // \134 octal = backslash
+		`/lone\bslash`:   `/lone\bslash`, // a non-octal escape is left as-is
+	}
+	for in, want := range cases {
+		if got := unescape(in); got != want {
+			t.Errorf("unescape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/test/it/spec/mount_spec.sh
+++ b/test/it/spec/mount_spec.sh
@@ -1,0 +1,14 @@
+Describe 'mount'
+    Include util-linux/mount_test.sh
+
+    It 'lists the root filesystem'
+        When call TestMountListsRoot
+        The status should be success
+        The output should not equal '0'
+    End
+    It 'refuses to perform a mount'
+        When call TestMountRejectsMount
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/mount_test.sh
+++ b/test/it/util-linux/mount_test.sh
@@ -1,0 +1,2 @@
+TestMountListsRoot() { mount | grep -cE ' on / type '; }
+TestMountRejectsMount() { mount /dev/sda1 /mnt 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `mount` in read-only listing mode, the most common local-filesystem flow the issue calls out. With no operands it lists every mounted filesystem as 'DEVICE on MOUNTPOINT type FSTYPE (OPTIONS)', read from /proc/mounts (matching host mount), and `-t TYPE` filters by filesystem type. The octal escapes in device/mount-point fields (\040 space, \011 tab, …) are decoded. Performing a mount is privileged and not done by this build; requesting one fails deterministically rather than silently. The mount-table path is injectable.

## Tests

- Unit (fixture /proc/mounts): the listing format, the octal-escape decoding, the `-t` type filter, the deterministic failure when a mount is requested, the missing-table error, and the `unescape` helper (octal, tab, and non-octal pass-through).
- shellspec: listing the root filesystem and refusing to perform a mount.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (609 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249