### PR TITLE
feat(util-linux): add mkfs.minix applet to create a Minix filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 273 commands. Run `mimixbox --list` to see them on the terminal.
+There are 274 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -152,6 +152,7 @@ There are 273 commands. Run `mimixbox --list` to see them on the terminal.
 | minips | Minimal process lister (PID, user, command) |
 | mkdir | Make directories |
 | mkfifo | Make FIFO (named pipe) |
+| mkfs.minix | Create a Minix filesystem |
 | mknod | Make block or character special files |
 | mkswap | Set up a Linux swap area |
 | mktemp | Create a temporary file or directory |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -236,6 +236,7 @@ import (
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
+	ap_util_linux_mkfs_minix "github.com/nao1215/mimixbox/internal/applets/util-linux/mkfs_minix"
 	ap_util_linux_mkswap "github.com/nao1215/mimixbox/internal/applets/util-linux/mkswap"
 	ap_util_linux_mount "github.com/nao1215/mimixbox/internal/applets/util-linux/mount"
 	ap_util_linux_nsenter "github.com/nao1215/mimixbox/internal/applets/util-linux/nsenter"
@@ -262,7 +263,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 273)
+	Applets = make(map[string]Applet, 274)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -512,6 +513,7 @@ func init() {
 	register(ap_util_linux_lspci.New())
 	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mesg.New())
+	register(ap_util_linux_mkfs_minix.New())
 	register(ap_util_linux_mkswap.New())
 	register(ap_util_linux_mount.New())
 	register(ap_util_linux_nsenter.New())

--- a/internal/applets/util-linux/mkfs_minix/mkfs_minix.go
+++ b/internal/applets/util-linux/mkfs_minix/mkfs_minix.go
@@ -1,0 +1,223 @@
+// Package mkfsminix implements the mkfs.minix applet: create a Minix version-1
+// filesystem on a device or image file.
+package mkfsminix
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the mkfs.minix applet.
+type Command struct{}
+
+// New returns a mkfs.minix command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mkfs.minix" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Create a Minix filesystem" }
+
+const (
+	blockSize    = 1024
+	minixMagic   = 0x137F // version 1, 14-character file names
+	inodesPerBlk = blockSize / 32
+	bitsPerBlock = blockSize * 8
+	sIFDIR       = 0o040000
+	rootMode     = sIFDIR | 0o755
+	dirEntrySize = 16         // 2-byte inode number + 14-byte name
+	maxSize      = 0x10081C00 // Minix v1 maximum file size (7+512+512*512 zones)
+	minBlocks    = 16         // refuse to format anything smaller
+)
+
+// Run executes mkfs.minix.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DEVICE [BLOCKS]", stdio.Err).WithHelp(command.Help{
+		Description: "Create a Minix version-1 filesystem (1 KiB blocks, 14-character names) on DEVICE, " +
+			"which may be a block device or an image file. BLOCKS sets the size in 1 KiB blocks; by " +
+			"default the whole device/file is used. The filesystem is created with an empty root " +
+			"directory.",
+		Examples: []command.Example{
+			{Command: "mkfs.minix disk.img", Explain: "Format the image as Minix."},
+			{Command: "mkfs.minix /dev/sdb1 65536", Explain: "Format 64 MiB of the device."},
+		},
+		ExitStatus: "0  the filesystem was created.\n1  the device was missing or too small.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a device or image is required")
+	}
+
+	f, err := os.OpenFile(rest[0], os.O_RDWR, 0o644) //nolint:gosec // user-named device or image
+	if err != nil {
+		return command.Failuref("cannot open %s: %v", rest[0], err)
+	}
+	defer func() { _ = f.Close() }()
+
+	nblocks, err := blockCount(f, rest)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	if nblocks < minBlocks {
+		return command.Failuref("%s: device is too small (need at least %d blocks)", rest[0], minBlocks)
+	}
+
+	if err := writeMinix(f, nblocks); err != nil {
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// blockCount returns the number of 1 KiB blocks to format, from the optional
+// BLOCKS operand or the file size.
+func blockCount(f *os.File, args []string) (int, error) {
+	if len(args) > 1 {
+		n, err := parseUint(args[1])
+		if err != nil {
+			return 0, err
+		}
+		return n, nil
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return int(info.Size() / blockSize), nil
+}
+
+// layout holds the computed on-disk geometry of a Minix v1 filesystem.
+type layout struct {
+	ninodes, nzones                     int
+	imapBlocks, zmapBlocks, inodeBlocks int
+	firstDataZone                       int
+}
+
+func upper(a, b int) int { return (a + b - 1) / b }
+
+// computeLayout derives the bitmap/inode geometry for nblocks 1 KiB blocks.
+func computeLayout(nblocks int) layout {
+	nzones := nblocks
+	ninodes := nblocks / 3
+	if ninodes < 1 {
+		ninodes = 1
+	}
+	ninodes = upper(ninodes, inodesPerBlk) * inodesPerBlk // fill the inode blocks
+
+	imapBlocks := upper(ninodes+1, bitsPerBlock)
+	inodeBlocks := upper(ninodes, inodesPerBlk)
+
+	zmapBlocks := 0
+	for {
+		firstDataZone := 2 + imapBlocks + zmapBlocks + inodeBlocks
+		next := upper(nzones-firstDataZone+1, bitsPerBlock)
+		if next == zmapBlocks {
+			break
+		}
+		zmapBlocks = next
+	}
+	return layout{
+		ninodes:       ninodes,
+		nzones:        nzones,
+		imapBlocks:    imapBlocks,
+		zmapBlocks:    zmapBlocks,
+		inodeBlocks:   inodeBlocks,
+		firstDataZone: 2 + imapBlocks + zmapBlocks + inodeBlocks,
+	}
+}
+
+// writeMinix lays out the superblock, bitmaps, root inode, and root directory.
+func writeMinix(f *os.File, nblocks int) error {
+	l := computeLayout(nblocks)
+
+	sb := make([]byte, blockSize)
+	binary.LittleEndian.PutUint16(sb[0:], uint16(l.ninodes))
+	binary.LittleEndian.PutUint16(sb[2:], uint16(l.nzones))
+	binary.LittleEndian.PutUint16(sb[4:], uint16(l.imapBlocks))
+	binary.LittleEndian.PutUint16(sb[6:], uint16(l.zmapBlocks))
+	binary.LittleEndian.PutUint16(sb[8:], uint16(l.firstDataZone))
+	binary.LittleEndian.PutUint16(sb[10:], 0) // log_zone_size
+	binary.LittleEndian.PutUint32(sb[12:], maxSize)
+	binary.LittleEndian.PutUint16(sb[16:], minixMagic)
+	binary.LittleEndian.PutUint16(sb[18:], 1) // MINIX_VALID_FS
+	if err := writeAt(f, sb, blockSize); err != nil {
+		return err
+	}
+
+	// Inode bitmap: bit 0 is reserved, bit 1 is the root inode, and every bit
+	// past the last inode is marked used so it is never allocated.
+	imap := make([]byte, l.imapBlocks*blockSize)
+	setBit(imap, 0)
+	setBit(imap, 1)
+	for b := l.ninodes + 1; b < l.imapBlocks*bitsPerBlock; b++ {
+		setBit(imap, b)
+	}
+	if err := writeAt(f, imap, 2*blockSize); err != nil {
+		return err
+	}
+
+	// Zone bitmap: bit 0 reserved, bit 1 is the root directory's data zone, and
+	// every bit past the last zone is marked used.
+	zmap := make([]byte, l.zmapBlocks*blockSize)
+	setBit(zmap, 0)
+	setBit(zmap, 1)
+	validZones := l.nzones - l.firstDataZone + 1
+	for b := validZones + 1; b < l.zmapBlocks*bitsPerBlock; b++ {
+		setBit(zmap, b)
+	}
+	if err := writeAt(f, zmap, int64(2+l.imapBlocks)*blockSize); err != nil {
+		return err
+	}
+
+	// Root inode (inode 1) sits at the start of the inode table.
+	inodeTable := int64(2+l.imapBlocks+l.zmapBlocks) * blockSize
+	ino := make([]byte, 32)
+	binary.LittleEndian.PutUint16(ino[0:], rootMode)
+	binary.LittleEndian.PutUint32(ino[4:], 2*dirEntrySize) // size: "." and ".."
+	ino[13] = 2                                            // nlinks
+	binary.LittleEndian.PutUint16(ino[14:], uint16(l.firstDataZone))
+	if err := writeAt(f, ino, inodeTable); err != nil {
+		return err
+	}
+
+	// Root directory data: "." and ".." both point at inode 1.
+	dir := make([]byte, blockSize)
+	binary.LittleEndian.PutUint16(dir[0:], 1)
+	copy(dir[2:], ".")
+	binary.LittleEndian.PutUint16(dir[dirEntrySize:], 1)
+	copy(dir[dirEntrySize+2:], "..")
+	return writeAt(f, dir, int64(l.firstDataZone)*blockSize)
+}
+
+func writeAt(f *os.File, data []byte, off int64) error {
+	_, err := f.WriteAt(data, off)
+	return err
+}
+
+// setBit sets bit n in the little-endian bitmap.
+func setBit(bitmap []byte, n int) {
+	bitmap[n/8] |= 1 << (uint(n) % 8)
+}
+
+// parseUint parses a positive base-10 integer.
+func parseUint(s string) (int, error) {
+	n := 0
+	if s == "" {
+		return 0, command.Failuref("invalid block count: %q", s)
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return 0, command.Failuref("invalid block count: %q", s)
+		}
+		n = n*10 + int(s[i]-'0')
+	}
+	return n, nil
+}

--- a/internal/applets/util-linux/mkfs_minix/mkfs_minix_test.go
+++ b/internal/applets/util-linux/mkfs_minix/mkfs_minix_test.go
@@ -1,0 +1,108 @@
+package mkfsminix
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func makeImage(t *testing.T, blocks int) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "minix.img")
+	if err := os.WriteFile(p, make([]byte, blocks*blockSize), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestCreatesValidSuperblock(t *testing.T) {
+	img := makeImage(t, 2048)
+	if err := run(t, img); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	sb := data[blockSize:] // superblock is block 1
+
+	if magic := binary.LittleEndian.Uint16(sb[16:]); magic != minixMagic {
+		t.Errorf("magic = %#x, want %#x", magic, minixMagic)
+	}
+	if state := binary.LittleEndian.Uint16(sb[18:]); state != 1 {
+		t.Errorf("state = %d, want 1 (clean)", state)
+	}
+	ninodes := binary.LittleEndian.Uint16(sb[0:])
+	nzones := binary.LittleEndian.Uint16(sb[2:])
+	if ninodes == 0 || nzones != 2048 {
+		t.Errorf("ninodes=%d nzones=%d", ninodes, nzones)
+	}
+	firstZone := int(binary.LittleEndian.Uint16(sb[8:]))
+	if firstZone < 3 {
+		t.Errorf("firstdatazone = %d, too small", firstZone)
+	}
+
+	// Root inode (inode 1) at the start of the inode table.
+	l := computeLayout(2048)
+	inodeOff := (2 + l.imapBlocks + l.zmapBlocks) * blockSize
+	mode := binary.LittleEndian.Uint16(data[inodeOff:])
+	if mode&sIFDIR == 0 {
+		t.Errorf("root inode mode %#o is not a directory", mode)
+	}
+
+	// Root directory must contain "." and ".." pointing at inode 1.
+	dirOff := firstZone * blockSize
+	if binary.LittleEndian.Uint16(data[dirOff:]) != 1 || string(bytes.TrimRight(data[dirOff+2:dirOff+16], "\x00")) != "." {
+		t.Errorf("first dir entry wrong")
+	}
+	if binary.LittleEndian.Uint16(data[dirOff+16:]) != 1 || string(bytes.TrimRight(data[dirOff+18:dirOff+32], "\x00")) != ".." {
+		t.Errorf("second dir entry wrong")
+	}
+}
+
+func TestBlocksOperand(t *testing.T) {
+	// A larger file but an explicit smaller block count must be honored.
+	img := makeImage(t, 4096)
+	if err := run(t, img, "1024"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	if nzones := binary.LittleEndian.Uint16(data[blockSize+2:]); nzones != 1024 {
+		t.Errorf("nzones = %d, want 1024 (from operand)", nzones)
+	}
+}
+
+func TestLayoutConsistency(t *testing.T) {
+	t.Parallel()
+	l := computeLayout(8192)
+	// firstDataZone must sit after the boot block, superblock, bitmaps, inodes.
+	want := 2 + l.imapBlocks + l.zmapBlocks + l.inodeBlocks
+	if l.firstDataZone != want {
+		t.Errorf("firstDataZone = %d, want %d", l.firstDataZone, want)
+	}
+	if l.firstDataZone >= l.nzones {
+		t.Errorf("firstDataZone %d >= nzones %d", l.firstDataZone, l.nzones)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if err := run(t); err == nil {
+		t.Errorf("missing device should fail")
+	}
+	if err := run(t, "/no/such/image"); err == nil {
+		t.Errorf("a missing image should fail")
+	}
+	small := makeImage(t, 4) // below minBlocks
+	if err := run(t, small); err == nil {
+		t.Errorf("a too-small device should fail")
+	}
+}

--- a/test/it/spec/mkfs_minix_spec.sh
+++ b/test/it/spec/mkfs_minix_spec.sh
@@ -1,0 +1,19 @@
+Describe 'mkfs.minix'
+    Include util-linux/mkfs_minix_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/mkfs_minix; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'writes the Minix v1 magic'
+        When call TestMkfsMinixMagic
+        The output should equal '7f13'
+        The status should be success
+    End
+    It 'refuses a too-small device'
+        When call TestMkfsMinixTooSmall
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/mkfs_minix_test.sh
+++ b/test/it/util-linux/mkfs_minix_test.sh
@@ -1,0 +1,11 @@
+TestMkfsMinixMagic() {
+    dd if=/dev/zero of="$TEST_DIR/m.img" bs=1024 count=2048 2>/dev/null
+    mkfs.minix "$TEST_DIR/m.img" >/dev/null
+    # The Minix v1 magic 0x137F (little-endian 7f 13) sits at byte offset 1040.
+    dd if="$TEST_DIR/m.img" bs=1 skip=1040 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n'
+}
+TestMkfsMinixTooSmall() {
+    dd if=/dev/zero of="$TEST_DIR/s.img" bs=1024 count=4 2>/dev/null
+    mkfs.minix "$TEST_DIR/s.img" 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `mkfs.minix`, which creates a Minix version-1 filesystem (1 KiB blocks, 14-character names) on a device or image file, with an empty root directory. It computes the bitmap/inode geometry (inode and zone bitmaps, inode table, first data zone), writes the superblock, marks the reserved/root inode and the root directory's data zone in the bitmaps, and writes the root inode and its "."/".." entries. An optional BLOCKS operand limits the size; files below a minimum are refused. The image-file workflow is hermetic per the issue's guidance.

The generated filesystem is validated by host `fsck.minix -f`, which accepts it with no errors.

## Tests

- Unit (hermetic temp images): the superblock magic/state/inode/zone counts and first-data-zone, the root inode being a directory, the "."/".." root entries, the BLOCKS operand overriding the file size, the layout-consistency invariant, and the missing-device / missing-image / too-small errors.
- shellspec: the Minix v1 magic at its on-disk offset, and the too-small refusal.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (647 examples, 0 failures); `golangci-lint` clean; the output passes host `fsck.minix -f`; registry/README in sync.

Part of #249