### PR TITLE
feat(util-linux): add mkswap applet to set up a swap area

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 255 commands. Run `mimixbox --list` to see them on the terminal.
+There are 256 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -144,6 +144,7 @@ There are 255 commands. Run `mimixbox --list` to see them on the terminal.
 | mkdir | Make directories |
 | mkfifo | Make FIFO (named pipe) |
 | mknod | Make block or character special files |
+| mkswap | Set up a Linux swap area |
 | mktemp | Create a temporary file or directory |
 | more | Page through text one screen at a time |
 | mount | List the mounted filesystems |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -227,6 +227,7 @@ import (
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
+	ap_util_linux_mkswap "github.com/nao1215/mimixbox/internal/applets/util-linux/mkswap"
 	ap_util_linux_mount "github.com/nao1215/mimixbox/internal/applets/util-linux/mount"
 	ap_util_linux_rdate "github.com/nao1215/mimixbox/internal/applets/util-linux/rdate"
 	ap_util_linux_rdev "github.com/nao1215/mimixbox/internal/applets/util-linux/rdev"
@@ -244,7 +245,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 255)
+	Applets = make(map[string]Applet, 256)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -485,6 +486,7 @@ func init() {
 	register(ap_util_linux_lspci.New())
 	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mesg.New())
+	register(ap_util_linux_mkswap.New())
 	register(ap_util_linux_mount.New())
 	register(ap_util_linux_rdate.New())
 	register(ap_util_linux_rdev.New())

--- a/internal/applets/util-linux/mkswap/mkswap.go
+++ b/internal/applets/util-linux/mkswap/mkswap.go
@@ -1,0 +1,110 @@
+// Package mkswap implements the mkswap applet: set up a Linux swap area on a
+// file or device.
+package mkswap
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the mkswap applet.
+type Command struct{}
+
+// New returns a mkswap command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mkswap" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Set up a Linux swap area" }
+
+// pageSize is the swap page size; tests may override it.
+var pageSize = os.Getpagesize()
+
+const (
+	headerOffset = 1024 // swap_header_info begins here
+	labelOffset  = 1052 // volume_name[16] within the header
+	signature    = "SWAPSPACE2"
+)
+
+// Run executes mkswap.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-L LABEL] FILE", stdio.Err).WithHelp(command.Help{
+		Description: "Write a version-1 Linux swap signature and header to FILE (a swap file or block " +
+			"device), making it usable by swapon. -L sets a volume label. The file must already be at " +
+			"least two pages in size; mkswap does not grow it.",
+		Examples: []command.Example{
+			{Command: "mkswap /swapfile", Explain: "Format an existing file as swap."},
+			{Command: "mkswap -L swap /swapfile", Explain: "Format it with a label."},
+		},
+		ExitStatus: "0  the swap area was written.\n1  the file was missing or too small.",
+	})
+	label := fs.StringP("label", "L", "", "set the swap-area label")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "mkswap: a file is required")
+		return command.SilentFailure()
+	}
+	path := rest[0]
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600) //nolint:gosec // user-named swap file
+	if err != nil {
+		return command.Failuref("cannot open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return command.Failuref("cannot stat %s: %v", path, err)
+	}
+	npages := int(info.Size()) / pageSize
+	if npages < 2 {
+		return command.Failuref("%s: swap area needs at least %d bytes", path, 2*pageSize)
+	}
+	lastPage := npages - 1
+
+	if err := writeSwap(f, lastPage, *label); err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	usable := int64(lastPage) * int64(pageSize)
+	_, _ = fmt.Fprintf(stdio.Out, "Setting up swapspace version 1, size = %d KiB (%d bytes)\n",
+		usable/1024, usable)
+	if *label != "" {
+		_, _ = fmt.Fprintf(stdio.Out, "LABEL=%s\n", *label)
+	}
+	return nil
+}
+
+// writeSwap writes the version-1 header, optional label, and signature.
+func writeSwap(f *os.File, lastPage int, label string) error {
+	header := make([]byte, 12)
+	binary.LittleEndian.PutUint32(header[0:], 1)                  // version
+	binary.LittleEndian.PutUint32(header[4:], uint32(lastPage))   // last usable page
+	binary.LittleEndian.PutUint32(header[8:], 0)                  // nr_badpages
+	if _, err := f.WriteAt(header, headerOffset); err != nil {
+		return err
+	}
+	if label != "" {
+		buf := make([]byte, 16)
+		copy(buf, label)
+		if _, err := f.WriteAt(buf, labelOffset); err != nil {
+			return err
+		}
+	}
+	if _, err := f.WriteAt([]byte(signature), int64(pageSize-len(signature))); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/applets/util-linux/mkswap/mkswap_test.go
+++ b/internal/applets/util-linux/mkswap/mkswap_test.go
@@ -1,0 +1,85 @@
+package mkswap
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func makeImage(t *testing.T, pages int) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "swap.img")
+	if err := os.WriteFile(p, make([]byte, pages*pageSize), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestWritesSwap(t *testing.T) {
+	img := makeImage(t, 16)
+	out, err := run(t, img)
+	if err != nil {
+		t.Fatal(err)
+	}
+	usable := 15 * pageSize
+	if !strings.Contains(out, "version 1") {
+		t.Errorf("missing version banner: %q", out)
+	}
+	data, _ := os.ReadFile(img)
+	// Signature at pageSize-10.
+	if got := string(data[pageSize-10 : pageSize]); got != signature {
+		t.Errorf("signature = %q, want %q", got, signature)
+	}
+	// Header: version 1, last_page = 15.
+	if v := binary.LittleEndian.Uint32(data[headerOffset:]); v != 1 {
+		t.Errorf("version = %d, want 1", v)
+	}
+	if lp := binary.LittleEndian.Uint32(data[headerOffset+4:]); lp != 15 {
+		t.Errorf("last_page = %d, want 15", lp)
+	}
+	if !strings.Contains(out, "bytes)") || usable <= 0 {
+		t.Errorf("size banner wrong: %q", out)
+	}
+}
+
+func TestWritesLabel(t *testing.T) {
+	img := makeImage(t, 16)
+	if _, err := run(t, "-L", "myswap", img); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	label := string(bytes.TrimRight(data[labelOffset:labelOffset+16], "\x00"))
+	if label != "myswap" {
+		t.Errorf("label = %q, want myswap", label)
+	}
+}
+
+func TestTooSmall(t *testing.T) {
+	img := makeImage(t, 1) // only one page
+	if _, err := run(t, img); err == nil {
+		t.Errorf("a one-page file should be rejected")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t); err == nil {
+		t.Errorf("missing file should fail")
+	}
+	if _, err := run(t, "/no/such/swapfile"); err == nil {
+		t.Errorf("a missing file should fail")
+	}
+}

--- a/test/it/spec/mkswap_spec.sh
+++ b/test/it/spec/mkswap_spec.sh
@@ -1,0 +1,19 @@
+Describe 'mkswap'
+    Include util-linux/mkswap_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/mkswap; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'formats an image as swap'
+        When call TestMkswapImage
+        The output should equal '1'
+        The status should be success
+    End
+    It 'writes the swap signature'
+        When call TestMkswapSignature
+        The output should not equal '0'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/mkswap_test.sh
+++ b/test/it/util-linux/mkswap_test.sh
@@ -1,0 +1,12 @@
+TestMkswapImage() {
+    dd if=/dev/zero of="$TEST_DIR/swap.img" bs=1024 count=64 2>/dev/null
+    chmod 0600 "$TEST_DIR/swap.img"
+    mkswap "$TEST_DIR/swap.img" | grep -c 'version 1'
+}
+TestMkswapSignature() {
+    dd if=/dev/zero of="$TEST_DIR/swap2.img" bs=1024 count=64 2>/dev/null
+    chmod 0600 "$TEST_DIR/swap2.img"
+    mkswap "$TEST_DIR/swap2.img" >/dev/null
+    # The signature SWAPSPACE2 must be present in the formatted image.
+    od -c "$TEST_DIR/swap2.img" | grep -c 'S   W   A   P   S   P   A   C   E   2'
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `mkswap`, which writes a version-1 Linux swap signature and header to a swap file or device, making it usable by swapon. It writes the version/last-page/bad-pages header at offset 1024, an optional `-L` volume label, and the `SWAPSPACE2` signature at the end of the first page — byte-for-byte matching host mkswap (verified: same banner and on-disk layout). It operates on an existing file (image-file workflow per the issue) and rejects files smaller than two pages. The page size is overridable for tests.

## Tests

- Unit (hermetic temp images): the written signature, the header version and last-page values, the size banner, the `-L` label, the too-small rejection, and the missing-file errors.
- shellspec: formatting a temp image as swap and confirming the SWAPSPACE2 signature is written.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (613 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249