### PR TITLE
feat(util-linux): add fsck applet to detect a filesystem type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 278 commands. Run `mimixbox --list` to see them on the terminal.
+There are 279 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -96,6 +96,7 @@ There are 278 commands. Run `mimixbox --list` to see them on the terminal.
 | fortune | Print a random, hopefully interesting, adage |
 | free | Display amount of free and used memory in the system |
 | freeramdisk | Free the memory used by a ramdisk |
+| fsck | Detect and report a filesystem type |
 | fsck.minix | Check a Minix filesystem |
 | fsfreeze | Suspend or resume a filesystem |
 | fstrim | Discard unused blocks on a filesystem |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -222,6 +222,7 @@ import (
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
 	ap_util_linux_freeramdisk "github.com/nao1215/mimixbox/internal/applets/util-linux/freeramdisk"
+	ap_util_linux_fsck "github.com/nao1215/mimixbox/internal/applets/util-linux/fsck"
 	ap_util_linux_fsck_minix "github.com/nao1215/mimixbox/internal/applets/util-linux/fsck_minix"
 	ap_util_linux_fsfreeze "github.com/nao1215/mimixbox/internal/applets/util-linux/fsfreeze"
 	ap_util_linux_fstrim "github.com/nao1215/mimixbox/internal/applets/util-linux/fstrim"
@@ -266,7 +267,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 278)
+	Applets = make(map[string]Applet, 279)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -501,6 +502,7 @@ func init() {
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())
 	register(ap_util_linux_freeramdisk.New())
+	register(ap_util_linux_fsck.New())
 	register(ap_util_linux_fsck_minix.New())
 	register(ap_util_linux_fsfreeze.New())
 	register(ap_util_linux_fstrim.New())

--- a/internal/applets/util-linux/fsck/fsck.go
+++ b/internal/applets/util-linux/fsck/fsck.go
@@ -1,0 +1,106 @@
+// Package fsck implements the fsck applet: detect the filesystem type on a
+// device or image and report it. A full consistency walk is delegated to the
+// type-specific checkers (e.g. fsck.minix).
+package fsck
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the fsck applet.
+type Command struct{}
+
+// New returns a fsck command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fsck" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Detect and report a filesystem type" }
+
+// minixMagics are the Minix superblock magics.
+var minixMagics = map[uint16]bool{0x137F: true, 0x138F: true, 0x2468: true, 0x2478: true}
+
+// Run executes fsck.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Detect the filesystem on DEVICE (a block device or image file) by inspecting its " +
+			"on-disk signatures and report the type (ext2/3/4, minix, vfat, or swap). A full " +
+			"consistency check is delegated to the type-specific checkers such as fsck.minix.",
+		Examples: []command.Example{
+			{Command: "fsck disk.img", Explain: "Report the filesystem type of the image."},
+		},
+		ExitStatus: "0  a known filesystem was detected.\n1  the device was unreadable or unrecognized.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a device or image is required")
+	}
+
+	buf, err := readHead(rest[0])
+	if err != nil {
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+
+	fstype := detect(buf)
+	if fstype == "" {
+		return command.Failuref("%s: unable to detect a known filesystem type", rest[0])
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "%s: %s\n", rest[0], fstype)
+	return nil
+}
+
+// detect identifies the filesystem from the on-disk signatures in buf.
+func detect(buf []byte) string {
+	// ext2/3/4: s_magic 0xEF53 at superblock offset 56 (block 1).
+	if len(buf) >= 1024+58 && binary.LittleEndian.Uint16(buf[1024+56:]) == 0xEF53 {
+		return "ext2/ext3/ext4"
+	}
+	// minix: s_magic at superblock offset 16.
+	if len(buf) >= 1024+18 && minixMagics[binary.LittleEndian.Uint16(buf[1024+16:])] {
+		return "minix"
+	}
+	// vfat: the 0x55AA boot signature plus a FATxx type label.
+	if len(buf) >= 512 && buf[510] == 0x55 && buf[511] == 0xAA {
+		if hasFATLabel(buf, 54) || hasFATLabel(buf, 82) {
+			return "vfat"
+		}
+	}
+	// swap: the "SWAPSPACE2" signature at the end of the first 4 KiB page.
+	if len(buf) >= 4096 && string(buf[4086:4096]) == "SWAPSPACE2" {
+		return "swap"
+	}
+	return ""
+}
+
+// hasFATLabel reports whether buf holds an "FAT" type label at off.
+func hasFATLabel(buf []byte, off int) bool {
+	return len(buf) >= off+3 && string(buf[off:off+3]) == "FAT"
+}
+
+// readHead reads the first 8 KiB of path (enough for every signature checked).
+func readHead(path string) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // user-named device or image
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, 8192)
+	n, err := f.ReadAt(buf, 0)
+	if n == 0 && err != nil {
+		return nil, fmt.Errorf("cannot read: %w", err)
+	}
+	return buf[:n], nil
+}

--- a/internal/applets/util-linux/fsck/fsck_test.go
+++ b/internal/applets/util-linux/fsck/fsck_test.go
@@ -1,0 +1,92 @@
+package fsck
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+
+	ext := make([]byte, 2048)
+	binary.LittleEndian.PutUint16(ext[1024+56:], 0xEF53)
+	if got := detect(ext); got != "ext2/ext3/ext4" {
+		t.Errorf("ext = %q", got)
+	}
+
+	minix := make([]byte, 2048)
+	binary.LittleEndian.PutUint16(minix[1024+16:], 0x137F)
+	if got := detect(minix); got != "minix" {
+		t.Errorf("minix = %q", got)
+	}
+
+	vfat := make([]byte, 512)
+	vfat[510], vfat[511] = 0x55, 0xAA
+	copy(vfat[54:], "FAT16   ")
+	if got := detect(vfat); got != "vfat" {
+		t.Errorf("vfat = %q", got)
+	}
+
+	// FAT32 keeps its type label at offset 82.
+	vfat32 := make([]byte, 512)
+	vfat32[510], vfat32[511] = 0x55, 0xAA
+	copy(vfat32[82:], "FAT32   ")
+	if got := detect(vfat32); got != "vfat" {
+		t.Errorf("vfat32 = %q", got)
+	}
+
+	swap := make([]byte, 4096)
+	copy(swap[4086:], "SWAPSPACE2")
+	if got := detect(swap); got != "swap" {
+		t.Errorf("swap = %q", got)
+	}
+
+	if got := detect(make([]byte, 8192)); got != "" {
+		t.Errorf("zeros should be unrecognized, got %q", got)
+	}
+}
+
+func TestRunReportsType(t *testing.T) {
+	buf := make([]byte, 2048)
+	binary.LittleEndian.PutUint16(buf[1024+16:], 0x2478) // minix v2, 30-char
+	img := filepath.Join(t.TempDir(), "fs.img")
+	if err := os.WriteFile(img, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{img}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "minix") {
+		t.Errorf("report = %q", out.String())
+	}
+}
+
+func TestRunErrors(t *testing.T) {
+	run := func(args ...string) error {
+		io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		return New().Run(context.Background(), io, args)
+	}
+	if err := run(); err == nil {
+		t.Errorf("missing device should fail")
+	}
+	if err := run("/no/such/image"); err == nil {
+		t.Errorf("a missing image should fail")
+	}
+	// An unrecognized image is an error.
+	img := filepath.Join(t.TempDir(), "u.img")
+	if err := os.WriteFile(img, make([]byte, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(img); err == nil {
+		t.Errorf("an unrecognized filesystem should fail")
+	}
+}

--- a/test/it/spec/fsck_spec.sh
+++ b/test/it/spec/fsck_spec.sh
@@ -1,0 +1,19 @@
+Describe 'fsck'
+    Include util-linux/fsck_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/fsck; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'detects a Minix filesystem'
+        When call TestFsckMinix
+        The output should include 'minix'
+        The status should be success
+    End
+    It 'fails on an unrecognized image'
+        When call TestFsckUnknown
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/fsck_test.sh
+++ b/test/it/util-linux/fsck_test.sh
@@ -1,0 +1,10 @@
+TestFsckMinix() {
+    dd if=/dev/zero of="$TEST_DIR/m.img" bs=1024 count=2048 2>/dev/null
+    mkfs.minix "$TEST_DIR/m.img" >/dev/null
+    fsck "$TEST_DIR/m.img"
+}
+TestFsckUnknown() {
+    dd if=/dev/zero of="$TEST_DIR/u.img" bs=1024 count=8 2>/dev/null
+    fsck "$TEST_DIR/u.img" 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fsck`, which detects the filesystem on a device or image by inspecting its on-disk signatures and reports the type — ext2/3/4 (s_magic 0xEF53), minix (the v1/v2 superblock magics), vfat (the 0x55AA boot signature plus a FATxx type label, including FAT32 at offset 82), or swap (the SWAPSPACE2 signature). A full consistency walk is delegated to the type-specific checkers such as fsck.minix; an unrecognized image fails deterministically. It ties together the filesystem creators in this batch: images made by mkfs.minix, mkfs.vfat, and mkswap are each detected correctly.

## Tests

- Unit (crafted signatures): detection of ext, minix, vfat (FAT16 and FAT32 label positions), and swap, plus zeros being unrecognized; a Run reporting the type; and the missing-device / missing-image / unrecognized errors.
- shellspec: detecting a Minix filesystem made by mkfs.minix, and failing on an unrecognized image.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (655 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249