### PR TITLE
fix(mkfs.vfat): size block devices via ioctl and bound the FAT16 cluster count

### DIFF
--- a/internal/applets/util-linux/mkfs_vfat/mkfs_vfat.go
+++ b/internal/applets/util-linux/mkfs_vfat/mkfs_vfat.go
@@ -5,9 +5,12 @@ package mkfsvfat
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"os"
+	"unsafe"
 
 	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
 )
 
 // Command is the mkfs.vfat applet. It is also registered under the traditional
@@ -32,9 +35,14 @@ const (
 	reservedSectors = 1
 	numFATs         = 2
 	mediaByte       = 0xF8
-	// FAT16 is only valid for at least this many data clusters.
+	// FAT16 is valid only for a data-cluster count in this inclusive range.
 	minFAT16Clusters = 4085
+	maxFAT16Clusters = 65524
 )
+
+// clusterSizes are the sectors-per-cluster values tried, smallest first, so the
+// cluster count lands in the FAT16 range as the device grows.
+var clusterSizes = []int{1, 2, 4, 8, 16, 32, 64}
 
 // Run executes mkfs.vfat.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
@@ -67,11 +75,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 	defer func() { _ = f.Close() }()
 
-	info, err := f.Stat()
+	totalSectors, err := deviceSectors(f)
 	if err != nil {
-		return command.Failuref("cannot stat %s: %v", rest[0], err)
+		return command.Failuref("cannot size %s: %v", rest[0], err)
 	}
-	totalSectors := int(info.Size() / sectorSize)
 
 	if err := writeFAT16(f, totalSectors, *label, hasLabel); err != nil {
 		return command.Failuref("%v", err)
@@ -79,46 +86,83 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	return nil
 }
 
+// deviceSectors returns the size of f in 512-byte sectors. For a regular file
+// the stat size is used; for a block device (where st_size is 0) the real
+// capacity is queried with BLKGETSIZE64.
+func deviceSectors(f *os.File) (int, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	size := info.Size()
+	if size == 0 {
+		var bytes uint64
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), uintptr(unix.BLKGETSIZE64), uintptr(unsafe.Pointer(&bytes)))
+		if errno != 0 {
+			return 0, errno
+		}
+		size = int64(bytes)
+	}
+	return int(size / sectorSize), nil
+}
+
 // geometry holds the computed FAT16 layout.
 type geometry struct {
-	totalSectors   int
-	rootDirSectors int
-	sectorsPerFAT  int
-	clusters       int
+	totalSectors      int
+	rootDirSectors    int
+	sectorsPerFAT     int
+	clusters          int
+	sectorsPerCluster int
 }
 
 func upper(a, b int) int { return (a + b - 1) / b }
 
-// computeGeometry derives the FAT16 layout for totalSectors 512-byte sectors,
-// using one sector per cluster.
-func computeGeometry(totalSectors int) geometry {
+// computeGeometry derives a FAT16 layout for totalSectors 512-byte sectors,
+// choosing the smallest sectors-per-cluster that keeps the data-cluster count
+// within the valid FAT16 range. It errors if no cluster size fits (the device
+// is too small for FAT16, or large enough to need FAT32).
+func computeGeometry(totalSectors int) (geometry, error) {
 	rootDirSectors := upper(rootEntries*32, sectorSize)
-	sectorsPerFAT := 1
-	for {
-		dataSectors := totalSectors - reservedSectors - rootDirSectors - numFATs*sectorsPerFAT
-		clusters := dataSectors // one sector per cluster
-		next := upper((clusters+2)*2, sectorSize)
-		if next == sectorsPerFAT {
-			return geometry{totalSectors, rootDirSectors, sectorsPerFAT, clusters}
+	tooSmall := false
+	for _, spc := range clusterSizes {
+		sectorsPerFAT := 1
+		var clusters int
+		for {
+			dataSectors := totalSectors - reservedSectors - rootDirSectors - numFATs*sectorsPerFAT
+			clusters = dataSectors / spc
+			next := upper((clusters+2)*2, sectorSize)
+			if next == sectorsPerFAT {
+				break
+			}
+			sectorsPerFAT = next
 		}
-		sectorsPerFAT = next
+		if clusters < minFAT16Clusters {
+			tooSmall = true
+			continue
+		}
+		if clusters <= maxFAT16Clusters {
+			return geometry{totalSectors, rootDirSectors, sectorsPerFAT, clusters, spc}, nil
+		}
 	}
+	if tooSmall {
+		return geometry{}, errors.New("device is too small for FAT16")
+	}
+	return geometry{}, errors.New("device is too large for FAT16; use FAT32")
 }
 
 // writeFAT16 writes the boot sector, the two FATs, and the root directory. When
 // hasLabel is set, the root directory gets a matching volume-label entry.
 func writeFAT16(f *os.File, totalSectors int, label string, hasLabel bool) error {
-	g := computeGeometry(totalSectors)
-	if g.clusters < minFAT16Clusters {
-		return command.Failuref("device is too small for FAT16 (%d clusters, need %d)",
-			g.clusters, minFAT16Clusters)
+	g, err := computeGeometry(totalSectors)
+	if err != nil {
+		return err
 	}
 
 	boot := make([]byte, sectorSize)
 	boot[0], boot[1], boot[2] = 0xEB, 0x3C, 0x90 // jump
 	copy(boot[3:11], "MIMIXBOX")
 	binary.LittleEndian.PutUint16(boot[11:], sectorSize)
-	boot[13] = 1 // sectors per cluster
+	boot[13] = byte(g.sectorsPerCluster)
 	binary.LittleEndian.PutUint16(boot[14:], reservedSectors)
 	boot[16] = numFATs
 	binary.LittleEndian.PutUint16(boot[17:], rootEntries)
@@ -160,7 +204,7 @@ func writeFAT16(f *os.File, totalSectors int, label string, hasLabel bool) error
 		root[11] = 0x08 // ATTR_VOLUME_ID
 	}
 	rootOff := int64(reservedSectors+numFATs*g.sectorsPerFAT) * sectorSize
-	_, err := f.WriteAt(root, rootOff)
+	_, err = f.WriteAt(root, rootOff)
 	return err
 }
 

--- a/internal/applets/util-linux/mkfs_vfat/mkfs_vfat_test.go
+++ b/internal/applets/util-linux/mkfs_vfat/mkfs_vfat_test.go
@@ -68,7 +68,7 @@ func TestVolumeLabelEntry(t *testing.T) {
 		t.Errorf("boot label = %q", data[43:54])
 	}
 	// Root directory volume-label entry.
-	g := computeGeometry(16384)
+	g, _ := computeGeometry(16384)
 	rootOff := (reservedSectors + numFATs*g.sectorsPerFAT) * sectorSize
 	if string(data[rootOff:rootOff+5]) != "MYVOL" || data[rootOff+11] != 0x08 {
 		t.Errorf("root volume entry wrong")
@@ -81,7 +81,7 @@ func TestNoLabelNoRootEntry(t *testing.T) {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(img)
-	g := computeGeometry(16384)
+	g, _ := computeGeometry(16384)
 	rootOff := (reservedSectors + numFATs*g.sectorsPerFAT) * sectorSize
 	if data[rootOff] != 0 {
 		t.Errorf("root dir should be empty without -n")
@@ -107,5 +107,32 @@ func TestErrors(t *testing.T) {
 	}
 	if err := run(t, "/no/such/image"); err == nil {
 		t.Errorf("a missing image should fail")
+	}
+}
+
+func TestComputeGeometryClusterRange(t *testing.T) {
+	t.Parallel()
+	// Small device: spc 1, clusters in the FAT16 range.
+	g, err := computeGeometry(16384)
+	if err != nil || g.sectorsPerCluster != 1 {
+		t.Fatalf("small geometry = %+v, err %v", g, err)
+	}
+	if g.clusters < minFAT16Clusters || g.clusters > maxFAT16Clusters {
+		t.Errorf("clusters %d out of FAT16 range", g.clusters)
+	}
+	// Large device (200 MiB): a bigger cluster keeps the count within FAT16.
+	big, err := computeGeometry(409600)
+	if err != nil {
+		t.Fatalf("large geometry err: %v", err)
+	}
+	if big.sectorsPerCluster <= 1 {
+		t.Errorf("expected spc>1 for a large device, got %d", big.sectorsPerCluster)
+	}
+	if big.clusters > maxFAT16Clusters {
+		t.Errorf("large clusters %d exceed FAT16 max", big.clusters)
+	}
+	// Way too small: an error rather than silent FAT12.
+	if _, err := computeGeometry(64); err == nil {
+		t.Errorf("a tiny device should error")
 	}
 }


### PR DESCRIPTION
Follow-up to #400 addressing two CodeRabbit Major findings:

- **Block-device sizing.** `totalSectors` came from `Stat().Size()`, which is 0 for Linux block-device nodes, so a valid device would be wrongly rejected as too small. Sizing now falls back to the BLKGETSIZE64 ioctl (as blockdev does) when the stat size is 0.
- **FAT16 cluster upper bound.** `writeFAT16` hard-coded one sector per cluster and only checked the cluster *minimum*, so a large image could exceed 65524 clusters yet still be stamped "FAT16" — an invalid layout. `computeGeometry` now chooses the smallest sectors-per-cluster (1,2,…,64) that keeps the data-cluster count within [4085, 65524], errors clearly when the device is too small (FAT12 territory) or too large (needs FAT32), and the boot sector records the chosen cluster size.

Validated against host `fsck.vfat`: an 8 MiB image (spc 1) and a 200 MiB image (spc 8 auto-selected) are both reported clean. Adds a unit test for the cluster-range/spc selection.

Part of #249