### PR TITLE
test(nc): harden the loopback spec against CI-load flakiness

### DIFF
--- a/test/it/netutils/nc_test.sh
+++ b/test/it/netutils/nc_test.sh
@@ -8,8 +8,9 @@ TestNcLoopback() {
     # message, instead of relying on fixed sleeps. Fixed sleeps race against the
     # listener's bind/flush under CI load and made this test flaky. The loop
     # keys off the received file's contents, so it is robust regardless of the
-    # nc client's exit status.
-    for _ in $(seq 1 50); do
+    # nc client's exit status. The window is generous (10s) because the failure
+    # mode under heavy CI load is the listener not having bound in time.
+    for _ in $(seq 1 100); do
         echo "from-client" | nc 127.0.0.1 18642 >/dev/null 2>&1
         if [ -s /tmp/mimixbox/it/nc_recv.txt ]; then
             break
@@ -17,5 +18,8 @@ TestNcLoopback() {
         sleep 0.1
     done
 
-    cat /tmp/mimixbox/it/nc_recv.txt
+    # Print only the first received line: if a retry races and two client sends
+    # both land before the listener closes, the file would otherwise contain the
+    # message twice and break the exact-match assertion.
+    head -n 1 /tmp/mimixbox/it/nc_recv.txt
 }


### PR DESCRIPTION
## Summary

The `nc_spec.sh` loopback test has intermittently failed on CI several times this session (always cleared by a re-run). It already retries the client send instead of using fixed sleeps, but two residual races remained:

- Under heavy CI load the listener occasionally did not bind within the retry window. The window is widened from 5s to 10s.
- If a retry races and two client sends both land before the one-shot listener closes, the received file contains the message twice, breaking the exact-match assertion. The helper now prints only the first received line.

This is a pre-existing flake (not caused by any applet change); hardening it removes the recurring re-run churn.

## Verification

- `make test-e2e` passes (627 examples, 0 failures); the change is confined to the test helper.

Part of #238