### PR TITLE
feat(util-linux): add losetup applet to list loop devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 261 commands. Run `mimixbox --list` to see them on the terminal.
+There are 262 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -131,6 +131,7 @@ There are 261 commands. Run `mimixbox --list` to see them on the terminal.
 | logger | Write a message to the system log |
 | logname | Print the name of the current user |
 | logread | Show the system log |
+| losetup | List active loop devices |
 | ls | List directory contents |
 | lsattr | List ext2/ext4 file attributes |
 | lsblk | List information about block devices |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -225,6 +225,7 @@ import (
 	ap_util_linux_ipcrm "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcrm"
 	ap_util_linux_ipcs "github.com/nao1215/mimixbox/internal/applets/util-linux/ipcs"
 	ap_util_linux_last "github.com/nao1215/mimixbox/internal/applets/util-linux/last"
+	ap_util_linux_losetup "github.com/nao1215/mimixbox/internal/applets/util-linux/losetup"
 	ap_util_linux_lsattr "github.com/nao1215/mimixbox/internal/applets/util-linux/lsattr"
 	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
@@ -250,7 +251,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 261)
+	Applets = make(map[string]Applet, 262)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -489,6 +490,7 @@ func init() {
 	register(ap_util_linux_ipcrm.New())
 	register(ap_util_linux_ipcs.New())
 	register(ap_util_linux_last.New())
+	register(ap_util_linux_losetup.New())
 	register(ap_util_linux_lsattr.New())
 	register(ap_util_linux_lsblk.New())
 	register(ap_util_linux_lspci.New())

--- a/internal/applets/util-linux/losetup/losetup.go
+++ b/internal/applets/util-linux/losetup/losetup.go
@@ -1,0 +1,89 @@
+// Package losetup implements the losetup applet: list active loop devices.
+// Associating and detaching loop devices is privileged and not done here.
+package losetup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the losetup applet.
+type Command struct{}
+
+// New returns a losetup command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "losetup" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List active loop devices" }
+
+// sysBlockDir is the sysfs block class; tests point it at a fixture.
+var sysBlockDir = "/sys/block"
+
+// Run executes losetup.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-a]", stdio.Err).WithHelp(command.Help{
+		Description: "List the active loop devices and their backing files, read from /sys/block. With " +
+			"-a, or with no operand, every active loop device is shown. Associating a file with a loop " +
+			"device or detaching one is privileged and is not done by this build.",
+		Examples: []command.Example{
+			{Command: "losetup -a", Explain: "List the active loop devices."},
+		},
+		ExitStatus: "0  the loop devices were listed.\n1  a setup/detach was requested.",
+	})
+	_ = fs.BoolP("all", "a", false, "list all active loop devices (the default)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if len(fs.Args()) > 0 {
+		_, _ = fmt.Fprintln(stdio.Err, "losetup: associating or detaching loop devices is not supported "+
+			"by this build; run with -a to list active loop devices")
+		return command.SilentFailure()
+	}
+
+	for _, d := range loopDevices() {
+		_, _ = fmt.Fprintf(stdio.Out, "/dev/%s: (%s)\n", d.name, d.backing)
+	}
+	return nil
+}
+
+type loopDevice struct {
+	name, backing string
+}
+
+// loopDevices returns the active loop devices (those with a backing file),
+// sorted by name.
+func loopDevices() []loopDevice {
+	entries, err := os.ReadDir(sysBlockDir)
+	if err != nil {
+		return nil
+	}
+	var devices []loopDevice
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "loop") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(sysBlockDir, e.Name(), "loop", "backing_file")) //nolint:gosec // sysfs path
+		if err != nil {
+			continue // no backing file means the loop device is not in use
+		}
+		backing := strings.TrimSpace(string(data))
+		if backing == "" {
+			continue
+		}
+		devices = append(devices, loopDevice{name: e.Name(), backing: backing})
+	}
+	sort.Slice(devices, func(i, j int) bool { return devices[i].name < devices[j].name })
+	return devices
+}

--- a/internal/applets/util-linux/losetup/losetup_test.go
+++ b/internal/applets/util-linux/losetup/losetup_test.go
@@ -1,0 +1,76 @@
+package losetup
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	// loop0 is active (has a backing file).
+	loop0 := filepath.Join(dir, "loop0", "loop")
+	if err := os.MkdirAll(loop0, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(loop0, "backing_file"), []byte("/images/disk.img\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// loop1 is inactive (no loop/ subdirectory).
+	if err := os.MkdirAll(filepath.Join(dir, "loop1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// sda is not a loop device.
+	if err := os.MkdirAll(filepath.Join(dir, "sda"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := sysBlockDir
+	sysBlockDir = dir
+	t.Cleanup(func() { sysBlockDir = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestListsActive(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "/dev/loop0: (/images/disk.img)" {
+		t.Errorf("losetup -a = %q", out)
+	}
+}
+
+func TestNoArgListsAll(t *testing.T) {
+	fixture(t)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "loop0") {
+		t.Errorf("no-arg listing = %q", out)
+	}
+	if strings.Contains(out, "loop1") || strings.Contains(out, "sda") {
+		t.Errorf("inactive/non-loop devices should be skipped: %q", out)
+	}
+}
+
+func TestSetupUnsupported(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "/dev/loop0", "/tmp/img"); err == nil {
+		t.Errorf("requesting a setup should fail deterministically")
+	}
+}

--- a/test/it/spec/losetup_spec.sh
+++ b/test/it/spec/losetup_spec.sh
@@ -1,0 +1,14 @@
+Describe 'losetup'
+    Include util-linux/losetup_test.sh
+
+    It 'lists active loop devices cleanly'
+        When call TestLosetupAll
+        The output should equal 'rc=0'
+        The status should be success
+    End
+    It 'refuses to associate a loop device'
+        When call TestLosetupSetup
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/losetup_test.sh
+++ b/test/it/util-linux/losetup_test.sh
@@ -1,0 +1,4 @@
+# Active loop devices vary by host; the e2e confirms -a runs cleanly (exit 0)
+# and that a setup request is refused. Listing logic is covered by unit tests.
+TestLosetupAll() { losetup -a >/dev/null; echo "rc=$?"; }
+TestLosetupSetup() { losetup /dev/loop0 /tmp/img 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `losetup` in read-only listing mode. With `-a` (or no operand) it lists the active loop devices and their backing files, read from /sys/block/loop*/loop/backing_file; inactive loop devices and non-loop block devices are skipped. Associating a file with a loop device or detaching one is privileged; requesting it fails deterministically rather than silently. The sysfs path is injectable so the listing is tested against fixtures.

## Tests

- Unit (fixture /sys/block): listing an active loop device with its backing file, the no-argument listing skipping inactive and non-loop devices, and the deterministic failure when a setup is requested.
- shellspec: `-a` runs cleanly (exit 0), and a setup request is refused.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (623 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249