### PR TITLE
test(nc): restart the listener to fix the loopback flake

### DIFF
--- a/test/it/netutils/nc_test.sh
+++ b/test/it/netutils/nc_test.sh
@@ -1,25 +1,38 @@
 Setup() { export TEST_DIR=/tmp/mimixbox/it; mkdir -p ${TEST_DIR}; }
 CleanUp() { rm -rf /tmp/mimixbox/it; }
 TestNcLoopback() {
-    # Listener writes whatever the client sends into a file.
-    (nc -l -p 18642 > /tmp/mimixbox/it/nc_recv.txt) &
+    recv=/tmp/mimixbox/it/nc_recv.txt
+    : > "$recv"
 
-    # Retry the client send until the listener has bound and recorded the
-    # message, instead of relying on fixed sleeps. Fixed sleeps race against the
-    # listener's bind/flush under CI load and made this test flaky. The loop
-    # keys off the received file's contents, so it is robust regardless of the
-    # nc client's exit status. The window is generous (10s) because the failure
-    # mode under heavy CI load is the listener not having bound in time.
-    for _ in $(seq 1 100); do
-        echo "from-client" | nc 127.0.0.1 18642 >/dev/null 2>&1
-        if [ -s /tmp/mimixbox/it/nc_recv.txt ]; then
+    # Each outer attempt starts a fresh listener on a fresh port and then retries
+    # the client send. Restarting the listener (rather than only retrying the
+    # client) is what makes this robust on loaded CI: the observed flake was an
+    # empty result because the one-shot listener occasionally failed to bind in
+    # time, and a fresh port also dodges TIME_WAIT from a previous attempt. The
+    # loop keys off the received file's contents, so it does not depend on the
+    # nc client's or listener's exit status.
+    for attempt in $(seq 1 8); do
+        port=$((18640 + attempt))
+        (nc -l -p "$port" > "$recv") &
+        lpid=$!
+
+        for _ in $(seq 1 20); do
+            echo "from-client" | nc 127.0.0.1 "$port" >/dev/null 2>&1
+            if [ -s "$recv" ]; then
+                break
+            fi
+            sleep 0.1
+        done
+
+        kill "$lpid" 2>/dev/null
+        wait "$lpid" 2>/dev/null
+        if [ -s "$recv" ]; then
             break
         fi
-        sleep 0.1
     done
 
     # Print only the first received line: if a retry races and two client sends
     # both land before the listener closes, the file would otherwise contain the
     # message twice and break the exact-match assertion.
-    head -n 1 /tmp/mimixbox/it/nc_recv.txt
+    head -n 1 "$recv"
 }


### PR DESCRIPTION
## Summary

The nc loopback spec kept flaking on CI even after the previous hardening (#385). The failure mode is an empty result: under load the one-shot listener occasionally fails to bind in time, so none of the client retries ever connect. Retrying only the client cannot recover from that.

This makes each outer attempt start a fresh listener on a fresh port (dodging TIME_WAIT) and then retry the client, looping up to 8 times. The test still keys off the received file's contents, independent of the nc client's/listener's exit status, and prints only the first received line.

Stress-tested locally at 0 failures over many runs.

## Verification

- `make test-e2e` passes; the change is confined to the test helper.

Part of #238