### PR TITLE
feat(util-linux): add eject applet to eject removable media

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 262 commands. Run `mimixbox --list` to see them on the terminal.
+There are 263 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -75,6 +75,7 @@ There are 262 commands. Run `mimixbox --list` to see them on the terminal.
 | echo | Display a line of text |
 | ed | A line-oriented text editor |
 | egrep | Search with extended regular expressions (grep -E) |
+| eject | Eject removable media |
 | env | Run a program in a modified environment / print the environment |
 | expand | Convert TAB to N space (default:N=8) |
 | expr | Evaluate expressions |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -213,6 +213,7 @@ import (
 	ap_util_linux_chattr "github.com/nao1215/mimixbox/internal/applets/util-linux/chattr"
 	ap_util_linux_chrt "github.com/nao1215/mimixbox/internal/applets/util-linux/chrt"
 	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
+	ap_util_linux_eject "github.com/nao1215/mimixbox/internal/applets/util-linux/eject"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
@@ -251,7 +252,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 262)
+	Applets = make(map[string]Applet, 263)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -477,6 +478,7 @@ func init() {
 	register(ap_util_linux_chattr.New())
 	register(ap_util_linux_chrt.New())
 	register(ap_util_linux_dmesg.New())
+	register(ap_util_linux_eject.New())
 	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())

--- a/internal/applets/util-linux/eject/eject.go
+++ b/internal/applets/util-linux/eject/eject.go
@@ -1,0 +1,79 @@
+// Package eject implements the eject applet: eject removable media (open or
+// close a CD-ROM tray).
+package eject
+
+import (
+	"context"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the eject applet.
+type Command struct{}
+
+// New returns an eject command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "eject" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Eject removable media" }
+
+// CD-ROM ioctls, not exported by this x/sys version.
+const (
+	cdromEject     = 0x5309
+	cdromCloseTray = 0x5319
+)
+
+// defaultDevice is the device used when none is given.
+const defaultDevice = "/dev/cdrom"
+
+// ejectFn is indirected so the privileged ioctl can be tested.
+var ejectFn = func(device string, closeTray bool) error {
+	f, err := os.Open(device) //nolint:gosec // user-named device
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	op := uintptr(cdromEject)
+	if closeTray {
+		op = cdromCloseTray
+	}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), op, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes eject.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-t] [DEVICE]", stdio.Err).WithHelp(command.Help{
+		Description: "Eject removable media by opening the tray of the CD-ROM DEVICE (default " +
+			"/dev/cdrom). With -t, close the tray instead. Operating the drive requires privilege.",
+		Examples: []command.Example{
+			{Command: "eject", Explain: "Open the /dev/cdrom tray."},
+			{Command: "eject -t /dev/sr0", Explain: "Close the tray of /dev/sr0."},
+		},
+		ExitStatus: "0  the tray was operated.\n1  the device could not be opened or the ioctl failed.",
+	})
+	closeTray := fs.BoolP("trayclose", "t", false, "close the tray instead of opening it")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	device := defaultDevice
+	if rest := fs.Args(); len(rest) > 0 {
+		device = rest[0]
+	}
+
+	if err := ejectFn(device, *closeTray); err != nil {
+		return command.Failuref("%s: %v", device, err)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/eject/eject_test.go
+++ b/internal/applets/util-linux/eject/eject_test.go
@@ -1,0 +1,61 @@
+package eject
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type call struct {
+	device    string
+	closeTray bool
+}
+
+func withStub(t *testing.T, err error) *call {
+	t.Helper()
+	got := &call{device: "<unset>"}
+	orig := ejectFn
+	ejectFn = func(device string, closeTray bool) error {
+		*got = call{device, closeTray}
+		return err
+	}
+	t.Cleanup(func() { ejectFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestDefaultDeviceEjects(t *testing.T) {
+	got := withStub(t, nil)
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	if got.device != defaultDevice || got.closeTray {
+		t.Errorf("eject call = %+v, want open of %s", *got, defaultDevice)
+	}
+}
+
+func TestNamedDeviceCloseTray(t *testing.T) {
+	got := withStub(t, nil)
+	if err := run(t, "-t", "/dev/sr0"); err != nil {
+		t.Fatal(err)
+	}
+	if got.device != "/dev/sr0" || !got.closeTray {
+		t.Errorf("eject -t call = %+v", *got)
+	}
+}
+
+func TestFailure(t *testing.T) {
+	withStub(t, errors.New("no medium found"))
+	if err := run(t, "/dev/sr0"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/spec/eject_spec.sh
+++ b/test/it/spec/eject_spec.sh
@@ -1,0 +1,15 @@
+Describe 'eject'
+    Include util-linux/eject_test.sh
+
+    It 'describes itself with --help'
+        When call TestEjectHelp
+        The status should be success
+        The output should include 'Usage: eject'
+        The output should include 'media'
+    End
+    It 'fails on a missing device'
+        When call TestEjectMissing
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/eject_test.sh
+++ b/test/it/util-linux/eject_test.sh
@@ -1,0 +1,4 @@
+# Operating a CD-ROM needs a real drive and privilege, so the e2e exercises the
+# --help and missing-device paths; the ioctl dispatch is covered by unit tests.
+TestEjectHelp() { eject --help; }
+TestEjectMissing() { eject /dev/no_such_cdrom 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `eject`, which ejects removable media by opening the tray of a CD-ROM DEVICE (default /dev/cdrom) via the CDROMEJECT ioctl; with `-t` it closes the tray (CDROMCLOSETRAY) instead. Operating the drive requires privilege; the ioctl is injectable so the device selection and tray dispatch are tested without a drive.

## Tests

- Unit (stubbed ioctl): the default device opening its tray, a named device closing its tray with `-t`, and an ioctl-failure error.
- shellspec: the `--help` path and a missing-device failure (operating a drive needs privilege, so the dispatch is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (625 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249