### PR TITLE
feat(util-linux): add switch_root applet to switch root and run init

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 269 commands. Run `mimixbox --list` to see them on the terminal.
+There are 270 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -233,6 +233,7 @@ There are 269 commands. Run `mimixbox --list` to see them on the terminal.
 | sum | Checksum and count the blocks in a file (BSD) |
 | swapoff | Disable a swap area |
 | swapon | Enable a swap area or list active swaps |
+| switch_root | Switch to another root and run init |
 | sync | Synchronize cached writes to persistent storage |
 | sysctl | Read and write kernel parameters at runtime |
 | syslogd | Minimal system logging daemon |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -248,6 +248,7 @@ import (
 	ap_util_linux_setsid "github.com/nao1215/mimixbox/internal/applets/util-linux/setsid"
 	ap_util_linux_swapoff "github.com/nao1215/mimixbox/internal/applets/util-linux/swapoff"
 	ap_util_linux_swapon "github.com/nao1215/mimixbox/internal/applets/util-linux/swapon"
+	ap_util_linux_switch_root "github.com/nao1215/mimixbox/internal/applets/util-linux/switch_root"
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
 	ap_util_linux_tune2fs "github.com/nao1215/mimixbox/internal/applets/util-linux/tune2fs"
 	ap_util_linux_umount "github.com/nao1215/mimixbox/internal/applets/util-linux/umount"
@@ -258,7 +259,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 269)
+	Applets = make(map[string]Applet, 270)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -523,6 +524,7 @@ func init() {
 	register(ap_util_linux_setsid.New())
 	register(ap_util_linux_swapoff.New())
 	register(ap_util_linux_swapon.New())
+	register(ap_util_linux_switch_root.New())
 	register(ap_util_linux_taskset.New())
 	register(ap_util_linux_tune2fs.New())
 	register(ap_util_linux_umount.New())

--- a/internal/applets/util-linux/switch_root/switch_root.go
+++ b/internal/applets/util-linux/switch_root/switch_root.go
@@ -1,0 +1,84 @@
+// Package switchroot implements the switch_root applet: switch to another root
+// filesystem and execute a new init. Intended to run as PID 1 in an initramfs.
+package switchroot
+
+import (
+	"context"
+	"os"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the switch_root applet.
+type Command struct{}
+
+// New returns a switch_root command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "switch_root" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Switch to another root and run init" }
+
+// Injected so the privileged switch and the exec are testable.
+var (
+	// switchFn moves the current mount onto NEW_ROOT and chroots into it.
+	switchFn = func(newRoot string) error {
+		if err := os.Chdir(newRoot); err != nil {
+			return err
+		}
+		if err := unix.Mount(newRoot, "/", "", unix.MS_MOVE, ""); err != nil {
+			return err
+		}
+		if err := unix.Chroot("."); err != nil {
+			return err
+		}
+		return os.Chdir("/")
+	}
+	// execFn replaces the current process with init; it does not return on success.
+	execFn = func(path string, argv []string) error {
+		return syscall.Exec(path, argv, os.Environ())
+	}
+)
+
+// Run executes switch_root.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "NEW_ROOT INIT [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Make NEW_ROOT the root filesystem of the current process and execute INIT (with " +
+			"any ARGs) as the new init. This is meant to run as PID 1 from an initramfs and requires " +
+			"privilege. The destructive removal of the old initramfs contents that the real switch_root " +
+			"performs is intentionally not done by this build.",
+		Examples: []command.Example{
+			{Command: "switch_root /mnt/root /sbin/init", Explain: "Switch to /mnt/root and run init."},
+		},
+		ExitStatus: "1  the arguments were wrong or the switch failed (it does not return on success).",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return command.Failuref("a NEW_ROOT directory and an INIT program are required")
+	}
+	newRoot := rest[0]
+
+	info, err := os.Stat(newRoot)
+	if err != nil || !info.IsDir() {
+		return command.Failuref("%s: not a directory", newRoot)
+	}
+
+	if err := switchFn(newRoot); err != nil {
+		return command.Failuref("cannot switch root to %s: %v", newRoot, err)
+	}
+
+	// execFn normally replaces the process; reaching here means it failed.
+	if err := execFn(rest[1], rest[1:]); err != nil {
+		return command.Failuref("cannot exec %s: %v", rest[1], err)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/switch_root/switch_root_test.go
+++ b/internal/applets/util-linux/switch_root/switch_root_test.go
@@ -1,0 +1,76 @@
+package switchroot
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, switchErr error) (*string, *[]string) {
+	t.Helper()
+	switched := new(string)
+	*switched = "<unset>"
+	var execArgv []string
+	osw, oex := switchFn, execFn
+	switchFn = func(newRoot string) error {
+		*switched = newRoot
+		return switchErr
+	}
+	execFn = func(path string, argv []string) error {
+		execArgv = append([]string{path}, argv...)
+		return nil // pretend the exec succeeded without replacing the process
+	}
+	t.Cleanup(func() { switchFn, execFn = osw, oex })
+	return switched, &execArgv
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSwitchesAndExecs(t *testing.T) {
+	switched, execArgv := withStub(t, nil)
+	dir := t.TempDir()
+	if err := run(t, dir, "/sbin/init", "single"); err != nil {
+		t.Fatal(err)
+	}
+	if *switched != dir {
+		t.Errorf("switched to %q, want %q", *switched, dir)
+	}
+	// execFn receives (path, argv) -> our stub records path + argv.
+	if len(*execArgv) != 3 || (*execArgv)[1] != "/sbin/init" || (*execArgv)[2] != "single" {
+		t.Errorf("exec argv = %v", *execArgv)
+	}
+}
+
+func TestRequiresNewRootAndInit(t *testing.T) {
+	withStub(t, nil)
+	dir := t.TempDir()
+	if err := run(t, dir); err == nil {
+		t.Errorf("missing init should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("no arguments should fail")
+	}
+}
+
+func TestNewRootMustBeDirectory(t *testing.T) {
+	withStub(t, nil)
+	if err := run(t, "/no/such/dir", "/init"); err == nil {
+		t.Errorf("a non-directory NEW_ROOT should fail")
+	}
+}
+
+func TestSwitchFailure(t *testing.T) {
+	withStub(t, errors.New("operation not permitted"))
+	dir := t.TempDir()
+	if err := run(t, dir, "/sbin/init"); err == nil {
+		t.Errorf("a switch failure should fail")
+	}
+}

--- a/test/it/spec/switch_root_spec.sh
+++ b/test/it/spec/switch_root_spec.sh
@@ -1,0 +1,14 @@
+Describe 'switch_root'
+    Include util-linux/switch_root_test.sh
+
+    It 'requires NEW_ROOT and INIT'
+        When call TestSwitchRootMissingInit
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects a non-directory NEW_ROOT'
+        When call TestSwitchRootBadDir
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/switch_root_test.sh
+++ b/test/it/util-linux/switch_root_test.sh
@@ -1,0 +1,4 @@
+# switch_root needs to run as PID 1 with privilege, so the e2e exercises the
+# deterministic validation paths; the switch and exec are covered by unit tests.
+TestSwitchRootMissingInit() { switch_root /tmp 2>/dev/null; echo "rc=$?"; }
+TestSwitchRootBadDir() { switch_root /no/such/dir /init 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `switch_root`, which makes NEW_ROOT the root filesystem of the current process (chdir → mount --move onto /, → chroot) and then execs INIT (with any ARGs) as the new init. It is meant to run as PID 1 from an initramfs and requires privilege. The destructive removal of the old initramfs contents that the real switch_root performs is intentionally not done by this build. The switch and the exec are injectable so the validation and dispatch are tested without privilege.

## Tests

- Unit (stubbed switch + exec): switching to NEW_ROOT and exec'ing INIT with its args, the missing-NEW_ROOT/INIT and no-argument errors, the non-directory NEW_ROOT rejection, and a switch-failure error.
- shellspec: a missing INIT and a non-directory NEW_ROOT both fail.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (639 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249