### PR TITLE
feat(loginutils): add addgroup and delgroup applets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 290 commands. Run `mimixbox --list` to see them on the terminal.
+There are 292 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
 | [ | Evaluate a conditional expression (test alias requiring ]) |
 | [[ | Evaluate a conditional expression (test alias requiring ]]) |
 | add-shell | Add shell name to /etc/shells |
+| addgroup | Add a group to /etc/group |
 | ar | Create, modify and extract from archives |
 | arch | Print machine hardware name (same as uname -m) |
 | ash | Command interpreter (MimixBox mbsh compatibility front-end) |
@@ -67,6 +68,7 @@ There are 290 commands. Run `mimixbox --list` to see them on the terminal.
 | date | Print or set the system date and time |
 | dc | Reverse-Polish (stack) desk calculator |
 | dd | Convert and copy a file |
+| delgroup | Remove a group from /etc/group |
 | df | Report file system disk space usage |
 | diff | Compare files line by line |
 | dirname | Print only directory path |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -72,7 +72,9 @@ import (
 	ap_jokeutils_fortune "github.com/nao1215/mimixbox/internal/applets/jokeutils/fortune"
 	ap_jokeutils_nyancat "github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
+	ap_loginutils_addgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/addgroup"
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
+	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
@@ -277,7 +279,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 290)
+	Applets = make(map[string]Applet, 292)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -358,7 +360,9 @@ func init() {
 	register(ap_jokeutils_fortune.New())
 	register(ap_jokeutils_nyancat.New())
 	register(ap_jokeutils_sl.New())
+	register(ap_loginutils_addgroup.New())
 	register(ap_loginutils_chpasswd.New())
+	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
 	register(ap_loginutils_runlevel.New())

--- a/internal/applets/loginutils/addgroup/addgroup.go
+++ b/internal/applets/loginutils/addgroup/addgroup.go
@@ -1,0 +1,147 @@
+// Package addgroup implements the addgroup applet: add a group to /etc/group.
+package addgroup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the addgroup applet.
+type Command struct{}
+
+// New returns an addgroup command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "addgroup" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Add a group to /etc/group" }
+
+// groupPath is the group database; tests point it at a fixture.
+var groupPath = "/etc/group"
+
+// The range of GIDs auto-assigned when --gid is not given.
+const (
+	firstGID = 1000
+	lastGID  = 64999
+)
+
+// Run executes addgroup.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[--gid GID] GROUP", stdio.Err).WithHelp(command.Help{
+		Description: "Add a new group named GROUP to /etc/group. With --gid the group is given that " +
+			"numeric ID; otherwise the first free ID in the normal range is chosen. It is an error if " +
+			"the group name or a requested GID already exists. Writing the real group database requires " +
+			"privilege.",
+		Examples: []command.Example{
+			{Command: "addgroup developers", Explain: "Add a group with an auto-assigned GID."},
+			{Command: "addgroup --gid 1500 staff", Explain: "Add a group with a specific GID."},
+		},
+		ExitStatus: "0  the group was added.\n1  the group or GID already exists, or the database is unwritable.",
+	})
+	gid := fs.Int("gid", -1, "numeric group ID (auto-assigned if unset)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a group name is required")
+	}
+	name := rest[0]
+
+	lines, byName, byGID, err := readGroups()
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", groupPath, err)
+	}
+	if byName[name] {
+		return command.Failuref("group %q already exists", name)
+	}
+
+	newGID := *gid
+	if fs.Changed("gid") {
+		if byGID[newGID] {
+			return command.Failuref("GID %d is already in use", newGID)
+		}
+	} else {
+		newGID = nextFreeGID(byGID)
+		if newGID < 0 {
+			return command.Failuref("no free GID available in %d-%d", firstGID, lastGID)
+		}
+	}
+
+	lines = append(lines, fmt.Sprintf("%s:x:%d:", name, newGID))
+	if err := writeGroups(lines); err != nil {
+		return command.Failuref("cannot write %s: %v", groupPath, err)
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "addgroup: group %q (GID %d) added\n", name, newGID)
+	return nil
+}
+
+// readGroups returns the group file's lines and indexes of used names and GIDs.
+func readGroups() (lines []string, byName map[string]bool, byGID map[int]bool, err error) {
+	byName = map[string]bool{}
+	byGID = map[int]bool{}
+	data, err := os.ReadFile(groupPath) //nolint:gosec // well-known group path
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	trimmed := strings.TrimRight(string(data), "\n")
+	if trimmed == "" {
+		return nil, byName, byGID, nil
+	}
+	lines = strings.Split(trimmed, "\n")
+	for _, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) < 3 {
+			continue
+		}
+		byName[fields[0]] = true
+		if g, err := strconv.Atoi(fields[2]); err == nil {
+			byGID[g] = true
+		}
+	}
+	return lines, byName, byGID, nil
+}
+
+// nextFreeGID returns the lowest unused GID in the normal range, or -1.
+func nextFreeGID(byGID map[int]bool) int {
+	for g := firstGID; g <= lastGID; g++ {
+		if !byGID[g] {
+			return g
+		}
+	}
+	return -1
+}
+
+// writeGroups atomically replaces the group file.
+func writeGroups(lines []string) error {
+	content := strings.Join(lines, "\n") + "\n"
+	tmp, err := os.CreateTemp(filepath.Dir(groupPath), ".addgroup-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, groupPath)
+}

--- a/internal/applets/loginutils/addgroup/addgroup_test.go
+++ b/internal/applets/loginutils/addgroup/addgroup_test.go
@@ -1,0 +1,91 @@
+package addgroup
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "group")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := groupPath
+	groupPath = p
+	t.Cleanup(func() { groupPath = orig })
+	return p
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func lineFor(t *testing.T, path, name string) string {
+	t.Helper()
+	data, _ := os.ReadFile(path)
+	for _, l := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if strings.HasPrefix(l, name+":") {
+			return l
+		}
+	}
+	return ""
+}
+
+func TestAddAutoGID(t *testing.T) {
+	p := fixture(t, "root:x:0:\nstaff:x:50:\n")
+	if err := run(t, "developers"); err != nil {
+		t.Fatal(err)
+	}
+	if got := lineFor(t, p, "developers"); got != "developers:x:1000:" {
+		t.Errorf("added line = %q, want developers:x:1000:", got)
+	}
+}
+
+func TestAddSpecificGID(t *testing.T) {
+	p := fixture(t, "root:x:0:\n")
+	if err := run(t, "--gid", "1500", "staff"); err != nil {
+		t.Fatal(err)
+	}
+	if got := lineFor(t, p, "staff"); got != "staff:x:1500:" {
+		t.Errorf("added line = %q", got)
+	}
+}
+
+func TestDuplicateNameAndGID(t *testing.T) {
+	fixture(t, "root:x:0:\nstaff:x:1500:\n")
+	if err := run(t, "staff"); err == nil {
+		t.Errorf("an existing group name should fail")
+	}
+	if err := run(t, "--gid", "1500", "other"); err == nil {
+		t.Errorf("an in-use GID should fail")
+	}
+}
+
+func TestNoTempLeft(t *testing.T) {
+	p := fixture(t, "root:x:0:\n")
+	if err := run(t, "newgrp"); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(filepath.Dir(p))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".addgroup-") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestNoName(t *testing.T) {
+	fixture(t, "root:x:0:\n")
+	if err := run(t); err == nil {
+		t.Errorf("missing group name should fail")
+	}
+}

--- a/internal/applets/loginutils/delgroup/delgroup.go
+++ b/internal/applets/loginutils/delgroup/delgroup.go
@@ -1,0 +1,109 @@
+// Package delgroup implements the delgroup applet: remove a group from
+// /etc/group.
+package delgroup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the delgroup applet.
+type Command struct{}
+
+// New returns a delgroup command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "delgroup" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Remove a group from /etc/group" }
+
+// groupPath is the group database; tests point it at a fixture.
+var groupPath = "/etc/group"
+
+// Run executes delgroup.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "GROUP", stdio.Err).WithHelp(command.Help{
+		Description: "Remove the group named GROUP from /etc/group. It is an error if no such group " +
+			"exists. Writing the real group database requires privilege.",
+		Examples: []command.Example{
+			{Command: "delgroup developers", Explain: "Remove the developers group."},
+		},
+		ExitStatus: "0  the group was removed.\n1  no such group, or the database is unwritable.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a group name is required")
+	}
+	name := rest[0]
+
+	data, err := os.ReadFile(groupPath) //nolint:gosec // well-known group path
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", groupPath, err)
+	}
+
+	kept, removed := remove(string(data), name)
+	if !removed {
+		return command.Failuref("group %q does not exist", name)
+	}
+	if err := writeGroups(kept); err != nil {
+		return command.Failuref("cannot write %s: %v", groupPath, err)
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "delgroup: group %q removed\n", name)
+	return nil
+}
+
+// remove returns the group file content with the named group's line dropped and
+// whether a line was removed.
+func remove(content, name string) (kept []string, removed bool) {
+	trimmed := strings.TrimRight(content, "\n")
+	if trimmed == "" {
+		return nil, false
+	}
+	for _, line := range strings.Split(trimmed, "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) > 0 && fields[0] == name {
+			removed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return kept, removed
+}
+
+// writeGroups atomically replaces the group file.
+func writeGroups(lines []string) error {
+	content := strings.Join(lines, "\n")
+	if content != "" {
+		content += "\n"
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(groupPath), ".delgroup-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, groupPath)
+}

--- a/internal/applets/loginutils/delgroup/delgroup_test.go
+++ b/internal/applets/loginutils/delgroup/delgroup_test.go
@@ -1,0 +1,67 @@
+package delgroup
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "group")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := groupPath
+	groupPath = p
+	t.Cleanup(func() { groupPath = orig })
+	return p
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestRemovesGroup(t *testing.T) {
+	p := fixture(t, "root:x:0:\nstaff:x:50:\ndevelopers:x:1000:\n")
+	if err := run(t, "staff"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(p)
+	if strings.Contains(string(data), "staff") {
+		t.Errorf("staff should be removed:\n%s", data)
+	}
+	// The other groups must remain.
+	if !strings.Contains(string(data), "root:x:0:") || !strings.Contains(string(data), "developers:x:1000:") {
+		t.Errorf("other groups must be preserved:\n%s", data)
+	}
+}
+
+func TestRemoveMatchesWholeName(t *testing.T) {
+	// "staff" must not remove "staffroom".
+	p := fixture(t, "staffroom:x:60:\n")
+	if err := run(t, "staff"); err == nil {
+		t.Errorf("a non-existent group should fail")
+	}
+	data, _ := os.ReadFile(p)
+	if !strings.Contains(string(data), "staffroom") {
+		t.Errorf("staffroom must not be removed")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixture(t, "root:x:0:\n")
+	if err := run(t, "ghost"); err == nil {
+		t.Errorf("removing a missing group should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("missing group name should fail")
+	}
+}

--- a/test/it/loginutils/group_test.sh
+++ b/test/it/loginutils/group_test.sh
@@ -1,0 +1,4 @@
+# Writing /etc/group needs privilege; the e2e exercises the deterministic
+# no-argument paths. The add/remove logic is covered by Go unit tests.
+TestAddgroupNoName() { addgroup 2>/dev/null; echo "rc=$?"; }
+TestDelgroupNoName() { delgroup 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/group_spec.sh
+++ b/test/it/spec/group_spec.sh
@@ -1,0 +1,14 @@
+Describe 'addgroup / delgroup'
+    Include loginutils/group_test.sh
+
+    It 'addgroup requires a group name'
+        When call TestAddgroupNoName
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'delgroup requires a group name'
+        When call TestDelgroupNoName
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with the group-management pair:

- **`addgroup`** — add a group to /etc/group; `--gid` sets a numeric ID, otherwise the first free ID in the normal range (1000–64999) is chosen. It is an error if the group name or a requested GID already exists.
- **`delgroup`** — remove a group from /etc/group; it is an error if no such group exists, and it matches the whole group name (so `staff` does not remove `staffroom`).

Both replace the group file atomically (write a temp file in the same directory, then rename) so an interruption cannot corrupt it, and the group path is injectable so the logic is tested against fixtures rather than the host database.

## Tests

- Unit (fixture group files): addgroup auto-assigning the first free GID, honoring `--gid`, rejecting a duplicate name and an in-use GID, leaving no temp file behind, and requiring a name; delgroup removing a group while preserving the others, matching the whole name, and the missing-group / missing-name errors.
- shellspec: addgroup and delgroup each require a group name.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (675 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `addgroup` command to add groups to the system group database
  * Added `delgroup` command to remove groups from the system group database

* **Documentation**
  * Updated command reference documentation (290 → 292 commands)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->