### PR TITLE
feat(util-linux): add fsck.minix applet to check a Minix filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 274 commands. Run `mimixbox --list` to see them on the terminal.
+There are 275 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -95,6 +95,7 @@ There are 274 commands. Run `mimixbox --list` to see them on the terminal.
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
 | freeramdisk | Free the memory used by a ramdisk |
+| fsck.minix | Check a Minix filesystem |
 | fsfreeze | Suspend or resume a filesystem |
 | fstrim | Discard unused blocks on a filesystem |
 | fsync | Flush a file's data to storage with fsync(2) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -221,6 +221,7 @@ import (
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
 	ap_util_linux_freeramdisk "github.com/nao1215/mimixbox/internal/applets/util-linux/freeramdisk"
+	ap_util_linux_fsck_minix "github.com/nao1215/mimixbox/internal/applets/util-linux/fsck_minix"
 	ap_util_linux_fsfreeze "github.com/nao1215/mimixbox/internal/applets/util-linux/fsfreeze"
 	ap_util_linux_fstrim "github.com/nao1215/mimixbox/internal/applets/util-linux/fstrim"
 	ap_util_linux_getopt "github.com/nao1215/mimixbox/internal/applets/util-linux/getopt"
@@ -263,7 +264,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 274)
+	Applets = make(map[string]Applet, 275)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -497,6 +498,7 @@ func init() {
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
 	register(ap_util_linux_freeramdisk.New())
+	register(ap_util_linux_fsck_minix.New())
 	register(ap_util_linux_fsfreeze.New())
 	register(ap_util_linux_fstrim.New())
 	register(ap_util_linux_getopt.New())

--- a/internal/applets/util-linux/fsck_minix/fsck_minix.go
+++ b/internal/applets/util-linux/fsck_minix/fsck_minix.go
@@ -1,0 +1,104 @@
+// Package fsckminix implements the fsck.minix applet: check a Minix filesystem
+// by validating its superblock and reporting its geometry.
+package fsckminix
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fsck.minix applet.
+type Command struct{}
+
+// New returns a fsck.minix command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fsck.minix" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Check a Minix filesystem" }
+
+const (
+	blockSize        = 1024
+	superblockOffset = 1024
+)
+
+// magics maps each Minix superblock magic to a human description.
+var magics = map[uint16]string{
+	0x137F: "Minix v1, 14-character names",
+	0x138F: "Minix v1, 30-character names",
+	0x2468: "Minix v2, 14-character names",
+	0x2478: "Minix v2, 30-character names",
+}
+
+// Run executes fsck.minix.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-f] DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Check the Minix filesystem on DEVICE (a block device or image file) by validating " +
+			"its superblock and reporting its version and geometry: the inode count, zone count, and " +
+			"first data zone. -f is accepted for compatibility. This build performs the superblock " +
+			"check, not a full inode/zone walk.",
+		Examples: []command.Example{
+			{Command: "fsck.minix disk.img", Explain: "Check the Minix filesystem in the image."},
+		},
+		ExitStatus: "0  the superblock is a valid Minix filesystem.\n1  the device was unreadable or not Minix.",
+	})
+	_ = fs.BoolP("force", "f", false, "force a check (accepted for compatibility)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a device or image is required")
+	}
+
+	sb, err := readSuperblock(rest[0])
+	if err != nil {
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+
+	desc, ok := magics[sb.magic]
+	if !ok {
+		return command.Failuref("%s: bad magic number in super-block (%#04x); not a Minix filesystem",
+			rest[0], sb.magic)
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "%s: %s\n", rest[0], desc)
+	_, _ = fmt.Fprintf(stdio.Out, "%d inodes\n", sb.ninodes)
+	_, _ = fmt.Fprintf(stdio.Out, "%d zones\n", sb.nzones)
+	_, _ = fmt.Fprintf(stdio.Out, "firstdatazone=%d\n", sb.firstZone)
+	return nil
+}
+
+type superblock struct {
+	ninodes, nzones, firstZone int
+	magic                      uint16
+}
+
+// readSuperblock reads and parses the Minix superblock at offset 1024.
+func readSuperblock(path string) (*superblock, error) {
+	f, err := os.Open(path) //nolint:gosec // user-named device or image
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, blockSize)
+	if _, err := f.ReadAt(buf, superblockOffset); err != nil {
+		return nil, fmt.Errorf("cannot read super-block: %w", err)
+	}
+	return &superblock{
+		ninodes:   int(binary.LittleEndian.Uint16(buf[0:])),
+		nzones:    int(binary.LittleEndian.Uint16(buf[2:])),
+		firstZone: int(binary.LittleEndian.Uint16(buf[8:])),
+		magic:     binary.LittleEndian.Uint16(buf[16:]),
+	}, nil
+}

--- a/internal/applets/util-linux/fsck_minix/fsck_minix_test.go
+++ b/internal/applets/util-linux/fsck_minix/fsck_minix_test.go
@@ -1,0 +1,83 @@
+package fsckminix
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func craft(t *testing.T, magic uint16, ninodes, nzones, firstZone uint16) string {
+	t.Helper()
+	buf := make([]byte, superblockOffset+blockSize)
+	sb := buf[superblockOffset:]
+	binary.LittleEndian.PutUint16(sb[0:], ninodes)
+	binary.LittleEndian.PutUint16(sb[2:], nzones)
+	binary.LittleEndian.PutUint16(sb[8:], firstZone)
+	binary.LittleEndian.PutUint16(sb[16:], magic)
+	p := filepath.Join(t.TempDir(), "fs.img")
+	if err := os.WriteFile(p, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestValidV1(t *testing.T) {
+	img := craft(t, 0x137F, 704, 2048, 26)
+	out, err := run(t, img)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Minix v1, 14-character names", "704 inodes", "2048 zones", "firstdatazone=26"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestValidV2(t *testing.T) {
+	img := craft(t, 0x2478, 100, 500, 10)
+	out, err := run(t, img)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Minix v2, 30-character names") {
+		t.Errorf("v2 not recognized:\n%s", out)
+	}
+}
+
+func TestBadMagic(t *testing.T) {
+	img := craft(t, 0x0000, 0, 0, 0)
+	if _, err := run(t, img); err == nil {
+		t.Errorf("a bad magic should fail")
+	}
+}
+
+func TestForceFlagAccepted(t *testing.T) {
+	img := craft(t, 0x137F, 1, 16, 3)
+	if _, err := run(t, "-f", img); err != nil {
+		t.Errorf("-f should be accepted: %v", err)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t); err == nil {
+		t.Errorf("missing device should fail")
+	}
+	if _, err := run(t, "/no/such/image"); err == nil {
+		t.Errorf("a missing image should fail")
+	}
+}

--- a/test/it/spec/fsck_minix_spec.sh
+++ b/test/it/spec/fsck_minix_spec.sh
@@ -1,0 +1,19 @@
+Describe 'fsck.minix'
+    Include util-linux/fsck_minix_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/fsck_minix; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'validates a freshly made Minix filesystem'
+        When call TestFsckMinixRoundTrip
+        The output should include 'Minix v1'
+        The status should be success
+    End
+    It 'rejects a non-Minix image'
+        When call TestFsckMinixBad
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/fsck_minix_test.sh
+++ b/test/it/util-linux/fsck_minix_test.sh
@@ -1,0 +1,10 @@
+TestFsckMinixRoundTrip() {
+    dd if=/dev/zero of="$TEST_DIR/f.img" bs=1024 count=2048 2>/dev/null
+    mkfs.minix "$TEST_DIR/f.img" >/dev/null
+    fsck.minix "$TEST_DIR/f.img" | sed -n '1p'
+}
+TestFsckMinixBad() {
+    dd if=/dev/zero of="$TEST_DIR/b.img" bs=1024 count=4 2>/dev/null
+    fsck.minix "$TEST_DIR/b.img" 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fsck.minix`, the counterpart to mkfs.minix. It checks the Minix filesystem on a device or image by validating the superblock magic and reporting the version (v1/v2, 14- or 30-character names) and geometry (inode count, zone count, first data zone). An invalid magic fails with a clear message; `-f` is accepted for compatibility. This build performs the superblock check, not a full inode/zone walk.

Round-trips with the mkfs.minix applet: a freshly created filesystem is reported as a valid Minix v1.

## Tests

- Unit (crafted superblocks): a valid v1 report (version + counts + first data zone), a v2 magic recognized, a bad magic rejected, `-f` accepted, and the missing-device / missing-image errors.
- shellspec: validating a filesystem freshly made by mkfs.minix, and rejecting a non-Minix image.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (649 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249