### PR TITLE
feat(util-linux): add fbset applet to show the framebuffer mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 272 commands. Run `mimixbox --list` to see them on the terminal.
+There are 273 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -84,6 +84,7 @@ There are 272 commands. Run `mimixbox --list` to see them on the terminal.
 | fallocate | Preallocate or extend space for a file |
 | false | Do nothing. Return failure(1) |
 | fatattr | Show or change FAT file attributes |
+| fbset | Show the framebuffer video mode |
 | fdflush | Flush a floppy device's buffers |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -216,6 +216,7 @@ import (
 	ap_util_linux_eject "github.com/nao1215/mimixbox/internal/applets/util-linux/eject"
 	ap_util_linux_fallocate "github.com/nao1215/mimixbox/internal/applets/util-linux/fallocate"
 	ap_util_linux_fatattr "github.com/nao1215/mimixbox/internal/applets/util-linux/fatattr"
+	ap_util_linux_fbset "github.com/nao1215/mimixbox/internal/applets/util-linux/fbset"
 	ap_util_linux_fdflush "github.com/nao1215/mimixbox/internal/applets/util-linux/fdflush"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
@@ -261,7 +262,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 272)
+	Applets = make(map[string]Applet, 273)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -490,6 +491,7 @@ func init() {
 	register(ap_util_linux_eject.New())
 	register(ap_util_linux_fallocate.New())
 	register(ap_util_linux_fatattr.New())
+	register(ap_util_linux_fbset.New())
 	register(ap_util_linux_fdflush.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())

--- a/internal/applets/util-linux/fbset/fbset.go
+++ b/internal/applets/util-linux/fbset/fbset.go
@@ -1,0 +1,92 @@
+// Package fbset implements the fbset applet: show the current framebuffer video
+// mode. Changing the mode is not done by this slice.
+package fbset
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the fbset applet.
+type Command struct{}
+
+// New returns a fbset command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fbset" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Show the framebuffer video mode" }
+
+// fbioGetVScreenInfo is FBIOGET_VSCREENINFO, not exported by this x/sys version.
+const fbioGetVScreenInfo = 0x4600
+
+// varScreenInfo holds the fields of struct fb_var_screeninfo this applet reports.
+type varScreenInfo struct {
+	xres, yres, bpp uint32
+}
+
+// readVarFn is indirected so the formatting can be tested without a framebuffer.
+var readVarFn = func(device string) (varScreenInfo, error) {
+	f, err := os.Open(device) //nolint:gosec // user-named framebuffer device
+	if err != nil {
+		return varScreenInfo{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var buf [160]byte // struct fb_var_screeninfo is 160 bytes
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fbioGetVScreenInfo, uintptr(unsafe.Pointer(&buf[0])))
+	if errno != 0 {
+		return varScreenInfo{}, errno
+	}
+	return varScreenInfo{
+		xres: binary.LittleEndian.Uint32(buf[0:]),
+		yres: binary.LittleEndian.Uint32(buf[4:]),
+		bpp:  binary.LittleEndian.Uint32(buf[24:]), // bits_per_pixel
+	}, nil
+}
+
+// Run executes fbset.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-fb DEVICE]", stdio.Err).WithHelp(command.Help{
+		Description: "Show the current video mode of the framebuffer DEVICE (default /dev/fb0): its " +
+			"resolution and color depth, in the usual mode/geometry/endmode block. Changing the mode " +
+			"is not done by this build.",
+		Examples: []command.Example{
+			{Command: "fbset", Explain: "Show the /dev/fb0 video mode."},
+			{Command: "fbset -fb /dev/fb1", Explain: "Show another framebuffer's mode."},
+		},
+		ExitStatus: "0  the mode was shown.\n1  the framebuffer could not be read.",
+	})
+	device := fs.String("fb", "/dev/fb0", "framebuffer device to query")
+
+	// fbset uses the historical single-dash "-fb"; rewrite it to the long form so
+	// pflag does not read it as a "-f -b" shorthand cluster.
+	for i, a := range args {
+		if a == "-fb" {
+			args[i] = "--fb"
+		}
+	}
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	info, err := readVarFn(*device)
+	if err != nil {
+		return command.Failuref("%s: %v", *device, err)
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "mode \"%dx%d\"\n", info.xres, info.yres)
+	_, _ = fmt.Fprintf(stdio.Out, "    geometry %d %d %d %d %d\n", info.xres, info.yres, info.xres, info.yres, info.bpp)
+	_, _ = fmt.Fprintln(stdio.Out, "endmode")
+	return nil
+}

--- a/internal/applets/util-linux/fbset/fbset_test.go
+++ b/internal/applets/util-linux/fbset/fbset_test.go
@@ -1,0 +1,65 @@
+package fbset
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, info varScreenInfo, err error) *string {
+	t.Helper()
+	asked := new(string)
+	*asked = "<unset>"
+	orig := readVarFn
+	readVarFn = func(device string) (varScreenInfo, error) {
+		*asked = device
+		return info, err
+	}
+	t.Cleanup(func() { readVarFn = orig })
+	return asked
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestShowsMode(t *testing.T) {
+	asked := withStub(t, varScreenInfo{xres: 1920, yres: 1080, bpp: 32}, nil)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *asked != "/dev/fb0" {
+		t.Errorf("default device = %q", *asked)
+	}
+	for _, want := range []string{`mode "1920x1080"`, "geometry 1920 1080 1920 1080 32", "endmode"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestCustomDevice(t *testing.T) {
+	asked := withStub(t, varScreenInfo{xres: 800, yres: 600, bpp: 16}, nil)
+	if _, err := run(t, "-fb", "/dev/fb1"); err != nil {
+		t.Fatal(err)
+	}
+	if *asked != "/dev/fb1" {
+		t.Errorf("device = %q, want /dev/fb1", *asked)
+	}
+}
+
+func TestReadFailure(t *testing.T) {
+	withStub(t, varScreenInfo{}, errors.New("no such device"))
+	if _, err := run(t); err == nil {
+		t.Errorf("a read failure should fail")
+	}
+}

--- a/test/it/spec/fbset_spec.sh
+++ b/test/it/spec/fbset_spec.sh
@@ -1,0 +1,15 @@
+Describe 'fbset'
+    Include util-linux/fbset_test.sh
+
+    It 'fails on a missing framebuffer'
+        When call TestFbsetNoFb
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestFbsetHelp
+        The status should be success
+        The output should include 'Usage: fbset'
+        The output should include 'framebuffer'
+    End
+End

--- a/test/it/util-linux/fbset_test.sh
+++ b/test/it/util-linux/fbset_test.sh
@@ -1,0 +1,4 @@
+# No framebuffer device is available on CI, so the e2e exercises the deterministic
+# missing-device path and --help; the mode formatting is covered by unit tests.
+TestFbsetNoFb() { fbset -fb /dev/no_such_fb 2>/dev/null; echo "rc=$?"; }
+TestFbsetHelp() { fbset --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fbset`, which shows the current video mode of a framebuffer device (default /dev/fb0, or `-fb DEVICE`) — its resolution and color depth — in the usual mode/geometry/endmode block, read via the FBIOGET_VSCREENINFO ioctl. The historical single-dash `-fb` is rewritten to the long form so pflag does not read it as a shorthand cluster. Changing the mode is not done by this build. The ioctl read is injectable so the formatting is tested without a framebuffer.

## Tests

- Unit (stubbed ioctl): the mode/geometry/endmode output for a given resolution and bpp on the default device, querying a custom `-fb` device, and a read-failure error.
- shellspec: a missing framebuffer fails, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (645 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fbset command to display framebuffer resolution and color depth information.
  * Supports --fb flag to specify custom framebuffer device (defaults to /dev/fb0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->