### PR TITLE
feat(util-linux): add nsenter applet to enter another process's namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 265 commands. Run `mimixbox --list` to see them on the terminal.
+There are 266 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -162,6 +162,7 @@ There are 265 commands. Run `mimixbox --list` to see them on the terminal.
 | nmeter | Print system statistics from a format string |
 | nohup | Run a command immune to hangups, with output to a non-tty |
 | nproc | Print the number of processing units available |
+| nsenter | Run a program in another process's namespaces |
 | nyancat | Animate the rainbow-trailing Nyan Cat |
 | od | Dump files in octal and other formats |
 | paste | Merge lines of files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -234,6 +234,7 @@ import (
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_mkswap "github.com/nao1215/mimixbox/internal/applets/util-linux/mkswap"
 	ap_util_linux_mount "github.com/nao1215/mimixbox/internal/applets/util-linux/mount"
+	ap_util_linux_nsenter "github.com/nao1215/mimixbox/internal/applets/util-linux/nsenter"
 	ap_util_linux_rdate "github.com/nao1215/mimixbox/internal/applets/util-linux/rdate"
 	ap_util_linux_rdev "github.com/nao1215/mimixbox/internal/applets/util-linux/rdev"
 	ap_util_linux_readprofile "github.com/nao1215/mimixbox/internal/applets/util-linux/readprofile"
@@ -254,7 +255,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 265)
+	Applets = make(map[string]Applet, 266)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -502,6 +503,7 @@ func init() {
 	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_mkswap.New())
 	register(ap_util_linux_mount.New())
+	register(ap_util_linux_nsenter.New())
 	register(ap_util_linux_rdate.New())
 	register(ap_util_linux_rdev.New())
 	register(ap_util_linux_readprofile.New())

--- a/internal/applets/util-linux/nsenter/nsenter.go
+++ b/internal/applets/util-linux/nsenter/nsenter.go
@@ -1,0 +1,120 @@
+// Package nsenter implements the nsenter applet: run a program in the
+// namespaces of another process.
+package nsenter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the nsenter applet.
+type Command struct{}
+
+// New returns an nsenter command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "nsenter" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program in another process's namespaces" }
+
+// setnsFn is indirected so entering namespaces can be tested without privilege.
+// It receives the /proc/PID/ns/<type> path to enter.
+var setnsFn = func(nsPath string) error {
+	f, err := os.Open(nsPath) //nolint:gosec // /proc namespace path
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return unix.Setns(int(f.Fd()), 0)
+}
+
+// namespace maps a --flag to the /proc/PID/ns file it enters.
+var namespaces = []struct {
+	long, short, nsFile, help string
+}{
+	{"mount", "m", "mnt", "enter the mount namespace"},
+	{"uts", "u", "uts", "enter the UTS (hostname) namespace"},
+	{"ipc", "i", "ipc", "enter the System V IPC namespace"},
+	{"net", "n", "net", "enter the network namespace"},
+	{"pid", "p", "pid", "enter the PID namespace"},
+	{"user", "U", "user", "enter the user namespace"},
+	{"cgroup", "C", "cgroup", "enter the cgroup namespace"},
+}
+
+// Run executes nsenter.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-t PID [namespaces] [COMMAND [ARG...]]", stdio.Err).WithHelp(command.Help{
+		Description: "Enter one or more namespaces of the target process given by -t PID, then run " +
+			"COMMAND (or a shell) inside them. Select namespaces with -m/-u/-i/-n/-p/-U/-C. Entering " +
+			"another process's namespaces requires privilege.",
+		Examples: []command.Example{
+			{Command: "nsenter -t 1234 -n ip addr", Explain: "Run ip in process 1234's network namespace."},
+			{Command: "nsenter -t 1234 -m -u sh", Explain: "Enter its mount and UTS namespaces."},
+		},
+		ExitStatus: "the command's exit status, or 1 if a namespace could not be entered.",
+	})
+	target := fs.IntP("target", "t", 0, "PID of the process whose namespaces to enter")
+	flags := map[string]*bool{}
+	for _, ns := range namespaces {
+		flags[ns.long] = fs.BoolP(ns.long, ns.short, false, ns.help)
+	}
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if !fs.Changed("target") {
+		return command.Failuref("a target PID (-t) is required")
+	}
+
+	var selected []string
+	for _, ns := range namespaces {
+		if *flags[ns.long] {
+			selected = append(selected, ns.nsFile)
+		}
+	}
+	if len(selected) == 0 {
+		return command.Failuref("at least one namespace flag is required")
+	}
+
+	for _, nsFile := range selected {
+		path := fmt.Sprintf("/proc/%d/ns/%s", *target, nsFile)
+		if err := setnsFn(path); err != nil {
+			return command.Failuref("cannot enter %s: %v", path, err)
+		}
+	}
+
+	name, cmdArgs := shellOr(fs.Args())
+	cmd := exec.Command(name, cmdArgs...) //nolint:gosec // user-specified command, as nsenter is designed to run
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// shellOr returns the command to run: the operands, or the login shell.
+func shellOr(operands []string) (string, []string) {
+	if len(operands) > 0 {
+		return operands[0], operands[1:]
+	}
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
+	return shell, nil
+}

--- a/internal/applets/util-linux/nsenter/nsenter_test.go
+++ b/internal/applets/util-linux/nsenter/nsenter_test.go
@@ -1,0 +1,86 @@
+package nsenter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, err error) *[]string {
+	t.Helper()
+	var entered []string
+	orig := setnsFn
+	setnsFn = func(path string) error {
+		entered = append(entered, path)
+		return err
+	}
+	t.Cleanup(func() { setnsFn = orig })
+	return &entered
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestEntersNamespaceAndRuns(t *testing.T) {
+	entered := withStub(t, nil)
+	out, err := run(t, "-t", "1234", "-n", "echo", "hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*entered) != 1 || (*entered)[0] != "/proc/1234/ns/net" {
+		t.Errorf("entered = %v", *entered)
+	}
+	if out != "hi" {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestEntersMultiple(t *testing.T) {
+	entered := withStub(t, nil)
+	if _, err := run(t, "-t", "5", "-m", "-u", "true"); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{"/proc/5/ns/mnt": true, "/proc/5/ns/uts": true}
+	if len(*entered) != 2 || !want[(*entered)[0]] || !want[(*entered)[1]] {
+		t.Errorf("entered = %v, want mnt and uts of PID 5", *entered)
+	}
+}
+
+func TestRequiresTarget(t *testing.T) {
+	withStub(t, nil)
+	if _, err := run(t, "-n", "echo", "x"); err == nil {
+		t.Errorf("missing -t should fail")
+	}
+}
+
+func TestRequiresNamespace(t *testing.T) {
+	withStub(t, nil)
+	if _, err := run(t, "-t", "1", "echo", "x"); err == nil {
+		t.Errorf("no namespace flag should fail")
+	}
+}
+
+func TestSetnsFailure(t *testing.T) {
+	withStub(t, errors.New("permission denied"))
+	if _, err := run(t, "-t", "1", "-n", "echo", "x"); err == nil {
+		t.Errorf("a setns failure should fail")
+	}
+}
+
+func TestExitCodePropagates(t *testing.T) {
+	withStub(t, nil)
+	_, err := run(t, "-t", "1", "-u", "sh", "-c", "exit 7")
+	ee, ok := err.(*command.ExitError)
+	if !ok || ee.Code != 7 {
+		t.Errorf("err = %v, want exit 7", err)
+	}
+}

--- a/test/it/spec/nsenter_spec.sh
+++ b/test/it/spec/nsenter_spec.sh
@@ -1,0 +1,14 @@
+Describe 'nsenter'
+    Include util-linux/nsenter_test.sh
+
+    It 'requires a target PID'
+        When call TestNsenterNoTarget
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'requires a namespace flag'
+        When call TestNsenterNoNs
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/nsenter_test.sh
+++ b/test/it/util-linux/nsenter_test.sh
@@ -1,0 +1,4 @@
+# Entering namespaces needs privilege, so the e2e exercises the deterministic
+# validation paths; the setns dispatch and command exec are unit-tested.
+TestNsenterNoTarget() { nsenter -n echo x 2>/dev/null; echo "rc=$?"; }
+TestNsenterNoNs() { nsenter -t 1 echo x 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `nsenter`, the counterpart to unshare. It enters one or more namespaces of the target process given by `-t PID` (selected with -m/-u/-i/-n/-p/-U/-C, each opening /proc/PID/ns/<type> and calling setns), then runs COMMAND (or a shell) inside them. Flag parsing stops at the first operand so the command's own flags pass through. Entering another process's namespaces requires privilege; the setns call is injectable so the namespace selection and command exec are tested without privilege.

## Tests

- Unit (stubbed setns): entering one namespace (correct /proc/PID/ns path) and running the command, entering multiple namespaces, the missing-target and no-namespace errors, a setns-failure error, and exit-code propagation.
- shellspec: a missing target PID and a missing namespace flag both fail.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (631 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `nsenter` applet to run programs in target process namespaces.

* **Tests**
  * Added unit and integration test coverage for nsenter functionality.

* **Documentation**
  * Updated command reference documentation (265 → 266 commands).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->