### PR TITLE
feat(util-linux): add pivot_root applet to change the root filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 267 commands. Run `mimixbox --list` to see them on the terminal.
+There are 268 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -173,6 +173,7 @@ There are 267 commands. Run `mimixbox --list` to see them on the terminal.
 | pidof | Find the process ID of a running program |
 | ping | Send ICMP ECHO_REQUEST to network hosts |
 | pipe_progress | Copy stdin to stdout, printing progress dots to stderr |
+| pivot_root | Change the root filesystem |
 | pkill | Signal processes by name |
 | pmap | Report the memory map of a process |
 | posixer | Report which POSIX utilities are installed |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -236,6 +236,7 @@ import (
 	ap_util_linux_mkswap "github.com/nao1215/mimixbox/internal/applets/util-linux/mkswap"
 	ap_util_linux_mount "github.com/nao1215/mimixbox/internal/applets/util-linux/mount"
 	ap_util_linux_nsenter "github.com/nao1215/mimixbox/internal/applets/util-linux/nsenter"
+	ap_util_linux_pivot_root "github.com/nao1215/mimixbox/internal/applets/util-linux/pivot_root"
 	ap_util_linux_rdate "github.com/nao1215/mimixbox/internal/applets/util-linux/rdate"
 	ap_util_linux_rdev "github.com/nao1215/mimixbox/internal/applets/util-linux/rdev"
 	ap_util_linux_readprofile "github.com/nao1215/mimixbox/internal/applets/util-linux/readprofile"
@@ -256,7 +257,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 267)
+	Applets = make(map[string]Applet, 268)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -506,6 +507,7 @@ func init() {
 	register(ap_util_linux_mkswap.New())
 	register(ap_util_linux_mount.New())
 	register(ap_util_linux_nsenter.New())
+	register(ap_util_linux_pivot_root.New())
 	register(ap_util_linux_rdate.New())
 	register(ap_util_linux_rdev.New())
 	register(ap_util_linux_readprofile.New())

--- a/internal/applets/util-linux/pivot_root/pivot_root.go
+++ b/internal/applets/util-linux/pivot_root/pivot_root.go
@@ -1,0 +1,52 @@
+// Package pivotroot implements the pivot_root applet: change the root
+// filesystem of the current mount namespace.
+package pivotroot
+
+import (
+	"context"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the pivot_root applet.
+type Command struct{}
+
+// New returns a pivot_root command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "pivot_root" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Change the root filesystem" }
+
+// pivotFn is indirected so the privileged syscall can be tested.
+var pivotFn = func(newRoot, putOld string) error { return unix.PivotRoot(newRoot, putOld) }
+
+// Run executes pivot_root.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "NEW_ROOT PUT_OLD", stdio.Err).WithHelp(command.Help{
+		Description: "Move the root filesystem of the current process to the directory PUT_OLD and make " +
+			"NEW_ROOT the new root. Both must be directories, NEW_ROOT must be a mount point, and " +
+			"PUT_OLD must be under NEW_ROOT. This changes the mount namespace and requires privilege.",
+		Examples: []command.Example{
+			{Command: "pivot_root /newroot /newroot/oldroot", Explain: "Pivot onto /newroot."},
+		},
+		ExitStatus: "0  the root was pivoted.\n1  the arguments were wrong or the syscall failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) != 2 {
+		return command.Failuref("exactly two directories (NEW_ROOT and PUT_OLD) are required")
+	}
+
+	if err := pivotFn(rest[0], rest[1]); err != nil {
+		return command.Failuref("%v", err)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/pivot_root/pivot_root_test.go
+++ b/internal/applets/util-linux/pivot_root/pivot_root_test.go
@@ -1,0 +1,61 @@
+package pivotroot
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type call struct{ newRoot, putOld string }
+
+func withStub(t *testing.T, err error) *call {
+	t.Helper()
+	got := &call{}
+	orig := pivotFn
+	pivotFn = func(newRoot, putOld string) error {
+		*got = call{newRoot, putOld}
+		return err
+	}
+	t.Cleanup(func() { pivotFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestPivots(t *testing.T) {
+	got := withStub(t, nil)
+	if err := run(t, "/newroot", "/newroot/old"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != (call{"/newroot", "/newroot/old"}) {
+		t.Errorf("pivotFn = %+v", *got)
+	}
+}
+
+func TestWrongArgCount(t *testing.T) {
+	withStub(t, nil)
+	if err := run(t, "/newroot"); err == nil {
+		t.Errorf("one argument should fail")
+	}
+	if err := run(t, "/a", "/b", "/c"); err == nil {
+		t.Errorf("three arguments should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("no arguments should fail")
+	}
+}
+
+func TestSyscallFailure(t *testing.T) {
+	withStub(t, errors.New("operation not permitted"))
+	if err := run(t, "/a", "/b"); err == nil {
+		t.Errorf("a syscall failure should fail")
+	}
+}

--- a/test/it/spec/pivot_root_spec.sh
+++ b/test/it/spec/pivot_root_spec.sh
@@ -1,0 +1,15 @@
+Describe 'pivot_root'
+    Include util-linux/pivot_root_test.sh
+
+    It 'requires two directories'
+        When call TestPivotRootBadArgs
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestPivotRootHelp
+        The status should be success
+        The output should include 'Usage: pivot_root'
+        The output should include 'root'
+    End
+End

--- a/test/it/util-linux/pivot_root_test.sh
+++ b/test/it/util-linux/pivot_root_test.sh
@@ -1,0 +1,4 @@
+# pivot_root needs privilege and a prepared mount; the e2e exercises the
+# deterministic argument-validation path. The dispatch is covered by unit tests.
+TestPivotRootBadArgs() { pivot_root /onlyone 2>/dev/null; echo "rc=$?"; }
+TestPivotRootHelp() { pivot_root --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `pivot_root`, which moves the current root filesystem to PUT_OLD and makes NEW_ROOT the new root via the pivot_root(2) syscall. It validates that exactly two directories are given and changes the mount namespace, which requires privilege; the syscall is injectable so the dispatch and argument validation are tested without privilege.

## Tests

- Unit (stubbed syscall): pivoting with the two directories passed through correctly, the wrong-argument-count errors (one, three, and none), and a syscall-failure error.
- shellspec: a single argument fails, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (635 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249