### PR TITLE
feat(util-linux): add unshare applet to run with unshared namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 264 commands. Run `mimixbox --list` to see them on the terminal.
+There are 265 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -259,6 +259,7 @@ There are 264 commands. Run `mimixbox --list` to see them on the terminal.
 | unlink | Remove a single file by calling the unlink function |
 | unlzma | Decompress lzma files |
 | unshadow | Combine passwd and shadow files for password auditing |
+| unshare | Run a program with unshared namespaces |
 | unxz | Decompress xz files |
 | unzip | Extract files from a ZIP archive |
 | uptime | Tell how long the system has been running |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -247,13 +247,14 @@ import (
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
 	ap_util_linux_tune2fs "github.com/nao1215/mimixbox/internal/applets/util-linux/tune2fs"
 	ap_util_linux_umount "github.com/nao1215/mimixbox/internal/applets/util-linux/umount"
+	ap_util_linux_unshare "github.com/nao1215/mimixbox/internal/applets/util-linux/unshare"
 	ap_util_linux_wall "github.com/nao1215/mimixbox/internal/applets/util-linux/wall"
 )
 
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 264)
+	Applets = make(map[string]Applet, 265)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -517,5 +518,6 @@ func init() {
 	register(ap_util_linux_taskset.New())
 	register(ap_util_linux_tune2fs.New())
 	register(ap_util_linux_umount.New())
+	register(ap_util_linux_unshare.New())
 	register(ap_util_linux_wall.New())
 }

--- a/internal/applets/util-linux/unshare/unshare.go
+++ b/internal/applets/util-linux/unshare/unshare.go
@@ -1,0 +1,108 @@
+// Package unshare implements the unshare applet: run a program with some
+// namespaces unshared from the parent.
+package unshare
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the unshare applet.
+type Command struct{}
+
+// New returns an unshare command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "unshare" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program with unshared namespaces" }
+
+// unshareFn is indirected so the namespace flags can be tested without the
+// privilege most namespaces require.
+var unshareFn = func(flags int) error { return unix.Unshare(flags) }
+
+// namespace describes one --flag and the clone bit it sets.
+var namespaces = []struct {
+	long, short string
+	bit         int
+	help        string
+}{
+	{"mount", "m", unix.CLONE_NEWNS, "unshare the mount namespace"},
+	{"uts", "u", unix.CLONE_NEWUTS, "unshare the UTS (hostname) namespace"},
+	{"ipc", "i", unix.CLONE_NEWIPC, "unshare the System V IPC namespace"},
+	{"net", "n", unix.CLONE_NEWNET, "unshare the network namespace"},
+	{"pid", "p", unix.CLONE_NEWPID, "unshare the PID namespace"},
+	{"user", "U", unix.CLONE_NEWUSER, "unshare the user namespace"},
+	{"cgroup", "C", unix.CLONE_NEWCGROUP, "unshare the cgroup namespace"},
+}
+
+// Run executes unshare.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[namespaces] [COMMAND [ARG...]]", stdio.Err).WithHelp(command.Help{
+		Description: "Unshare the selected namespaces from the parent process, then run COMMAND (or a " +
+			"shell if none is given) in the new namespaces. Most namespaces require privilege; the " +
+			"user namespace (-U) can usually be unshared unprivileged.",
+		Examples: []command.Example{
+			{Command: "unshare -u hostname newname", Explain: "Run with a private UTS namespace."},
+			{Command: "unshare --net ip addr", Explain: "Run with a fresh network namespace."},
+		},
+		ExitStatus: "the command's exit status, or 1 if a namespace could not be unshared.",
+	})
+	flags := map[string]*bool{}
+	for _, ns := range namespaces {
+		flags[ns.long] = fs.BoolP(ns.long, ns.short, false, ns.help)
+	}
+	// Stop at the first operand so the command's own flags (e.g. sh -c) are
+	// passed through rather than parsed as unshare options.
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	var clone int
+	for _, ns := range namespaces {
+		if *flags[ns.long] {
+			clone |= ns.bit
+		}
+	}
+	if clone == 0 {
+		return command.Failuref("at least one namespace flag is required")
+	}
+
+	if err := unshareFn(clone); err != nil {
+		return command.Failuref("unshare failed: %v", err)
+	}
+
+	name, cmdArgs := shellOr(fs.Args())
+	cmd := exec.Command(name, cmdArgs...) //nolint:gosec // user-specified command, as unshare is designed to run
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// shellOr returns the command to run: the operands, or the login shell.
+func shellOr(operands []string) (string, []string) {
+	if len(operands) > 0 {
+		return operands[0], operands[1:]
+	}
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
+	return shell, nil
+}

--- a/internal/applets/util-linux/unshare/unshare_test.go
+++ b/internal/applets/util-linux/unshare/unshare_test.go
@@ -1,0 +1,81 @@
+package unshare
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+func withStub(t *testing.T, err error) *int {
+	t.Helper()
+	flags := new(int)
+	*flags = -1
+	orig := unshareFn
+	unshareFn = func(f int) error {
+		*flags = f
+		return err
+	}
+	t.Cleanup(func() { unshareFn = orig })
+	return flags
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestSingleNamespaceRunsCommand(t *testing.T) {
+	flags := withStub(t, nil)
+	out, err := run(t, "-u", "echo", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *flags != unix.CLONE_NEWUTS {
+		t.Errorf("flags = %#x, want CLONE_NEWUTS", *flags)
+	}
+	if out != "hello" {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestCombinedNamespaces(t *testing.T) {
+	flags := withStub(t, nil)
+	if _, err := run(t, "-m", "-i", "true"); err != nil {
+		t.Fatal(err)
+	}
+	want := unix.CLONE_NEWNS | unix.CLONE_NEWIPC
+	if *flags != want {
+		t.Errorf("flags = %#x, want %#x", *flags, want)
+	}
+}
+
+func TestRequiresNamespace(t *testing.T) {
+	withStub(t, nil)
+	if _, err := run(t, "echo", "x"); err == nil {
+		t.Errorf("no namespace flag should fail")
+	}
+}
+
+func TestUnshareFailure(t *testing.T) {
+	withStub(t, errors.New("operation not permitted"))
+	if _, err := run(t, "-m", "echo", "x"); err == nil {
+		t.Errorf("an unshare failure should fail")
+	}
+}
+
+func TestExitCodePropagates(t *testing.T) {
+	withStub(t, nil)
+	_, err := run(t, "-u", "sh", "-c", "exit 5")
+	ee, ok := err.(*command.ExitError)
+	if !ok || ee.Code != 5 {
+		t.Errorf("err = %v, want exit 5", err)
+	}
+}

--- a/test/it/spec/unshare_spec.sh
+++ b/test/it/spec/unshare_spec.sh
@@ -1,0 +1,15 @@
+Describe 'unshare'
+    Include util-linux/unshare_test.sh
+
+    It 'requires a namespace flag'
+        When call TestUnshareNoFlag
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestUnshareHelp
+        The status should be success
+        The output should include 'Usage: unshare'
+        The output should include 'namespace'
+    End
+End

--- a/test/it/util-linux/unshare_test.sh
+++ b/test/it/util-linux/unshare_test.sh
@@ -1,0 +1,4 @@
+# Most namespaces need privilege, so the e2e exercises the deterministic
+# no-namespace-flag path; the flag math and command exec are unit-tested.
+TestUnshareNoFlag() { unshare echo x 2>/dev/null; echo "rc=$?"; }
+TestUnshareHelp() { unshare --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `unshare`, which unshares the selected namespaces from the parent and then runs a command (or a shell) in the new namespaces. It supports `-m` mount, `-u` UTS, `-i` IPC, `-n` net, `-p` PID, `-U` user, and `-C` cgroup, mapping each to its CLONE_NEW* bit. Flag parsing stops at the first operand so the command's own flags (e.g. `sh -c`) pass through. Most namespaces require privilege (the user namespace can usually be unshared unprivileged); the unshare(2) call is injectable so the flag math and command exec are tested without privilege.

## Tests

- Unit (stubbed unshare): a single namespace mapping to its clone bit and running the command, combined namespaces OR-ing their bits, the no-namespace-flag error, an unshare-failure error, and exit-code propagation.
- shellspec: a missing namespace flag fails, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (629 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `unshare` command for namespace isolation. Supports mount, UTS, IPC, network, PID, user, and cgroup namespaces. Executes specified commands or defaults to login shell.

* **Documentation**
  * Updated command reference documentation.

* **Tests**
  * Added unit and integration test coverage for namespace flag handling and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->