### PR TITLE
feat(loginutils): add crond applet to run cron jobs in foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 296 commands. Run `mimixbox --list` to see them on the terminal.
+There are 297 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -64,6 +64,7 @@ There are 296 commands. Run `mimixbox --list` to see them on the terminal.
 | cp | Copy file(s) to Directory(s) |
 | cpio | Copy files to and from archives |
 | crc32 | Print the CRC-32 checksum of each file |
+| crond | Run scheduled cron jobs (foreground) |
 | crontab | Maintain a user's crontab |
 | cttyhack | Run PROGRAM with the current stdio (no controlling-TTY trick) |
 | cut | Remove sections from each line of files |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -75,6 +75,7 @@ import (
 	ap_loginutils_addgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/addgroup"
 	ap_loginutils_adduser "github.com/nao1215/mimixbox/internal/applets/loginutils/adduser"
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
+	ap_loginutils_crond "github.com/nao1215/mimixbox/internal/applets/loginutils/crond"
 	ap_loginutils_crontab "github.com/nao1215/mimixbox/internal/applets/loginutils/crontab"
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
@@ -283,7 +284,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 296)
+	Applets = make(map[string]Applet, 297)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -367,6 +368,7 @@ func init() {
 	register(ap_loginutils_addgroup.New())
 	register(ap_loginutils_adduser.New())
 	register(ap_loginutils_chpasswd.New())
+	register(ap_loginutils_crond.New())
 	register(ap_loginutils_crontab.New())
 	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_deluser.New())

--- a/internal/applets/loginutils/crond/crond.go
+++ b/internal/applets/loginutils/crond/crond.go
@@ -1,0 +1,211 @@
+// Package crond implements the crond applet: a foreground cron daemon that runs
+// the jobs in the cron spool directory at their scheduled times.
+package crond
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the crond applet.
+type Command struct{}
+
+// New returns a crond command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "crond" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run scheduled cron jobs (foreground)" }
+
+// Injected so the spool, the clock, and job execution are testable.
+var (
+	spoolDir = "/var/spool/cron/crontabs"
+	now      = time.Now
+	runFn    = func(cmdline string) {
+		cmd := exec.Command("sh", "-c", cmdline) //nolint:gosec // running scheduled jobs is the point
+		_ = cmd.Start()
+	}
+)
+
+// Run executes crond.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-f", stdio.Err).WithHelp(command.Help{
+		Description: "Run cron jobs from the spool directory at their scheduled times. Only the " +
+			"foreground mode (-f) is supported: crond stays in the foreground, checks every minute, " +
+			"and runs each crontab entry whose schedule matches the current time, until interrupted. " +
+			"Each crontab line is 'minute hour day-of-month month day-of-week command'.",
+		Examples: []command.Example{
+			{Command: "crond -f", Explain: "Run the cron daemon in the foreground."},
+		},
+		ExitStatus: "0  the daemon stopped cleanly.\n1  -f was not given.",
+	})
+	foreground := fs.BoolP("foreground", "f", false, "run in the foreground (the only supported mode)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if !*foreground {
+		_, _ = fmt.Fprintln(stdio.Err, "crond: only the foreground mode (-f) is supported by this build")
+		return command.SilentFailure()
+	}
+
+	for {
+		next := now().Truncate(time.Minute).Add(time.Minute)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(time.Until(next)):
+			runDue(loadEntries(), now(), runFn)
+		}
+	}
+}
+
+// entry is one parsed crontab schedule and its command.
+type entry struct {
+	minute, hour, dom, month, dow string
+	command                       string
+}
+
+// loadEntries reads and parses every crontab in the spool directory.
+func loadEntries() []entry {
+	files, err := os.ReadDir(spoolDir)
+	if err != nil {
+		return nil
+	}
+	var entries []entry
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(spoolDir, f.Name())) //nolint:gosec // spool path
+		if err != nil {
+			continue
+		}
+		entries = append(entries, parseEntries(string(data))...)
+	}
+	return entries
+}
+
+// parseEntries parses crontab text into schedule entries, skipping blank lines,
+// comments, and environment assignments.
+func parseEntries(text string) []entry {
+	var entries []entry
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 6 || strings.Contains(fields[0], "=") {
+			continue
+		}
+		entries = append(entries, entry{
+			minute:  fields[0],
+			hour:    fields[1],
+			dom:     fields[2],
+			month:   fields[3],
+			dow:     fields[4],
+			command: strings.Join(fields[5:], " "),
+		})
+	}
+	return entries
+}
+
+// runDue runs every entry whose schedule matches t.
+func runDue(entries []entry, t time.Time, run func(string)) {
+	for _, e := range entries {
+		if e.matches(t) {
+			run(e.command)
+		}
+	}
+}
+
+// matches reports whether the entry's schedule fires at time t. Following Vixie
+// cron, when both day-of-month and day-of-week are restricted the entry fires if
+// either matches; otherwise all fields must match.
+func (e entry) matches(t time.Time) bool {
+	dowVal := int(t.Weekday()) // 0 = Sunday
+	if !matchField(e.minute, t.Minute(), 0, 59) ||
+		!matchField(e.hour, t.Hour(), 0, 23) ||
+		!matchField(e.month, int(t.Month()), 1, 12) {
+		return false
+	}
+	domRestricted := e.dom != "*"
+	dowRestricted := e.dow != "*"
+	domOK := matchField(e.dom, t.Day(), 1, 31)
+	dowOK := matchDow(e.dow, dowVal)
+	if domRestricted && dowRestricted {
+		return domOK || dowOK
+	}
+	return domOK && dowOK
+}
+
+// matchDow matches a day-of-week field, treating 7 as Sunday (0).
+func matchDow(spec string, value int) bool {
+	if matchField(spec, value, 0, 7) {
+		return true
+	}
+	if value == 0 { // Sunday may also be written as 7
+		return matchField(spec, 7, 0, 7)
+	}
+	return false
+}
+
+// matchField reports whether value satisfies a single cron field (supporting
+// '*', 'N', 'N-M', 'STEP' forms, and comma-separated lists).
+func matchField(spec string, value, min, max int) bool {
+	for _, part := range strings.Split(spec, ",") {
+		if matchPart(part, value, min, max) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchPart(part string, value, min, max int) bool {
+	step := 1
+	if slash := strings.IndexByte(part, '/'); slash >= 0 {
+		s, err := strconv.Atoi(part[slash+1:])
+		if err != nil || s <= 0 {
+			return false
+		}
+		step = s
+		part = part[:slash]
+	}
+
+	lo, hi := min, max
+	switch {
+	case part == "*":
+		// full range
+	case strings.ContainsRune(part, '-'):
+		bounds := strings.SplitN(part, "-", 2)
+		a, err1 := strconv.Atoi(bounds[0])
+		b, err2 := strconv.Atoi(bounds[1])
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		lo, hi = a, b
+	default:
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return false
+		}
+		lo, hi = n, n
+	}
+
+	if value < lo || value > hi {
+		return false
+	}
+	return (value-lo)%step == 0
+}

--- a/internal/applets/loginutils/crond/crond_test.go
+++ b/internal/applets/loginutils/crond/crond_test.go
@@ -1,0 +1,119 @@
+package crond
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestMatchField(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		spec     string
+		val      int
+		min, max int
+		want     bool
+	}{
+		{"*", 30, 0, 59, true},
+		{"30", 30, 0, 59, true},
+		{"30", 31, 0, 59, false},
+		{"1-5", 3, 0, 59, true},
+		{"1-5", 6, 0, 59, false},
+		{"*/15", 30, 0, 59, true},
+		{"*/15", 31, 0, 59, false},
+		{"10-20/5", 15, 0, 59, true},
+		{"10-20/5", 16, 0, 59, false},
+		{"1,3,5", 5, 0, 59, true},
+		{"1,3,5", 4, 0, 59, false},
+	}
+	for _, c := range cases {
+		if got := matchField(c.spec, c.val, c.min, c.max); got != c.want {
+			t.Errorf("matchField(%q, %d) = %v, want %v", c.spec, c.val, got, c.want)
+		}
+	}
+}
+
+// 2026-06-11 14:30 is a Thursday (weekday 4).
+var ref = time.Date(2026, 6, 11, 14, 30, 0, 0, time.UTC)
+
+func TestEntryMatches(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"30 14 * * *":  true,
+		"0 14 * * *":   false, // wrong minute
+		"*/15 * * * *": true,  // 30 % 15 == 0
+		"30 14 11 6 *": true,  // day 11, month 6
+		"30 14 * * 4":  true,  // Thursday
+		"30 14 * * 1":  false, // Monday
+		"30 14 1 * 4":  true,  // dom and dow both restricted -> either matches (Thu)
+		"30 14 11 * 1": true,  // dom matches even though dow (Mon) doesn't
+		"30 14 1 * 1":  false, // neither dom (1) nor dow (Mon) matches
+	}
+	for spec, want := range cases {
+		e := parseEntries(spec + " /bin/true")[0]
+		if got := e.matches(ref); got != want {
+			t.Errorf("%q matches = %v, want %v", spec, got, want)
+		}
+	}
+}
+
+func TestSundayAsSeven(t *testing.T) {
+	t.Parallel()
+	// 2026-06-14 is a Sunday (weekday 0); "* * * * 7" should match it.
+	sun := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	e := parseEntries("* * * * 7 cmd")[0]
+	if !e.matches(sun) {
+		t.Errorf("dow 7 should match Sunday")
+	}
+}
+
+func TestParseEntries(t *testing.T) {
+	t.Parallel()
+	text := "# a comment\n\nMAILTO=root\n*/5 * * * * /usr/bin/backup --now\n0 0 * * 0 weekly\n"
+	entries := parseEntries(text)
+	if len(entries) != 2 {
+		t.Fatalf("parsed %d entries, want 2", len(entries))
+	}
+	if entries[0].command != "/usr/bin/backup --now" {
+		t.Errorf("command = %q", entries[0].command)
+	}
+}
+
+func TestRunDue(t *testing.T) {
+	t.Parallel()
+	entries := parseEntries("30 14 * * * yes-job\n0 0 * * * no-job")
+	var ran []string
+	runDue(entries, ref, func(c string) { ran = append(ran, c) })
+	if len(ran) != 1 || ran[0] != "yes-job" {
+		t.Errorf("ran = %v, want [yes-job]", ran)
+	}
+}
+
+func TestForegroundRequired(t *testing.T) {
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("crond without -f should fail")
+	}
+}
+
+func TestStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		done <- New().Run(ctx, io, []string{"-f"})
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v after cancel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("crond did not stop after cancellation")
+	}
+}

--- a/test/it/loginutils/crond_test.sh
+++ b/test/it/loginutils/crond_test.sh
@@ -1,0 +1,5 @@
+# crond -f runs until interrupted (and fires only on minute boundaries), so the
+# e2e exercises the no-foreground path and --help; the cron-matching engine is
+# covered by Go unit tests.
+TestCrondNoForeground() { crond 2>/dev/null; echo "rc=$?"; }
+TestCrondHelp() { crond --help; }

--- a/test/it/spec/crond_spec.sh
+++ b/test/it/spec/crond_spec.sh
@@ -1,0 +1,15 @@
+Describe 'crond'
+    Include loginutils/crond_test.sh
+
+    It 'requires foreground mode'
+        When call TestCrondNoForeground
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestCrondHelp
+        The status should be success
+        The output should include 'Usage: crond'
+        The output should include 'cron'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `crond` in foreground mode (`-f`), the mode the issue calls out as important. It reads the crontabs in the spool directory and, every minute, runs each entry whose 'minute hour day-of-month month day-of-week' schedule matches the current time, until interrupted. The cron-matching engine supports `*`, single values, ranges (`N-M`), steps (`*/K`, `N-M/K`), and comma lists; Sunday may be written as 0 or 7; and — following Vixie cron — when both day-of-month and day-of-week are restricted the entry fires if either matches. Without `-f` it fails deterministically. The spool, clock, and job runner are injectable so the engine is tested deterministically.

## Tests

- Unit: the `matchField` parser across all field forms, `entry.matches` against a fixed time (including the dom/dow OR semantics), Sunday-as-7, `parseEntries` (skipping comments/blank/env lines), `runDue` running only matching entries, the require-`-f` behavior, and stopping cleanly on context cancellation.
- shellspec: requiring foreground mode, and the `--help` path (the loop fires only on minute boundaries, so the engine is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (685 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250