### PR TITLE
feat(util-linux): add swapon and swapoff applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 256 commands. Run `mimixbox --list` to see them on the terminal.
+There are 258 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -222,6 +222,8 @@ There are 256 commands. Run `mimixbox --list` to see them on the terminal.
 | strings | Print printable character sequences in files |
 | stty | Print or change terminal line settings |
 | sum | Checksum and count the blocks in a file (BSD) |
+| swapoff | Disable a swap area |
+| swapon | Enable a swap area or list active swaps |
 | sync | Synchronize cached writes to persistent storage |
 | sysctl | Read and write kernel parameters at runtime |
 | syslogd | Minimal system logging daemon |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -237,6 +237,8 @@ import (
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
 	ap_util_linux_setpriv "github.com/nao1215/mimixbox/internal/applets/util-linux/setpriv"
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
+	ap_util_linux_swapoff "github.com/nao1215/mimixbox/internal/applets/util-linux/swapoff"
+	ap_util_linux_swapon "github.com/nao1215/mimixbox/internal/applets/util-linux/swapon"
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
 	ap_util_linux_umount "github.com/nao1215/mimixbox/internal/applets/util-linux/umount"
 	ap_util_linux_wall "github.com/nao1215/mimixbox/internal/applets/util-linux/wall"
@@ -245,7 +247,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 256)
+	Applets = make(map[string]Applet, 258)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -499,6 +501,8 @@ func init() {
 	register(ap_util_linux_setarch.NewSetarch())
 	register(ap_util_linux_setpriv.New())
 	register(ap_util_linux_setsid.New())
+	register(ap_util_linux_swapoff.New())
+	register(ap_util_linux_swapon.New())
 	register(ap_util_linux_taskset.New())
 	register(ap_util_linux_umount.New())
 	register(ap_util_linux_wall.New())

--- a/internal/applets/util-linux/swapoff/swapoff.go
+++ b/internal/applets/util-linux/swapoff/swapoff.go
@@ -1,0 +1,106 @@
+// Package swapoff implements the swapoff applet: disable a swap area.
+package swapoff
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the swapoff applet.
+type Command struct{}
+
+// New returns a swapoff command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "swapoff" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Disable a swap area" }
+
+// Injected so the privileged call and the table are testable.
+var (
+	swapsPath = "/proc/swaps"
+	swapoffFn = func(path string) error {
+		p, err := unix.BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
+		_, _, errno := unix.Syscall(unix.SYS_SWAPOFF, uintptr(unsafe.Pointer(p)), 0, 0)
+		if errno != 0 {
+			return errno
+		}
+		return nil
+	}
+)
+
+// Run executes swapoff.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-a] [FILE...]", stdio.Err).WithHelp(command.Help{
+		Description: "Disable swapping on each FILE or device. With -a, disable every swap area listed " +
+			"in /proc/swaps. Disabling swap requires privilege.",
+		Examples: []command.Example{
+			{Command: "swapoff /swapfile", Explain: "Disable swapping on /swapfile."},
+			{Command: "swapoff -a", Explain: "Disable all swap areas."},
+		},
+		ExitStatus: "0  success.\n1  a swap area could not be disabled.",
+	})
+	all := fs.BoolP("all", "a", false, "disable all swap areas in /proc/swaps")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	targets := fs.Args()
+	if *all {
+		targets = activeSwaps()
+	}
+	if len(targets) == 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "swapoff: a swap area or -a is required")
+		return command.SilentFailure()
+	}
+
+	failed := false
+	for _, path := range targets {
+		if err := swapoffFn(path); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "swapoff: %s: %v\n", path, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// activeSwaps returns the device/file column of /proc/swaps (skipping the header).
+func activeSwaps() []string {
+	f, err := os.Open(swapsPath)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []string
+	sc := bufio.NewScanner(f)
+	first := true
+	for sc.Scan() {
+		if first { // skip the "Filename Type ..." header
+			first = false
+			continue
+		}
+		fields := strings.Fields(sc.Text())
+		if len(fields) > 0 {
+			out = append(out, fields[0])
+		}
+	}
+	return out
+}

--- a/internal/applets/util-linux/swapoff/swapoff_test.go
+++ b/internal/applets/util-linux/swapoff/swapoff_test.go
@@ -1,0 +1,75 @@
+package swapoff
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T, swapoffErr error) *[]string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "swaps")
+	content := "Filename\tType\tSize\tUsed\tPriority\n/dev/sda2 partition 2097148 0 -2\n/swapfile file 1024 0 -3\n"
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var called []string
+	op, of := swapsPath, swapoffFn
+	swapsPath = f
+	swapoffFn = func(path string) error {
+		called = append(called, path)
+		return swapoffErr
+	}
+	t.Cleanup(func() { swapsPath, swapoffFn = op, of })
+	return &called
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestDisableOne(t *testing.T) {
+	called := setup(t, nil)
+	if err := run(t, "/swapfile"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*called) != 1 || (*called)[0] != "/swapfile" {
+		t.Errorf("swapoffFn called with %v", *called)
+	}
+}
+
+func TestDisableAll(t *testing.T) {
+	called := setup(t, nil)
+	if err := run(t, "-a"); err != nil {
+		t.Fatal(err)
+	}
+	got := append([]string{}, *called...)
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "/dev/sda2" || got[1] != "/swapfile" {
+		t.Errorf("-a disabled %v, want both swaps", got)
+	}
+}
+
+func TestDisableFails(t *testing.T) {
+	setup(t, errors.New("operation not permitted"))
+	if err := run(t, "/swapfile"); err == nil {
+		t.Errorf("a disable failure should fail")
+	}
+}
+
+func TestNoArg(t *testing.T) {
+	setup(t, nil)
+	if err := run(t); err == nil {
+		t.Errorf("no target should fail")
+	}
+}

--- a/internal/applets/util-linux/swapon/swapon.go
+++ b/internal/applets/util-linux/swapon/swapon.go
@@ -1,0 +1,82 @@
+// Package swapon implements the swapon applet: enable a swap area, or list the
+// active ones.
+package swapon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the swapon applet.
+type Command struct{}
+
+// New returns a swapon command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "swapon" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Enable a swap area or list active swaps" }
+
+// Injected so the privileged call and the table are testable.
+var (
+	swapsPath = "/proc/swaps"
+	swaponFn  = func(path string) error {
+		p, err := unix.BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
+		_, _, errno := unix.Syscall(unix.SYS_SWAPON, uintptr(unsafe.Pointer(p)), 0, 0)
+		if errno != 0 {
+			return errno
+		}
+		return nil
+	}
+)
+
+// Run executes swapon.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-s] [FILE...]", stdio.Err).WithHelp(command.Help{
+		Description: "Enable swapping on each FILE or device. With -s, or with no operand, print the " +
+			"table of active swap areas from /proc/swaps instead. Enabling swap requires privilege.",
+		Examples: []command.Example{
+			{Command: "swapon -s", Explain: "List the active swap areas."},
+			{Command: "swapon /swapfile", Explain: "Enable swapping on /swapfile."},
+		},
+		ExitStatus: "0  success.\n1  a swap area could not be enabled, or the table could not be read.",
+	})
+	summary := fs.BoolP("summary", "s", false, "print the active swap areas and exit")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if *summary || len(rest) == 0 {
+		data, err := os.ReadFile(swapsPath)
+		if err != nil {
+			return command.Failuref("cannot read %s: %v", swapsPath, err)
+		}
+		_, _ = stdio.Out.Write(data)
+		return nil
+	}
+
+	failed := false
+	for _, path := range rest {
+		if err := swaponFn(path); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "swapon: %s: %v\n", path, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}

--- a/internal/applets/util-linux/swapon/swapon_test.go
+++ b/internal/applets/util-linux/swapon/swapon_test.go
@@ -1,0 +1,68 @@
+package swapon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T, swaponErr error) *[]string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "swaps")
+	content := "Filename\tType\tSize\tUsed\tPriority\n/dev/sda2 partition 2097148 0 -2\n"
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var called []string
+	op, of := swapsPath, swaponFn
+	swapsPath = f
+	swaponFn = func(path string) error {
+		called = append(called, path)
+		return swaponErr
+	}
+	t.Cleanup(func() { swapsPath, swaponFn = op, of })
+	return &called
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestSummary(t *testing.T) {
+	setup(t, nil)
+	out, err := run(t, "-s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "/dev/sda2") || !strings.Contains(out, "Filename") {
+		t.Errorf("summary wrong:\n%s", out)
+	}
+}
+
+func TestEnable(t *testing.T) {
+	called := setup(t, nil)
+	if _, err := run(t, "/swapfile"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*called) != 1 || (*called)[0] != "/swapfile" {
+		t.Errorf("swaponFn called with %v", *called)
+	}
+}
+
+func TestEnableFails(t *testing.T) {
+	setup(t, errors.New("operation not permitted"))
+	if _, err := run(t, "/swapfile"); err == nil {
+		t.Errorf("an enable failure should fail")
+	}
+}

--- a/test/it/spec/swap_spec.sh
+++ b/test/it/spec/swap_spec.sh
@@ -1,0 +1,14 @@
+Describe 'swapon / swapoff'
+    Include util-linux/swap_test.sh
+
+    It 'swapon -s prints the swaps header'
+        When call TestSwaponSummary
+        The output should equal '1'
+        The status should be success
+    End
+    It 'swapoff requires a target'
+        When call TestSwapoffNoArg
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/swap_test.sh
+++ b/test/it/util-linux/swap_test.sh
@@ -1,0 +1,2 @@
+TestSwaponSummary() { swapon -s | sed -n '1p' | grep -c 'Filename'; }
+TestSwapoffNoArg() { swapoff 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with the swap-activation pair:

- **`swapon`** — enable swapping on each FILE/device; with `-s` (or no operand) it prints the active swap table from /proc/swaps.
- **`swapoff`** — disable swapping on each FILE/device; with `-a` it disables every area listed in /proc/swaps.

Both enable/disable through the swapon(2)/swapoff(2) syscalls, which require privilege. The syscalls and the /proc/swaps path are injectable so the listing, dispatch, and error paths are tested without privilege.

## Tests

- Unit (fixture /proc/swaps + stubbed syscalls): swapon's `-s` summary, enabling a file (and its failure path); swapoff disabling one target, `-a` disabling every active swap, the failure path, and the missing-target error.
- shellspec: `swapon -s` prints the swaps header, and `swapoff` requires a target.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (615 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `swapoff` command to disable specified swap areas or all swap areas with the `-a` flag.
  * Added `swapon` command to enable swap areas or display active swap areas with the `-s` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->