### PR TITLE
feat(util-linux): add mdev applet to create /dev nodes from /sys

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 280 commands. Run `mimixbox --list` to see them on the terminal.
+There are 281 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -152,6 +152,7 @@ There are 280 commands. Run `mimixbox --list` to see them on the terminal.
 | man | Display a manual page |
 | mbsh | Mimix Box Shell |
 | md5sum | Calculate or Check md5sum message digest |
+| mdev | Create /dev nodes from /sys (scan mode) |
 | mesg | Display or control write access to your terminal |
 | minips | Minimal process lister (PID, user, command) |
 | mkdir | Make directories |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -239,6 +239,7 @@ import (
 	ap_util_linux_lsblk "github.com/nao1215/mimixbox/internal/applets/util-linux/lsblk"
 	ap_util_linux_lspci "github.com/nao1215/mimixbox/internal/applets/util-linux/lspci"
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
+	ap_util_linux_mdev "github.com/nao1215/mimixbox/internal/applets/util-linux/mdev"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
 	ap_util_linux_mkfs_minix "github.com/nao1215/mimixbox/internal/applets/util-linux/mkfs_minix"
 	ap_util_linux_mkfs_vfat "github.com/nao1215/mimixbox/internal/applets/util-linux/mkfs_vfat"
@@ -268,7 +269,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 280)
+	Applets = make(map[string]Applet, 281)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -521,6 +522,7 @@ func init() {
 	register(ap_util_linux_lsblk.New())
 	register(ap_util_linux_lspci.New())
 	register(ap_util_linux_lsusb.New())
+	register(ap_util_linux_mdev.New())
 	register(ap_util_linux_mesg.New())
 	register(ap_util_linux_mkfs_minix.New())
 	register(ap_util_linux_mkfs_vfat.New())

--- a/internal/applets/util-linux/mdev/mdev.go
+++ b/internal/applets/util-linux/mdev/mdev.go
@@ -1,0 +1,130 @@
+// Package mdev implements the mdev applet in scan mode: create device nodes in
+// /dev from the entries advertised under /sys/class.
+package mdev
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the mdev applet.
+type Command struct{}
+
+// New returns a mdev command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mdev" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Create /dev nodes from /sys (scan mode)" }
+
+// Injected so the scan and the privileged mknod are testable.
+var (
+	sysClassDir = "/sys/class"
+	devDir      = "/dev"
+	mknodFn     = func(path string, isBlock bool, major, minor uint32) error {
+		mode := uint32(unix.S_IFCHR | 0o660)
+		if isBlock {
+			mode = unix.S_IFBLK | 0o660
+		}
+		return unix.Mknod(path, mode, int(unix.Mkdev(major, minor)))
+	}
+)
+
+// Run executes mdev.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-s", stdio.Err).WithHelp(command.Help{
+		Description: "In scan mode (-s), walk /sys/class and create a device node under /dev for every " +
+			"device that advertises a 'dev' (major:minor) attribute, as a block node for the block " +
+			"class and a character node otherwise. The hotplug-helper mode is not implemented. " +
+			"Creating device nodes requires privilege.",
+		Examples: []command.Example{
+			{Command: "mdev -s", Explain: "Populate /dev from /sys."},
+		},
+		ExitStatus: "0  the nodes were created.\n1  -s was not given or a node could not be created.",
+	})
+	scan := fs.BoolP("scan", "s", false, "scan /sys and create device nodes")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if !*scan {
+		_, _ = fmt.Fprintln(stdio.Err, "mdev: only scan mode (-s) is supported by this build")
+		return command.SilentFailure()
+	}
+
+	created, failed := 0, false
+	for _, d := range scanDevices() {
+		path := filepath.Join(devDir, d.name)
+		if err := mknodFn(path, d.isBlock, d.major, d.minor); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "mdev: %s: %v\n", path, err)
+			failed = true
+			continue
+		}
+		created++
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "mdev: created %d device node(s)\n", created)
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+type device struct {
+	name         string
+	isBlock      bool
+	major, minor uint32
+}
+
+// scanDevices returns every device advertised under /sys/class that has a valid
+// dev attribute.
+func scanDevices() []device {
+	classes, err := os.ReadDir(sysClassDir)
+	if err != nil {
+		return nil
+	}
+	var devices []device
+	for _, class := range classes {
+		isBlock := class.Name() == "block"
+		classPath := filepath.Join(sysClassDir, class.Name())
+		entries, err := os.ReadDir(classPath)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			major, minor, ok := readDev(filepath.Join(classPath, e.Name(), "dev"))
+			if !ok {
+				continue
+			}
+			devices = append(devices, device{name: e.Name(), isBlock: isBlock, major: major, minor: minor})
+		}
+	}
+	return devices
+}
+
+// readDev parses a "major:minor" sysfs dev attribute file.
+func readDev(path string) (major, minor uint32, ok bool) {
+	data, err := os.ReadFile(path) //nolint:gosec // sysfs attribute path
+	if err != nil {
+		return 0, 0, false
+	}
+	maj, min, found := strings.Cut(strings.TrimSpace(string(data)), ":")
+	if !found {
+		return 0, 0, false
+	}
+	majN, err1 := strconv.ParseUint(maj, 10, 32)
+	minN, err2 := strconv.ParseUint(min, 10, 32)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return uint32(majN), uint32(minN), true
+}

--- a/internal/applets/util-linux/mdev/mdev_test.go
+++ b/internal/applets/util-linux/mdev/mdev_test.go
@@ -1,0 +1,122 @@
+package mdev
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type mknodCall struct {
+	path         string
+	isBlock      bool
+	major, minor uint32
+}
+
+func fixture(t *testing.T, failMknod bool) *[]mknodCall {
+	t.Helper()
+	dir := t.TempDir()
+	mk := func(class, name, dev string) {
+		d := filepath.Join(dir, class, name)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if dev != "" {
+			if err := os.WriteFile(filepath.Join(d, "dev"), []byte(dev+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	mk("block", "sda", "8:0")
+	mk("mem", "null", "1:3")
+	mk("tty", "tty0", "4:0")
+	mk("net", "eth0", "") // no dev attribute -> skipped
+
+	var calls []mknodCall
+	osc, odv, omk := sysClassDir, devDir, mknodFn
+	sysClassDir = dir
+	devDir = filepath.Join(dir, "dev")
+	mknodFn = func(path string, isBlock bool, major, minor uint32) error {
+		if failMknod {
+			return errors.New("permission denied")
+		}
+		calls = append(calls, mknodCall{path, isBlock, major, minor})
+		return nil
+	}
+	t.Cleanup(func() { sysClassDir, devDir, mknodFn = osc, odv, omk })
+	return &calls
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestScanCreatesNodes(t *testing.T) {
+	calls := fixture(t, false)
+	out, err := run(t, "-s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 3 {
+		t.Fatalf("created %d nodes, want 3: %+v", len(*calls), *calls)
+	}
+	sort.Slice(*calls, func(i, j int) bool { return (*calls)[i].path < (*calls)[j].path })
+	byName := map[string]mknodCall{}
+	for _, c := range *calls {
+		byName[filepath.Base(c.path)] = c
+	}
+	if c := byName["sda"]; !c.isBlock || c.major != 8 || c.minor != 0 {
+		t.Errorf("sda node = %+v, want block 8:0", c)
+	}
+	if c := byName["null"]; c.isBlock || c.major != 1 || c.minor != 3 {
+		t.Errorf("null node = %+v, want char 1:3", c)
+	}
+	if c := byName["tty0"]; c.isBlock || c.major != 4 || c.minor != 0 {
+		t.Errorf("tty0 node = %+v, want char 4:0", c)
+	}
+	if !strings.Contains(out, "created 3") {
+		t.Errorf("summary = %q", out)
+	}
+}
+
+func TestRequiresScan(t *testing.T) {
+	fixture(t, false)
+	if _, err := run(t); err == nil {
+		t.Errorf("without -s it should fail")
+	}
+}
+
+func TestMknodFailure(t *testing.T) {
+	fixture(t, true)
+	if _, err := run(t, "-s"); err == nil {
+		t.Errorf("a mknod failure should fail")
+	}
+}
+
+func TestReadDev(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	good := filepath.Join(dir, "dev")
+	_ = os.WriteFile(good, []byte("259:5\n"), 0o644)
+	if maj, min, ok := readDev(good); !ok || maj != 259 || min != 5 {
+		t.Errorf("readDev good = %d,%d,%v", maj, min, ok)
+	}
+	bad := filepath.Join(dir, "bad")
+	_ = os.WriteFile(bad, []byte("notanumber\n"), 0o644)
+	if _, _, ok := readDev(bad); ok {
+		t.Errorf("readDev should reject a malformed dev file")
+	}
+	if _, _, ok := readDev(filepath.Join(dir, "missing")); ok {
+		t.Errorf("readDev should reject a missing file")
+	}
+}

--- a/test/it/spec/mdev_spec.sh
+++ b/test/it/spec/mdev_spec.sh
@@ -1,0 +1,15 @@
+Describe 'mdev'
+    Include util-linux/mdev_test.sh
+
+    It 'requires scan mode'
+        When call TestMdevNoScan
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestMdevHelp
+        The status should be success
+        The output should include 'Usage: mdev'
+        The output should include 'device'
+    End
+End

--- a/test/it/util-linux/mdev_test.sh
+++ b/test/it/util-linux/mdev_test.sh
@@ -1,0 +1,4 @@
+# Creating /dev nodes needs privilege, so the e2e exercises the deterministic
+# no-scan-flag path and --help; the scan/mknod logic is covered by unit tests.
+TestMdevNoScan() { mdev 2>/dev/null; echo "rc=$?"; }
+TestMdevHelp() { mdev --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `mdev` in scan mode (`-s`): it walks /sys/class and creates a device node under /dev for every device that advertises a 'dev' (major:minor) attribute — a block node for the block class and a character node otherwise. The hotplug-helper mode is out of scope; without `-s` it fails deterministically. Creating device nodes requires privilege; the scan paths and the mknod call are injectable so the logic is tested against fixtures.

## Tests

- Unit (fixture /sys/class + stubbed mknod): creating block (sda 8:0) and character (null 1:3, tty0 4:0) nodes with the right type/major/minor, skipping a device without a dev attribute, the require-`-s` behavior, a mknod-failure error, and the `readDev` parser (valid, malformed, missing).
- shellspec: a missing `-s` fails, and the `--help` path (node creation needs privilege, so the scan/mknod is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (659 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249