### PR TITLE
feat(loginutils): add run-parts applet to run a directory's executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 286 commands. Run `mimixbox --list` to see them on the terminal.
+There are 287 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -219,6 +219,7 @@ There are 286 commands. Run `mimixbox --list` to see them on the terminal.
 | rpm | Query an RPM package file |
 | rpm2cpio | Extract the cpio payload from an RPM package |
 | rtcwake | Arm the RTC to wake the system |
+| run-parts | Run all executables in a directory |
 | script | Record a command's output to a typescript |
 | scriptreplay | Replay a typescript using its timing file |
 | sddf | Search & Delete Duplicated File |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -73,6 +73,7 @@ import (
 	ap_jokeutils_nyancat "github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
+	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
 	ap_netutils_httpstatus "github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
 	ap_netutils_nc "github.com/nao1215/mimixbox/internal/applets/netutils/nc"
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
@@ -273,7 +274,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 286)
+	Applets = make(map[string]Applet, 287)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -355,6 +356,7 @@ func init() {
 	register(ap_jokeutils_nyancat.New())
 	register(ap_jokeutils_sl.New())
 	register(ap_loginutils_nologin.New())
+	register(ap_loginutils_runparts.New())
 	register(ap_netutils_httpstatus.New())
 	register(ap_netutils_nc.New())
 	register(ap_netutils_ping.New())

--- a/internal/applets/loginutils/runparts/runparts.go
+++ b/internal/applets/loginutils/runparts/runparts.go
@@ -1,0 +1,130 @@
+// Package runparts implements the run-parts applet: run every valid executable
+// in a directory, in alphabetical order.
+package runparts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the run-parts applet.
+type Command struct{}
+
+// New returns a run-parts command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "run-parts" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run all executables in a directory" }
+
+// validName matches the names run-parts accepts (LSB rule): letters, digits,
+// underscores, and hyphens only — so editor backups and packaging leftovers
+// (foo~, foo.bak, foo.dpkg-new) are skipped.
+var validName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// Run executes run-parts.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[--test] [--list] [--arg=ARG]... DIRECTORY", stdio.Err).WithHelp(command.Help{
+		Description: "Run every executable in DIRECTORY whose name contains only letters, digits, " +
+			"underscores, and hyphens, in alphabetical order. --list prints the matching files " +
+			"without running them; --test prints those that would run (matching and executable); " +
+			"--arg adds an argument passed to each program; --verbose announces each one before " +
+			"running it.",
+		Examples: []command.Example{
+			{Command: "run-parts /etc/cron.daily", Explain: "Run the daily cron scripts in order."},
+			{Command: "run-parts --test /etc/cron.daily", Explain: "Show what would run."},
+		},
+		ExitStatus: "0  all programs succeeded.\n1  no directory was given or a program failed.",
+	})
+	test := fs.Bool("test", false, "print the programs that would run, without running them")
+	list := fs.Bool("list", false, "list the matching files without running them")
+	verbose := fs.BoolP("verbose", "v", false, "print each program name before running it")
+	extraArgs := fs.StringArray("arg", nil, "argument to pass to each program (repeatable)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a directory is required")
+	}
+	dir := rest[0]
+
+	names, err := matching(dir)
+	if err != nil {
+		return command.Failuref("%s: %v", dir, err)
+	}
+
+	failed := false
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		executable := isExecutable(path)
+
+		if *list {
+			_, _ = fmt.Fprintln(stdio.Out, path)
+			continue
+		}
+		if !executable {
+			continue
+		}
+		if *test {
+			_, _ = fmt.Fprintln(stdio.Out, path)
+			continue
+		}
+		if *verbose {
+			_, _ = fmt.Fprintf(stdio.Err, "run-parts: executing %s\n", path)
+		}
+		cmd := exec.Command(path, *extraArgs...) //nolint:gosec // running the directory's programs is the point
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		if err := cmd.Run(); err != nil {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				_, _ = fmt.Fprintf(stdio.Err, "run-parts: %s exited with code %d\n", path, ee.ExitCode())
+			} else {
+				_, _ = fmt.Fprintf(stdio.Err, "run-parts: %s: %v\n", path, err)
+			}
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// matching returns the valid run-parts file names in dir, sorted.
+func matching(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !validName.MatchString(e.Name()) {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir() && info.Mode()&0o111 != 0
+}

--- a/internal/applets/loginutils/runparts/runparts_test.go
+++ b/internal/applets/loginutils/runparts/runparts_test.go
@@ -1,0 +1,109 @@
+package runparts
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func script(t *testing.T, dir, name, body string, exec bool) {
+	t.Helper()
+	mode := os.FileMode(0o644)
+	if exec {
+		mode = 0o755
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestRunsInOrder(t *testing.T) {
+	dir := t.TempDir()
+	script(t, dir, "20-second", "#!/bin/sh\necho second\n", true)
+	script(t, dir, "10-first", "#!/bin/sh\necho first\n", true)
+	out, err := run(t, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "first\nsecond\n" {
+		t.Errorf("order = %q, want first then second", out)
+	}
+}
+
+func TestSkipsNonExecAndInvalid(t *testing.T) {
+	dir := t.TempDir()
+	script(t, dir, "10-run", "#!/bin/sh\necho ran\n", true)
+	script(t, dir, "20-noexec", "#!/bin/sh\necho nope\n", false)
+	script(t, dir, "30-bad.bak", "#!/bin/sh\necho nope\n", true) // invalid name (dot)
+	out, err := run(t, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "ran\n" {
+		t.Errorf("output = %q, want only the valid executable", out)
+	}
+}
+
+func TestListAndTest(t *testing.T) {
+	dir := t.TempDir()
+	script(t, dir, "10-exec", "#!/bin/sh\n", true)
+	script(t, dir, "20-plain", "data\n", false)
+
+	list, err := run(t, "--list", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(list, "10-exec") || !strings.Contains(list, "20-plain") {
+		t.Errorf("--list should include both valid files:\n%s", list)
+	}
+
+	test, err := run(t, "--test", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(test, "10-exec") || strings.Contains(test, "20-plain") {
+		t.Errorf("--test should include only the executable:\n%s", test)
+	}
+}
+
+func TestPassesArg(t *testing.T) {
+	dir := t.TempDir()
+	script(t, dir, "10-echo", "#!/bin/sh\necho \"got:$1\"\n", true)
+	out, err := run(t, "--arg", "hello", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "got:hello\n" {
+		t.Errorf("arg not passed: %q", out)
+	}
+}
+
+func TestFailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+	script(t, dir, "10-fail", "#!/bin/sh\nexit 3\n", true)
+	if _, err := run(t, dir); err == nil {
+		t.Errorf("a failing program should make run-parts fail")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t); err == nil {
+		t.Errorf("missing directory should fail")
+	}
+	if _, err := run(t, "/no/such/dir"); err == nil {
+		t.Errorf("a missing directory should fail")
+	}
+}

--- a/test/it/loginutils/run_parts_test.sh
+++ b/test/it/loginutils/run_parts_test.sh
@@ -1,0 +1,7 @@
+TestRunPartsOrder() {
+    d="$TEST_DIR/parts"; mkdir -p "$d"
+    printf '#!/bin/sh\necho B\n' > "$d/20-b"; chmod +x "$d/20-b"
+    printf '#!/bin/sh\necho A\n' > "$d/10-a"; chmod +x "$d/10-a"
+    run-parts "$d"
+}
+TestRunPartsNoDir() { run-parts 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/run_parts_spec.sh
+++ b/test/it/spec/run_parts_spec.sh
@@ -1,0 +1,20 @@
+Describe 'run-parts'
+    Include loginutils/run_parts_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/run_parts; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'runs executables in alphabetical order'
+        When call TestRunPartsOrder
+        The line 1 of output should equal 'A'
+        The line 2 of output should equal 'B'
+        The status should be success
+    End
+    It 'requires a directory'
+        When call TestRunPartsNoDir
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `run-parts`, which runs every executable in a directory whose name contains only letters, digits, underscores, and hyphens (the LSB rule, so editor backups and packaging leftovers like foo~, foo.bak, foo.dpkg-new are skipped), in alphabetical order — the ordering the issue calls out as important. `--list` prints the matching files without running them, `--test` prints those that would run (matching and executable), `--arg` adds an argument passed to each program, and `--verbose` announces each one. A program exiting non-zero makes run-parts fail. It works in temp directories per the issue's guidance.

## Tests

- Unit (hermetic temp dirs with scripts): alphabetical run order, skipping non-executable and invalid-named files, `--list` (all valid) vs `--test` (executable only), `--arg` being passed through, failure propagation, and the missing-directory errors.
- shellspec: running executables in alphabetical order, and requiring a directory.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (668 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250