### PR TITLE
feat(util-linux): add rtcwake applet to arm the RTC wake alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 268 commands. Run `mimixbox --list` to see them on the terminal.
+There are 269 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -203,6 +203,7 @@ There are 268 commands. Run `mimixbox --list` to see them on the terminal.
 | rmdir | Remove directory |
 | rpm | Query an RPM package file |
 | rpm2cpio | Extract the cpio payload from an RPM package |
+| rtcwake | Arm the RTC to wake the system |
 | script | Record a command's output to a typescript |
 | scriptreplay | Replay a typescript using its timing file |
 | sddf | Search & Delete Duplicated File |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -241,6 +241,7 @@ import (
 	ap_util_linux_rdev "github.com/nao1215/mimixbox/internal/applets/util-linux/rdev"
 	ap_util_linux_readprofile "github.com/nao1215/mimixbox/internal/applets/util-linux/readprofile"
 	ap_util_linux_renice "github.com/nao1215/mimixbox/internal/applets/util-linux/renice"
+	ap_util_linux_rtcwake "github.com/nao1215/mimixbox/internal/applets/util-linux/rtcwake"
 	ap_util_linux_script "github.com/nao1215/mimixbox/internal/applets/util-linux/script"
 	ap_util_linux_setarch "github.com/nao1215/mimixbox/internal/applets/util-linux/setarch"
 	ap_util_linux_setpriv "github.com/nao1215/mimixbox/internal/applets/util-linux/setpriv"
@@ -257,7 +258,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 268)
+	Applets = make(map[string]Applet, 269)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -512,6 +513,7 @@ func init() {
 	register(ap_util_linux_rdev.New())
 	register(ap_util_linux_readprofile.New())
 	register(ap_util_linux_renice.New())
+	register(ap_util_linux_rtcwake.New())
 	register(ap_util_linux_script.NewScript())
 	register(ap_util_linux_script.NewScriptreplay())
 	register(ap_util_linux_setarch.NewLinux32())

--- a/internal/applets/util-linux/rtcwake/rtcwake.go
+++ b/internal/applets/util-linux/rtcwake/rtcwake.go
@@ -1,0 +1,92 @@
+// Package rtcwake implements the rtcwake applet: arm the real-time clock to wake
+// the system at a future time.
+package rtcwake
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the rtcwake applet.
+type Command struct{}
+
+// New returns a rtcwake command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "rtcwake" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Arm the RTC to wake the system" }
+
+// Injected so the alarm can be set against a fixture and a fixed clock.
+var (
+	sysRTCDir = "/sys/class/rtc"
+	now       = time.Now
+)
+
+// suspendModes are the rtcwake modes that put the system to sleep; this build
+// only arms the alarm, so they are rejected.
+var suspendModes = map[string]bool{
+	"mem": true, "disk": true, "standby": true, "freeze": true, "off": true,
+}
+
+// Run executes rtcwake.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-d DEVICE] [-m no] {-s SECONDS|-t EPOCH}", stdio.Err).WithHelp(command.Help{
+		Description: "Arm the real-time clock alarm to fire at a future time, by writing the wake time " +
+			"to /sys/class/rtc/<device>/wakealarm. Give the time as -s SECONDS from now or -t as an " +
+			"absolute Unix epoch. Only -m no (arm the alarm without suspending) is supported; the " +
+			"suspend modes are not, since this build does not put the system to sleep.",
+		Examples: []command.Example{
+			{Command: "rtcwake -m no -s 300", Explain: "Arm the alarm for 5 minutes from now."},
+		},
+		ExitStatus: "0  the alarm was armed.\n1  invalid options or the alarm could not be written.",
+	})
+	device := fs.StringP("device", "d", "rtc0", "RTC device under /sys/class/rtc")
+	mode := fs.StringP("mode", "m", "no", "standby mode (only 'no' is supported)")
+	seconds := fs.IntP("seconds", "s", 0, "seconds from now to wake")
+	epoch := fs.Int64P("time", "t", 0, "absolute Unix epoch to wake at")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if suspendModes[*mode] {
+		return command.Failuref("suspend mode %q is not supported; use -m no to arm the alarm only", *mode)
+	}
+	if *mode != "no" && *mode != "on" {
+		return command.Failuref("unknown mode: %q", *mode)
+	}
+
+	var wake int64
+	switch {
+	case fs.Changed("time"):
+		wake = *epoch
+	case fs.Changed("seconds"):
+		wake = now().Unix() + int64(*seconds)
+	default:
+		return command.Failuref("a wake time is required (-s SECONDS or -t EPOCH)")
+	}
+
+	alarm := filepath.Join(sysRTCDir, *device, "wakealarm")
+	// Clear any existing alarm before setting the new one, as the kernel rejects
+	// a write while an alarm is already pending.
+	if err := os.WriteFile(alarm, []byte("0\n"), 0o644); err != nil {
+		return command.Failuref("cannot access %s: %v", alarm, err)
+	}
+	if err := os.WriteFile(alarm, []byte(strconv.FormatInt(wake, 10)+"\n"), 0o644); err != nil {
+		return command.Failuref("cannot set alarm on %s: %v", alarm, err)
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "rtcwake: alarm armed for %s (epoch %d)\n",
+		time.Unix(wake, 0).Format("2006-01-02 15:04:05"), wake)
+	return nil
+}

--- a/internal/applets/util-linux/rtcwake/rtcwake_test.go
+++ b/internal/applets/util-linux/rtcwake/rtcwake_test.go
@@ -1,0 +1,81 @@
+package rtcwake
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	alarm := filepath.Join(dir, "rtc0", "wakealarm")
+	if err := os.MkdirAll(filepath.Dir(alarm), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(alarm, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	od, on := sysRTCDir, now
+	sysRTCDir = dir
+	now = func() time.Time { return time.Unix(1_000_000, 0) }
+	t.Cleanup(func() { sysRTCDir, now = od, on })
+	return alarm
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestRelativeAlarm(t *testing.T) {
+	alarm := fixture(t)
+	out, err := run(t, "-m", "no", "-s", "300")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(alarm)
+	if strings.TrimSpace(string(data)) != "1000300" { // 1_000_000 + 300
+		t.Errorf("wakealarm = %q, want 1000300", data)
+	}
+	if !strings.Contains(out, "epoch 1000300") {
+		t.Errorf("report = %q", out)
+	}
+}
+
+func TestAbsoluteAlarm(t *testing.T) {
+	alarm := fixture(t)
+	if _, err := run(t, "-t", "1500000"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(alarm)
+	if strings.TrimSpace(string(data)) != "1500000" {
+		t.Errorf("wakealarm = %q, want 1500000", data)
+	}
+}
+
+func TestSuspendModeRejected(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "-m", "mem", "-s", "10"); err == nil {
+		t.Errorf("suspend mode should be rejected")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "-m", "no"); err == nil {
+		t.Errorf("missing wake time should fail")
+	}
+	if _, err := run(t, "-m", "bogus", "-s", "1"); err == nil {
+		t.Errorf("unknown mode should fail")
+	}
+}

--- a/test/it/spec/rtcwake_spec.sh
+++ b/test/it/spec/rtcwake_spec.sh
@@ -1,0 +1,14 @@
+Describe 'rtcwake'
+    Include util-linux/rtcwake_test.sh
+
+    It 'rejects a suspend mode'
+        When call TestRtcwakeSuspendRejected
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'requires a wake time'
+        When call TestRtcwakeNoTime
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/rtcwake_test.sh
+++ b/test/it/util-linux/rtcwake_test.sh
@@ -1,0 +1,2 @@
+TestRtcwakeSuspendRejected() { rtcwake -m mem -s 10 2>/dev/null; echo "rc=$?"; }
+TestRtcwakeNoTime() { rtcwake -m no 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `rtcwake`, which arms the real-time clock alarm to fire at a future time by writing the wake time to /sys/class/rtc/<device>/wakealarm. The time is given as `-s SECONDS` from now or `-t EPOCH` (absolute Unix time); the existing alarm is cleared before the new one is written, as the kernel requires. Only `-m no` (arm without suspending) is supported — the suspend modes (mem/disk/standby/freeze/off) are rejected deterministically since this build does not put the system to sleep. The sysfs directory and the clock are injectable so the alarm value is tested against a fixture.

## Tests

- Unit (fixture sysfs + fixed clock): a relative `-s` alarm writing now+seconds, an absolute `-t` alarm, the suspend-mode rejection, and the missing-time / unknown-mode errors.
- shellspec: a suspend mode is rejected, and a missing wake time fails.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (637 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249