### PR TITLE
feat(util-linux): add mkfs.vfat/mkdosfs applet to create a FAT16 filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 276 commands. Run `mimixbox --list` to see them on the terminal.
+There are 278 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -153,8 +153,10 @@ There are 276 commands. Run `mimixbox --list` to see them on the terminal.
 | mesg | Display or control write access to your terminal |
 | minips | Minimal process lister (PID, user, command) |
 | mkdir | Make directories |
+| mkdosfs | Create a FAT16 filesystem |
 | mkfifo | Make FIFO (named pipe) |
 | mkfs.minix | Create a Minix filesystem |
+| mkfs.vfat | Create a FAT16 filesystem |
 | mknod | Make block or character special files |
 | mkswap | Set up a Linux swap area |
 | mktemp | Create a temporary file or directory |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -239,6 +239,7 @@ import (
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_mkfs_minix "github.com/nao1215/mimixbox/internal/applets/util-linux/mkfs_minix"
+	ap_util_linux_mkfs_vfat "github.com/nao1215/mimixbox/internal/applets/util-linux/mkfs_vfat"
 	ap_util_linux_mkswap "github.com/nao1215/mimixbox/internal/applets/util-linux/mkswap"
 	ap_util_linux_mount "github.com/nao1215/mimixbox/internal/applets/util-linux/mount"
 	ap_util_linux_nsenter "github.com/nao1215/mimixbox/internal/applets/util-linux/nsenter"
@@ -265,7 +266,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 276)
+	Applets = make(map[string]Applet, 278)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -518,6 +519,8 @@ func init() {
 	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_mkfs_minix.New())
+	register(ap_util_linux_mkfs_vfat.New())
+	register(ap_util_linux_mkfs_vfat.NewMkdosfs())
 	register(ap_util_linux_mkswap.New())
 	register(ap_util_linux_mount.New())
 	register(ap_util_linux_nsenter.New())

--- a/internal/applets/util-linux/mkfs_vfat/mkfs_vfat.go
+++ b/internal/applets/util-linux/mkfs_vfat/mkfs_vfat.go
@@ -1,0 +1,175 @@
+// Package mkfsvfat implements the mkfs.vfat applet (also mkdosfs): create a
+// FAT16 filesystem on a device or image file.
+package mkfsvfat
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the mkfs.vfat applet. It is also registered under the traditional
+// name mkdosfs.
+type Command struct{ name string }
+
+// New returns a mkfs.vfat command.
+func New() *Command { return &Command{name: "mkfs.vfat"} }
+
+// NewMkdosfs returns the same applet under the name mkdosfs.
+func NewMkdosfs() *Command { return &Command{name: "mkdosfs"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Create a FAT16 filesystem" }
+
+const (
+	sectorSize      = 512
+	rootEntries     = 512
+	reservedSectors = 1
+	numFATs         = 2
+	mediaByte       = 0xF8
+	// FAT16 is only valid for at least this many data clusters.
+	minFAT16Clusters = 4085
+)
+
+// Run executes mkfs.vfat.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-n LABEL] DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Create a FAT16 filesystem on DEVICE (a block device or image file) with an empty " +
+			"root directory. -n sets an 11-character volume label. The device must be large enough for " +
+			"a FAT16 filesystem (a few MiB); smaller sizes are refused rather than silently making FAT12.",
+		Examples: []command.Example{
+			{Command: "mkfs.vfat disk.img", Explain: "Format the image as FAT16."},
+			{Command: "mkfs.vfat -n DATA disk.img", Explain: "Format it with the label DATA."},
+		},
+		ExitStatus: "0  the filesystem was created.\n1  the device was missing or too small.",
+	})
+	label := fs.StringP("label", "n", "NO NAME", "volume label (up to 11 characters)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	hasLabel := fs.Changed("label")
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a device or image is required")
+	}
+
+	f, err := os.OpenFile(rest[0], os.O_RDWR, 0o644) //nolint:gosec // user-named device or image
+	if err != nil {
+		return command.Failuref("cannot open %s: %v", rest[0], err)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return command.Failuref("cannot stat %s: %v", rest[0], err)
+	}
+	totalSectors := int(info.Size() / sectorSize)
+
+	if err := writeFAT16(f, totalSectors, *label, hasLabel); err != nil {
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// geometry holds the computed FAT16 layout.
+type geometry struct {
+	totalSectors   int
+	rootDirSectors int
+	sectorsPerFAT  int
+	clusters       int
+}
+
+func upper(a, b int) int { return (a + b - 1) / b }
+
+// computeGeometry derives the FAT16 layout for totalSectors 512-byte sectors,
+// using one sector per cluster.
+func computeGeometry(totalSectors int) geometry {
+	rootDirSectors := upper(rootEntries*32, sectorSize)
+	sectorsPerFAT := 1
+	for {
+		dataSectors := totalSectors - reservedSectors - rootDirSectors - numFATs*sectorsPerFAT
+		clusters := dataSectors // one sector per cluster
+		next := upper((clusters+2)*2, sectorSize)
+		if next == sectorsPerFAT {
+			return geometry{totalSectors, rootDirSectors, sectorsPerFAT, clusters}
+		}
+		sectorsPerFAT = next
+	}
+}
+
+// writeFAT16 writes the boot sector, the two FATs, and the root directory. When
+// hasLabel is set, the root directory gets a matching volume-label entry.
+func writeFAT16(f *os.File, totalSectors int, label string, hasLabel bool) error {
+	g := computeGeometry(totalSectors)
+	if g.clusters < minFAT16Clusters {
+		return command.Failuref("device is too small for FAT16 (%d clusters, need %d)",
+			g.clusters, minFAT16Clusters)
+	}
+
+	boot := make([]byte, sectorSize)
+	boot[0], boot[1], boot[2] = 0xEB, 0x3C, 0x90 // jump
+	copy(boot[3:11], "MIMIXBOX")
+	binary.LittleEndian.PutUint16(boot[11:], sectorSize)
+	boot[13] = 1 // sectors per cluster
+	binary.LittleEndian.PutUint16(boot[14:], reservedSectors)
+	boot[16] = numFATs
+	binary.LittleEndian.PutUint16(boot[17:], rootEntries)
+	if totalSectors < 0x10000 {
+		binary.LittleEndian.PutUint16(boot[19:], uint16(totalSectors))
+	}
+	boot[21] = mediaByte
+	binary.LittleEndian.PutUint16(boot[22:], uint16(g.sectorsPerFAT))
+	binary.LittleEndian.PutUint16(boot[24:], 32) // sectors per track
+	binary.LittleEndian.PutUint16(boot[26:], 64) // heads
+	if totalSectors >= 0x10000 {
+		binary.LittleEndian.PutUint32(boot[32:], uint32(totalSectors))
+	}
+	boot[36] = 0x80 // drive number
+	boot[38] = 0x29 // extended boot signature
+	binary.LittleEndian.PutUint32(boot[39:], 0x12345678)
+	copy(boot[43:54], padLabel(label))
+	copy(boot[54:62], "FAT16   ")
+	boot[510], boot[511] = 0x55, 0xAA
+	if _, err := f.WriteAt(boot, 0); err != nil {
+		return err
+	}
+
+	// Each FAT starts with the media byte and an end-of-chain marker.
+	fat := make([]byte, g.sectorsPerFAT*sectorSize)
+	fat[0], fat[1], fat[2], fat[3] = mediaByte, 0xFF, 0xFF, 0xFF // entry 0 and 1
+	for i := 0; i < numFATs; i++ {
+		off := int64(reservedSectors+i*g.sectorsPerFAT) * sectorSize
+		if _, err := f.WriteAt(fat, off); err != nil {
+			return err
+		}
+	}
+
+	// The root directory is empty, except for a volume-label entry when -n was
+	// given (so a checker finds the label both in the boot sector and the root).
+	root := make([]byte, g.rootDirSectors*sectorSize)
+	if hasLabel {
+		copy(root[0:11], padLabel(label))
+		root[11] = 0x08 // ATTR_VOLUME_ID
+	}
+	rootOff := int64(reservedSectors+numFATs*g.sectorsPerFAT) * sectorSize
+	_, err := f.WriteAt(root, rootOff)
+	return err
+}
+
+// padLabel returns the 11-byte, space-padded, uppercase-ish volume label.
+func padLabel(label string) []byte {
+	out := []byte("           ") // 11 spaces
+	copy(out, label)
+	if len(label) > 11 {
+		out = out[:11]
+	}
+	return out
+}

--- a/internal/applets/util-linux/mkfs_vfat/mkfs_vfat_test.go
+++ b/internal/applets/util-linux/mkfs_vfat/mkfs_vfat_test.go
@@ -1,0 +1,111 @@
+package mkfsvfat
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func makeImage(t *testing.T, kib int) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "fat.img")
+	if err := os.WriteFile(p, make([]byte, kib*1024), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestBootSector(t *testing.T) {
+	img := makeImage(t, 8192)
+	if err := run(t, img); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	if binary.LittleEndian.Uint16(data[11:]) != sectorSize {
+		t.Errorf("bytes per sector wrong")
+	}
+	if data[13] != 1 || data[16] != numFATs {
+		t.Errorf("spc=%d nfats=%d", data[13], data[16])
+	}
+	if binary.LittleEndian.Uint16(data[17:]) != rootEntries {
+		t.Errorf("root entries wrong")
+	}
+	if data[21] != mediaByte {
+		t.Errorf("media byte = %#x", data[21])
+	}
+	if string(data[54:62]) != "FAT16   " {
+		t.Errorf("fs type = %q", data[54:62])
+	}
+	if data[510] != 0x55 || data[511] != 0xAA {
+		t.Errorf("boot signature missing")
+	}
+	// FAT starts with the media byte and end-of-chain markers.
+	fatOff := reservedSectors * sectorSize
+	if data[fatOff] != mediaByte || data[fatOff+1] != 0xFF {
+		t.Errorf("FAT head wrong: % x", data[fatOff:fatOff+4])
+	}
+}
+
+func TestVolumeLabelEntry(t *testing.T) {
+	img := makeImage(t, 8192)
+	if err := run(t, "-n", "MYVOL", img); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	if string(data[43:48]) != "MYVOL" {
+		t.Errorf("boot label = %q", data[43:54])
+	}
+	// Root directory volume-label entry.
+	g := computeGeometry(16384)
+	rootOff := (reservedSectors + numFATs*g.sectorsPerFAT) * sectorSize
+	if string(data[rootOff:rootOff+5]) != "MYVOL" || data[rootOff+11] != 0x08 {
+		t.Errorf("root volume entry wrong")
+	}
+}
+
+func TestNoLabelNoRootEntry(t *testing.T) {
+	img := makeImage(t, 8192)
+	if err := run(t, img); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	g := computeGeometry(16384)
+	rootOff := (reservedSectors + numFATs*g.sectorsPerFAT) * sectorSize
+	if data[rootOff] != 0 {
+		t.Errorf("root dir should be empty without -n")
+	}
+}
+
+func TestTooSmall(t *testing.T) {
+	img := makeImage(t, 1024) // below the FAT16 cluster minimum
+	if err := run(t, img); err == nil {
+		t.Errorf("a too-small image should be rejected")
+	}
+}
+
+func TestMkdosfsAlias(t *testing.T) {
+	if New().Name() != "mkfs.vfat" || NewMkdosfs().Name() != "mkdosfs" {
+		t.Errorf("alias names wrong: %q / %q", New().Name(), NewMkdosfs().Name())
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if err := run(t); err == nil {
+		t.Errorf("missing device should fail")
+	}
+	if err := run(t, "/no/such/image"); err == nil {
+		t.Errorf("a missing image should fail")
+	}
+}

--- a/test/it/spec/mkfs_vfat_spec.sh
+++ b/test/it/spec/mkfs_vfat_spec.sh
@@ -1,0 +1,19 @@
+Describe 'mkfs.vfat / mkdosfs'
+    Include util-linux/mkfs_vfat_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/mkfs_vfat; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'writes the FAT16 type label'
+        When call TestMkfsVfatSig
+        The output should equal 'FAT16'
+        The status should be success
+    End
+    It 'mkdosfs refuses a too-small image'
+        When call TestMkdosfsTooSmall
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/mkfs_vfat_test.sh
+++ b/test/it/util-linux/mkfs_vfat_test.sh
@@ -1,0 +1,11 @@
+TestMkfsVfatSig() {
+    dd if=/dev/zero of="$TEST_DIR/v.img" bs=1024 count=8192 2>/dev/null
+    mkfs.vfat "$TEST_DIR/v.img" >/dev/null
+    # FAT16 fs-type label at byte offset 54.
+    dd if="$TEST_DIR/v.img" bs=1 skip=54 count=5 2>/dev/null
+}
+TestMkdosfsTooSmall() {
+    dd if=/dev/zero of="$TEST_DIR/s.img" bs=1024 count=512 2>/dev/null
+    mkdosfs "$TEST_DIR/s.img" 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `mkfs.vfat` (also registered as the traditional `mkdosfs`), which creates a FAT16 filesystem on a device or image file with an empty root directory. It writes the boot sector BPB (bytes/sector, sectors/cluster, two FATs, 512 root entries, media byte, computed sectors-per-FAT, FAT16 type label, 0x55AA signature), the two FATs each starting with the media byte and end-of-chain markers, and — when `-n LABEL` is given — a matching volume-label entry in both the boot sector and the root directory. Images too small for FAT16 are refused rather than silently producing FAT12.

The generated filesystem is validated by host `fsck.vfat`, which reports it clean (0/16223 clusters) with no warnings, both with and without a label.

## Tests

- Unit (hermetic temp images): the boot-sector BPB fields and signature, the FAT head bytes, the volume-label entry in boot sector and root with `-n`, the empty root without `-n`, the too-small rejection, the mkdosfs alias name, and the missing-device / missing-image errors.
- shellspec: the FAT16 type label on disk, and mkdosfs refusing a too-small image.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (653 examples, 0 failures); `golangci-lint` clean; the output passes host `fsck.vfat`; registry/README in sync.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mkfs.vfat` and `mkdosfs` commands for creating FAT16 filesystem images with optional volume label support.

* **Tests**
  * Added unit and integration tests for filesystem creation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->