### PR TITLE
feat(util-linux): add mke2fs/mkfs.ext2 applet to create an ext2 filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 282 commands. Run `mimixbox --list` to see them on the terminal.
+There are 284 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -157,7 +157,9 @@ There are 282 commands. Run `mimixbox --list` to see them on the terminal.
 | minips | Minimal process lister (PID, user, command) |
 | mkdir | Make directories |
 | mkdosfs | Create a FAT16 filesystem |
+| mke2fs | Create an ext2 filesystem |
 | mkfifo | Make FIFO (named pipe) |
+| mkfs.ext2 | Create an ext2 filesystem |
 | mkfs.minix | Create a Minix filesystem |
 | mkfs.vfat | Create a FAT16 filesystem |
 | mknod | Make block or character special files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -241,6 +241,7 @@ import (
 	ap_util_linux_lsusb "github.com/nao1215/mimixbox/internal/applets/util-linux/lsusb"
 	ap_util_linux_mdev "github.com/nao1215/mimixbox/internal/applets/util-linux/mdev"
 	ap_util_linux_mesg "github.com/nao1215/mimixbox/internal/applets/util-linux/mesg"
+	ap_util_linux_mke2fs "github.com/nao1215/mimixbox/internal/applets/util-linux/mke2fs"
 	ap_util_linux_mkfs_minix "github.com/nao1215/mimixbox/internal/applets/util-linux/mkfs_minix"
 	ap_util_linux_mkfs_vfat "github.com/nao1215/mimixbox/internal/applets/util-linux/mkfs_vfat"
 	ap_util_linux_mkswap "github.com/nao1215/mimixbox/internal/applets/util-linux/mkswap"
@@ -270,7 +271,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 282)
+	Applets = make(map[string]Applet, 284)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -525,6 +526,8 @@ func init() {
 	register(ap_util_linux_lsusb.New())
 	register(ap_util_linux_mdev.New())
 	register(ap_util_linux_mesg.New())
+	register(ap_util_linux_mke2fs.New())
+	register(ap_util_linux_mke2fs.NewMkfsExt2())
 	register(ap_util_linux_mkfs_minix.New())
 	register(ap_util_linux_mkfs_vfat.New())
 	register(ap_util_linux_mkfs_vfat.NewMkdosfs())

--- a/internal/applets/util-linux/mke2fs/mke2fs.go
+++ b/internal/applets/util-linux/mke2fs/mke2fs.go
@@ -1,0 +1,340 @@
+// Package mke2fs implements the mke2fs applet (also mkfs.ext2): create a small
+// single-block-group ext2 filesystem on a device or image file.
+package mke2fs
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the mke2fs applet. It is also registered as mkfs.ext2.
+type Command struct{ name string }
+
+// New returns a mke2fs command.
+func New() *Command { return &Command{name: "mke2fs"} }
+
+// NewMkfsExt2 returns the same applet under the name mkfs.ext2.
+func NewMkfsExt2() *Command { return &Command{name: "mkfs.ext2"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Create an ext2 filesystem" }
+
+// now is indirected so the recorded timestamps are deterministic in tests.
+var now = time.Now
+
+const (
+	blockSize            = 1024
+	inodeSize            = 128
+	firstDataBlock       = 1
+	blocksPerGroup       = 8192
+	inodesPerBlock       = blockSize / inodeSize // 8
+	inodeRatio           = 16384
+	extMagic             = 0xEF53
+	rootInode            = 2
+	lostFoundInode       = 11
+	firstInode           = 11
+	featIncompatFiletype = 0x0002
+	sIFDIR               = 0x4000
+)
+
+// Run executes mke2fs.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DEVICE [BLOCKS]", stdio.Err).WithHelp(command.Help{
+		Description: "Create an ext2 filesystem (1 KiB blocks, 128-byte inodes, a single block group) " +
+			"on DEVICE, a block device or image file, with a root directory and a lost+found " +
+			"directory. BLOCKS sets the size in 1 KiB blocks; by default the whole device/file is " +
+			"used. The size must fit one block group (up to 8192 blocks).",
+		Examples: []command.Example{
+			{Command: "mke2fs disk.img", Explain: "Format the image as ext2."},
+			{Command: "mkfs.ext2 -F disk.img 4096", Explain: "Format 4 MiB as ext2."},
+		},
+		ExitStatus: "0  the filesystem was created.\n1  the device was missing, too small, or too large.",
+	})
+	_ = fs.BoolP("force", "F", false, "force creation (accepted for compatibility)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a device or image is required")
+	}
+
+	f, err := os.OpenFile(rest[0], os.O_RDWR, 0o644) //nolint:gosec // user-named device or image
+	if err != nil {
+		return command.Failuref("cannot open %s: %v", rest[0], err)
+	}
+	defer func() { _ = f.Close() }()
+
+	nblocks, err := blockCount(f, rest)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	if err := writeExt2(f, nblocks); err != nil {
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+func blockCount(f *os.File, args []string) (int, error) {
+	if len(args) > 1 {
+		return parseUint(args[1])
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return int(info.Size() / blockSize), nil
+}
+
+// layout is the computed single-group ext2 geometry.
+type layout struct {
+	blocks           int
+	inodes           int
+	inodeTableBlocks int
+	blockBitmapBlock int
+	inodeBitmapBlock int
+	inodeTableBlock  int
+	rootDirBlock     int
+	lostFoundBlock   int
+	usedBlocks       int
+	usedInodes       int
+}
+
+func roundUp(a, b int) int { return ((a + b - 1) / b) * b }
+
+// computeLayout derives the single-group layout for nblocks 1 KiB blocks.
+func computeLayout(nblocks int) (layout, error) {
+	if nblocks < 64 {
+		return layout{}, command.Failuref("filesystem too small (need at least 64 blocks)")
+	}
+	if nblocks > blocksPerGroup {
+		return layout{}, command.Failuref("filesystem too large for a single block group (max %d blocks)", blocksPerGroup)
+	}
+	inodes := nblocks * blockSize / inodeRatio
+	if inodes < 16 {
+		inodes = 16
+	}
+	inodes = roundUp(inodes, inodesPerBlock)
+	inodeTableBlocks := inodes / inodesPerBlock
+
+	blockBitmapBlock := firstDataBlock + 2 // after superblock(1) and GDT(2)
+	inodeBitmapBlock := blockBitmapBlock + 1
+	inodeTableBlock := inodeBitmapBlock + 1
+	rootDirBlock := inodeTableBlock + inodeTableBlocks
+	lostFoundBlock := rootDirBlock + 1
+
+	return layout{
+		blocks:           nblocks,
+		inodes:           inodes,
+		inodeTableBlocks: inodeTableBlocks,
+		blockBitmapBlock: blockBitmapBlock,
+		inodeBitmapBlock: inodeBitmapBlock,
+		inodeTableBlock:  inodeTableBlock,
+		rootDirBlock:     rootDirBlock,
+		lostFoundBlock:   lostFoundBlock,
+		usedBlocks:       lostFoundBlock, // blocks firstDataBlock..lostFoundBlock are used
+		usedInodes:       firstInode,     // inodes 1..11 are used
+	}, nil
+}
+
+// writeExt2 lays out the superblock, group descriptor, bitmaps, inode table,
+// and the root and lost+found directories.
+func writeExt2(f *os.File, nblocks int) error {
+	l, err := computeLayout(nblocks)
+	if err != nil {
+		return err
+	}
+	groupBlocks := l.blocks - firstDataBlock // blocks firstDataBlock..blocks-1
+	freeBlocks := groupBlocks - l.usedBlocks
+	freeInodes := l.inodes - l.usedInodes
+	reserved := l.blocks / 20
+	ts := uint32(now().Unix())
+
+	if err := writeAt(f, superblock(l, freeBlocks, freeInodes, reserved, ts), firstDataBlock*blockSize); err != nil {
+		return err
+	}
+	if err := writeAt(f, groupDesc(l, freeBlocks, freeInodes), (firstDataBlock+1)*blockSize); err != nil {
+		return err
+	}
+	if err := writeAt(f, blockBitmap(l, groupBlocks), int64(l.blockBitmapBlock)*blockSize); err != nil {
+		return err
+	}
+	if err := writeAt(f, inodeBitmap(l), int64(l.inodeBitmapBlock)*blockSize); err != nil {
+		return err
+	}
+	if err := writeAt(f, inodeTable(l, ts), int64(l.inodeTableBlock)*blockSize); err != nil {
+		return err
+	}
+	if err := writeAt(f, rootDirData(l), int64(l.rootDirBlock)*blockSize); err != nil {
+		return err
+	}
+	return writeAt(f, lostFoundData(), int64(l.lostFoundBlock)*blockSize)
+}
+
+func superblock(l layout, freeBlocks, freeInodes, reserved int, ts uint32) []byte {
+	sb := make([]byte, blockSize)
+	le32(sb, 0, uint32(l.inodes))
+	le32(sb, 4, uint32(l.blocks))
+	le32(sb, 8, uint32(reserved))
+	le32(sb, 12, uint32(freeBlocks))
+	le32(sb, 16, uint32(freeInodes))
+	le32(sb, 20, firstDataBlock)
+	le32(sb, 24, 0) // log_block_size: 1024 << 0
+	le32(sb, 28, 0) // log_frag_size
+	le32(sb, 32, blocksPerGroup)
+	le32(sb, 36, blocksPerGroup) // frags_per_group
+	le32(sb, 40, uint32(l.inodes))
+	le32(sb, 44, ts)     // mtime
+	le32(sb, 48, ts)     // wtime
+	le16(sb, 52, 0)      // mnt_count
+	le16(sb, 54, 0xFFFF) // max_mnt_count = -1
+	le16(sb, 56, extMagic)
+	le16(sb, 58, 1)  // state: clean
+	le16(sb, 60, 1)  // errors: continue
+	le16(sb, 62, 0)  // minor_rev
+	le32(sb, 64, ts) // lastcheck
+	le32(sb, 68, 0)  // checkinterval
+	le32(sb, 72, 0)  // creator_os: Linux
+	le32(sb, 76, 1)  // rev_level: dynamic
+	le16(sb, 80, 0)  // def_resuid
+	le16(sb, 82, 0)  // def_resgid
+	le32(sb, 84, firstInode)
+	le16(sb, 88, inodeSize)
+	le16(sb, 90, 0) // block_group_nr
+	le32(sb, 92, 0) // feature_compat
+	le32(sb, 96, featIncompatFiletype)
+	le32(sb, 100, 0) // feature_ro_compat
+	return sb
+}
+
+func groupDesc(l layout, freeBlocks, freeInodes int) []byte {
+	// The descriptor lives at the start of the GDT block.
+	blk := make([]byte, blockSize)
+	le32(blk, 0, uint32(l.blockBitmapBlock))
+	le32(blk, 4, uint32(l.inodeBitmapBlock))
+	le32(blk, 8, uint32(l.inodeTableBlock))
+	le16(blk, 12, uint16(freeBlocks))
+	le16(blk, 14, uint16(freeInodes))
+	le16(blk, 16, 2) // used_dirs_count: root and lost+found
+	return blk
+}
+
+func blockBitmap(l layout, groupBlocks int) []byte {
+	bm := make([]byte, blockSize)
+	// Bit i == block (firstDataBlock + i). Mark used metadata+data blocks.
+	for b := 0; b < l.usedBlocks; b++ {
+		setBit(bm, b)
+	}
+	// Mark blocks past the end of the group (non-existent) as used.
+	for b := groupBlocks; b < blockSize*8; b++ {
+		setBit(bm, b)
+	}
+	return bm
+}
+
+func inodeBitmap(l layout) []byte {
+	bm := make([]byte, blockSize)
+	for i := 0; i < l.usedInodes; i++ { // inodes 1..usedInodes -> bits 0..usedInodes-1
+		setBit(bm, i)
+	}
+	for i := l.inodes; i < blockSize*8; i++ {
+		setBit(bm, i)
+	}
+	return bm
+}
+
+func inodeTable(l layout, ts uint32) []byte {
+	table := make([]byte, l.inodeTableBlocks*blockSize)
+	writeInode(table, rootInode, dirInode(sIFDIR|0o755, 3, l.rootDirBlock, ts))
+	writeInode(table, lostFoundInode, dirInode(sIFDIR|0o700, 2, l.lostFoundBlock, ts))
+	return table
+}
+
+// dirInode builds a 128-byte directory inode occupying a single block.
+func dirInode(mode uint16, links int, block int, ts uint32) []byte {
+	ino := make([]byte, inodeSize)
+	le16(ino, 0, mode)
+	le32(ino, 4, blockSize)      // size
+	le32(ino, 8, ts)             // atime
+	le32(ino, 12, ts)            // ctime
+	le32(ino, 16, ts)            // mtime
+	le16(ino, 26, uint16(links)) // links_count
+	le32(ino, 28, blockSize/512) // i_blocks in 512-byte units
+	le32(ino, 40, uint32(block)) // i_block[0]
+	return ino
+}
+
+// writeInode places a 128-byte inode at its 1-indexed slot.
+func writeInode(table []byte, num int, ino []byte) {
+	copy(table[(num-1)*inodeSize:], ino)
+}
+
+func rootDirData(l layout) []byte {
+	blk := make([]byte, blockSize)
+	off := putDirEntry(blk, 0, rootInode, 2, ".")
+	off = putDirEntry(blk, off, rootInode, 2, "..")
+	putDirEntryFill(blk, off, lostFoundInode, 2, "lost+found")
+	return blk
+}
+
+func lostFoundData() []byte {
+	blk := make([]byte, blockSize)
+	off := putDirEntry(blk, 0, lostFoundInode, 2, ".")
+	putDirEntryFill(blk, off, rootInode, 2, "..")
+	return blk
+}
+
+// putDirEntry writes a directory entry with the minimal aligned rec_len and
+// returns the next offset.
+func putDirEntry(blk []byte, off int, inode uint32, fileType byte, name string) int {
+	recLen := roundUp(8+len(name), 4)
+	writeDirEntry(blk, off, inode, recLen, fileType, name)
+	return off + recLen
+}
+
+// putDirEntryFill writes the last entry, extending rec_len to the block end.
+func putDirEntryFill(blk []byte, off int, inode uint32, fileType byte, name string) {
+	writeDirEntry(blk, off, inode, blockSize-off, fileType, name)
+}
+
+func writeDirEntry(blk []byte, off int, inode uint32, recLen int, fileType byte, name string) {
+	le32(blk, off, inode)
+	le16(blk, off+4, uint16(recLen))
+	blk[off+6] = byte(len(name))
+	blk[off+7] = fileType
+	copy(blk[off+8:], name)
+}
+
+func writeAt(f *os.File, data []byte, off int64) error {
+	_, err := f.WriteAt(data, off)
+	return err
+}
+
+func le16(b []byte, off int, v uint16) { binary.LittleEndian.PutUint16(b[off:], v) }
+func le32(b []byte, off int, v uint32) { binary.LittleEndian.PutUint32(b[off:], v) }
+
+func setBit(bm []byte, n int) { bm[n/8] |= 1 << (uint(n) % 8) }
+
+func parseUint(s string) (int, error) {
+	if s == "" {
+		return 0, command.Failuref("invalid block count: %q", s)
+	}
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return 0, command.Failuref("invalid block count: %q", s)
+		}
+		n = n*10 + int(s[i]-'0')
+	}
+	return n, nil
+}

--- a/internal/applets/util-linux/mke2fs/mke2fs_test.go
+++ b/internal/applets/util-linux/mke2fs/mke2fs_test.go
@@ -1,0 +1,146 @@
+package mke2fs
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func makeImage(t *testing.T, blocks int) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "ext2.img")
+	if err := os.WriteFile(p, make([]byte, blocks*blockSize), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	on := now
+	now = func() time.Time { return time.Unix(1_700_000_000, 0) }
+	defer func() { now = on }()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSuperblock(t *testing.T) {
+	img := makeImage(t, 1024)
+	if err := run(t, img); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	sb := data[firstDataBlock*blockSize:]
+
+	if binary.LittleEndian.Uint16(sb[56:]) != extMagic {
+		t.Errorf("magic wrong")
+	}
+	if binary.LittleEndian.Uint32(sb[4:]) != 1024 {
+		t.Errorf("block count = %d", binary.LittleEndian.Uint32(sb[4:]))
+	}
+	if got := binary.LittleEndian.Uint16(sb[58:]); got != 1 {
+		t.Errorf("state = %d, want 1 (clean)", got)
+	}
+	if got := binary.LittleEndian.Uint32(sb[84:]); got != firstInode {
+		t.Errorf("first inode = %d", got)
+	}
+	if got := binary.LittleEndian.Uint16(sb[88:]); got != inodeSize {
+		t.Errorf("inode size = %d", got)
+	}
+	if got := binary.LittleEndian.Uint32(sb[76:]); got != 1 {
+		t.Errorf("rev level = %d, want 1", got)
+	}
+	// free counts must be internally consistent.
+	l, _ := computeLayout(1024)
+	wantFreeBlocks := (1024 - firstDataBlock) - l.usedBlocks
+	if got := int(binary.LittleEndian.Uint32(sb[12:])); got != wantFreeBlocks {
+		t.Errorf("free blocks = %d, want %d", got, wantFreeBlocks)
+	}
+	if got := int(binary.LittleEndian.Uint32(sb[16:])); got != l.inodes-firstInode {
+		t.Errorf("free inodes = %d, want %d", got, l.inodes-firstInode)
+	}
+}
+
+func TestRootDirectory(t *testing.T) {
+	img := makeImage(t, 1024)
+	if err := run(t, img); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	l, _ := computeLayout(1024)
+
+	// Root inode (#2) must be a directory.
+	inodeOff := l.inodeTableBlock*blockSize + (rootInode-1)*inodeSize
+	mode := binary.LittleEndian.Uint16(data[inodeOff:])
+	if mode&sIFDIR == 0 {
+		t.Errorf("root inode mode %#o not a directory", mode)
+	}
+
+	// Root directory entries: ".", "..", "lost+found".
+	dir := data[l.rootDirBlock*blockSize:]
+	names := dirNames(dir)
+	for _, want := range []string{".", "..", "lost+found"} {
+		if !names[want] {
+			t.Errorf("root dir missing %q (have %v)", want, names)
+		}
+	}
+}
+
+func dirNames(dir []byte) map[string]bool {
+	names := map[string]bool{}
+	off := 0
+	for off+8 <= len(dir) {
+		recLen := int(binary.LittleEndian.Uint16(dir[off+4:]))
+		if recLen < 8 {
+			break
+		}
+		nameLen := int(dir[off+6])
+		if inode := binary.LittleEndian.Uint32(dir[off:]); inode != 0 && nameLen > 0 {
+			names[string(dir[off+8:off+8+nameLen])] = true
+		}
+		off += recLen
+	}
+	return names
+}
+
+func TestBounds(t *testing.T) {
+	if err := run(t, makeImage(t, 32)); err == nil {
+		t.Errorf("a too-small image should fail")
+	}
+	if err := run(t, makeImage(t, 10000)); err == nil {
+		t.Errorf("a too-large image should fail")
+	}
+}
+
+func TestBlocksOperand(t *testing.T) {
+	img := makeImage(t, 4096)
+	if err := run(t, img, "1024"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(img)
+	if got := binary.LittleEndian.Uint32(data[firstDataBlock*blockSize+4:]); got != 1024 {
+		t.Errorf("block count from operand = %d, want 1024", got)
+	}
+}
+
+func TestAlias(t *testing.T) {
+	if New().Name() != "mke2fs" || NewMkfsExt2().Name() != "mkfs.ext2" {
+		t.Errorf("alias names wrong")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if err := run(t); err == nil {
+		t.Errorf("missing device should fail")
+	}
+	if err := run(t, "/no/such/image"); err == nil {
+		t.Errorf("a missing image should fail")
+	}
+}

--- a/test/it/spec/mke2fs_spec.sh
+++ b/test/it/spec/mke2fs_spec.sh
@@ -1,0 +1,19 @@
+Describe 'mke2fs / mkfs.ext2'
+    Include util-linux/mke2fs_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/mke2fs; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'writes the ext2 magic'
+        When call TestMke2fsMagic
+        The output should equal '53ef'
+        The status should be success
+    End
+    It 'mkfs.ext2 refuses an oversized image'
+        When call TestMkfsExt2TooLarge
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End

--- a/test/it/util-linux/mke2fs_test.sh
+++ b/test/it/util-linux/mke2fs_test.sh
@@ -1,0 +1,11 @@
+TestMke2fsMagic() {
+    dd if=/dev/zero of="$TEST_DIR/e.img" bs=1024 count=1024 2>/dev/null
+    mke2fs "$TEST_DIR/e.img" >/dev/null
+    # ext2 magic 0xEF53 (little-endian 53 ef) at superblock offset 1024+56 = 1080.
+    dd if="$TEST_DIR/e.img" bs=1 skip=1080 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n'
+}
+TestMkfsExt2TooLarge() {
+    dd if=/dev/zero of="$TEST_DIR/b.img" bs=1024 count=10000 2>/dev/null
+    mkfs.ext2 "$TEST_DIR/b.img" 2>/dev/null
+    echo "rc=$?"
+}


### PR DESCRIPTION
## Summary

Advances the util-linux batch (#249) with `mke2fs` (also registered as `mkfs.ext2`), which creates an ext2 filesystem (1 KiB blocks, 128-byte inodes, a single block group) on a device or image file, with a root directory and a lost+found directory. It writes the superblock (revision-1 dynamic, magic, counts, reserved blocks, first-inode, filetype incompat feature), the single group descriptor, the block and inode bitmaps (marking the metadata, directories, and out-of-range bits used), the inode table with the root (inode 2) and lost+found (inode 11) directory inodes, and the root and lost+found directory blocks. An optional BLOCKS operand sets the size; sizes below 64 blocks or above one block group (8192 blocks) are refused. The image-file workflow is hermetic.

The generated filesystem passes host e2fsck's full five-pass check (`fsck.ext2 -f`) with no errors, across 1 MiB and 4 MiB sizes.

## Tests

- Unit (hermetic temp images): the superblock fields (magic, block count, clean state, first-inode, inode size, revision) and internally consistent free-block/free-inode counts; the root inode being a directory and the root directory containing ".", "..", and "lost+found"; the BLOCKS operand; the too-small/too-large bounds; the mkfs.ext2 alias; and the missing-device / missing-image errors.
- shellspec: the ext2 magic at its on-disk offset, and mkfs.ext2 refusing an oversized image.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (662 examples, 0 failures); `golangci-lint` clean; the output passes host `fsck.ext2 -f`; registry/README in sync.

Part of #249