### PR TITLE
feat(util-linux): add fdflush applet to flush a floppy device

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 270 commands. Run `mimixbox --list` to see them on the terminal.
+There are 271 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -83,6 +83,7 @@ There are 270 commands. Run `mimixbox --list` to see them on the terminal.
 | fakemovie | Adds a video playback button to the image |
 | fallocate | Preallocate or extend space for a file |
 | false | Do nothing. Return failure(1) |
+| fdflush | Flush a floppy device's buffers |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |
 | findfs | Find a filesystem by label or UUID |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -215,6 +215,7 @@ import (
 	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
 	ap_util_linux_eject "github.com/nao1215/mimixbox/internal/applets/util-linux/eject"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
+	ap_util_linux_fdflush "github.com/nao1215/mimixbox/internal/applets/util-linux/fdflush"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
 	ap_util_linux_freeramdisk "github.com/nao1215/mimixbox/internal/applets/util-linux/freeramdisk"
@@ -259,7 +260,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 270)
+	Applets = make(map[string]Applet, 271)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -487,6 +488,7 @@ func init() {
 	register(ap_util_linux_dmesg.New())
 	register(ap_util_linux_eject.New())
 	register(ap_util_linux_fallocate.New())
+	register(ap_util_linux_fdflush.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
 	register(ap_util_linux_freeramdisk.New())

--- a/internal/applets/util-linux/fdflush/fdflush.go
+++ b/internal/applets/util-linux/fdflush/fdflush.go
@@ -1,0 +1,66 @@
+// Package fdflush implements the fdflush applet: flush a floppy device's buffers
+// so the next access re-reads the medium.
+package fdflush
+
+import (
+	"context"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the fdflush applet.
+type Command struct{}
+
+// New returns a fdflush command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fdflush" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Flush a floppy device's buffers" }
+
+// fdFlush is the FDFLUSH ioctl, not exported by this x/sys version.
+const fdFlush = 0x254b
+
+// flushFn is indirected so the privileged ioctl can be tested.
+var flushFn = func(device string) error {
+	f, err := os.Open(device) //nolint:gosec // user-named device
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fdFlush, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes fdflush.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Force the kernel to forget its cached view of the floppy DEVICE, so the next " +
+			"access re-reads the medium (useful after swapping a disk). Requires privilege.",
+		Examples: []command.Example{
+			{Command: "fdflush /dev/fd0", Explain: "Flush the buffers of /dev/fd0."},
+		},
+		ExitStatus: "0  the buffers were flushed.\n1  no device was given or the ioctl failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a floppy device is required")
+	}
+
+	if err := flushFn(rest[0]); err != nil {
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	return nil
+}

--- a/internal/applets/util-linux/fdflush/fdflush_test.go
+++ b/internal/applets/util-linux/fdflush/fdflush_test.go
@@ -1,0 +1,51 @@
+package fdflush
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, err error) *string {
+	t.Helper()
+	got := new(string)
+	*got = "<unset>"
+	orig := flushFn
+	flushFn = func(device string) error { *got = device; return err }
+	t.Cleanup(func() { flushFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestFlushesDevice(t *testing.T) {
+	got := withStub(t, nil)
+	if err := run(t, "/dev/fd0"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != "/dev/fd0" {
+		t.Errorf("flushFn called with %q", *got)
+	}
+}
+
+func TestNoDevice(t *testing.T) {
+	withStub(t, nil)
+	if err := run(t); err == nil {
+		t.Errorf("missing device should fail")
+	}
+}
+
+func TestFailure(t *testing.T) {
+	withStub(t, errors.New("no such device"))
+	if err := run(t, "/dev/fd0"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/spec/fdflush_spec.sh
+++ b/test/it/spec/fdflush_spec.sh
@@ -1,0 +1,15 @@
+Describe 'fdflush'
+    Include util-linux/fdflush_test.sh
+
+    It 'requires a device'
+        When call TestFdflushNoDev
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestFdflushHelp
+        The status should be success
+        The output should include 'Usage: fdflush'
+        The output should include 'floppy'
+    End
+End

--- a/test/it/util-linux/fdflush_test.sh
+++ b/test/it/util-linux/fdflush_test.sh
@@ -1,0 +1,2 @@
+TestFdflushNoDev() { fdflush 2>/dev/null; echo "rc=$?"; }
+TestFdflushHelp() { fdflush --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fdflush`, which forces the kernel to forget its cached view of a floppy DEVICE (via the FDFLUSH ioctl) so the next access re-reads the medium — useful after swapping a disk. Requires privilege; the ioctl is injectable so the dispatch is tested without a device.

## Tests

- Unit (stubbed ioctl): flushing the named device, the missing-device error, and an ioctl-failure error.
- shellspec: a missing device fails, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (641 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249