### PR TITLE
feat(util-linux): add umount applet to unmount a filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 254 commands. Run `mimixbox --list` to see them on the terminal.
+There are 255 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -240,6 +240,7 @@ There are 254 commands. Run `mimixbox --list` to see them on the terminal.
 | truncate | Shrink or extend the size of a file to a given size |
 | tsort | Topological sort of a directed graph |
 | tty | Print the file name of the terminal connected to stdin |
+| umount | Unmount a filesystem |
 | uname | Print system information |
 | uncompress | Decompress LZW (.Z) files |
 | unexpand | Convert N space to TAB(default:N=8) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -237,13 +237,14 @@ import (
 	ap_util_linux_setpriv "github.com/nao1215/mimixbox/internal/applets/util-linux/setpriv"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
+	ap_util_linux_umount "github.com/nao1215/mimixbox/internal/applets/util-linux/umount"
 	ap_util_linux_wall "github.com/nao1215/mimixbox/internal/applets/util-linux/wall"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 254)
+	Applets = make(map[string]Applet, 255)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -497,5 +498,6 @@ func init() {
 	register(ap_util_linux_setpriv.New())
 	register(ap_util_linux_setsid.New())
 	register(ap_util_linux_taskset.New())
+	register(ap_util_linux_umount.New())
 	register(ap_util_linux_wall.New())
 }

--- a/internal/applets/util-linux/umount/umount.go
+++ b/internal/applets/util-linux/umount/umount.go
@@ -1,0 +1,87 @@
+// Package umount implements the umount applet: unmount a filesystem.
+package umount
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the umount applet.
+type Command struct{}
+
+// New returns a umount command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "umount" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Unmount a filesystem" }
+
+// Injected so the privileged call and the table are testable.
+var (
+	mountsPath = "/proc/mounts"
+	unmountFn  = func(target string) error { return unix.Unmount(target, 0) }
+)
+
+// Run executes umount.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "TARGET", stdio.Err).WithHelp(command.Help{
+		Description: "Unmount the filesystem named by TARGET, given either as the mount point or as the " +
+			"mounted device. The target must be currently mounted. Unmounting requires privilege.",
+		Examples: []command.Example{
+			{Command: "umount /mnt/usb", Explain: "Unmount the filesystem at /mnt/usb."},
+			{Command: "umount /dev/sdb1", Explain: "Unmount by device."},
+		},
+		ExitStatus: "0  the filesystem was unmounted.\n1  the target was not mounted or could not be unmounted.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "umount: a target is required")
+		return command.SilentFailure()
+	}
+	target := rest[0]
+
+	mountpoint, ok := resolveMount(target)
+	if !ok {
+		return command.Failuref("%s: not mounted", target)
+	}
+	if err := unmountFn(mountpoint); err != nil {
+		return command.Failuref("%s: %v", target, err)
+	}
+	return nil
+}
+
+// resolveMount returns the mount point matching target (by mount point or by
+// device) and whether it was found.
+func resolveMount(target string) (string, bool) {
+	f, err := os.Open(mountsPath)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		device, mountpoint := fields[0], fields[1]
+		if mountpoint == target || device == target {
+			return mountpoint, true
+		}
+	}
+	return "", false
+}

--- a/internal/applets/util-linux/umount/umount_test.go
+++ b/internal/applets/util-linux/umount/umount_test.go
@@ -1,0 +1,79 @@
+package umount
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T, unmountErr error) *string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "mounts")
+	content := "/dev/sda1 / ext4 rw 0 0\n/dev/sdb1 /mnt/usb ext4 rw 0 0\n"
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	unmounted := new(string)
+	om, ou := mountsPath, unmountFn
+	mountsPath = f
+	unmountFn = func(target string) error {
+		*unmounted = target
+		return unmountErr
+	}
+	t.Cleanup(func() { mountsPath, unmountFn = om, ou })
+	return unmounted
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestUnmountByMountpoint(t *testing.T) {
+	got := setup(t, nil)
+	if err := run(t, "/mnt/usb"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != "/mnt/usb" {
+		t.Errorf("unmounted %q, want /mnt/usb", *got)
+	}
+}
+
+func TestUnmountByDevice(t *testing.T) {
+	got := setup(t, nil)
+	if err := run(t, "/dev/sdb1"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != "/mnt/usb" {
+		t.Errorf("device unmount resolved to %q, want /mnt/usb", *got)
+	}
+}
+
+func TestNotMounted(t *testing.T) {
+	setup(t, nil)
+	if err := run(t, "/not/mounted"); err == nil {
+		t.Errorf("an unmounted target should fail")
+	}
+}
+
+func TestUnmountFails(t *testing.T) {
+	setup(t, errors.New("operation not permitted"))
+	if err := run(t, "/mnt/usb"); err == nil {
+		t.Errorf("an unmount failure should fail")
+	}
+}
+
+func TestNoArg(t *testing.T) {
+	setup(t, nil)
+	if err := run(t); err == nil {
+		t.Errorf("no target should fail")
+	}
+}

--- a/test/it/spec/umount_spec.sh
+++ b/test/it/spec/umount_spec.sh
@@ -1,0 +1,14 @@
+Describe 'umount'
+    Include util-linux/umount_test.sh
+
+    It 'fails for a target that is not mounted'
+        When call TestUmountNotMounted
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'requires a target'
+        When call TestUmountNoArg
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/umount_test.sh
+++ b/test/it/util-linux/umount_test.sh
@@ -1,0 +1,2 @@
+TestUmountNotMounted() { umount /not/a/real/mountpoint 2>/dev/null; echo "rc=$?"; }
+TestUmountNoArg() { umount 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `umount`, the counterpart to mount. It unmounts the filesystem named by TARGET — given as either the mount point or the mounted device — after confirming it is currently mounted (via /proc/mounts). A device argument is resolved to its mount point before unmounting. The target is unmounted with the umount(2) syscall, which requires privilege; a target that is not mounted fails deterministically. The mount-table path and the unmount call are injectable so the resolution and error paths are tested without privilege.

## Tests

- Unit (fixture /proc/mounts + stubbed unmount): unmounting by mount point and by device (resolved to the mount point), the not-mounted error, an unmount-failure error, and the missing-target error.
- shellspec: a not-mounted target and a missing target both fail.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (611 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249