### PR TITLE
feat(loginutils): add chpasswd applet to update passwords in batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 289 commands. Run `mimixbox --list` to see them on the terminal.
+There are 290 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -48,6 +48,7 @@ There are 289 commands. Run `mimixbox --list` to see them on the terminal.
 | chgrp | Change the group of each FILE to GROUP |
 | chmod | Change file mode bits |
 | chown | Change the owner and/or group of each FILE to OWNER and/or GROUP |
+| chpasswd | Update passwords in batch |
 | chroot | Run command or interactive shell with special root directory |
 | chrt | Get or set a process's real-time scheduling attributes |
 | cksum | Print CRC checksum and byte count of each file |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -72,6 +72,7 @@ import (
 	ap_jokeutils_fortune "github.com/nao1215/mimixbox/internal/applets/jokeutils/fortune"
 	ap_jokeutils_nyancat "github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
+	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
@@ -276,7 +277,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 289)
+	Applets = make(map[string]Applet, 290)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -357,6 +358,7 @@ func init() {
 	register(ap_jokeutils_fortune.New())
 	register(ap_jokeutils_nyancat.New())
 	register(ap_jokeutils_sl.New())
+	register(ap_loginutils_chpasswd.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
 	register(ap_loginutils_runlevel.New())

--- a/internal/applets/loginutils/chpasswd/chpasswd.go
+++ b/internal/applets/loginutils/chpasswd/chpasswd.go
@@ -1,0 +1,150 @@
+// Package chpasswd implements the chpasswd applet: update user passwords in
+// batch from "user:password" lines on standard input.
+package chpasswd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/GehirnInc/crypt"
+	_ "github.com/GehirnInc/crypt/md5_crypt"    // register $1$
+	_ "github.com/GehirnInc/crypt/sha256_crypt" // register $5$
+	_ "github.com/GehirnInc/crypt/sha512_crypt" // register $6$
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the chpasswd applet.
+type Command struct{}
+
+// New returns a chpasswd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "chpasswd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Update passwords in batch" }
+
+// shadowPath is the shadow database; tests point it at a fixture.
+var shadowPath = "/etc/shadow"
+
+var cryptMethods = map[string]crypt.Crypt{
+	"sha-512": crypt.SHA512, "sha512": crypt.SHA512,
+	"sha-256": crypt.SHA256, "sha256": crypt.SHA256,
+	"md5": crypt.MD5,
+}
+
+// Run executes chpasswd.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-e] [-c METHOD]", stdio.Err).WithHelp(command.Help{
+		Description: "Read 'user:password' lines from standard input and set each user's password in " +
+			"/etc/shadow. Passwords are hashed with -c METHOD (sha-512 by default); with -e the " +
+			"supplied values are already-encrypted hashes and are stored verbatim. Requires privilege " +
+			"to write the real shadow database.",
+		Examples: []command.Example{
+			{Command: "echo 'alice:secret' | chpasswd", Explain: "Set alice's password."},
+			{Command: "chpasswd -e < hashes.txt", Explain: "Load already-hashed passwords."},
+		},
+		ExitStatus: "0  all passwords were updated.\n1  a user was unknown or the database is unreadable.",
+	})
+	encrypted := fs.BoolP("encrypted", "e", false, "the supplied passwords are already hashed")
+	methodName := fs.StringP("crypt-method", "c", "sha-512", "hashing method: sha-512, sha-256, or md5")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	method, ok := cryptMethods[strings.ToLower(*methodName)]
+	if !ok {
+		return command.Failuref("unknown method: %q (use sha-512, sha-256, or md5)", *methodName)
+	}
+
+	updates, err := readUpdates(stdio.In, *encrypted, method)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	lines, err := readLines(shadowPath)
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", shadowPath, err)
+	}
+
+	applied := map[string]bool{}
+	for i, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) < 2 {
+			continue
+		}
+		if hash, ok := updates[fields[0]]; ok {
+			fields[1] = hash
+			lines[i] = strings.Join(fields, ":")
+			applied[fields[0]] = true
+		}
+	}
+
+	failed := false
+	for user := range updates {
+		if !applied[user] {
+			_, _ = fmt.Fprintf(stdio.Err, "chpasswd: unknown user: %s\n", user)
+			failed = true
+		}
+	}
+
+	if err := writeLines(shadowPath, lines); err != nil {
+		return command.Failuref("cannot write %s: %v", shadowPath, err)
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// readUpdates parses the "user:password" lines into a map of user to the hash
+// (or verbatim value when already encrypted) to store.
+func readUpdates(r io.Reader, encrypted bool, method crypt.Crypt) (map[string]string, error) {
+	updates := map[string]string{}
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), "\r\n")
+		if line == "" {
+			continue
+		}
+		user, password, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, fmt.Errorf("malformed input line (need user:password): %q", line)
+		}
+		if encrypted {
+			updates[user] = password
+			continue
+		}
+		hash, err := crypt.New(method).Generate([]byte(password), nil)
+		if err != nil {
+			return nil, fmt.Errorf("cannot hash password for %s: %v", user, err)
+		}
+		updates[user] = hash
+	}
+	return updates, sc.Err()
+}
+
+func readLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // well-known shadow path
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimRight(string(data), "\n")
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
+func writeLines(path string, lines []string) error {
+	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(path, []byte(content), 0o600) //nolint:gosec // shadow is mode 0600
+}

--- a/internal/applets/loginutils/chpasswd/chpasswd_test.go
+++ b/internal/applets/loginutils/chpasswd/chpasswd_test.go
@@ -1,0 +1,103 @@
+package chpasswd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GehirnInc/crypt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixtureShadow(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "shadow")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	orig := shadowPath
+	shadowPath = p
+	t.Cleanup(func() { shadowPath = orig })
+	return p
+}
+
+func run(t *testing.T, stdin string, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(stdin), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func field(t *testing.T, path, user string, idx int) string {
+	t.Helper()
+	data, _ := os.ReadFile(path)
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		f := strings.Split(line, ":")
+		if f[0] == user {
+			return f[idx]
+		}
+	}
+	t.Fatalf("user %s not found", user)
+	return ""
+}
+
+func TestHashesAndUpdates(t *testing.T) {
+	p := fixtureShadow(t, "alice:!:19000:0:99999:7:::\nbob:!:19000:0:99999:7:::\n")
+	if err := run(t, "alice:newsecret\n"); err != nil {
+		t.Fatal(err)
+	}
+	hash := field(t, p, "alice", 1)
+	if !strings.HasPrefix(hash, "$6$") {
+		t.Errorf("alice hash = %q, want $6$ sha-512", hash)
+	}
+	if crypt.NewFromHash(hash).Verify(hash, []byte("newsecret")) != nil {
+		t.Errorf("alice's new hash does not verify against the password")
+	}
+	// bob is untouched, and the other fields are preserved.
+	if field(t, p, "bob", 1) != "!" {
+		t.Errorf("bob should be unchanged")
+	}
+	if field(t, p, "alice", 4) != "99999" {
+		t.Errorf("alice's other shadow fields must be preserved")
+	}
+}
+
+func TestEncryptedStoredVerbatim(t *testing.T) {
+	p := fixtureShadow(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, "alice:$6$prehashed$abc\n", "-e"); err != nil {
+		t.Fatal(err)
+	}
+	if got := field(t, p, "alice", 1); got != "$6$prehashed$abc" {
+		t.Errorf("encrypted value = %q, want stored verbatim", got)
+	}
+}
+
+func TestMD5Method(t *testing.T) {
+	p := fixtureShadow(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, "alice:secret\n", "-c", "md5"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(field(t, p, "alice", 1), "$1$") {
+		t.Errorf("md5 method should produce a $1$ hash")
+	}
+}
+
+func TestUnknownUser(t *testing.T) {
+	fixtureShadow(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, "carol:secret\n"); err == nil {
+		t.Errorf("an unknown user should fail")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixtureShadow(t, "alice:!::::::: \n")
+	if err := run(t, "alice:secret\n", "-c", "bogus"); err == nil {
+		t.Errorf("unknown method should fail")
+	}
+	if err := run(t, "no-colon-line\n"); err == nil {
+		t.Errorf("a malformed input line should fail")
+	}
+}

--- a/test/it/loginutils/chpasswd_test.sh
+++ b/test/it/loginutils/chpasswd_test.sh
@@ -1,0 +1,4 @@
+# chpasswd writes /etc/shadow (privileged); the e2e exercises the deterministic
+# unknown-method path. The shadow update is covered by Go unit tests.
+TestChpasswdBadMethod() { echo 'alice:secret' | chpasswd -c bogus 2>/dev/null; echo "rc=$?"; }
+TestChpasswdHelp() { chpasswd --help; }

--- a/test/it/spec/chpasswd_spec.sh
+++ b/test/it/spec/chpasswd_spec.sh
@@ -1,0 +1,15 @@
+Describe 'chpasswd'
+    Include loginutils/chpasswd_test.sh
+
+    It 'rejects an unknown method'
+        When call TestChpasswdBadMethod
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestChpasswdHelp
+        The status should be success
+        The output should include 'Usage: chpasswd'
+        The output should include 'password'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `chpasswd`, which reads 'user:password' lines from standard input and sets each user's password in /etc/shadow. Passwords are hashed with `-c METHOD` (sha-512 by default, also sha-256 or md5) using the repo's crypt backend; with `-e` the supplied values are already-encrypted hashes and are stored verbatim. Unknown users are reported and cause a non-zero exit, and the other shadow fields are preserved. The shadow path is injectable so the update is tested against fixtures rather than the host database.

## Tests

- Unit (fixture shadow files): hashing and updating a user's entry (a $6$ hash that verifies against the password) while leaving other users and fields intact, storing an `-e` encrypted value verbatim, the md5 method producing a $1$ hash, an unknown user failing, and the unknown-method / malformed-line errors.
- shellspec: an unknown method is rejected, and the `--help` path (writing the real shadow needs privilege, so the update is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (673 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `chpasswd` command for batch password updates, supporting pre-encrypted password input and configurable hashing algorithms.

* **Documentation**
  * Updated README to include the new command in the command listing.

* **Tests**
  * Added comprehensive unit and integration tests covering password hashing, encryption handling, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->