### PR TITLE
feat(util-linux): add fdformat applet to low-level format a floppy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 279 commands. Run `mimixbox --list` to see them on the terminal.
+There are 280 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -86,6 +86,7 @@ There are 279 commands. Run `mimixbox --list` to see them on the terminal.
 | fatattr | Show or change FAT file attributes |
 | fbset | Show the framebuffer video mode |
 | fdflush | Flush a floppy device's buffers |
+| fdformat | Low-level format a floppy device |
 | fdisk | List the MBR partition table |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -218,6 +218,7 @@ import (
 	ap_util_linux_fatattr "github.com/nao1215/mimixbox/internal/applets/util-linux/fatattr"
 	ap_util_linux_fbset "github.com/nao1215/mimixbox/internal/applets/util-linux/fbset"
 	ap_util_linux_fdflush "github.com/nao1215/mimixbox/internal/applets/util-linux/fdflush"
+	ap_util_linux_fdformat "github.com/nao1215/mimixbox/internal/applets/util-linux/fdformat"
 	ap_util_linux_fdisk "github.com/nao1215/mimixbox/internal/applets/util-linux/fdisk"
 	ap_util_linux_findfs "github.com/nao1215/mimixbox/internal/applets/util-linux/findfs"
 	ap_util_linux_flock "github.com/nao1215/mimixbox/internal/applets/util-linux/flock"
@@ -267,7 +268,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 279)
+	Applets = make(map[string]Applet, 280)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -498,6 +499,7 @@ func init() {
 	register(ap_util_linux_fatattr.New())
 	register(ap_util_linux_fbset.New())
 	register(ap_util_linux_fdflush.New())
+	register(ap_util_linux_fdformat.New())
 	register(ap_util_linux_fdisk.New())
 	register(ap_util_linux_findfs.New())
 	register(ap_util_linux_flock.New())

--- a/internal/applets/util-linux/fdformat/fdformat.go
+++ b/internal/applets/util-linux/fdformat/fdformat.go
@@ -1,0 +1,111 @@
+// Package fdformat implements the fdformat applet: low-level format a floppy
+// device, track by track.
+package fdformat
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the fdformat applet.
+type Command struct{}
+
+// New returns a fdformat command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fdformat" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Low-level format a floppy device" }
+
+// Floppy ioctls, not exported by this x/sys version.
+const (
+	fdGetPrm = 0x0204 // FDGETPRM: read the drive geometry
+	fdFmtBeg = 0x0247 // FDFMTBEG: begin a format session
+	fdFmtTrk = 0x0248 // FDFMTTRK: format one track
+	fdFmtEnd = 0x0249 // FDFMTEND: end a format session
+)
+
+// floppyStruct mirrors the kernel's struct floppy_struct (FDGETPRM). The C
+// fields are 32-bit, so they are uint32 here, not Go's 64-bit uint.
+type floppyStruct struct {
+	Size, Sect, Head, Track, Stretch uint32
+	Gap, Rate, Spec1, FmtGap         uint8
+	Name                             uintptr
+}
+
+// formatDescr mirrors struct format_descr (FDFMTTRK): the device field is
+// unused, and head/track select the track to format.
+type formatDescr struct {
+	Device, Head, Track uint32
+}
+
+// formatFn is indirected so the privileged format sequence can be tested.
+var formatFn = func(device string) (tracks int, err error) {
+	f, err := os.Open(device) //nolint:gosec // user-named device
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var g floppyStruct
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fdGetPrm, uintptr(unsafe.Pointer(&g))); errno != 0 {
+		return 0, errno
+	}
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fdFmtBeg, 0); errno != 0 {
+		return 0, errno
+	}
+	heads := g.Head
+	if heads == 0 {
+		heads = 1
+	}
+	cylinders := g.Size / (g.Sect * heads)
+	for cyl := uint32(0); cyl < cylinders; cyl++ {
+		for head := uint32(0); head < heads; head++ {
+			fd := formatDescr{Head: head, Track: cyl}
+			if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fdFmtTrk, uintptr(unsafe.Pointer(&fd))); errno != 0 {
+				return 0, errno
+			}
+		}
+	}
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fdFmtEnd, 0); errno != 0 {
+		return 0, errno
+	}
+	return int(cylinders * heads), nil
+}
+
+// Run executes fdformat.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DEVICE", stdio.Err).WithHelp(command.Help{
+		Description: "Low-level format the floppy DEVICE: read its geometry, then format every track. " +
+			"This erases the medium and writes fresh sector headers; it does not create a filesystem " +
+			"(use mkfs.* afterwards). It requires a real floppy drive and privilege.",
+		Examples: []command.Example{
+			{Command: "fdformat /dev/fd0", Explain: "Format the floppy in /dev/fd0."},
+		},
+		ExitStatus: "0  the floppy was formatted.\n1  no device was given or the format failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a floppy device is required")
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "Formatting %s ...\n", rest[0])
+	tracks, err := formatFn(rest[0])
+	if err != nil {
+		return command.Failuref("%s: %v", rest[0], err)
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "done (%d tracks)\n", tracks)
+	return nil
+}

--- a/internal/applets/util-linux/fdformat/fdformat_test.go
+++ b/internal/applets/util-linux/fdformat/fdformat_test.go
@@ -1,0 +1,60 @@
+package fdformat
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, tracks int, err error) *string {
+	t.Helper()
+	got := new(string)
+	*got = "<unset>"
+	orig := formatFn
+	formatFn = func(device string) (int, error) {
+		*got = device
+		return tracks, err
+	}
+	t.Cleanup(func() { formatFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestFormatsDevice(t *testing.T) {
+	got := withStub(t, 160, nil)
+	out, err := run(t, "/dev/fd0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *got != "/dev/fd0" {
+		t.Errorf("formatFn called with %q", *got)
+	}
+	if !strings.Contains(out, "Formatting /dev/fd0") || !strings.Contains(out, "160 tracks") {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestNoDevice(t *testing.T) {
+	withStub(t, 0, nil)
+	if _, err := run(t); err == nil {
+		t.Errorf("missing device should fail")
+	}
+}
+
+func TestFailure(t *testing.T) {
+	withStub(t, 0, errors.New("no such device"))
+	if _, err := run(t, "/dev/fd0"); err == nil {
+		t.Errorf("a format failure should fail")
+	}
+}

--- a/test/it/spec/fdformat_spec.sh
+++ b/test/it/spec/fdformat_spec.sh
@@ -1,0 +1,15 @@
+Describe 'fdformat'
+    Include util-linux/fdformat_test.sh
+
+    It 'requires a device'
+        When call TestFdformatNoDev
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestFdformatHelp
+        The status should be success
+        The output should include 'Usage: fdformat'
+        The output should include 'floppy'
+    End
+End

--- a/test/it/util-linux/fdformat_test.sh
+++ b/test/it/util-linux/fdformat_test.sh
@@ -1,0 +1,4 @@
+# Formatting needs a real floppy drive and privilege, so the e2e exercises the
+# deterministic no-device path and --help; the format sequence is unit-tested.
+TestFdformatNoDev() { fdformat 2>/dev/null; echo "rc=$?"; }
+TestFdformatHelp() { fdformat --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `fdformat`, which low-level formats a floppy DEVICE: it reads the drive geometry (FDGETPRM), begins a format session (FDFMTBEG), formats every track (FDFMTTRK over each cylinder/head), and ends the session (FDFMTEND). It erases the medium and writes fresh sector headers without creating a filesystem. The kernel structs are mirrored with 32-bit fields to match the C layout. It requires a real floppy drive and privilege; the format sequence is injectable so the dispatch is tested without hardware.

## Tests

- Unit (stubbed format): formatting the named device with the reported track count in the output, the missing-device error, and a format-failure error.
- shellspec: a missing device fails, and the `--help` path (formatting needs a floppy drive and privilege, so the sequence is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (657 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249