### PR TITLE
feat(util-linux): add tune2fs applet to show ext filesystem parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 263 commands. Run `mimixbox --list` to see them on the terminal.
+There are 264 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -248,6 +248,7 @@ There are 263 commands. Run `mimixbox --list` to see them on the terminal.
 | truncate | Shrink or extend the size of a file to a given size |
 | tsort | Topological sort of a directed graph |
 | tty | Print the file name of the terminal connected to stdin |
+| tune2fs | Show ext2/ext3/ext4 filesystem parameters |
 | umount | Unmount a filesystem |
 | uname | Print system information |
 | uncompress | Decompress LZW (.Z) files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -245,6 +245,7 @@ import (
 	ap_util_linux_swapoff "github.com/nao1215/mimixbox/internal/applets/util-linux/swapoff"
 	ap_util_linux_swapon "github.com/nao1215/mimixbox/internal/applets/util-linux/swapon"
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
+	ap_util_linux_tune2fs "github.com/nao1215/mimixbox/internal/applets/util-linux/tune2fs"
 	ap_util_linux_umount "github.com/nao1215/mimixbox/internal/applets/util-linux/umount"
 	ap_util_linux_wall "github.com/nao1215/mimixbox/internal/applets/util-linux/wall"
 )
@@ -252,7 +253,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 263)
+	Applets = make(map[string]Applet, 264)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -514,6 +515,7 @@ func init() {
 	register(ap_util_linux_swapoff.New())
 	register(ap_util_linux_swapon.New())
 	register(ap_util_linux_taskset.New())
+	register(ap_util_linux_tune2fs.New())
 	register(ap_util_linux_umount.New())
 	register(ap_util_linux_wall.New())
 }

--- a/internal/applets/util-linux/tune2fs/tune2fs.go
+++ b/internal/applets/util-linux/tune2fs/tune2fs.go
@@ -1,0 +1,117 @@
+// Package tune2fs implements the tune2fs applet: display ext2/ext3/ext4
+// filesystem parameters from a superblock. Adjusting parameters is not done by
+// this slice.
+package tune2fs
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the tune2fs applet.
+type Command struct{}
+
+// New returns a tune2fs command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "tune2fs" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show ext2/ext3/ext4 filesystem parameters" }
+
+const (
+	superblockOffset = 1024   // the ext2 superblock starts here
+	extMagic         = 0xEF53 // s_magic
+)
+
+// Run executes tune2fs.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-l FILE", stdio.Err).WithHelp(command.Help{
+		Description: "List the parameters of the ext2/ext3/ext4 filesystem in FILE (a device or image): " +
+			"its volume name, UUID, and inode/block counts and block size, read from the superblock. " +
+			"Only the read-only listing (-l) is implemented; changing parameters is not.",
+		Examples: []command.Example{
+			{Command: "tune2fs -l disk.img", Explain: "Show the filesystem parameters."},
+		},
+		ExitStatus: "0  the parameters were listed.\n1  the file was unreadable or not an ext filesystem.",
+	})
+	list := fs.BoolP("list", "l", false, "list the filesystem superblock contents")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a filesystem (device or image) is required")
+	}
+	if !*list {
+		_, _ = fmt.Fprintln(stdio.Err, "tune2fs: only the read-only listing (-l) is supported by this build")
+		return command.SilentFailure()
+	}
+
+	sb, err := readSuperblock(rest[0])
+	if err != nil {
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "Filesystem volume name:   %s\n", orNone(sb.volumeName))
+	_, _ = fmt.Fprintf(stdio.Out, "Filesystem UUID:          %s\n", sb.uuid)
+	_, _ = fmt.Fprintf(stdio.Out, "Inode count:              %d\n", sb.inodes)
+	_, _ = fmt.Fprintf(stdio.Out, "Block count:              %d\n", sb.blocks)
+	_, _ = fmt.Fprintf(stdio.Out, "Block size:               %d\n", sb.blockSize)
+	return nil
+}
+
+type superblock struct {
+	inodes, blocks uint32
+	blockSize      int
+	uuid           string
+	volumeName     string
+}
+
+// readSuperblock reads and parses the ext2 superblock from path.
+func readSuperblock(path string) (*superblock, error) {
+	f, err := os.Open(path) //nolint:gosec // user-named device or image
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, 264) // up to s_volume_name (offset 120) + 16
+	if _, err := f.ReadAt(buf, superblockOffset); err != nil {
+		return nil, fmt.Errorf("cannot read superblock: %w", err)
+	}
+	if binary.LittleEndian.Uint16(buf[56:]) != extMagic {
+		return nil, fmt.Errorf("not an ext2/3/4 filesystem (bad magic)")
+	}
+
+	return &superblock{
+		inodes:     binary.LittleEndian.Uint32(buf[0:]),
+		blocks:     binary.LittleEndian.Uint32(buf[4:]),
+		blockSize:  1024 << binary.LittleEndian.Uint32(buf[24:]),
+		uuid:       formatUUID(buf[104:120]),
+		volumeName: strings.TrimRight(string(buf[120:136]), "\x00"),
+	}, nil
+}
+
+func formatUUID(b []byte) string {
+	if len(b) < 16 {
+		return ""
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "<none>"
+	}
+	return s
+}

--- a/internal/applets/util-linux/tune2fs/tune2fs_test.go
+++ b/internal/applets/util-linux/tune2fs/tune2fs_test.go
@@ -1,0 +1,81 @@
+package tune2fs
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// craftImage builds a minimal valid ext2 superblock image.
+func craftImage(t *testing.T, withMagic bool) string {
+	t.Helper()
+	buf := make([]byte, superblockOffset+1024)
+	sb := buf[superblockOffset:]
+	binary.LittleEndian.PutUint32(sb[0:], 100)  // inodes
+	binary.LittleEndian.PutUint32(sb[4:], 200)  // blocks
+	binary.LittleEndian.PutUint32(sb[24:], 2)   // log_block_size -> 1024<<2 = 4096
+	copy(sb[120:136], "testfs")                 // volume name
+	if withMagic {
+		binary.LittleEndian.PutUint16(sb[56:], extMagic)
+	}
+	p := filepath.Join(t.TempDir(), "fs.img")
+	if err := os.WriteFile(p, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestList(t *testing.T) {
+	img := craftImage(t, true)
+	out, err := run(t, "-l", img)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Filesystem volume name:   testfs",
+		"Inode count:              100",
+		"Block count:              200",
+		"Block size:               4096",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestNotExt(t *testing.T) {
+	img := craftImage(t, false) // no magic
+	if _, err := run(t, "-l", img); err == nil {
+		t.Errorf("a non-ext image should fail")
+	}
+}
+
+func TestRequiresList(t *testing.T) {
+	img := craftImage(t, true)
+	if _, err := run(t, img); err == nil {
+		t.Errorf("without -l it should fail (no mutation supported)")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t, "-l"); err == nil {
+		t.Errorf("missing file should fail")
+	}
+	if _, err := run(t, "-l", "/no/such/image"); err == nil {
+		t.Errorf("a missing image should fail")
+	}
+}

--- a/test/it/spec/tune2fs_spec.sh
+++ b/test/it/spec/tune2fs_spec.sh
@@ -1,0 +1,20 @@
+Describe 'tune2fs'
+    Include util-linux/tune2fs_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/tune2fs; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'rejects a non-ext image'
+        When call TestTune2fsNotExt
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestTune2fsHelp
+        The status should be success
+        The output should include 'Usage: tune2fs'
+        The output should include 'filesystem'
+    End
+End

--- a/test/it/util-linux/tune2fs_test.sh
+++ b/test/it/util-linux/tune2fs_test.sh
@@ -1,0 +1,6 @@
+TestTune2fsNotExt() {
+    printf 'not a filesystem' > "$TEST_DIR/bad.img"
+    tune2fs -l "$TEST_DIR/bad.img" 2>/dev/null
+    echo "rc=$?"
+}
+TestTune2fsHelp() { tune2fs --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `tune2fs -l`, which lists the parameters of an ext2/ext3/ext4 filesystem in a device or image — its volume name, UUID, inode and block counts, and block size — parsed from the superblock at offset 1024 (verified against host tune2fs on a real mkfs.ext2 image: matching UUID, counts, and block size). Only the read-only listing is implemented; without `-l`, or on a non-ext image, it fails deterministically. It works on image files per the issue's image-file-workflow guidance.

## Tests

- Unit (crafted superblock image): listing the volume name, inode/block counts, and block size; rejecting an image with a bad magic; requiring `-l` (no mutation supported); and the missing-file errors.
- shellspec: rejecting a non-ext image and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (627 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249