### PR TITLE
feat(util-linux): add freeramdisk applet to free a ramdisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 266 commands. Run `mimixbox --list` to see them on the terminal.
+There are 267 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -91,6 +91,7 @@ There are 266 commands. Run `mimixbox --list` to see them on the terminal.
 | fold | Wrap each input line to fit in specified width |
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
+| freeramdisk | Free the memory used by a ramdisk |
 | fsfreeze | Suspend or resume a filesystem |
 | fstrim | Discard unused blocks on a filesystem |
 | fsync | Flush a file's data to storage with fsync(2) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -217,6 +217,7 @@ import (
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
+	ap_util_linux_freeramdisk "github.com/nao1215/mimixbox/internal/applets/util-linux/freeramdisk"
 	ap_util_linux_fsfreeze "github.com/nao1215/mimixbox/internal/applets/util-linux/fsfreeze"
 	ap_util_linux_fstrim "github.com/nao1215/mimixbox/internal/applets/util-linux/fstrim"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
@@ -255,7 +256,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 266)
+	Applets = make(map[string]Applet, 267)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -485,6 +486,7 @@ func init() {
 	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
+	register(ap_util_linux_freeramdisk.New())
 	register(ap_util_linux_fsfreeze.New())
 	register(ap_util_linux_fstrim.New())
 	register(ap_util_linux_getopt.New())

--- a/internal/applets/util-linux/freeramdisk/freeramdisk.go
+++ b/internal/applets/util-linux/freeramdisk/freeramdisk.go
@@ -1,0 +1,66 @@
+// Package freeramdisk implements the freeramdisk applet: free the memory used by
+// a ramdisk device.
+package freeramdisk
+
+import (
+	"context"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+// Command is the freeramdisk applet.
+type Command struct{}
+
+// New returns a freeramdisk command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "freeramdisk" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Free the memory used by a ramdisk" }
+
+// blkFlsBuf is the BLKFLSBUF ioctl, not exported by this x/sys version.
+const blkFlsBuf = 0x1261
+
+// flushFn is indirected so the privileged ioctl can be tested.
+var flushFn = func(device string) error {
+	f, err := os.OpenFile(device, os.O_RDWR, 0) //nolint:gosec // user-named device
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), blkFlsBuf, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes freeramdisk.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Free (flush the buffers of) the ramdisk block DEVICE, returning its memory to the " +
+			"system. The device must not be in use, and the operation requires privilege.",
+		Examples: []command.Example{
+			{Command: "freeramdisk /dev/ram0", Explain: "Free the ramdisk /dev/ram0."},
+		},
+		ExitStatus: "0  the ramdisk was freed.\n1  no device was given or the ioctl failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a ramdisk device is required")
+	}
+
+	if err := flushFn(rest[0]); err != nil {
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/freeramdisk/freeramdisk_test.go
+++ b/internal/applets/util-linux/freeramdisk/freeramdisk_test.go
@@ -1,0 +1,54 @@
+package freeramdisk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, err error) *string {
+	t.Helper()
+	got := new(string)
+	*got = "<unset>"
+	orig := flushFn
+	flushFn = func(device string) error {
+		*got = device
+		return err
+	}
+	t.Cleanup(func() { flushFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestFreesDevice(t *testing.T) {
+	got := withStub(t, nil)
+	if err := run(t, "/dev/ram0"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != "/dev/ram0" {
+		t.Errorf("flushFn called with %q", *got)
+	}
+}
+
+func TestNoDevice(t *testing.T) {
+	withStub(t, nil)
+	if err := run(t); err == nil {
+		t.Errorf("missing device should fail")
+	}
+}
+
+func TestIoctlFailure(t *testing.T) {
+	withStub(t, errors.New("operation not permitted"))
+	if err := run(t, "/dev/ram0"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/spec/freeramdisk_spec.sh
+++ b/test/it/spec/freeramdisk_spec.sh
@@ -1,0 +1,15 @@
+Describe 'freeramdisk'
+    Include util-linux/freeramdisk_test.sh
+
+    It 'requires a device'
+        When call TestFreeramdiskNoDev
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestFreeramdiskHelp
+        The status should be success
+        The output should include 'Usage: freeramdisk'
+        The output should include 'ramdisk'
+    End
+End

--- a/test/it/util-linux/freeramdisk_test.sh
+++ b/test/it/util-linux/freeramdisk_test.sh
@@ -1,0 +1,4 @@
+# Freeing a ramdisk needs the device and privilege; the e2e exercises the
+# deterministic no-device path. The ioctl dispatch is covered by unit tests.
+TestFreeramdiskNoDev() { freeramdisk 2>/dev/null; echo "rc=$?"; }
+TestFreeramdiskHelp() { freeramdisk --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `freeramdisk`, which frees (flushes the buffers of) a ramdisk block DEVICE via the BLKFLSBUF ioctl, returning its memory to the system. The operation requires privilege; the ioctl is injectable so the dispatch is tested without a device.

## Tests

- Unit (stubbed ioctl): freeing the named device, the missing-device error, and an ioctl-failure error.
- shellspec: a missing device fails, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (633 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249