### PR TITLE
feat(loginutils): add mkpasswd applet to hash a password

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 287 commands. Run `mimixbox --list` to see them on the terminal.
+There are 288 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -164,6 +164,7 @@ There are 287 commands. Run `mimixbox --list` to see them on the terminal.
 | mkfs.reiser | Create a ReiserFS filesystem (unsupported) |
 | mkfs.vfat | Create a FAT16 filesystem |
 | mknod | Make block or character special files |
+| mkpasswd | Compute the crypt hash of a password |
 | mkswap | Set up a Linux swap area |
 | mktemp | Create a temporary file or directory |
 | more | Page through text one screen at a time |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -72,6 +72,7 @@ import (
 	ap_jokeutils_fortune "github.com/nao1215/mimixbox/internal/applets/jokeutils/fortune"
 	ap_jokeutils_nyancat "github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
+	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
 	ap_netutils_httpstatus "github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
@@ -274,7 +275,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 287)
+	Applets = make(map[string]Applet, 288)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -355,6 +356,7 @@ func init() {
 	register(ap_jokeutils_fortune.New())
 	register(ap_jokeutils_nyancat.New())
 	register(ap_jokeutils_sl.New())
+	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
 	register(ap_loginutils_runparts.New())
 	register(ap_netutils_httpstatus.New())

--- a/internal/applets/loginutils/mkpasswd/mkpasswd.go
+++ b/internal/applets/loginutils/mkpasswd/mkpasswd.go
@@ -1,0 +1,101 @@
+// Package mkpasswd implements the mkpasswd applet: compute the crypt(3) hash of
+// a password, as stored in /etc/shadow.
+package mkpasswd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GehirnInc/crypt"
+	_ "github.com/GehirnInc/crypt/md5_crypt"    // register $1$
+	_ "github.com/GehirnInc/crypt/sha256_crypt" // register $5$
+	_ "github.com/GehirnInc/crypt/sha512_crypt" // register $6$
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the mkpasswd applet.
+type Command struct{}
+
+// New returns a mkpasswd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "mkpasswd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Compute the crypt hash of a password" }
+
+// method describes a supported hashing method and its crypt magic prefix.
+type method struct {
+	crypt crypt.Crypt
+	magic string
+}
+
+var methods = map[string]method{
+	"sha-512": {crypt.SHA512, "$6$"},
+	"sha512":  {crypt.SHA512, "$6$"},
+	"sha-256": {crypt.SHA256, "$5$"},
+	"sha256":  {crypt.SHA256, "$5$"},
+	"md5":     {crypt.MD5, "$1$"},
+}
+
+// Run executes mkpasswd.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-m METHOD] [-S SALT] [PASSWORD]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the crypt(3) hash of PASSWORD, in the format stored in /etc/shadow. -m " +
+			"selects the method: sha-512 (the default), sha-256, or md5. -S sets the salt; without it " +
+			"a random salt is used. If PASSWORD is omitted it is read from standard input.",
+		Examples: []command.Example{
+			{Command: "mkpasswd -m sha-512 -S abcdefgh secret", Explain: "Hash 'secret' with a fixed salt."},
+			{Command: "echo secret | mkpasswd", Explain: "Hash a password read from stdin."},
+		},
+		ExitStatus: "0  the hash was printed.\n1  an unknown method or a hashing error.",
+	})
+	methodName := fs.StringP("method", "m", "sha-512", "hashing method: sha-512, sha-256, or md5")
+	salt := fs.StringP("salt", "S", "", "salt to use (random if unset)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	m, ok := methods[strings.ToLower(*methodName)]
+	if !ok {
+		return command.Failuref("unknown method: %q (use sha-512, sha-256, or md5)", *methodName)
+	}
+
+	password, err := readPassword(stdio, fs.Args())
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	var saltArg []byte
+	if *salt != "" {
+		saltArg = []byte(m.magic + *salt)
+	}
+	hash, err := crypt.New(m.crypt).Generate([]byte(password), saltArg)
+	if err != nil {
+		return command.Failuref("cannot hash the password: %v", err)
+	}
+	_, _ = fmt.Fprintln(stdio.Out, hash)
+	return nil
+}
+
+// readPassword returns the password from the first operand, or the first line
+// of standard input.
+func readPassword(stdio command.IO, operands []string) (string, error) {
+	if len(operands) > 0 {
+		return operands[0], nil
+	}
+	sc := bufio.NewScanner(stdio.In)
+	if !sc.Scan() {
+		if err := sc.Err(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("no password given")
+	}
+	return sc.Text(), nil
+}

--- a/internal/applets/loginutils/mkpasswd/mkpasswd_test.go
+++ b/internal/applets/loginutils/mkpasswd/mkpasswd_test.go
@@ -1,0 +1,72 @@
+package mkpasswd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GehirnInc/crypt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestSHA512MatchesReference(t *testing.T) {
+	// Identical to `openssl passwd -6 -salt abcdefgh secret`.
+	const want = "$6$abcdefgh$ltjgWl6579NluT/Vi1nwEvcil.G5Nbc4NiXZaNGStk8PSwGfQv72N2CKPPrVACtLtip/cZ/1GM/O6IND4WQhG."
+	got, err := run(t, "", "-m", "sha-512", "-S", "abcdefgh", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("sha-512 hash =\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestMD5MatchesReference(t *testing.T) {
+	const want = "$1$abcdefgh$cHJi5PXp/ki/ktXzqlk6I1"
+	got, err := run(t, "", "-m", "md5", "-S", "abcdefgh", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("md5 hash = %s, want %s", got, want)
+	}
+}
+
+func TestHashVerifies(t *testing.T) {
+	got, err := run(t, "", "-S", "saltsalt", "hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if crypt.NewFromHash(got).Verify(got, []byte("hunter2")) != nil {
+		t.Errorf("generated hash does not verify against the password")
+	}
+}
+
+func TestStdinPassword(t *testing.T) {
+	got, err := run(t, "frompipe\n", "-m", "sha-256", "-S", "abcdefgh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, "$5$abcdefgh$") {
+		t.Errorf("stdin hash = %s", got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t, "", "-m", "bogus", "secret"); err == nil {
+		t.Errorf("an unknown method should fail")
+	}
+	if _, err := run(t, ""); err == nil { // empty stdin, no operand
+		t.Errorf("no password should fail")
+	}
+}

--- a/test/it/loginutils/mkpasswd_test.sh
+++ b/test/it/loginutils/mkpasswd_test.sh
@@ -1,0 +1,2 @@
+TestMkpasswdSha512() { mkpasswd -m sha-512 -S abcdefgh secret; }
+TestMkpasswdStdin() { echo "frompipe" | mkpasswd -m md5 -S abcdefgh | head -c 12; echo; }

--- a/test/it/spec/mkpasswd_spec.sh
+++ b/test/it/spec/mkpasswd_spec.sh
@@ -1,0 +1,14 @@
+Describe 'mkpasswd'
+    Include loginutils/mkpasswd_test.sh
+
+    It 'hashes with sha-512 and a fixed salt'
+        When call TestMkpasswdSha512
+        The output should equal '$6$abcdefgh$ltjgWl6579NluT/Vi1nwEvcil.G5Nbc4NiXZaNGStk8PSwGfQv72N2CKPPrVACtLtip/cZ/1GM/O6IND4WQhG.'
+        The status should be success
+    End
+    It 'reads the password from stdin'
+        When call TestMkpasswdStdin
+        The output should equal '$1$abcdefgh$'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `mkpasswd`, which prints the crypt(3) hash of a password in the format stored in /etc/shadow. `-m` selects the method — sha-512 ($6$, the default), sha-256 ($5$), or md5 ($1$) — `-S` sets the salt (random if unset), and the password may be given as an operand or read from standard input. It uses the repo's existing crypt backend and produces hashes byte-for-byte identical to `openssl passwd` (verified for -6 and -1).

## Tests

- Unit: the sha-512 and md5 hashes matching the openssl reference exactly, a generated hash verifying against its password, reading the password from stdin (sha-256), and the unknown-method / no-password errors.
- shellspec: the sha-512 hash with a fixed salt, and reading the password from stdin (md5 prefix).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (670 examples, 0 failures); `golangci-lint` clean; output matches `openssl passwd`; registry/README in sync.

Part of #250