### PR TITLE
feat(loginutils): add deluser applet to remove a user account

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 293 commands. Run `mimixbox --list` to see them on the terminal.
+There are 294 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -70,6 +70,7 @@ There are 293 commands. Run `mimixbox --list` to see them on the terminal.
 | dc | Reverse-Polish (stack) desk calculator |
 | dd | Convert and copy a file |
 | delgroup | Remove a group from /etc/group |
+| deluser | Remove a user account |
 | df | Report file system disk space usage |
 | diff | Compare files line by line |
 | dirname | Print only directory path |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -76,6 +76,7 @@ import (
 	ap_loginutils_adduser "github.com/nao1215/mimixbox/internal/applets/loginutils/adduser"
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
+	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
@@ -280,7 +281,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 293)
+	Applets = make(map[string]Applet, 294)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -365,6 +366,7 @@ func init() {
 	register(ap_loginutils_adduser.New())
 	register(ap_loginutils_chpasswd.New())
 	register(ap_loginutils_delgroup.New())
+	register(ap_loginutils_deluser.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
 	register(ap_loginutils_runlevel.New())

--- a/internal/applets/loginutils/deluser/deluser.go
+++ b/internal/applets/loginutils/deluser/deluser.go
@@ -1,0 +1,159 @@
+// Package deluser implements the deluser applet: remove a user account from
+// /etc/passwd and /etc/shadow, and from group memberships.
+package deluser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the deluser applet.
+type Command struct{}
+
+// New returns a deluser command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "deluser" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Remove a user account" }
+
+// The account databases; tests point these at fixtures.
+var (
+	passwdPath = "/etc/passwd"
+	shadowPath = "/etc/shadow"
+	groupPath  = "/etc/group"
+)
+
+// Run executes deluser.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "USER", stdio.Err).WithHelp(command.Help{
+		Description: "Remove the user account USER from /etc/passwd and /etc/shadow, and remove it from " +
+			"the member list of every group in /etc/group. It is an error if the user does not exist. " +
+			"Writing the real databases requires privilege.",
+		Examples: []command.Example{
+			{Command: "deluser alice", Explain: "Remove the user alice."},
+		},
+		ExitStatus: "0  the user was removed.\n1  no such user, or a database is unwritable.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a user name is required")
+	}
+	name := rest[0]
+
+	passwd, err := readLines(passwdPath)
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", passwdPath, err)
+	}
+	kept, removed := removeByName(passwd, name)
+	if !removed {
+		return command.Failuref("user %q does not exist", name)
+	}
+	if err := writeFile(passwdPath, kept, 0o644); err != nil {
+		return command.Failuref("cannot write %s: %v", passwdPath, err)
+	}
+
+	shadow, err := readLines(shadowPath)
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", shadowPath, err)
+	}
+	shadowKept, _ := removeByName(shadow, name)
+	if err := writeFile(shadowPath, shadowKept, 0o600); err != nil {
+		return command.Failuref("cannot write %s: %v", shadowPath, err)
+	}
+
+	groups, err := readLines(groupPath)
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", groupPath, err)
+	}
+	if err := writeFile(groupPath, removeFromMembers(groups, name), 0o644); err != nil {
+		return command.Failuref("cannot write %s: %v", groupPath, err)
+	}
+
+	_, _ = fmt.Fprintf(stdio.Out, "deluser: user %q removed\n", name)
+	return nil
+}
+
+// removeByName drops the line whose first colon-field equals name.
+func removeByName(lines []string, name string) (kept []string, removed bool) {
+	for _, line := range lines {
+		if f := strings.Split(line, ":"); len(f) > 0 && f[0] == name {
+			removed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return kept, removed
+}
+
+// removeFromMembers drops name from the comma-separated member list (field 4)
+// of every group line.
+func removeFromMembers(lines []string, name string) []string {
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Split(line, ":")
+		if len(fields) < 4 || fields[3] == "" {
+			out = append(out, line)
+			continue
+		}
+		var members []string
+		for _, m := range strings.Split(fields[3], ",") {
+			if m != name && m != "" {
+				members = append(members, m)
+			}
+		}
+		fields[3] = strings.Join(members, ",")
+		out = append(out, strings.Join(fields, ":"))
+	}
+	return out
+}
+
+func readLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // well-known account database path
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimRight(string(data), "\n")
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
+// writeFile atomically replaces path with the given lines.
+func writeFile(path string, lines []string, mode os.FileMode) error {
+	content := strings.Join(lines, "\n")
+	if content != "" {
+		content += "\n"
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".deluser-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/applets/loginutils/deluser/deluser_test.go
+++ b/internal/applets/loginutils/deluser/deluser_test.go
@@ -1,0 +1,88 @@
+package deluser
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixtures(t *testing.T, passwd, shadow, group string) (string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	op, os1, og := passwdPath, shadowPath, groupPath
+	passwdPath = write("passwd", passwd)
+	shadowPath = write("shadow", shadow)
+	groupPath = write("group", group)
+	t.Cleanup(func() { passwdPath, shadowPath, groupPath = op, os1, og })
+	return passwdPath, shadowPath, groupPath
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	data, _ := os.ReadFile(path)
+	return string(data)
+}
+
+func TestRemovesUserEverywhere(t *testing.T) {
+	pw, sh, gr := fixtures(t,
+		"root:x:0:0:root:/root:/bin/sh\nalice:x:1000:1000:alice:/home/alice:/bin/sh\n",
+		"root:x:19000:0:99999:7:::\nalice:!:19000:0:99999:7:::\n",
+		"root:x:0:\nstaff:x:50:alice,bob\nalice:x:1000:\n")
+	if err := run(t, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(read(t, pw), "alice") {
+		t.Errorf("alice should be gone from passwd:\n%s", read(t, pw))
+	}
+	if strings.Contains(read(t, sh), "alice:!") {
+		t.Errorf("alice should be gone from shadow")
+	}
+	// alice removed from staff's member list, bob kept; the alice group line stays.
+	if !strings.Contains(read(t, gr), "staff:x:50:bob") {
+		t.Errorf("staff member list = %q", read(t, gr))
+	}
+	if !strings.Contains(read(t, pw), "root:x:0:") {
+		t.Errorf("root must be preserved")
+	}
+}
+
+func TestMembershipExactMatch(t *testing.T) {
+	_, _, gr := fixtures(t,
+		"al:x:1000:1000:al:/home/al:/bin/sh\n", "al:!:19000:0:99999:7:::\n",
+		"team:x:60:al,alice,albert\n")
+	if err := run(t, "al"); err != nil {
+		t.Fatal(err)
+	}
+	// Only "al" removed; "alice" and "albert" kept.
+	if got := read(t, gr); !strings.Contains(got, "team:x:60:alice,albert") {
+		t.Errorf("member list = %q", got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixtures(t, "root:x:0:0:root:/root:/bin/sh\n", "root:x:19000:0:99999:7:::\n", "root:x:0:\n")
+	if err := run(t, "ghost"); err == nil {
+		t.Errorf("removing a missing user should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("missing user name should fail")
+	}
+}

--- a/test/it/loginutils/deluser_test.sh
+++ b/test/it/loginutils/deluser_test.sh
@@ -1,0 +1,2 @@
+TestDeluserNoName() { deluser 2>/dev/null; echo "rc=$?"; }
+TestDeluserHelp() { deluser --help; }

--- a/test/it/spec/deluser_spec.sh
+++ b/test/it/spec/deluser_spec.sh
@@ -1,0 +1,15 @@
+Describe 'deluser'
+    Include loginutils/deluser_test.sh
+
+    It 'requires a user name'
+        When call TestDeluserNoName
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestDeluserHelp
+        The status should be success
+        The output should include 'Usage: deluser'
+        The output should include 'user'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `deluser`, the counterpart to adduser. It removes the user from /etc/passwd and /etc/shadow, and removes it from the comma-separated member list of every group in /etc/group, matching the whole user name (so removing `al` does not touch `alice` or `albert`). It is an error if the user does not exist. All three databases are written atomically (temp file + rename) and their paths are injectable so the logic is tested against fixtures.

## Tests

- Unit (fixture passwd/shadow/group): removing a user from passwd, shadow, and a group's member list while preserving other users/groups; exact-name membership matching; and the missing-user / missing-name errors.
- shellspec: deluser requires a user name, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (679 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250