### PR TITLE
feat(util-linux): add uevent applet to monitor kernel uevents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 281 commands. Run `mimixbox --list` to see them on the terminal.
+There are 282 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -265,6 +265,7 @@ There are 281 commands. Run `mimixbox --list` to see them on the terminal.
 | tsort | Topological sort of a directed graph |
 | tty | Print the file name of the terminal connected to stdin |
 | tune2fs | Show ext2/ext3/ext4 filesystem parameters |
+| uevent | Monitor kernel uevents |
 | umount | Unmount a filesystem |
 | uname | Print system information |
 | uncompress | Decompress LZW (.Z) files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -261,6 +261,7 @@ import (
 	ap_util_linux_switch_root "github.com/nao1215/mimixbox/internal/applets/util-linux/switch_root"
 	ap_util_linux_taskset "github.com/nao1215/mimixbox/internal/applets/util-linux/taskset"
 	ap_util_linux_tune2fs "github.com/nao1215/mimixbox/internal/applets/util-linux/tune2fs"
+	ap_util_linux_uevent "github.com/nao1215/mimixbox/internal/applets/util-linux/uevent"
 	ap_util_linux_umount "github.com/nao1215/mimixbox/internal/applets/util-linux/umount"
 	ap_util_linux_unshare "github.com/nao1215/mimixbox/internal/applets/util-linux/unshare"
 	ap_util_linux_wall "github.com/nao1215/mimixbox/internal/applets/util-linux/wall"
@@ -269,7 +270,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 281)
+	Applets = make(map[string]Applet, 282)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -548,6 +549,7 @@ func init() {
 	register(ap_util_linux_switch_root.New())
 	register(ap_util_linux_taskset.New())
 	register(ap_util_linux_tune2fs.New())
+	register(ap_util_linux_uevent.New())
 	register(ap_util_linux_umount.New())
 	register(ap_util_linux_unshare.New())
 	register(ap_util_linux_wall.New())

--- a/internal/applets/util-linux/uevent/uevent.go
+++ b/internal/applets/util-linux/uevent/uevent.go
@@ -1,0 +1,116 @@
+// Package uevent implements the uevent applet: monitor kernel uevents from the
+// netlink socket and print each one until interrupted.
+package uevent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the uevent applet.
+type Command struct{}
+
+// New returns a uevent command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "uevent" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Monitor kernel uevents" }
+
+// ueventSource yields kernel uevent messages.
+type ueventSource interface {
+	Recv() ([]byte, error)
+	Close() error
+}
+
+// dialFn is indirected so the monitor can be tested without a netlink socket.
+var dialFn = func() (ueventSource, error) { return openNetlink() }
+
+// Run executes uevent.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Listen on the kernel uevent netlink socket and print each event as 'ACTION " +
+			"DEVPATH' as devices are added, removed, or changed, until interrupted. Opening the " +
+			"netlink socket requires privilege.",
+		Examples: []command.Example{
+			{Command: "uevent", Explain: "Print kernel uevents as they arrive."},
+		},
+		ExitStatus: "0  the monitor stopped cleanly.\n1  the netlink socket could not be opened.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	src, err := dialFn()
+	if err != nil {
+		return command.Failuref("cannot open the uevent netlink socket: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	// Closing the source on cancellation unblocks Recv.
+	go func() {
+		<-ctx.Done()
+		_ = src.Close()
+	}()
+
+	for {
+		msg, err := src.Recv()
+		if err != nil {
+			return nil // closed via cancellation, or the source ended
+		}
+		action, devpath := parseEvent(msg)
+		if action == "" {
+			continue
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%s %s\n", action, devpath)
+	}
+}
+
+// parseEvent extracts the action and device path from a uevent message, whose
+// header is "ACTION@DEVPATH" followed by NUL-separated KEY=VALUE pairs.
+func parseEvent(msg []byte) (action, devpath string) {
+	header := msg
+	if i := bytes.IndexByte(msg, 0); i >= 0 {
+		header = msg[:i]
+	}
+	a, d, found := strings.Cut(string(header), "@")
+	if !found {
+		return "", ""
+	}
+	return a, d
+}
+
+// netlinkSource reads uevents from a NETLINK_KOBJECT_UEVENT socket.
+type netlinkSource struct{ fd int }
+
+func openNetlink() (ueventSource, error) {
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_KOBJECT_UEVENT)
+	if err != nil {
+		return nil, err
+	}
+	addr := &unix.SockaddrNetlink{Family: unix.AF_NETLINK, Groups: 1}
+	if err := unix.Bind(fd, addr); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	return &netlinkSource{fd: fd}, nil
+}
+
+func (s *netlinkSource) Recv() ([]byte, error) {
+	buf := make([]byte, 8192)
+	n, _, err := unix.Recvfrom(s.fd, buf, 0)
+	if err != nil {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+func (s *netlinkSource) Close() error { return unix.Close(s.fd) }

--- a/internal/applets/util-linux/uevent/uevent_test.go
+++ b/internal/applets/util-linux/uevent/uevent_test.go
@@ -1,0 +1,116 @@
+package uevent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// queueSource yields the queued messages, then reports EOF.
+type queueSource struct {
+	msgs [][]byte
+	i    int
+}
+
+func (q *queueSource) Recv() ([]byte, error) {
+	if q.i >= len(q.msgs) {
+		return nil, io.EOF
+	}
+	m := q.msgs[q.i]
+	q.i++
+	return m, nil
+}
+func (q *queueSource) Close() error { return nil }
+
+func withSource(t *testing.T, src ueventSource, dialErr error) {
+	t.Helper()
+	orig := dialFn
+	dialFn = func() (ueventSource, error) {
+		if dialErr != nil {
+			return nil, dialErr
+		}
+		return src, nil
+	}
+	t.Cleanup(func() { dialFn = orig })
+}
+
+func TestPrintsEvents(t *testing.T) {
+	withSource(t, &queueSource{msgs: [][]byte{
+		[]byte("add@/devices/pci0000:00/usb1\x00ACTION=add\x00SUBSYSTEM=usb\x00"),
+		[]byte("remove@/devices/virtual/net/eth0\x00ACTION=remove\x00"),
+	}}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := &bytes.Buffer{}
+	io2 := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(ctx, io2, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "add /devices/pci0000:00/usb1") {
+		t.Errorf("missing add event:\n%s", out)
+	}
+	if !strings.Contains(out.String(), "remove /devices/virtual/net/eth0") {
+		t.Errorf("missing remove event:\n%s", out)
+	}
+}
+
+// blockingSource blocks in Recv until it is closed.
+type blockingSource struct{ closed chan struct{} }
+
+func (b *blockingSource) Recv() ([]byte, error) {
+	<-b.closed
+	return nil, errors.New("closed")
+}
+func (b *blockingSource) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+func TestStopsOnCancel(t *testing.T) {
+	withSource(t, &blockingSource{closed: make(chan struct{})}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		done <- New().Run(ctx, io2, nil)
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v after cancel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("uevent did not stop after cancellation")
+	}
+}
+
+func TestDialFailure(t *testing.T) {
+	withSource(t, nil, errors.New("operation not permitted"))
+	io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io2, nil); err == nil {
+		t.Errorf("a dial failure should fail")
+	}
+}
+
+func TestParseEvent(t *testing.T) {
+	t.Parallel()
+	a, d := parseEvent([]byte("change@/devices/foo\x00KEY=val\x00"))
+	if a != "change" || d != "/devices/foo" {
+		t.Errorf("parseEvent = %q, %q", a, d)
+	}
+	if a, _ := parseEvent([]byte("malformed-no-at")); a != "" {
+		t.Errorf("malformed header should yield empty action")
+	}
+}

--- a/test/it/spec/uevent_spec.sh
+++ b/test/it/spec/uevent_spec.sh
@@ -1,0 +1,10 @@
+Describe 'uevent'
+    Include util-linux/uevent_test.sh
+
+    It 'describes itself with --help'
+        When call TestUeventHelp
+        The status should be success
+        The output should include 'Usage: uevent'
+        The output should include 'uevent'
+    End
+End

--- a/test/it/util-linux/uevent_test.sh
+++ b/test/it/util-linux/uevent_test.sh
@@ -1,0 +1,3 @@
+# uevent blocks monitoring the netlink socket (privileged), so the e2e exercises
+# --help; the receive/parse loop is covered by Go unit tests.
+TestUeventHelp() { uevent --help; }


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `uevent`, which listens on the kernel uevent netlink socket (NETLINK_KOBJECT_UEVENT) and prints each event as 'ACTION DEVPATH' as devices are added, removed, or changed, until interrupted (the context is cancelled on SIGINT). Opening the netlink socket requires privilege. The event source is injectable so the receive/parse loop and cancellation are tested without netlink.

## Tests

- Unit (fake source + cancellable context): printing queued add/remove events as 'ACTION DEVPATH', stopping cleanly when the context is cancelled (the blocking receive is unblocked by closing the source), a dial-failure error, and the `parseEvent` parser (valid header and a malformed one).
- shellspec: the `--help` path (the monitor blocks on a privileged socket, so its behavior is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (660 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #249