### PR TITLE
feat(util-linux): add fdisk applet to list the MBR partition table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 275 commands. Run `mimixbox --list` to see them on the terminal.
+There are 276 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -86,6 +86,7 @@ There are 275 commands. Run `mimixbox --list` to see them on the terminal.
 | fatattr | Show or change FAT file attributes |
 | fbset | Show the framebuffer video mode |
 | fdflush | Flush a floppy device's buffers |
+| fdisk | List the MBR partition table |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |
 | findfs | Find a filesystem by label or UUID |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -218,6 +218,7 @@ import (
 	ap_util_linux_fatattr "github.com/nao1215/mimixbox/internal/applets/util-linux/fatattr"
 	ap_util_linux_fbset "github.com/nao1215/mimixbox/internal/applets/util-linux/fbset"
 	ap_util_linux_fdflush "github.com/nao1215/mimixbox/internal/applets/util-linux/fdflush"
+	ap_util_linux_fdisk "github.com/nao1215/mimixbox/internal/applets/util-linux/fdisk"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
 	ap_util_linux_freeramdisk "github.com/nao1215/mimixbox/internal/applets/util-linux/freeramdisk"
@@ -264,7 +265,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 275)
+	Applets = make(map[string]Applet, 276)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -495,6 +496,7 @@ func init() {
 	register(ap_util_linux_fatattr.New())
 	register(ap_util_linux_fbset.New())
 	register(ap_util_linux_fdflush.New())
+	register(ap_util_linux_fdisk.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
 	register(ap_util_linux_freeramdisk.New())

--- a/internal/applets/util-linux/fdisk/fdisk.go
+++ b/internal/applets/util-linux/fdisk/fdisk.go
@@ -1,0 +1,122 @@
+// Package fdisk implements the fdisk applet in list mode: read and print the MBR
+// partition table of a device or image. Interactive editing is not provided.
+package fdisk
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fdisk applet.
+type Command struct{}
+
+// New returns a fdisk command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fdisk" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "List the MBR partition table" }
+
+const (
+	sectorSize   = 512
+	tableOffset  = 446 // 0x1BE
+	entrySize    = 16
+	numEntries   = 4
+	signatureLow = 510
+	bootableFlag = 0x80
+)
+
+// partTypes names the common MBR partition type bytes.
+var partTypes = map[byte]string{
+	0x00: "Empty", 0x01: "FAT12", 0x04: "FAT16 <32M", 0x05: "Extended",
+	0x06: "FAT16", 0x07: "HPFS/NTFS/exFAT", 0x0b: "W95 FAT32", 0x0c: "W95 FAT32 (LBA)",
+	0x0e: "W95 FAT16 (LBA)", 0x82: "Linux swap", 0x83: "Linux", 0x8e: "Linux LVM",
+	0xfd: "Linux raid autodetect", 0xef: "EFI (FAT-12/16/32)", 0xee: "GPT protective",
+}
+
+// Run executes fdisk.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-l DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "List the MBR (DOS) partition table of DEVICE (a block device or image file): each " +
+			"partition's boot flag, start and end sector, sector count, and type. Only the list mode " +
+			"(-l) is implemented; the interactive partition editor is not.",
+		Examples: []command.Example{
+			{Command: "fdisk -l disk.img", Explain: "List the partitions in the image."},
+		},
+		ExitStatus: "0  the table was listed.\n1  the device was unreadable or had no valid MBR.",
+	})
+	list := fs.BoolP("list", "l", false, "list the partition table and exit")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a device or image is required")
+	}
+	if !*list {
+		_, _ = fmt.Fprintln(stdio.Err, "fdisk: only the list mode (-l) is supported by this build")
+		return command.SilentFailure()
+	}
+	device := rest[0]
+
+	mbr, err := readSector(device)
+	if err != nil {
+		return command.Failuref("%s: %v", device, err)
+	}
+	if mbr[signatureLow] != 0x55 || mbr[signatureLow+1] != 0xAA {
+		return command.Failuref("%s: no valid MBR signature", device)
+	}
+
+	tw := tabwriter.NewWriter(stdio.Out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "Device\tBoot\tStart\tEnd\tSectors\tType")
+	for i := 0; i < numEntries; i++ {
+		e := mbr[tableOffset+i*entrySize:]
+		typeByte := e[4]
+		if typeByte == 0 {
+			continue // unused entry
+		}
+		start := binary.LittleEndian.Uint32(e[8:])
+		sectors := binary.LittleEndian.Uint32(e[12:])
+		boot := ""
+		if e[0] == bootableFlag {
+			boot = "*"
+		}
+		end := start + sectors - 1
+		_, _ = fmt.Fprintf(tw, "%s%d\t%s\t%d\t%d\t%d\t%s\n",
+			device, i+1, boot, start, end, sectors, typeName(typeByte))
+	}
+	_ = tw.Flush()
+	return nil
+}
+
+func typeName(b byte) string {
+	if name, ok := partTypes[b]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown (0x%02x)", b)
+}
+
+// readSector reads the first 512-byte sector of path.
+func readSector(path string) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // user-named device or image
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, sectorSize)
+	if _, err := f.ReadAt(buf, 0); err != nil {
+		return nil, fmt.Errorf("cannot read the MBR: %w", err)
+	}
+	return buf, nil
+}

--- a/internal/applets/util-linux/fdisk/fdisk_test.go
+++ b/internal/applets/util-linux/fdisk/fdisk_test.go
@@ -1,0 +1,107 @@
+package fdisk
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// craftMBR builds a 512-byte MBR image; each part is {bootable, type, start, sectors}.
+func craftMBR(t *testing.T, withSig bool, parts ...[4]uint32) string {
+	t.Helper()
+	mbr := make([]byte, sectorSize)
+	for i, p := range parts {
+		e := tableOffset + i*entrySize
+		if p[0] != 0 {
+			mbr[e] = bootableFlag
+		}
+		mbr[e+4] = byte(p[1])
+		binary.LittleEndian.PutUint32(mbr[e+8:], p[2])
+		binary.LittleEndian.PutUint32(mbr[e+12:], p[3])
+	}
+	if withSig {
+		mbr[signatureLow] = 0x55
+		mbr[signatureLow+1] = 0xAA
+	}
+	p := filepath.Join(t.TempDir(), "disk.img")
+	if err := os.WriteFile(p, mbr, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestListsPartitions(t *testing.T) {
+	img := craftMBR(t, true,
+		[4]uint32{1, 0x83, 2048, 4192256},  // bootable Linux
+		[4]uint32{0, 0x82, 4194304, 2097152}, // swap
+	)
+	out, err := run(t, "-l", img)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "2048") || !strings.Contains(out, "4194303") || !strings.Contains(out, "Linux") {
+		t.Errorf("first partition wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "Linux swap") {
+		t.Errorf("swap partition wrong:\n%s", out)
+	}
+	// The bootable flag column must show '*' for the first partition only.
+	if strings.Count(out, "*") != 1 {
+		t.Errorf("boot flag count wrong:\n%s", out)
+	}
+}
+
+func TestUnknownTypeAndEmptySkipped(t *testing.T) {
+	img := craftMBR(t, true,
+		[4]uint32{0, 0xAB, 100, 200}, // unknown type
+		[4]uint32{0, 0x00, 0, 0},     // empty -> skipped
+	)
+	out, err := run(t, "-l", img)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "unknown (0xab)") {
+		t.Errorf("unknown type not labeled:\n%s", out)
+	}
+	// Only one data row (the empty entry is skipped): header + one row.
+	if lines := strings.Count(strings.TrimSpace(out), "\n"); lines != 1 {
+		t.Errorf("expected one partition row, got:\n%s", out)
+	}
+}
+
+func TestBadSignature(t *testing.T) {
+	img := craftMBR(t, false, [4]uint32{0, 0x83, 2048, 1000})
+	if _, err := run(t, "-l", img); err == nil {
+		t.Errorf("a missing MBR signature should fail")
+	}
+}
+
+func TestRequiresListMode(t *testing.T) {
+	img := craftMBR(t, true, [4]uint32{0, 0x83, 2048, 1000})
+	if _, err := run(t, img); err == nil {
+		t.Errorf("without -l it should fail")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t, "-l"); err == nil {
+		t.Errorf("missing device should fail")
+	}
+	if _, err := run(t, "-l", "/no/such/image"); err == nil {
+		t.Errorf("a missing image should fail")
+	}
+}

--- a/test/it/spec/fdisk_spec.sh
+++ b/test/it/spec/fdisk_spec.sh
@@ -1,0 +1,19 @@
+Describe 'fdisk'
+    Include util-linux/fdisk_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/fdisk; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'lists an MBR Linux partition'
+        When call TestFdiskList
+        The output should equal '1'
+        The status should be success
+    End
+    It 'rejects an image without an MBR signature'
+        When call TestFdiskBad
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/fdisk_test.sh
+++ b/test/it/util-linux/fdisk_test.sh
@@ -1,0 +1,19 @@
+# Build a tiny MBR with one Linux partition using printf, then list it.
+TestFdiskList() {
+    img="$TEST_DIR/disk.img"
+    dd if=/dev/zero of="$img" bs=512 count=1 2>/dev/null
+    # type byte 0x83 (Linux) at offset 450 (446+4)
+    printf '\203' | dd of="$img" bs=1 seek=450 count=1 conv=notrunc 2>/dev/null
+    # LBA start = 2048 (0x00000800 little-endian) at offset 454
+    printf '\000\010\000\000' | dd of="$img" bs=1 seek=454 count=4 conv=notrunc 2>/dev/null
+    # sector count = 100 (0x64) at offset 458
+    printf '\144\000\000\000' | dd of="$img" bs=1 seek=458 count=4 conv=notrunc 2>/dev/null
+    # MBR signature 0x55AA at 510
+    printf '\125\252' | dd of="$img" bs=1 seek=510 count=2 conv=notrunc 2>/dev/null
+    fdisk -l "$img" | grep -c 'Linux'
+}
+TestFdiskBad() {
+    dd if=/dev/zero of="$TEST_DIR/n.img" bs=512 count=1 2>/dev/null
+    fdisk -l "$TEST_DIR/n.img" 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fdisk -l`, which lists the MBR (DOS) partition table of a device or image file: each partition's boot flag, start and end sector, sector count, and type (mapped from the type byte, e.g. Linux, Linux swap, W95 FAT32, EFI). Empty entries are skipped and unknown types show their hex byte. It validates the 0x55AA signature and fails deterministically without it. Only the list mode is implemented; the interactive partition editor is not, and requesting it fails with a clear message. The MBR read is hermetic (image-file workflow).

## Tests

- Unit (crafted MBR images): listing multiple partitions with correct start/end/sectors/types and the boot flag, an unknown type labeled by hex with empty entries skipped, the bad-signature rejection, the require-`-l` behavior, and the missing-device / missing-image errors.
- shellspec: listing a Linux partition from a hand-built MBR, and rejecting an image without a signature.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (651 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249