### PR TITLE
feat(loginutils): add crontab applet to maintain a user crontab

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 294 commands. Run `mimixbox --list` to see them on the terminal.
+There are 295 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -64,6 +64,7 @@ There are 294 commands. Run `mimixbox --list` to see them on the terminal.
 | cp | Copy file(s) to Directory(s) |
 | cpio | Copy files to and from archives |
 | crc32 | Print the CRC-32 checksum of each file |
+| crontab | Maintain a user's crontab |
 | cttyhack | Run PROGRAM with the current stdio (no controlling-TTY trick) |
 | cut | Remove sections from each line of files |
 | date | Print or set the system date and time |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -75,6 +75,7 @@ import (
 	ap_loginutils_addgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/addgroup"
 	ap_loginutils_adduser "github.com/nao1215/mimixbox/internal/applets/loginutils/adduser"
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
+	ap_loginutils_crontab "github.com/nao1215/mimixbox/internal/applets/loginutils/crontab"
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
@@ -281,7 +282,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 294)
+	Applets = make(map[string]Applet, 295)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -365,6 +366,7 @@ func init() {
 	register(ap_loginutils_addgroup.New())
 	register(ap_loginutils_adduser.New())
 	register(ap_loginutils_chpasswd.New())
+	register(ap_loginutils_crontab.New())
 	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_deluser.New())
 	register(ap_loginutils_mkpasswd.New())

--- a/internal/applets/loginutils/crontab/crontab.go
+++ b/internal/applets/loginutils/crontab/crontab.go
@@ -1,0 +1,121 @@
+// Package crontab implements the crontab applet: install, list, or remove a
+// user's crontab in the cron spool directory.
+package crontab
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the crontab applet.
+type Command struct{}
+
+// New returns a crontab command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "crontab" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Maintain a user's crontab" }
+
+// Injected so the spool directory and the current user are testable.
+var (
+	spoolDir      = "/var/spool/cron/crontabs"
+	currentUserFn = func() (string, error) {
+		u, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		return u.Username, nil
+	}
+)
+
+// Run executes crontab.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-u USER] {-l | -r | [FILE]}", stdio.Err).WithHelp(command.Help{
+		Description: "Maintain a user's crontab in the cron spool directory. With -l the crontab is " +
+			"printed; with -r it is removed; with a FILE (or '-' / no operand, meaning standard input) " +
+			"the crontab is replaced with that content. -u operates on another user's crontab and " +
+			"requires privilege. Interactive editing (-e) is not implemented.",
+		Examples: []command.Example{
+			{Command: "crontab -l", Explain: "Print the current crontab."},
+			{Command: "crontab mycron.txt", Explain: "Install mycron.txt as the crontab."},
+			{Command: "crontab -r", Explain: "Remove the crontab."},
+		},
+		ExitStatus: "0  the operation succeeded.\n1  no crontab, an unsupported mode, or an I/O error.",
+	})
+	list := fs.BoolP("list", "l", false, "print the crontab")
+	remove := fs.BoolP("remove", "r", false, "remove the crontab")
+	edit := fs.BoolP("edit", "e", false, "edit the crontab (not supported)")
+	userName := fs.StringP("user", "u", "", "operate on this user's crontab")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	target := *userName
+	if target == "" {
+		target, err = currentUserFn()
+		if err != nil {
+			return command.Failuref("cannot determine the current user: %v", err)
+		}
+	}
+	path := filepath.Join(spoolDir, target)
+
+	switch {
+	case *edit:
+		return command.Failuref("interactive editing (-e) is not supported; install a file instead")
+	case *list:
+		return listCrontab(stdio, path)
+	case *remove:
+		return removeCrontab(path)
+	default:
+		return installCrontab(stdio, path, fs.Args())
+	}
+}
+
+func listCrontab(stdio command.IO, path string) error {
+	data, err := os.ReadFile(path) //nolint:gosec // spool path
+	if err != nil {
+		return command.Failuref("no crontab for this user")
+	}
+	_, _ = stdio.Out.Write(data)
+	return nil
+}
+
+func removeCrontab(path string) error {
+	if err := os.Remove(path); err != nil {
+		return command.Failuref("no crontab to remove")
+	}
+	return nil
+}
+
+func installCrontab(stdio command.IO, path string, operands []string) error {
+	var data []byte
+	var err error
+	if len(operands) == 0 || operands[0] == "-" {
+		data, err = io.ReadAll(stdio.In)
+	} else {
+		data, err = os.ReadFile(operands[0]) //nolint:gosec // user-named crontab file
+	}
+	if err != nil {
+		return command.Failuref("cannot read the new crontab: %v", err)
+	}
+
+	if err := os.MkdirAll(spoolDir, 0o755); err != nil {
+		return command.Failuref("cannot create the spool directory: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return command.Failuref("cannot install the crontab: %v", err)
+	}
+	_, _ = fmt.Fprintln(stdio.Err, "crontab: installing new crontab")
+	return nil
+}

--- a/internal/applets/loginutils/crontab/crontab_test.go
+++ b/internal/applets/loginutils/crontab/crontab_test.go
@@ -1,0 +1,100 @@
+package crontab
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "crontabs")
+	od, ou := spoolDir, currentUserFn
+	spoolDir = dir
+	currentUserFn = func() (string, error) { return "tester", nil }
+	t.Cleanup(func() { spoolDir, currentUserFn = od, ou })
+	return dir
+}
+
+func run(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestInstallFromStdinThenList(t *testing.T) {
+	dir := setup(t)
+	const cron = "*/5 * * * * /usr/bin/backup\n"
+	if _, err := run(t, cron); err != nil {
+		t.Fatal(err)
+	}
+	// The spool file for "tester" must hold the content.
+	data, err := os.ReadFile(filepath.Join(dir, "tester"))
+	if err != nil || string(data) != cron {
+		t.Fatalf("installed crontab = %q, err %v", data, err)
+	}
+	// -l prints it back.
+	out, err := run(t, "", "-l")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != cron {
+		t.Errorf("-l output = %q", out)
+	}
+}
+
+func TestInstallFromFile(t *testing.T) {
+	setup(t)
+	src := filepath.Join(t.TempDir(), "my.cron")
+	_ = os.WriteFile(src, []byte("0 0 * * * /bin/true\n"), 0o644)
+	if _, err := run(t, "", src); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := run(t, "", "-l")
+	if !strings.Contains(out, "/bin/true") {
+		t.Errorf("file not installed: %q", out)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	dir := setup(t)
+	if _, err := run(t, "1 2 3 4 5 cmd\n"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, "", "-r"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "tester")); !os.IsNotExist(err) {
+		t.Errorf("crontab should be removed")
+	}
+}
+
+func TestSpecificUser(t *testing.T) {
+	dir := setup(t)
+	if _, err := run(t, "@daily x\n", "-u", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "alice")); err != nil {
+		t.Errorf("alice crontab not installed: %v", err)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	setup(t)
+	if _, err := run(t, "", "-l"); err == nil {
+		t.Errorf("listing a missing crontab should fail")
+	}
+	if _, err := run(t, "", "-r"); err == nil {
+		t.Errorf("removing a missing crontab should fail")
+	}
+	if _, err := run(t, "", "-e"); err == nil {
+		t.Errorf("interactive edit should be unsupported")
+	}
+}

--- a/test/it/loginutils/crontab_test.sh
+++ b/test/it/loginutils/crontab_test.sh
@@ -1,0 +1,4 @@
+# crontab uses the system spool dir (privileged); the e2e exercises the
+# deterministic unsupported-edit path. Install/list/remove are unit-tested.
+TestCrontabEdit() { crontab -e 2>/dev/null; echo "rc=$?"; }
+TestCrontabHelp() { crontab --help; }

--- a/test/it/spec/crontab_spec.sh
+++ b/test/it/spec/crontab_spec.sh
@@ -1,0 +1,15 @@
+Describe 'crontab'
+    Include loginutils/crontab_test.sh
+
+    It 'reports that interactive edit is unsupported'
+        When call TestCrontabEdit
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestCrontabHelp
+        The status should be success
+        The output should include 'Usage: crontab'
+        The output should include 'crontab'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `crontab`, which maintains a user's crontab in the cron spool directory. `-l` prints the crontab, `-r` removes it, and a FILE (or '-' / no operand, meaning standard input) replaces it with that content. `-u` operates on another user's crontab. Interactive editing (`-e`) is not implemented and fails deterministically with a clear message. The spool directory and the current-user lookup are injectable so install/list/remove are tested against fixtures.

## Tests

- Unit (injected spool dir + user): installing from stdin and listing it back, installing from a FILE, removing the crontab, targeting another user with `-u`, and the missing-crontab (list/remove) and unsupported-edit errors.
- shellspec: `-e` reports unsupported, and the `--help` path (the real spool dir is privileged, so install/list/remove are unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (681 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250