### PR TITLE
feat(util-linux): add blkdiscard applet to discard device sectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 260 commands. Run `mimixbox --list` to see them on the terminal.
+There are 261 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -36,6 +36,7 @@ There are 260 commands. Run `mimixbox --list` to see them on the terminal.
 | basename | Print basename (PATH without "/") from file path |
 | bash | Command interpreter (MimixBox mbsh compatibility front-end) |
 | bc | An arbitrary-precision calculator language |
+| blkdiscard | Discard sectors on a block device |
 | blkid | Identify the filesystem type of a device or image |
 | blockdev | Report block device properties |
 | bunzip2 | Decompress bzip2 (.bz2) files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -207,6 +207,7 @@ import (
 	ap_textutils_uucode "github.com/nao1215/mimixbox/internal/applets/textutils/uucode"
 	ap_textutils_wc "github.com/nao1215/mimixbox/internal/applets/textutils/wc"
 	ap_textutils_xxd "github.com/nao1215/mimixbox/internal/applets/textutils/xxd"
+	ap_util_linux_blkdiscard "github.com/nao1215/mimixbox/internal/applets/util-linux/blkdiscard"
 	ap_util_linux_blkid "github.com/nao1215/mimixbox/internal/applets/util-linux/blkid"
 	ap_util_linux_blockdev "github.com/nao1215/mimixbox/internal/applets/util-linux/blockdev"
 	ap_util_linux_chattr "github.com/nao1215/mimixbox/internal/applets/util-linux/chattr"
@@ -249,7 +250,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 260)
+	Applets = make(map[string]Applet, 261)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -469,6 +470,7 @@ func init() {
 	register(ap_textutils_uucode.NewUuencode())
 	register(ap_textutils_wc.New())
 	register(ap_textutils_xxd.New())
+	register(ap_util_linux_blkdiscard.New())
 	register(ap_util_linux_blkid.New())
 	register(ap_util_linux_blockdev.New())
 	register(ap_util_linux_chattr.New())

--- a/internal/applets/util-linux/blkdiscard/blkdiscard.go
+++ b/internal/applets/util-linux/blkdiscard/blkdiscard.go
@@ -1,0 +1,106 @@
+// Package blkdiscard implements the blkdiscard applet: discard sectors on a
+// block device.
+package blkdiscard
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the blkdiscard applet.
+type Command struct{}
+
+// New returns a blkdiscard command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "blkdiscard" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Discard sectors on a block device" }
+
+// blkDiscard is the BLKDISCARD ioctl, not exported by this x/sys version.
+const blkDiscard = 0x1277
+
+// Injected so the privileged ioctls can be tested.
+var (
+	sizeFn = func(device string) (uint64, error) {
+		f, err := os.Open(device) //nolint:gosec // user-named device
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = f.Close() }()
+		var sz uint64
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), uintptr(unix.BLKGETSIZE64), uintptr(unsafe.Pointer(&sz)))
+		if errno != 0 {
+			return 0, errno
+		}
+		return sz, nil
+	}
+	discardFn = func(device string, offset, length uint64) error {
+		f, err := os.OpenFile(device, os.O_WRONLY, 0) //nolint:gosec // user-named device
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		rng := [2]uint64{offset, length}
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), blkDiscard, uintptr(unsafe.Pointer(&rng)))
+		if errno != 0 {
+			return errno
+		}
+		return nil
+	}
+)
+
+// Run executes blkdiscard.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-o OFFSET] [-l LENGTH] [-v] DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Discard (tell the device to forget) a range of sectors on a block DEVICE. By " +
+			"default the whole device is discarded; -o sets the byte offset to start at and -l the " +
+			"number of bytes. -v reports the discarded range. This destroys data and requires privilege.",
+		Examples: []command.Example{
+			{Command: "blkdiscard -v /dev/sdb", Explain: "Discard the entire device."},
+			{Command: "blkdiscard -o 0 -l 1048576 /dev/sdb", Explain: "Discard the first MiB."},
+		},
+		ExitStatus: "0  the range was discarded.\n1  no device was given or the ioctl failed.",
+	})
+	offset := fs.Uint64P("offset", "o", 0, "byte offset to start at")
+	length := fs.Uint64P("length", "l", 0, "number of bytes to discard (0 = to end)")
+	verbose := fs.BoolP("verbose", "v", false, "report the discarded range")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a device is required")
+	}
+	device := rest[0]
+
+	count := *length
+	if count == 0 {
+		size, err := sizeFn(device)
+		if err != nil {
+			return command.Failuref("%s: %v", device, err)
+		}
+		if *offset > size {
+			return command.Failuref("%s: offset is past the end of the device", device)
+		}
+		count = size - *offset
+	}
+
+	if err := discardFn(device, *offset, count); err != nil {
+		return command.Failuref("%s: %v", device, err)
+	}
+	if *verbose {
+		_, _ = fmt.Fprintf(stdio.Out, "%s: discarded %d bytes from offset %d\n", device, count, *offset)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/blkdiscard/blkdiscard_test.go
+++ b/internal/applets/util-linux/blkdiscard/blkdiscard_test.go
@@ -1,0 +1,96 @@
+package blkdiscard
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type discard struct {
+	device         string
+	offset, length uint64
+}
+
+func withStub(t *testing.T, size uint64, sizeErr, discardErr error) *discard {
+	t.Helper()
+	got := &discard{}
+	os, od := sizeFn, discardFn
+	sizeFn = func(string) (uint64, error) { return size, sizeErr }
+	discardFn = func(device string, offset, length uint64) error {
+		*got = discard{device, offset, length}
+		return discardErr
+	}
+	t.Cleanup(func() { sizeFn, discardFn = os, od })
+	return got
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestExplicitRange(t *testing.T) {
+	got := withStub(t, 0, nil, nil)
+	if _, err := run(t, "-o", "4096", "-l", "8192", "/dev/sdb"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != (discard{"/dev/sdb", 4096, 8192}) {
+		t.Errorf("discard = %+v", *got)
+	}
+}
+
+func TestWholeDevice(t *testing.T) {
+	got := withStub(t, 1000000, nil, nil)
+	if _, err := run(t, "/dev/sdb"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != (discard{"/dev/sdb", 0, 1000000}) {
+		t.Errorf("whole-device discard = %+v", *got)
+	}
+}
+
+func TestOffsetToEnd(t *testing.T) {
+	got := withStub(t, 1000000, nil, nil)
+	if _, err := run(t, "-o", "200000", "/dev/sdb"); err != nil {
+		t.Fatal(err)
+	}
+	if got.length != 800000 {
+		t.Errorf("offset-to-end length = %d, want 800000", got.length)
+	}
+}
+
+func TestVerbose(t *testing.T) {
+	withStub(t, 0, nil, nil)
+	out, err := run(t, "-v", "-o", "0", "-l", "4096", "/dev/sdb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "discarded 4096 bytes from offset 0") {
+		t.Errorf("verbose = %q", out)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	withStub(t, 1000, nil, nil)
+	if _, err := run(t); err == nil {
+		t.Errorf("no device should fail")
+	}
+	if _, err := run(t, "-o", "5000", "/dev/sdb"); err == nil {
+		t.Errorf("offset past end should fail")
+	}
+	withStub(t, 0, errors.New("permission denied"), nil)
+	if _, err := run(t, "/dev/sdb"); err == nil {
+		t.Errorf("a size failure should fail")
+	}
+	withStub(t, 0, nil, errors.New("permission denied"))
+	if _, err := run(t, "-l", "4096", "/dev/sdb"); err == nil {
+		t.Errorf("a discard failure should fail")
+	}
+}

--- a/test/it/spec/blkdiscard_spec.sh
+++ b/test/it/spec/blkdiscard_spec.sh
@@ -1,0 +1,15 @@
+Describe 'blkdiscard'
+    Include util-linux/blkdiscard_test.sh
+
+    It 'requires a device'
+        When call TestBlkdiscardNoDev
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestBlkdiscardHelp
+        The status should be success
+        The output should include 'Usage: blkdiscard'
+        The output should include 'Discard'
+    End
+End

--- a/test/it/util-linux/blkdiscard_test.sh
+++ b/test/it/util-linux/blkdiscard_test.sh
@@ -1,0 +1,4 @@
+# Discarding needs a real block device and privilege; the e2e exercises the
+# deterministic no-device path. The range math is covered by unit tests.
+TestBlkdiscardNoDev() { blkdiscard 2>/dev/null; echo "rc=$?"; }
+TestBlkdiscardHelp() { blkdiscard --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `blkdiscard`, which discards (tells the device to forget) a range of sectors on a block DEVICE via the BLKDISCARD ioctl. By default the whole device is discarded; `-o` sets the starting byte offset, `-l` the number of bytes (0 means to the end, computed from BLKGETSIZE64), and `-v` reports the discarded range. This destroys data and requires privilege; the size and discard ioctls are injectable so the range math and dispatch are tested without a device.

## Tests

- Unit (stubbed ioctls): an explicit `-o`/`-l` range, the whole-device default (size queried), the offset-to-end length computation, the `-v` report, and the no-device / offset-past-end / size-failure / discard-failure errors.
- shellspec: a missing device fails, and the `--help` path (discarding needs privilege and a real device, so the range math is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (621 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249