### PR TITLE
feat(util-linux): add fstrim applet to discard unused blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 259 commands. Run `mimixbox --list` to see them on the terminal.
+There are 260 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -90,6 +90,7 @@ There are 259 commands. Run `mimixbox --list` to see them on the terminal.
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
 | fsfreeze | Suspend or resume a filesystem |
+| fstrim | Discard unused blocks on a filesystem |
 | fsync | Flush a file's data to storage with fsync(2) |
 | fuser | Identify processes using a file |
 | getopt | Parse command options (enhanced, like util-linux getopt) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -216,6 +216,7 @@ import (
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
 	ap_util_linux_fsfreeze "github.com/nao1215/mimixbox/internal/applets/util-linux/fsfreeze"
+	ap_util_linux_fstrim "github.com/nao1215/mimixbox/internal/applets/util-linux/fstrim"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
 	ap_util_linux_hexdump "github.com/nao1215/mimixbox/internal/applets/util-linux/hexdump"
 	ap_util_linux_hwclock "github.com/nao1215/mimixbox/internal/applets/util-linux/hwclock"
@@ -248,7 +249,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 259)
+	Applets = make(map[string]Applet, 260)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -477,6 +478,7 @@ func init() {
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
 	register(ap_util_linux_fsfreeze.New())
+	register(ap_util_linux_fstrim.New())
 	register(ap_util_linux_getopt.New())
 	register(ap_util_linux_hexdump.NewHd())
 	register(ap_util_linux_hexdump.NewHexdump())

--- a/internal/applets/util-linux/fstrim/fstrim.go
+++ b/internal/applets/util-linux/fstrim/fstrim.go
@@ -1,0 +1,87 @@
+// Package fstrim implements the fstrim applet: discard unused blocks on a
+// mounted filesystem.
+package fstrim
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the fstrim applet.
+type Command struct{}
+
+// New returns a fstrim command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fstrim" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Discard unused blocks on a filesystem" }
+
+// fiTrim is the FITRIM ioctl, not exported by this x/sys version.
+const fiTrim = 0xC0185879
+
+// fstrimRange mirrors struct fstrim_range.
+type fstrimRange struct {
+	start  uint64
+	length uint64
+	minlen uint64
+}
+
+// trimFn is indirected so the privileged ioctl can be tested. It returns the
+// number of bytes the kernel reported as trimmed.
+var trimFn = func(path string) (uint64, error) {
+	f, err := os.Open(path) //nolint:gosec // user-named mount point
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	r := fstrimRange{start: 0, length: ^uint64(0), minlen: 0}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fiTrim, uintptr(unsafe.Pointer(&r)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return r.length, nil
+}
+
+// Run executes fstrim.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-v] MOUNTPOINT", stdio.Err).WithHelp(command.Help{
+		Description: "Discard blocks that are not in use by the filesystem mounted at MOUNTPOINT, " +
+			"telling the underlying device (SSD/thin volume) it may reclaim them. With -v, report how " +
+			"many bytes were trimmed. The operation requires privilege.",
+		Examples: []command.Example{
+			{Command: "fstrim /", Explain: "Trim the root filesystem."},
+			{Command: "fstrim -v /home", Explain: "Trim /home and report the amount."},
+		},
+		ExitStatus: "0  the filesystem was trimmed.\n1  no mount point was given or the ioctl failed.",
+	})
+	verbose := fs.BoolP("verbose", "v", false, "report the number of bytes trimmed")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a mount point is required")
+	}
+	mountpoint := rest[0]
+
+	trimmed, err := trimFn(mountpoint)
+	if err != nil {
+		return command.Failuref("%s: %v", mountpoint, err)
+	}
+	if *verbose {
+		_, _ = fmt.Fprintf(stdio.Out, "%s: %d bytes were trimmed\n", mountpoint, trimmed)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/fstrim/fstrim_test.go
+++ b/internal/applets/util-linux/fstrim/fstrim_test.go
@@ -1,0 +1,71 @@
+package fstrim
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, trimmed uint64, err error) *string {
+	t.Helper()
+	asked := new(string)
+	*asked = "<unset>"
+	orig := trimFn
+	trimFn = func(path string) (uint64, error) {
+		*asked = path
+		return trimmed, err
+	}
+	t.Cleanup(func() { trimFn = orig })
+	return asked
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestVerboseReportsBytes(t *testing.T) {
+	asked := withStub(t, 1024000, nil)
+	out, err := run(t, "-v", "/home")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *asked != "/home" {
+		t.Errorf("trimFn called with %q", *asked)
+	}
+	if out != "/home: 1024000 bytes were trimmed" {
+		t.Errorf("verbose output = %q", out)
+	}
+}
+
+func TestQuietByDefault(t *testing.T) {
+	withStub(t, 1024000, nil)
+	out, err := run(t, "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "" {
+		t.Errorf("non-verbose should print nothing, got %q", out)
+	}
+}
+
+func TestNoMountpoint(t *testing.T) {
+	withStub(t, 0, nil)
+	if _, err := run(t); err == nil {
+		t.Errorf("a missing mount point should fail")
+	}
+}
+
+func TestIoctlFailure(t *testing.T) {
+	withStub(t, 0, errors.New("operation not permitted"))
+	if _, err := run(t, "-v", "/"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/spec/fstrim_spec.sh
+++ b/test/it/spec/fstrim_spec.sh
@@ -1,0 +1,15 @@
+Describe 'fstrim'
+    Include util-linux/fstrim_test.sh
+
+    It 'requires a mount point'
+        When call TestFstrimNoArg
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestFstrimHelp
+        The status should be success
+        The output should include 'Usage: fstrim'
+        The output should include 'Discard'
+    End
+End

--- a/test/it/util-linux/fstrim_test.sh
+++ b/test/it/util-linux/fstrim_test.sh
@@ -1,0 +1,4 @@
+# Trimming needs privilege, so the e2e exercises the deterministic
+# missing-argument path; the ioctl dispatch is covered by unit tests.
+TestFstrimNoArg() { fstrim 2>/dev/null; echo "rc=$?"; }
+TestFstrimHelp() { fstrim --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fstrim`, which discards blocks not in use by the filesystem mounted at MOUNTPOINT via the FITRIM ioctl, letting the underlying SSD/thin volume reclaim them. With `-v` it reports the number of bytes trimmed. The operation requires privilege; the ioctl is injectable so the dispatch and output are tested without privilege.

## Tests

- Unit (stubbed ioctl): `-v` reporting the trimmed byte count for the requested mount point, the quiet default (no output), the missing-mount-point error, and an ioctl-failure error.
- shellspec: a missing mount point fails, and the `--help` path (trimming needs privilege, so the dispatch is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (619 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249