### PR TITLE
feat(util-linux): add fatattr applet to show/change FAT attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 271 commands. Run `mimixbox --list` to see them on the terminal.
+There are 272 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -83,6 +83,7 @@ There are 271 commands. Run `mimixbox --list` to see them on the terminal.
 | fakemovie | Adds a video playback button to the image |
 | fallocate | Preallocate or extend space for a file |
 | false | Do nothing. Return failure(1) |
+| fatattr | Show or change FAT file attributes |
 | fdflush | Flush a floppy device's buffers |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -215,6 +215,7 @@ import (
 	ap_util_linux_dmesg "github.com/nao1215/mimixbox/internal/applets/util-linux/dmesg"
 	ap_util_linux_eject "github.com/nao1215/mimixbox/internal/applets/util-linux/eject"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
+	ap_util_linux_fatattr "github.com/nao1215/mimixbox/internal/applets/util-linux/fatattr"
 	ap_util_linux_fdflush "github.com/nao1215/mimixbox/internal/applets/util-linux/fdflush"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
@@ -260,7 +261,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 271)
+	Applets = make(map[string]Applet, 272)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -488,6 +489,7 @@ func init() {
 	register(ap_util_linux_dmesg.New())
 	register(ap_util_linux_eject.New())
 	register(ap_util_linux_fallocate.New())
+	register(ap_util_linux_fatattr.New())
 	register(ap_util_linux_fdflush.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())

--- a/internal/applets/util-linux/fatattr/fatattr.go
+++ b/internal/applets/util-linux/fatattr/fatattr.go
@@ -1,0 +1,179 @@
+// Package fatattr implements the fatattr applet: display or change the
+// attributes of files on a FAT filesystem.
+package fatattr
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the fatattr applet.
+type Command struct{}
+
+// New returns a fatattr command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fatattr" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show or change FAT file attributes" }
+
+// FAT_IOCTL_GET/SET_ATTRIBUTES, not exported by this x/sys version.
+const (
+	fatGetAttrs = 0x80047210
+	fatSetAttrs = 0x40047211
+)
+
+// attrBits maps the fatattr letters to the FAT attribute bits, in display order.
+var attrBits = []struct {
+	ch  byte
+	bit uint32
+}{
+	{'r', 0x01}, // read only
+	{'h', 0x02}, // hidden
+	{'s', 0x04}, // system
+	{'v', 0x08}, // volume label
+	{'d', 0x10}, // directory
+	{'a', 0x20}, // archive
+}
+
+// Injected so the logic is testable without a FAT filesystem.
+var (
+	getAttrFn = func(path string) (uint32, error) {
+		f, err := os.Open(path) //nolint:gosec // user-named file
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = f.Close() }()
+		var attr uint32
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fatGetAttrs, uintptr(unsafe.Pointer(&attr)))
+		if errno != 0 {
+			return 0, errno
+		}
+		return attr, nil
+	}
+	setAttrFn = func(path string, attr uint32) error {
+		f, err := os.Open(path) //nolint:gosec // user-named file
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fatSetAttrs, uintptr(unsafe.Pointer(&attr)))
+		if errno != 0 {
+			return errno
+		}
+		return nil
+	}
+)
+
+// Run executes fatattr.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[+|-attrs]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Show or change the attributes of files on a FAT filesystem. With no +/- argument " +
+			"each FILE's attributes are printed as a letter string (r read-only, h hidden, s system, " +
+			"v volume, d directory, a archive). +X adds and -X removes the listed attributes.",
+		Examples: []command.Example{
+			{Command: "fatattr file.txt", Explain: "Show the attributes of file.txt."},
+			{Command: "fatattr +r -a file.txt", Explain: "Set read-only and clear archive."},
+		},
+		ExitStatus: "0  all files were handled.\n1  an unknown attribute or an I/O error.",
+	})
+	// Leading "-X" looks like a flag; protect it and stop interspersed parsing so
+	// the +/-attr tokens and file names are all treated as operands.
+	if len(args) > 0 && strings.HasPrefix(args[0], "-") && args[0] != "--help" && args[0] != "--version" {
+		args = append([]string{"--"}, args...)
+	}
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	var addBits, removeBits uint32
+	var files []string
+	modify := false
+	for _, a := range fs.Args() {
+		if (strings.HasPrefix(a, "+") || strings.HasPrefix(a, "-")) && len(a) > 1 {
+			bits, err := parseAttrs(a[1:])
+			if err != nil {
+				return command.Failuref("%v", err)
+			}
+			if a[0] == '+' {
+				addBits |= bits
+			} else {
+				removeBits |= bits
+			}
+			modify = true
+			continue
+		}
+		files = append(files, a)
+	}
+	if len(files) == 0 {
+		return command.Failuref("a file is required")
+	}
+
+	failed := false
+	for _, file := range files {
+		cur, err := getAttrFn(file)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "fatattr: %s: %v\n", file, err)
+			failed = true
+			continue
+		}
+		if !modify {
+			_, _ = fmt.Fprintf(stdio.Out, "%s %s\n", decode(cur), file)
+			continue
+		}
+		if err := setAttrFn(file, (cur|addBits)&^removeBits); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "fatattr: %s: %v\n", file, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// parseAttrs turns attribute letters into their combined bits.
+func parseAttrs(letters string) (uint32, error) {
+	var bits uint32
+	for i := 0; i < len(letters); i++ {
+		bit, ok := bitFor(letters[i])
+		if !ok {
+			return 0, fmt.Errorf("unknown attribute: %q", string(letters[i]))
+		}
+		bits |= bit
+	}
+	return bits, nil
+}
+
+func bitFor(ch byte) (uint32, bool) {
+	for _, a := range attrBits {
+		if a.ch == ch {
+			return a.bit, true
+		}
+	}
+	return 0, false
+}
+
+// decode renders the attribute bits as the fatattr letter string.
+func decode(attr uint32) string {
+	b := make([]byte, len(attrBits))
+	for i, a := range attrBits {
+		if attr&a.bit != 0 {
+			b[i] = a.ch
+		} else {
+			b[i] = '-'
+		}
+	}
+	return string(b)
+}

--- a/internal/applets/util-linux/fatattr/fatattr_test.go
+++ b/internal/applets/util-linux/fatattr/fatattr_test.go
@@ -1,0 +1,101 @@
+package fatattr
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, cur uint32, getErr error) *uint32 {
+	t.Helper()
+	written := new(uint32)
+	*written = 0xffff
+	og, os := getAttrFn, setAttrFn
+	getAttrFn = func(string) (uint32, error) { return cur, getErr }
+	setAttrFn = func(_ string, attr uint32) error { *written = attr; return nil }
+	t.Cleanup(func() { getAttrFn, setAttrFn = og, os })
+	return written
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestDisplay(t *testing.T) {
+	withStub(t, 0x21, nil) // read-only + archive
+	out, err := run(t, "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "r----a file.txt" {
+		t.Errorf("display = %q, want \"r----a file.txt\"", out)
+	}
+}
+
+func TestAddAndRemove(t *testing.T) {
+	// cur = archive (0x20); +r adds read-only, -a clears archive.
+	w := withStub(t, 0x20, nil)
+	if _, err := run(t, "+r", "-a", "file.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if *w != 0x01 {
+		t.Errorf("set wrote %#x, want 0x01", *w)
+	}
+}
+
+func TestLeadingRemove(t *testing.T) {
+	// A leading "-h" must be treated as a remove operand, not a flag.
+	w := withStub(t, 0x02, nil) // hidden set
+	if _, err := run(t, "-h", "file.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if *w != 0x00 {
+		t.Errorf("set wrote %#x, want 0x00", *w)
+	}
+}
+
+func TestDecode(t *testing.T) {
+	t.Parallel()
+	if got := decode(0); got != "------" {
+		t.Errorf("decode(0) = %q", got)
+	}
+	if got := decode(0x02); got != "-h----" {
+		t.Errorf("decode(hidden) = %q", got)
+	}
+	if got := decode(0x21); got != "r----a" {
+		t.Errorf("decode(ro|archive) = %q", got)
+	}
+}
+
+func TestParseAttrs(t *testing.T) {
+	t.Parallel()
+	bits, err := parseAttrs("rh")
+	if err != nil || bits != 0x03 {
+		t.Errorf("parseAttrs(rh) = %#x, %v", bits, err)
+	}
+	if _, err := parseAttrs("Z"); err == nil {
+		t.Errorf("unknown attribute should error")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	withStub(t, 0, nil)
+	if _, err := run(t); err == nil {
+		t.Errorf("no file should fail")
+	}
+	if _, err := run(t, "+Z", "file"); err == nil {
+		t.Errorf("bad attribute should fail")
+	}
+	withStub(t, 0, errors.New("inappropriate ioctl"))
+	if _, err := run(t, "file"); err == nil {
+		t.Errorf("a get failure should fail")
+	}
+}

--- a/test/it/spec/fatattr_spec.sh
+++ b/test/it/spec/fatattr_spec.sh
@@ -1,0 +1,14 @@
+Describe 'fatattr'
+    Include util-linux/fatattr_test.sh
+
+    It 'requires a file'
+        When call TestFatattrNoFile
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects an unknown attribute'
+        When call TestFatattrBadAttr
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/fatattr_test.sh
+++ b/test/it/util-linux/fatattr_test.sh
@@ -1,0 +1,4 @@
+# A FAT filesystem isn't available on CI, so the e2e exercises the deterministic
+# validation paths; the attribute math is covered by unit tests.
+TestFatattrNoFile() { fatattr 2>/dev/null; echo "rc=$?"; }
+TestFatattrBadAttr() { fatattr +Z /tmp/x 2>/dev/null; echo "rc=$?"; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fatattr`, which shows or changes the attributes of files on a FAT filesystem via the FAT_IOCTL_GET/SET_ATTRIBUTES ioctls. With no +/- argument each FILE's attributes are printed as a letter string (r read-only, h hidden, s system, v volume, d directory, a archive); `+X` adds and `-X` removes the listed attributes. A leading `-X` (which looks like a flag) is protected and interspersed parsing is stopped so the +/- tokens and file names are all operands. The get/set ioctls are injectable so the attribute math is tested without a FAT filesystem.

## Tests

- Unit (stubbed ioctls): displaying the decoded attribute string, `+r -a` adding and removing in one call, a leading `-h` treated as a remove, the `decode` and `parseAttrs` helpers, and the no-file / unknown-attribute / get-failure errors.
- shellspec: a missing file and an unknown attribute are both rejected.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (643 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249