### PR TITLE
feat(loginutils): add nologin applet to refuse a login

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 285 commands. Run `mimixbox --list` to see them on the terminal.
+There are 286 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -176,6 +176,7 @@ There are 285 commands. Run `mimixbox --list` to see them on the terminal.
 | nl | Write each FILE to standard output with line numbers added |
 | nmeter | Print system statistics from a format string |
 | nohup | Run a command immune to hangups, with output to a non-tty |
+| nologin | Refuse a login and exit non-zero |
 | nproc | Print the number of processing units available |
 | nsenter | Run a program in another process's namespaces |
 | nyancat | Animate the rainbow-trailing Nyan Cat |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -72,6 +72,7 @@ import (
 	ap_jokeutils_fortune "github.com/nao1215/mimixbox/internal/applets/jokeutils/fortune"
 	ap_jokeutils_nyancat "github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
+	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_netutils_httpstatus "github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
 	ap_netutils_nc "github.com/nao1215/mimixbox/internal/applets/netutils/nc"
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
@@ -272,7 +273,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 285)
+	Applets = make(map[string]Applet, 286)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -353,6 +354,7 @@ func init() {
 	register(ap_jokeutils_fortune.New())
 	register(ap_jokeutils_nyancat.New())
 	register(ap_jokeutils_sl.New())
+	register(ap_loginutils_nologin.New())
 	register(ap_netutils_httpstatus.New())
 	register(ap_netutils_nc.New())
 	register(ap_netutils_ping.New())

--- a/internal/applets/loginutils/nologin/nologin.go
+++ b/internal/applets/loginutils/nologin/nologin.go
@@ -1,0 +1,65 @@
+// Package nologin implements the nologin applet: politely refuse a login and
+// exit non-zero, as the shell of an account that may not log in.
+package nologin
+
+import (
+	"context"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the nologin applet.
+type Command struct{}
+
+// New returns a nologin command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "nologin" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Refuse a login and exit non-zero" }
+
+// messageFile holds the optional custom refusal message; tests override it.
+var messageFile = "/etc/nologin.txt"
+
+// defaultMessage is printed when no message file is present.
+const defaultMessage = "This account is currently not available."
+
+// Run executes nologin.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print a refusal message and exit non-zero, so it can serve as the login shell of " +
+			"an account that must not log in. If /etc/nologin.txt exists its contents are shown; " +
+			"otherwise a default message is printed. Any arguments (e.g. a shell '-c command') are " +
+			"ignored, and no command is ever run.",
+		Examples: []command.Example{
+			{Command: "nologin", Explain: "Print the refusal message and exit 1."},
+		},
+		ExitStatus: "1  always: the login is refused.",
+	})
+	// nologin must ignore the arguments a calling shell passes (e.g. "-c command"),
+	// so only consult the flag parser for --help/--version; otherwise refuse
+	// without complaining about unknown flags.
+	for _, a := range args {
+		if a == "--help" || a == "-h" || a == "--version" {
+			if proceed, _ := fs.Parse(stdio, args); !proceed {
+				return nil
+			}
+			break
+		}
+	}
+
+	_, _ = stdio.Out.Write(message())
+	return command.SilentFailure()
+}
+
+// message returns the refusal text: the message file verbatim if present and
+// non-empty, otherwise the default with a trailing newline.
+func message() []byte {
+	if data, err := os.ReadFile(messageFile); err == nil && len(data) > 0 {
+		return data
+	}
+	return []byte(defaultMessage + "\n")
+}

--- a/internal/applets/loginutils/nologin/nologin_test.go
+++ b/internal/applets/loginutils/nologin/nologin_test.go
@@ -1,0 +1,63 @@
+package nologin
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestDefaultMessageAndExit(t *testing.T) {
+	orig := messageFile
+	messageFile = "/no/such/nologin.txt"
+	defer func() { messageFile = orig }()
+	out, err := run(t)
+	if err == nil {
+		t.Errorf("nologin must exit non-zero")
+	}
+	if !strings.Contains(out, defaultMessage) {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestCustomMessage(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "nologin.txt")
+	_ = os.WriteFile(f, []byte("System is down for maintenance.\n"), 0o644)
+	orig := messageFile
+	messageFile = f
+	defer func() { messageFile = orig }()
+	out, err := run(t)
+	if err == nil {
+		t.Errorf("nologin must exit non-zero")
+	}
+	if out != "System is down for maintenance.\n" {
+		t.Errorf("custom message = %q", out)
+	}
+}
+
+func TestIgnoresArguments(t *testing.T) {
+	orig := messageFile
+	messageFile = "/no/such/nologin.txt"
+	defer func() { messageFile = orig }()
+	// A shell-style "-c command" must be ignored and still refuse.
+	out, err := run(t, "-c", "echo pwned")
+	if err == nil {
+		t.Errorf("nologin must exit non-zero even with arguments")
+	}
+	if strings.Contains(out, "pwned") {
+		t.Errorf("nologin must not run the command")
+	}
+}

--- a/test/it/loginutils/nologin_test.sh
+++ b/test/it/loginutils/nologin_test.sh
@@ -1,0 +1,5 @@
+TestNologinRefuses() { nologin; echo "rc=$?"; }
+TestNologinIgnoresArgs() {
+    count=$(nologin -c "echo pwned" 2>/dev/null | grep -c pwned)
+    echo "$count"
+}

--- a/test/it/spec/nologin_spec.sh
+++ b/test/it/spec/nologin_spec.sh
@@ -1,0 +1,14 @@
+Describe 'nologin'
+    Include loginutils/nologin_test.sh
+
+    It 'prints a refusal and exits non-zero'
+        When call TestNologinRefuses
+        The line 1 of output should include 'not available'
+        The line 2 of output should equal 'rc=1'
+    End
+    It 'never runs a passed command'
+        When call TestNologinIgnoresArgs
+        The output should equal '0'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Starts the loginutils batch (#250) with `nologin`, the simple applet the issue calls out: it prints a refusal message and exits non-zero, so it can serve as the login shell of an account that must not log in. If /etc/nologin.txt exists its contents are shown verbatim; otherwise the standard default ("This account is currently not available.") is printed. The arguments a calling shell passes (e.g. "-c command") are ignored and no command is ever run. The message-file path is injectable so the behavior is tested against fixtures.

## Tests

- Unit: the default message with a non-zero exit, a custom message file shown verbatim, and a shell-style "-c command" being ignored (the command never runs) while still refusing.
- shellspec: printing a refusal and exiting non-zero, and never running a passed command.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (666 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250