### PR TITLE
feat(loginutils): add adduser applet to create a user account

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 292 commands. Run `mimixbox --list` to see them on the terminal.
+There are 293 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -27,6 +27,7 @@ There are 292 commands. Run `mimixbox --list` to see them on the terminal.
 | [[ | Evaluate a conditional expression (test alias requiring ]]) |
 | add-shell | Add shell name to /etc/shells |
 | addgroup | Add a group to /etc/group |
+| adduser | Create a user account |
 | ar | Create, modify and extract from archives |
 | arch | Print machine hardware name (same as uname -m) |
 | ash | Command interpreter (MimixBox mbsh compatibility front-end) |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -73,6 +73,7 @@ import (
 	ap_jokeutils_nyancat "github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
 	ap_loginutils_addgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/addgroup"
+	ap_loginutils_adduser "github.com/nao1215/mimixbox/internal/applets/loginutils/adduser"
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
@@ -279,7 +280,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 292)
+	Applets = make(map[string]Applet, 293)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -361,6 +362,7 @@ func init() {
 	register(ap_jokeutils_nyancat.New())
 	register(ap_jokeutils_sl.New())
 	register(ap_loginutils_addgroup.New())
+	register(ap_loginutils_adduser.New())
 	register(ap_loginutils_chpasswd.New())
 	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_mkpasswd.New())

--- a/internal/applets/loginutils/adduser/adduser.go
+++ b/internal/applets/loginutils/adduser/adduser.go
@@ -1,0 +1,215 @@
+// Package adduser implements the adduser applet: create a user account in
+// /etc/passwd and /etc/shadow, with a primary group.
+package adduser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the adduser applet.
+type Command struct{}
+
+// New returns an adduser command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "adduser" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Create a user account" }
+
+// The account databases; tests point these at fixtures.
+var (
+	passwdPath = "/etc/passwd"
+	shadowPath = "/etc/shadow"
+	groupPath  = "/etc/group"
+)
+
+const (
+	firstID = 1000
+	lastID  = 64999
+)
+
+// Run executes adduser.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-u UID] [-h HOME] [-s SHELL] [-G GROUP] USER", stdio.Err).WithHelp(command.Help{
+		Description: "Create the user account USER in /etc/passwd and /etc/shadow. -u sets the UID " +
+			"(auto-assigned otherwise); -h sets the home directory (default /home/USER); -s sets the " +
+			"login shell (default /bin/sh); -G makes an existing group the primary group, otherwise a " +
+			"new group named USER is created. The account is created locked; set a password with " +
+			"passwd or chpasswd. Writing the real databases requires privilege.",
+		Examples: []command.Example{
+			{Command: "adduser alice", Explain: "Create alice with a matching group."},
+			{Command: "adduser -G staff -s /bin/bash bob", Explain: "Create bob in the staff group."},
+		},
+		ExitStatus: "0  the account was created.\n1  the user exists or a database is unwritable.",
+	})
+	uid := fs.IntP("uid", "u", -1, "numeric user ID (auto-assigned if unset)")
+	home := fs.StringP("home", "h", "", "home directory (default /home/USER)")
+	shell := fs.StringP("shell", "s", "/bin/sh", "login shell")
+	group := fs.StringP("ingroup", "G", "", "existing group to use as the primary group")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a user name is required")
+	}
+	name := rest[0]
+
+	passwd, err := readLines(passwdPath)
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", passwdPath, err)
+	}
+	usedNames, usedUIDs := indexColumn(passwd, 0), indexNumeric(passwd, 2)
+	if usedNames[name] {
+		return command.Failuref("user %q already exists", name)
+	}
+
+	newUID := *uid
+	if fs.Changed("uid") {
+		if usedUIDs[newUID] {
+			return command.Failuref("UID %d is already in use", newUID)
+		}
+	} else if newUID = nextFree(usedUIDs); newUID < 0 {
+		return command.Failuref("no free UID available in %d-%d", firstID, lastID)
+	}
+
+	gid, err := resolveGroup(name, newUID, *group)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	homeDir := *home
+	if homeDir == "" {
+		homeDir = "/home/" + name
+	}
+
+	passwd = append(passwd, fmt.Sprintf("%s:x:%d:%d:%s:%s:%s", name, newUID, gid, name, homeDir, *shell))
+	if err := writeFile(passwdPath, passwd, 0o644); err != nil {
+		return command.Failuref("cannot write %s: %v", passwdPath, err)
+	}
+
+	shadow, err := readLines(shadowPath)
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", shadowPath, err)
+	}
+	shadow = append(shadow, fmt.Sprintf("%s:!:19000:0:99999:7:::", name))
+	if err := writeFile(shadowPath, shadow, 0o600); err != nil {
+		return command.Failuref("cannot write %s: %v", shadowPath, err)
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "adduser: user %q (UID %d, GID %d) created\n", name, newUID, gid)
+	return nil
+}
+
+// resolveGroup returns the primary GID: the GID of an existing -G group, or a
+// freshly created group named after the user (with GID = uid).
+func resolveGroup(name string, uid int, ingroup string) (int, error) {
+	groups, err := readLines(groupPath)
+	if err != nil {
+		return 0, fmt.Errorf("cannot read %s: %v", groupPath, err)
+	}
+	if ingroup != "" {
+		for _, line := range groups {
+			f := strings.Split(line, ":")
+			if len(f) >= 3 && f[0] == ingroup {
+				gid, err := strconv.Atoi(f[2])
+				if err != nil {
+					return 0, fmt.Errorf("group %q has an invalid GID", ingroup)
+				}
+				return gid, nil
+			}
+		}
+		return 0, fmt.Errorf("group %q does not exist", ingroup)
+	}
+	// Create a new group named after the user.
+	usedGIDs := indexNumeric(groups, 2)
+	gid := uid
+	if usedGIDs[gid] {
+		if gid = nextFree(usedGIDs); gid < 0 {
+			return 0, fmt.Errorf("no free GID available")
+		}
+	}
+	groups = append(groups, fmt.Sprintf("%s:x:%d:", name, gid))
+	if err := writeFile(groupPath, groups, 0o644); err != nil {
+		return 0, fmt.Errorf("cannot write %s: %v", groupPath, err)
+	}
+	return gid, nil
+}
+
+func readLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // well-known account database path
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimRight(string(data), "\n")
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
+func indexColumn(lines []string, col int) map[string]bool {
+	out := map[string]bool{}
+	for _, line := range lines {
+		if f := strings.Split(line, ":"); len(f) > col {
+			out[f[col]] = true
+		}
+	}
+	return out
+}
+
+func indexNumeric(lines []string, col int) map[int]bool {
+	out := map[int]bool{}
+	for _, line := range lines {
+		if f := strings.Split(line, ":"); len(f) > col {
+			if n, err := strconv.Atoi(f[col]); err == nil {
+				out[n] = true
+			}
+		}
+	}
+	return out
+}
+
+func nextFree(used map[int]bool) int {
+	for id := firstID; id <= lastID; id++ {
+		if !used[id] {
+			return id
+		}
+	}
+	return -1
+}
+
+// writeFile atomically replaces path with the given lines.
+func writeFile(path string, lines []string, mode os.FileMode) error {
+	content := strings.Join(lines, "\n") + "\n"
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".adduser-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/applets/loginutils/adduser/adduser_test.go
+++ b/internal/applets/loginutils/adduser/adduser_test.go
@@ -1,0 +1,104 @@
+package adduser
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixtures(t *testing.T, passwd, shadow, group string) (string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	op, os1, og := passwdPath, shadowPath, groupPath
+	passwdPath = write("passwd", passwd)
+	shadowPath = write("shadow", shadow)
+	groupPath = write("group", group)
+	t.Cleanup(func() { passwdPath, shadowPath, groupPath = op, os1, og })
+	return passwdPath, shadowPath, groupPath
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func lineFor(t *testing.T, path, name string) string {
+	t.Helper()
+	data, _ := os.ReadFile(path)
+	for _, l := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if strings.HasPrefix(l, name+":") {
+			return l
+		}
+	}
+	return ""
+}
+
+func TestCreatesUserAndGroup(t *testing.T) {
+	pw, sh, gr := fixtures(t, "root:x:0:0:root:/root:/bin/sh\n", "root:x:19000:0:99999:7:::\n", "root:x:0:\n")
+	if err := run(t, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	// passwd: alice with auto UID 1000, GID 1000, default home/shell.
+	if got := lineFor(t, pw, "alice"); got != "alice:x:1000:1000:alice:/home/alice:/bin/sh" {
+		t.Errorf("passwd line = %q", got)
+	}
+	// shadow: locked account.
+	if got := lineFor(t, sh, "alice"); !strings.HasPrefix(got, "alice:!:") {
+		t.Errorf("shadow line = %q, want locked", got)
+	}
+	// a matching group was created.
+	if got := lineFor(t, gr, "alice"); got != "alice:x:1000:" {
+		t.Errorf("group line = %q", got)
+	}
+}
+
+func TestUsesExistingGroup(t *testing.T) {
+	pw, _, _ := fixtures(t, "root:x:0:0:root:/root:/bin/sh\n", "root:x:19000:0:99999:7:::\n", "root:x:0:\nstaff:x:50:\n")
+	if err := run(t, "-G", "staff", "-s", "/bin/bash", "bob"); err != nil {
+		t.Fatal(err)
+	}
+	got := lineFor(t, pw, "bob")
+	if !strings.Contains(got, ":1000:50:") || !strings.HasSuffix(got, ":/bin/bash") {
+		t.Errorf("passwd line = %q, want GID 50 and bash", got)
+	}
+}
+
+func TestSpecificUID(t *testing.T) {
+	pw, _, _ := fixtures(t, "root:x:0:0:root:/root:/bin/sh\n", "root:x:19000:0:99999:7:::\n", "root:x:0:\n")
+	if err := run(t, "-u", "2000", "-h", "/srv/carol", "carol"); err != nil {
+		t.Fatal(err)
+	}
+	got := lineFor(t, pw, "carol")
+	if !strings.HasPrefix(got, "carol:x:2000:") || !strings.Contains(got, ":/srv/carol:") {
+		t.Errorf("passwd line = %q", got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixtures(t, "alice:x:1000:1000:alice:/home/alice:/bin/sh\n", "alice:!:19000:0:99999:7:::\n", "alice:x:1000:\n")
+	if err := run(t, "alice"); err == nil {
+		t.Errorf("an existing user should fail")
+	}
+	if err := run(t, "-u", "1000", "newuser"); err == nil {
+		t.Errorf("an in-use UID should fail")
+	}
+	if err := run(t, "-G", "nosuchgroup", "newuser"); err == nil {
+		t.Errorf("a missing primary group should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("missing user name should fail")
+	}
+}

--- a/test/it/loginutils/adduser_test.sh
+++ b/test/it/loginutils/adduser_test.sh
@@ -1,0 +1,4 @@
+# Writing the account databases needs privilege; the e2e exercises the
+# deterministic no-argument path. The account creation is covered by unit tests.
+TestAdduserNoName() { adduser 2>/dev/null; echo "rc=$?"; }
+TestAdduserHelp() { adduser --help; }

--- a/test/it/spec/adduser_spec.sh
+++ b/test/it/spec/adduser_spec.sh
@@ -1,0 +1,15 @@
+Describe 'adduser'
+    Include loginutils/adduser_test.sh
+
+    It 'requires a user name'
+        When call TestAdduserNoName
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestAdduserHelp
+        The status should be success
+        The output should include 'Usage: adduser'
+        The output should include 'account'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `adduser`, which creates a user account in /etc/passwd and /etc/shadow. `-u` sets the UID (auto-assigned in 1000–64999 otherwise), `-h` the home directory (default /home/USER), `-s` the login shell (default /bin/sh), and `-G` makes an existing group the primary group — otherwise a new group named after the user is created in /etc/group. The account is created locked (shadow '!'), to be set later with passwd or chpasswd. It rejects an existing user name or an in-use UID, and a missing `-G` group. All three databases are written atomically (temp file + rename) and their paths are injectable so the logic is tested against fixtures.

## Tests

- Unit (fixture passwd/shadow/group): creating a user with an auto UID, default home/shell, a locked shadow entry, and a matching new group; using an existing `-G` group and a custom shell; honoring `-u`/`-h`; and the existing-user / in-use-UID / missing-group / missing-name errors.
- shellspec: adduser requires a user name, and the `--help` path (writing the real databases needs privilege, so account creation is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (677 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250