### PR TITLE
feat(loginutils): add start-stop-daemon applet to start/stop a daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 295 commands. Run `mimixbox --list` to see them on the terminal.
+There are 296 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -251,6 +251,7 @@ There are 295 commands. Run `mimixbox --list` to see them on the terminal.
 | sort | Sort lines of text files |
 | speaker | Read text aloud using an installed TTS engine |
 | split | Split a file into pieces |
+| start-stop-daemon | Start or stop a background program |
 | stat | Display file or file system status |
 | strings | Print printable character sequences in files |
 | stty | Print or change terminal line settings |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -82,6 +82,7 @@ import (
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
 	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
+	ap_loginutils_startstopdaemon "github.com/nao1215/mimixbox/internal/applets/loginutils/startstopdaemon"
 	ap_netutils_httpstatus "github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
 	ap_netutils_nc "github.com/nao1215/mimixbox/internal/applets/netutils/nc"
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
@@ -282,7 +283,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 295)
+	Applets = make(map[string]Applet, 296)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -373,6 +374,7 @@ func init() {
 	register(ap_loginutils_nologin.New())
 	register(ap_loginutils_runlevel.New())
 	register(ap_loginutils_runparts.New())
+	register(ap_loginutils_startstopdaemon.New())
 	register(ap_netutils_httpstatus.New())
 	register(ap_netutils_nc.New())
 	register(ap_netutils_ping.New())

--- a/internal/applets/loginutils/startstopdaemon/startstopdaemon.go
+++ b/internal/applets/loginutils/startstopdaemon/startstopdaemon.go
@@ -1,0 +1,149 @@
+// Package startstopdaemon implements the start-stop-daemon applet: start or
+// stop a background program, tracked by a pidfile.
+package startstopdaemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the start-stop-daemon applet.
+type Command struct{}
+
+// New returns a start-stop-daemon command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "start-stop-daemon" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Start or stop a background program" }
+
+// Injected so the privileged process actions are testable.
+var (
+	isRunning = func(pid int) bool { return unix.Kill(pid, 0) == nil }
+	startProc = func(path string, args []string) (int, error) {
+		attr := &os.ProcAttr{Files: []*os.File{nil, nil, nil}}
+		p, err := os.StartProcess(path, append([]string{path}, args...), attr)
+		if err != nil {
+			return 0, err
+		}
+		pid := p.Pid
+		_ = p.Release()
+		return pid, nil
+	}
+	signalProc = func(pid int, sig syscall.Signal) error { return unix.Kill(pid, sig) }
+)
+
+// Run executes start-stop-daemon.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "{-S|-K} [-p PIDFILE] [-x EXEC] [-s SIGNAL] [-- ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Start (-S) or stop (-K) a background program tracked by a pidfile. For -S, if " +
+			"-p PIDFILE names a running process nothing is done; otherwise -x EXEC is started and its " +
+			"PID written to the pidfile. For -K, the process in -p PIDFILE is sent -s SIGNAL (TERM by " +
+			"default) and the pidfile is removed. Arguments after -- are passed to the started program.",
+		Examples: []command.Example{
+			{Command: "start-stop-daemon -S -p /run/foo.pid -x /usr/bin/foo", Explain: "Start foo if not running."},
+			{Command: "start-stop-daemon -K -p /run/foo.pid", Explain: "Stop foo and remove its pidfile."},
+		},
+		ExitStatus: "0  the action succeeded (or -S found it already running).\n1  bad options or the action failed.",
+	})
+	start := fs.BoolP("start", "S", false, "start the program")
+	stop := fs.BoolP("stop", "K", false, "stop the program")
+	pidfile := fs.StringP("pidfile", "p", "", "pidfile tracking the process")
+	execPath := fs.StringP("exec", "x", "", "program to start")
+	signalName := fs.StringP("signal", "s", "TERM", "signal to send when stopping")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if *start == *stop {
+		return command.Failuref("exactly one of -S (start) or -K (stop) is required")
+	}
+	if *start {
+		return doStart(stdio, *pidfile, *execPath, fs.Args())
+	}
+	return doStop(stdio, *pidfile, *signalName)
+}
+
+func doStart(stdio command.IO, pidfile, execPath string, args []string) error {
+	if execPath == "" {
+		return command.Failuref("-x EXEC is required to start a program")
+	}
+	if pidfile != "" {
+		if pid, ok := readPidfile(pidfile); ok && isRunning(pid) {
+			_, _ = fmt.Fprintf(stdio.Err, "start-stop-daemon: %s is already running (pid %d)\n", execPath, pid)
+			return nil
+		}
+	}
+
+	pid, err := startProc(execPath, args)
+	if err != nil {
+		return command.Failuref("cannot start %s: %v", execPath, err)
+	}
+	if pidfile != "" {
+		if err := os.WriteFile(pidfile, []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
+			return command.Failuref("cannot write %s: %v", pidfile, err)
+		}
+	}
+	return nil
+}
+
+func doStop(stdio command.IO, pidfile, signalName string) error {
+	if pidfile == "" {
+		return command.Failuref("-p PIDFILE is required to stop a program")
+	}
+	pid, ok := readPidfile(pidfile)
+	if !ok || !isRunning(pid) {
+		return command.Failuref("no running process found for %s", pidfile)
+	}
+	sig, err := parseSignal(signalName)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	if err := signalProc(pid, sig); err != nil {
+		return command.Failuref("cannot signal pid %d: %v", pid, err)
+	}
+	_ = os.Remove(pidfile)
+	_, _ = fmt.Fprintf(stdio.Err, "start-stop-daemon: stopped pid %d\n", pid)
+	return nil
+}
+
+func readPidfile(path string) (int, bool) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-named pidfile
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
+}
+
+// signals maps the supported signal names to their numbers.
+var signals = map[string]syscall.Signal{
+	"TERM": syscall.SIGTERM, "KILL": syscall.SIGKILL, "HUP": syscall.SIGHUP,
+	"INT": syscall.SIGINT, "QUIT": syscall.SIGQUIT, "USR1": syscall.SIGUSR1, "USR2": syscall.SIGUSR2,
+}
+
+// parseSignal accepts a signal name (with or without SIG) or a number.
+func parseSignal(name string) (syscall.Signal, error) {
+	name = strings.ToUpper(strings.TrimPrefix(strings.ToUpper(name), "SIG"))
+	if sig, ok := signals[name]; ok {
+		return sig, nil
+	}
+	if n, err := strconv.Atoi(name); err == nil && n > 0 {
+		return syscall.Signal(n), nil
+	}
+	return 0, fmt.Errorf("unknown signal: %q", name)
+}

--- a/internal/applets/loginutils/startstopdaemon/startstopdaemon_test.go
+++ b/internal/applets/loginutils/startstopdaemon/startstopdaemon_test.go
@@ -1,0 +1,128 @@
+package startstopdaemon
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type signalCall struct {
+	pid int
+	sig syscall.Signal
+}
+
+func stub(t *testing.T, running bool, startPID int, startErr error) (*[]string, *signalCall) {
+	t.Helper()
+	var started []string
+	sig := &signalCall{pid: -1}
+	oir, osp, osig := isRunning, startProc, signalProc
+	isRunning = func(int) bool { return running }
+	startProc = func(path string, args []string) (int, error) {
+		started = append([]string{path}, args...)
+		return startPID, startErr
+	}
+	signalProc = func(pid int, s syscall.Signal) error { *sig = signalCall{pid, s}; return nil }
+	t.Cleanup(func() { isRunning, startProc, signalProc = oir, osp, osig })
+	return &started, sig
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestStartWhenNotRunning(t *testing.T) {
+	started, _ := stub(t, false, 4242, nil)
+	pidfile := filepath.Join(t.TempDir(), "foo.pid")
+	if err := run(t, "-S", "-p", pidfile, "-x", "/usr/bin/foo", "--", "arg1"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*started) != 2 || (*started)[0] != "/usr/bin/foo" || (*started)[1] != "arg1" {
+		t.Errorf("started = %v", *started)
+	}
+	data, _ := os.ReadFile(pidfile)
+	if strings.TrimSpace(string(data)) != "4242" {
+		t.Errorf("pidfile = %q, want 4242", data)
+	}
+}
+
+func TestStartWhenAlreadyRunning(t *testing.T) {
+	started, _ := stub(t, true, 0, nil)
+	pidfile := filepath.Join(t.TempDir(), "foo.pid")
+	_ = os.WriteFile(pidfile, []byte("999\n"), 0o644)
+	if err := run(t, "-S", "-p", pidfile, "-x", "/usr/bin/foo"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*started) != 0 {
+		t.Errorf("should not start when already running, got %v", *started)
+	}
+}
+
+func TestStop(t *testing.T) {
+	_, sig := stub(t, true, 0, nil)
+	pidfile := filepath.Join(t.TempDir(), "foo.pid")
+	_ = os.WriteFile(pidfile, []byte("1234\n"), 0o644)
+	if err := run(t, "-K", "-p", pidfile, "-s", "KILL"); err != nil {
+		t.Fatal(err)
+	}
+	if sig.pid != 1234 || sig.sig != syscall.SIGKILL {
+		t.Errorf("signal call = %+v, want pid 1234 SIGKILL", *sig)
+	}
+	if _, err := os.Stat(pidfile); !os.IsNotExist(err) {
+		t.Errorf("pidfile should be removed after stop")
+	}
+}
+
+func TestStopDefaultsToTerm(t *testing.T) {
+	_, sig := stub(t, true, 0, nil)
+	pidfile := filepath.Join(t.TempDir(), "foo.pid")
+	_ = os.WriteFile(pidfile, []byte("7\n"), 0o644)
+	if err := run(t, "-K", "-p", pidfile); err != nil {
+		t.Fatal(err)
+	}
+	if sig.sig != syscall.SIGTERM {
+		t.Errorf("default signal = %v, want SIGTERM", sig.sig)
+	}
+}
+
+func TestStopNotRunning(t *testing.T) {
+	stub(t, false, 0, nil)
+	pidfile := filepath.Join(t.TempDir(), "foo.pid")
+	_ = os.WriteFile(pidfile, []byte("1234\n"), 0o644)
+	if err := run(t, "-K", "-p", pidfile); err == nil {
+		t.Errorf("stopping a non-running process should fail")
+	}
+}
+
+func TestModeAndArgErrors(t *testing.T) {
+	stub(t, false, 1, nil)
+	if err := run(t, "-p", "/tmp/x"); err == nil {
+		t.Errorf("neither -S nor -K should fail")
+	}
+	if err := run(t, "-S", "-K"); err == nil {
+		t.Errorf("both -S and -K should fail")
+	}
+	if err := run(t, "-S"); err == nil {
+		t.Errorf("start without -x should fail")
+	}
+}
+
+func TestParseSignal(t *testing.T) {
+	t.Parallel()
+	cases := map[string]syscall.Signal{"TERM": syscall.SIGTERM, "SIGKILL": syscall.SIGKILL, "9": syscall.Signal(9), "hup": syscall.SIGHUP}
+	for in, want := range cases {
+		if got, err := parseSignal(in); err != nil || got != want {
+			t.Errorf("parseSignal(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+	if _, err := parseSignal("BOGUS"); err == nil {
+		t.Errorf("unknown signal should error")
+	}
+}

--- a/test/it/loginutils/start_stop_daemon_test.sh
+++ b/test/it/loginutils/start_stop_daemon_test.sh
@@ -1,0 +1,9 @@
+TestSsdStartStop() {
+    p="$TEST_DIR/foo.pid"
+    start-stop-daemon -S -p "$p" -x /bin/sleep -- 30 >/dev/null 2>&1
+    pid=$(cat "$p")
+    start-stop-daemon -K -p "$p" >/dev/null 2>&1
+    # After stopping, the process must be gone and the pidfile removed.
+    if kill -0 "$pid" 2>/dev/null; then echo alive; else echo "stopped"; fi
+}
+TestSsdNoMode() { start-stop-daemon -p /tmp/x 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/start_stop_daemon_spec.sh
+++ b/test/it/spec/start_stop_daemon_spec.sh
@@ -1,0 +1,19 @@
+Describe 'start-stop-daemon'
+    Include loginutils/start_stop_daemon_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/ssd; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'starts and stops a background program'
+        When call TestSsdStartStop
+        The output should equal 'stopped'
+        The status should be success
+    End
+    It 'requires a start or stop mode'
+        When call TestSsdNoMode
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `start-stop-daemon`, covering the common flows the issue calls out. `-S` starts `-x EXEC` (passing arguments after `--`) and writes its PID to `-p PIDFILE`, but does nothing if the pidfile already names a running process (idempotent start). `-K` sends the process in the pidfile a signal (`-s`, TERM by default; names with/without SIG, or a number) and removes the pidfile. Exactly one of `-S`/`-K` is required. The process-running check, the start, and the signal send are injectable so the flows are tested without spawning real processes, and the whole start→already-running→stop cycle is also exercised end-to-end in the shellspec.

## Tests

- Unit (stubbed process actions): starting when not running (the program is launched with its args and the PID written), skipping the start when already running, stopping with an explicit signal (pid + signal + pidfile removed), defaulting to SIGTERM, failing to stop a non-running process, the mode errors (neither/both -S/-K, start without -x), and the `parseSignal` parser.
- shellspec: a real start→stop cycle confirming the process is gone, and requiring a mode.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (683 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250