### PR TITLE
fix(swapoff): treat -a with no active swaps as success

### DIFF
--- a/internal/applets/util-linux/swapoff/swapoff.go
+++ b/internal/applets/util-linux/swapoff/swapoff.go
@@ -59,13 +59,16 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return err
 	}
 
-	targets := fs.Args()
+	var targets []string
 	if *all {
+		// -a disables every active swap; having none to disable is success.
 		targets = activeSwaps()
-	}
-	if len(targets) == 0 {
-		_, _ = fmt.Fprintln(stdio.Err, "swapoff: a swap area or -a is required")
-		return command.SilentFailure()
+	} else {
+		targets = fs.Args()
+		if len(targets) == 0 {
+			_, _ = fmt.Fprintln(stdio.Err, "swapoff: a swap area or -a is required")
+			return command.SilentFailure()
+		}
 	}
 
 	failed := false

--- a/internal/applets/util-linux/swapoff/swapoff_test.go
+++ b/internal/applets/util-linux/swapoff/swapoff_test.go
@@ -73,3 +73,19 @@ func TestNoArg(t *testing.T) {
 		t.Errorf("no target should fail")
 	}
 }
+
+func TestDisableAllEmpty(t *testing.T) {
+	// -a with no active swaps (empty table) is a no-op success, not an error.
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "swaps")
+	if err := os.WriteFile(empty, []byte("Filename\tType\tSize\tUsed\tPriority\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	op, of := swapsPath, swapoffFn
+	swapsPath = empty
+	swapoffFn = func(string) error { t.Fatal("should not be called"); return nil }
+	defer func() { swapsPath, swapoffFn = op, of }()
+	if err := run(t, "-a"); err != nil {
+		t.Errorf("-a with no swaps should succeed, got %v", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #377 addressing a CodeRabbit Major finding: `swapoff -a` fell into the 'a swap area or -a is required' failure path when /proc/swaps was empty or unreadable. With `-a`, having nothing to disable is a no-op success, not an error; only an explicit invocation with neither `-a` nor a target should fail. Adds a unit test for the empty-table `-a` case.

Part of #249