### PR TITLE
fix(chpasswd): write shadow atomically and reject empty usernames

### DIFF
--- a/internal/applets/loginutils/chpasswd/chpasswd.go
+++ b/internal/applets/loginutils/chpasswd/chpasswd.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/GehirnInc/crypt"
@@ -116,7 +117,7 @@ func readUpdates(r io.Reader, encrypted bool, method crypt.Crypt) (map[string]st
 			continue
 		}
 		user, password, ok := strings.Cut(line, ":")
-		if !ok {
+		if !ok || user == "" {
 			return nil, fmt.Errorf("malformed input line (need user:password): %q", line)
 		}
 		if encrypted {
@@ -144,7 +145,28 @@ func readLines(path string) ([]string, error) {
 	return strings.Split(trimmed, "\n"), nil
 }
 
+// writeLines atomically replaces path: it writes a temporary file in the same
+// directory and renames it into place, so an interrupted write cannot leave the
+// shadow database truncated or corrupted.
 func writeLines(path string, lines []string) error {
 	content := strings.Join(lines, "\n") + "\n"
-	return os.WriteFile(path, []byte(content), 0o600) //nolint:gosec // shadow is mode 0600
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".chpasswd-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename succeeds
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil { //nolint:gosec // shadow is mode 0600
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }

--- a/internal/applets/loginutils/chpasswd/chpasswd_test.go
+++ b/internal/applets/loginutils/chpasswd/chpasswd_test.go
@@ -101,3 +101,35 @@ func TestErrors(t *testing.T) {
 		t.Errorf("a malformed input line should fail")
 	}
 }
+
+func TestRejectsEmptyUsername(t *testing.T) {
+	fixtureShadow(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, ":secret\n"); err == nil {
+		t.Errorf("an empty username should be rejected")
+	}
+}
+
+func TestAtomicWritePreservesModeAndContent(t *testing.T) {
+	p := fixtureShadow(t, "alice:!:19000:0:99999:7:::\n")
+	// -e stores the value verbatim, so the "hash" is just "secret".
+	if err := run(t, "alice:secret\n", "-e"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("shadow mode = %o, want 0600", info.Mode().Perm())
+	}
+	if field(t, p, "alice", 1) != "secret" {
+		t.Errorf("atomic write lost the update")
+	}
+	// No stray temp files should remain in the directory.
+	entries, _ := os.ReadDir(filepath.Dir(p))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".chpasswd-") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #412 addressing two CodeRabbit findings:

- **Atomic shadow write (Major).** The read-modify-write of /etc/shadow used an in-place truncating write, so an interruption could leave the shadow database corrupted. writeLines now writes a temporary file in the same directory (mode 0600) and renames it into place, which is atomic on a single filesystem; the temp file is cleaned up if the rename never happens.
- **Empty usernames (Minor).** An input line like ':password' produced an empty username; it is now treated as a malformed line and rejected.

Adds unit tests for the empty-username rejection and for the atomic write preserving mode/content and leaving no stray temp files.

Part of #250