### PR TITLE
feat(loginutils): add runlevel applet to print the system runlevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 288 commands. Run `mimixbox --list` to see them on the terminal.
+There are 289 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -221,6 +221,7 @@ There are 288 commands. Run `mimixbox --list` to see them on the terminal.
 | rpm2cpio | Extract the cpio payload from an RPM package |
 | rtcwake | Arm the RTC to wake the system |
 | run-parts | Run all executables in a directory |
+| runlevel | Print the previous and current runlevel |
 | script | Record a command's output to a typescript |
 | scriptreplay | Replay a typescript using its timing file |
 | sddf | Search & Delete Duplicated File |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -74,6 +74,7 @@ import (
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
+	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
 	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
 	ap_netutils_httpstatus "github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
 	ap_netutils_nc "github.com/nao1215/mimixbox/internal/applets/netutils/nc"
@@ -275,7 +276,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 288)
+	Applets = make(map[string]Applet, 289)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -358,6 +359,7 @@ func init() {
 	register(ap_jokeutils_sl.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
+	register(ap_loginutils_runlevel.New())
 	register(ap_loginutils_runparts.New())
 	register(ap_netutils_httpstatus.New())
 	register(ap_netutils_nc.New())

--- a/internal/applets/loginutils/runlevel/runlevel.go
+++ b/internal/applets/loginutils/runlevel/runlevel.go
@@ -1,0 +1,83 @@
+// Package runlevel implements the runlevel applet: print the previous and
+// current system runlevel, read from the utmp run-level record.
+package runlevel
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the runlevel applet.
+type Command struct{}
+
+// New returns a runlevel command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "runlevel" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the previous and current runlevel" }
+
+// Linux utmp layout (x86_64): 384-byte records. The run-level record stores the
+// two runlevels in the ut_pid field as the current and previous ASCII bytes.
+const (
+	recordSize = 384
+	typeOffset = 0
+	pidOffset  = 4
+	runLevel   = 1 // RUN_LVL
+)
+
+// utmpPath is the utmp database; tests point it at a fixture.
+var utmpPath = "/var/run/utmp"
+
+// Run executes runlevel.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the previous and current system runlevel, separated by a space, read from " +
+			"the run-level record in the utmp database. The previous runlevel is 'N' if the system " +
+			"has not changed runlevel since boot. Prints 'unknown' if no run-level record is found.",
+		Examples: []command.Example{
+			{Command: "runlevel", Explain: "Print e.g. 'N 5'."},
+		},
+		ExitStatus: "0  a runlevel was printed.\n1  no run-level record was found.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	prev, cur, ok := readRunlevel()
+	if !ok {
+		_, _ = fmt.Fprintln(stdio.Out, "unknown")
+		return command.SilentFailure()
+	}
+	prevStr := "N"
+	if prev != 0 {
+		prevStr = string(rune(prev))
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "%s %c\n", prevStr, rune(cur))
+	return nil
+}
+
+// readRunlevel returns the previous and current runlevel bytes from the utmp
+// run-level record, and whether one was found.
+func readRunlevel() (prev, cur byte, ok bool) {
+	data, err := os.ReadFile(utmpPath)
+	if err != nil {
+		return 0, 0, false
+	}
+	for off := 0; off+recordSize <= len(data); off += recordSize {
+		rec := data[off : off+recordSize]
+		if binary.LittleEndian.Uint16(rec[typeOffset:]) != runLevel {
+			continue
+		}
+		pid := binary.LittleEndian.Uint32(rec[pidOffset:])
+		return byte(pid >> 8), byte(pid & 0xFF), true
+	}
+	return 0, 0, false
+}

--- a/internal/applets/loginutils/runlevel/runlevel_test.go
+++ b/internal/applets/loginutils/runlevel/runlevel_test.go
@@ -1,0 +1,79 @@
+package runlevel
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// utmpWithRunLevel writes a utmp fixture containing a RUN_LVL record encoding
+// the given previous and current runlevel bytes (prev 0 means "since boot").
+func utmpWithRunLevel(t *testing.T, recType uint16, prev, cur byte) string {
+	t.Helper()
+	rec := make([]byte, recordSize)
+	binary.LittleEndian.PutUint16(rec[typeOffset:], recType)
+	binary.LittleEndian.PutUint32(rec[pidOffset:], uint32(prev)<<8|uint32(cur))
+	p := filepath.Join(t.TempDir(), "utmp")
+	if err := os.WriteFile(p, rec, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func run(t *testing.T, path string) (string, error) {
+	t.Helper()
+	orig := utmpPath
+	utmpPath = path
+	defer func() { utmpPath = orig }()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, nil)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestSinceBoot(t *testing.T) {
+	out, err := run(t, utmpWithRunLevel(t, runLevel, 0, '5'))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "N 5" {
+		t.Errorf("runlevel = %q, want \"N 5\"", out)
+	}
+}
+
+func TestPreviousRunlevel(t *testing.T) {
+	out, err := run(t, utmpWithRunLevel(t, runLevel, '3', '5'))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "3 5" {
+		t.Errorf("runlevel = %q, want \"3 5\"", out)
+	}
+}
+
+func TestNoRunLevelRecord(t *testing.T) {
+	// A record of a different type must be ignored.
+	out, err := run(t, utmpWithRunLevel(t, 7 /* USER_PROCESS */, 0, '5'))
+	if err == nil {
+		t.Errorf("missing run-level record should fail")
+	}
+	if out != "unknown" {
+		t.Errorf("output = %q, want unknown", out)
+	}
+}
+
+func TestMissingUtmp(t *testing.T) {
+	out, err := run(t, "/no/such/utmp")
+	if err == nil {
+		t.Errorf("a missing utmp should fail")
+	}
+	if out != "unknown" {
+		t.Errorf("output = %q, want unknown", out)
+	}
+}

--- a/test/it/loginutils/runlevel_test.sh
+++ b/test/it/loginutils/runlevel_test.sh
@@ -1,0 +1,3 @@
+# The CI/WSL utmp has no run-level record, so runlevel prints 'unknown' and
+# exits 1 there; the parsing of a real record is covered by Go unit tests.
+TestRunlevelRuns() { runlevel; echo "rc=$?"; }

--- a/test/it/spec/runlevel_spec.sh
+++ b/test/it/spec/runlevel_spec.sh
@@ -1,0 +1,9 @@
+Describe 'runlevel'
+    Include loginutils/runlevel_test.sh
+
+    It 'reports a runlevel or unknown'
+        When call TestRunlevelRuns
+        The line 1 of output should match pattern '*'
+        The line 2 of output should match pattern 'rc=*'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `runlevel`, which prints the previous and current system runlevel (separated by a space) read from the run-level record in the utmp database. The previous runlevel is 'N' when the system has not changed runlevel since boot; if no run-level record is found it prints 'unknown' and exits non-zero (matching host runlevel on systems without one). The utmp path is injectable so the parsing is tested against fixtures.

## Tests

- Unit (utmp fixtures with a RUN_LVL record): 'N 5' since boot (previous byte 0), '3 5' with an explicit previous runlevel, a non-run-level record being ignored (unknown + failure), and a missing utmp (unknown + failure).
- shellspec: runlevel reports a runlevel or 'unknown' and an exit code.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (671 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250