### PR TITLE
feat(util-linux): add fsfreeze applet to suspend/resume a filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 258 commands. Run `mimixbox --list` to see them on the terminal.
+There are 259 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -89,6 +89,7 @@ There are 258 commands. Run `mimixbox --list` to see them on the terminal.
 | fold | Wrap each input line to fit in specified width |
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
+| fsfreeze | Suspend or resume a filesystem |
 | fsync | Flush a file's data to storage with fsync(2) |
 | fuser | Identify processes using a file |
 | getopt | Parse command options (enhanced, like util-linux getopt) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -215,6 +215,7 @@ import (
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
+	ap_util_linux_fsfreeze "github.com/nao1215/mimixbox/internal/applets/util-linux/fsfreeze"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_hwclock "github.com/nao1215/mimixbox/internal/applets/util-linux/hwclock"
@@ -247,7 +248,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 258)
+	Applets = make(map[string]Applet, 259)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -475,6 +476,7 @@ func init() {
 	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
+	register(ap_util_linux_fsfreeze.New())
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())

--- a/internal/applets/util-linux/fsfreeze/fsfreeze.go
+++ b/internal/applets/util-linux/fsfreeze/fsfreeze.go
@@ -1,0 +1,83 @@
+// Package fsfreeze implements the fsfreeze applet: suspend or resume access to a
+// mounted filesystem.
+package fsfreeze
+
+import (
+	"context"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the fsfreeze applet.
+type Command struct{}
+
+// New returns a fsfreeze command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fsfreeze" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Suspend or resume a filesystem" }
+
+// FIFREEZE/FITHAW are not exported by this x/sys version.
+const (
+	fiFreeze = 0xC0045877
+	fiThaw   = 0xC0045878
+)
+
+// freezeFn is indirected so the privileged ioctl can be tested.
+var freezeFn = func(path string, freeze bool) error {
+	f, err := os.Open(path) //nolint:gosec // user-named mount point
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	op := uintptr(fiThaw)
+	if freeze {
+		op = fiFreeze
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), op, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes fsfreeze.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "{-f|-u} MOUNTPOINT", stdio.Err).WithHelp(command.Help{
+		Description: "Freeze (-f) or unfreeze (-u) the filesystem mounted at MOUNTPOINT. Freezing " +
+			"suspends new writes and flushes pending ones, leaving the filesystem in a consistent " +
+			"state (e.g. for a snapshot) until it is unfrozen. Exactly one of -f or -u is required, " +
+			"and the operation needs privilege.",
+		Examples: []command.Example{
+			{Command: "fsfreeze -f /mnt/data", Explain: "Freeze the filesystem at /mnt/data."},
+			{Command: "fsfreeze -u /mnt/data", Explain: "Unfreeze it again."},
+		},
+		ExitStatus: "0  the filesystem was frozen or unfrozen.\n1  invalid options or the ioctl failed.",
+	})
+	freeze := fs.BoolP("freeze", "f", false, "freeze the filesystem")
+	unfreeze := fs.BoolP("unfreeze", "u", false, "unfreeze the filesystem")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if *freeze == *unfreeze { // neither or both
+		return command.Failuref("exactly one of -f (freeze) or -u (unfreeze) is required")
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a mount point is required")
+	}
+
+	if err := freezeFn(rest[0], *freeze); err != nil {
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/fsfreeze/fsfreeze_test.go
+++ b/internal/applets/util-linux/fsfreeze/fsfreeze_test.go
@@ -1,0 +1,79 @@
+package fsfreeze
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type call struct {
+	path   string
+	freeze bool
+}
+
+func withStub(t *testing.T, err error) *call {
+	t.Helper()
+	got := &call{}
+	got.path = "<unset>"
+	orig := freezeFn
+	freezeFn = func(path string, freeze bool) error {
+		*got = call{path, freeze}
+		return err
+	}
+	t.Cleanup(func() { freezeFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestFreeze(t *testing.T) {
+	got := withStub(t, nil)
+	if err := run(t, "-f", "/mnt/data"); err != nil {
+		t.Fatal(err)
+	}
+	if got.path != "/mnt/data" || !got.freeze {
+		t.Errorf("freeze call = %+v", *got)
+	}
+}
+
+func TestUnfreeze(t *testing.T) {
+	got := withStub(t, nil)
+	if err := run(t, "-u", "/mnt/data"); err != nil {
+		t.Fatal(err)
+	}
+	if got.path != "/mnt/data" || got.freeze {
+		t.Errorf("unfreeze call = %+v", *got)
+	}
+}
+
+func TestRequiresExactlyOneMode(t *testing.T) {
+	withStub(t, nil)
+	if err := run(t, "/mnt"); err == nil {
+		t.Errorf("no -f/-u should fail")
+	}
+	if err := run(t, "-f", "-u", "/mnt"); err == nil {
+		t.Errorf("both -f and -u should fail")
+	}
+}
+
+func TestRequiresMountpoint(t *testing.T) {
+	withStub(t, nil)
+	if err := run(t, "-f"); err == nil {
+		t.Errorf("missing mount point should fail")
+	}
+}
+
+func TestIoctlFailure(t *testing.T) {
+	withStub(t, errors.New("operation not permitted"))
+	if err := run(t, "-f", "/mnt"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/spec/fsfreeze_spec.sh
+++ b/test/it/spec/fsfreeze_spec.sh
@@ -1,0 +1,14 @@
+Describe 'fsfreeze'
+    Include util-linux/fsfreeze_test.sh
+
+    It 'requires a freeze or unfreeze mode'
+        When call TestFsfreezeNoMode
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects both modes at once'
+        When call TestFsfreezeBothModes
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/fsfreeze_test.sh
+++ b/test/it/util-linux/fsfreeze_test.sh
@@ -1,0 +1,2 @@
+TestFsfreezeNoMode() { fsfreeze /mnt 2>/dev/null; echo "rc=$?"; }
+TestFsfreezeBothModes() { fsfreeze -f -u /mnt 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fsfreeze`, which freezes (`-f`) or unfreezes (`-u`) the filesystem mounted at MOUNTPOINT via the FIFREEZE/FITHAW ioctls. Freezing suspends new writes and flushes pending ones for a consistent on-disk state (e.g. before a snapshot). Exactly one of -f/-u is required and the operation needs privilege; the ioctl is injectable so the validation and dispatch are tested without privilege.

## Tests

- Unit (stubbed ioctl): `-f` and `-u` dispatching with the correct freeze flag, the exactly-one-mode rule (neither and both rejected), the missing-mount-point error, and an ioctl-failure error.
- shellspec: a missing mode and both modes at once are both rejected.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (617 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249