### PR TITLE
feat(loginutils): add passwd applet to change a user's password

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 297 commands. Run `mimixbox --list` to see them on the terminal.
+There are 298 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -189,6 +189,7 @@ There are 297 commands. Run `mimixbox --list` to see them on the terminal.
 | nsenter | Run a program in another process's namespaces |
 | nyancat | Animate the rainbow-trailing Nyan Cat |
 | od | Dump files in octal and other formats |
+| passwd | Change a user's password |
 | paste | Merge lines of files |
 | patch | Apply a diff file to an original |
 | path | Manipulate filename path |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -81,6 +81,7 @@ import (
 	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
+	ap_loginutils_passwd "github.com/nao1215/mimixbox/internal/applets/loginutils/passwd"
 	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
 	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
 	ap_loginutils_startstopdaemon "github.com/nao1215/mimixbox/internal/applets/loginutils/startstopdaemon"
@@ -284,7 +285,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 297)
+	Applets = make(map[string]Applet, 298)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -374,6 +375,7 @@ func init() {
 	register(ap_loginutils_deluser.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
+	register(ap_loginutils_passwd.New())
 	register(ap_loginutils_runlevel.New())
 	register(ap_loginutils_runparts.New())
 	register(ap_loginutils_startstopdaemon.New())

--- a/internal/applets/loginutils/passwd/passwd.go
+++ b/internal/applets/loginutils/passwd/passwd.go
@@ -1,0 +1,178 @@
+// Package passwd implements the passwd applet: change, lock, unlock, or clear a
+// user's password in /etc/shadow.
+package passwd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/GehirnInc/crypt"
+	_ "github.com/GehirnInc/crypt/sha512_crypt" // register $6$
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the passwd applet.
+type Command struct{}
+
+// New returns a passwd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "passwd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Change a user's password" }
+
+// Injected so the database and the current user are testable.
+var (
+	shadowPath    = "/etc/shadow"
+	currentUserFn = func() (string, error) {
+		u, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		return u.Username, nil
+	}
+)
+
+// Run executes passwd.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-l|-u|-d] [USER]", stdio.Err).WithHelp(command.Help{
+		Description: "Change the password of USER (the current user by default) in /etc/shadow. With no " +
+			"flag the new password is read from standard input (and, if a second line is present, must " +
+			"match it) and stored as a sha-512 hash. -l locks the account, -u unlocks it, and -d clears " +
+			"its password. Changing the real database requires privilege.",
+		Examples: []command.Example{
+			{Command: "echo newpass | passwd alice", Explain: "Set alice's password."},
+			{Command: "passwd -l bob", Explain: "Lock bob's account."},
+		},
+		ExitStatus: "0  the password was changed.\n1  the user is unknown or the database is unwritable.",
+	})
+	lock := fs.BoolP("lock", "l", false, "lock the account")
+	unlock := fs.BoolP("unlock", "u", false, "unlock the account")
+	del := fs.BoolP("delete", "d", false, "clear the password")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if countTrue(*lock, *unlock, *del) > 1 {
+		return command.Failuref("-l, -u, and -d are mutually exclusive")
+	}
+
+	target := ""
+	if rest := fs.Args(); len(rest) > 0 {
+		target = rest[0]
+	} else if target, err = currentUserFn(); err != nil {
+		return command.Failuref("cannot determine the current user: %v", err)
+	}
+
+	lines, idx, fields, err := findUser(target)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	switch {
+	case *lock:
+		if !strings.HasPrefix(fields[1], "!") {
+			fields[1] = "!" + fields[1]
+		}
+	case *unlock:
+		fields[1] = strings.TrimPrefix(fields[1], "!")
+	case *del:
+		fields[1] = ""
+	default:
+		hash, err := newHash(stdio)
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
+		fields[1] = hash
+	}
+
+	lines[idx] = strings.Join(fields, ":")
+	if err := writeLines(lines); err != nil {
+		return command.Failuref("cannot write %s: %v", shadowPath, err)
+	}
+	_, _ = fmt.Fprintf(stdio.Err, "passwd: password for %q changed\n", target)
+	return nil
+}
+
+func countTrue(bs ...bool) int {
+	n := 0
+	for _, b := range bs {
+		if b {
+			n++
+		}
+	}
+	return n
+}
+
+// findUser returns the shadow lines, the index of target's line, and that
+// line's colon fields.
+func findUser(target string) (lines []string, idx int, fields []string, err error) {
+	data, err := os.ReadFile(shadowPath) //nolint:gosec // well-known shadow path
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("cannot read %s: %v", shadowPath, err)
+	}
+	trimmed := strings.TrimRight(string(data), "\n")
+	if trimmed != "" {
+		lines = strings.Split(trimmed, "\n")
+	}
+	for i, line := range lines {
+		f := strings.Split(line, ":")
+		if len(f) >= 2 && f[0] == target {
+			return lines, i, f, nil
+		}
+	}
+	return nil, 0, nil, fmt.Errorf("user %q does not exist", target)
+}
+
+// newHash reads the new password (and an optional confirmation) from stdin and
+// returns its sha-512 crypt hash.
+func newHash(stdio command.IO) (string, error) {
+	sc := bufio.NewScanner(stdio.In)
+	if !sc.Scan() {
+		return "", fmt.Errorf("no password provided")
+	}
+	password := sc.Text()
+	if password == "" {
+		return "", fmt.Errorf("empty password is not allowed")
+	}
+	if sc.Scan() && sc.Text() != password {
+		return "", fmt.Errorf("passwords do not match")
+	}
+	hash, err := crypt.New(crypt.SHA512).Generate([]byte(password), nil)
+	if err != nil {
+		return "", fmt.Errorf("cannot hash the password: %v", err)
+	}
+	return hash, nil
+}
+
+// writeLines atomically replaces the shadow file.
+func writeLines(lines []string) error {
+	content := strings.Join(lines, "\n") + "\n"
+	tmp, err := os.CreateTemp(filepath.Dir(shadowPath), ".passwd-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, shadowPath)
+}

--- a/internal/applets/loginutils/passwd/passwd_test.go
+++ b/internal/applets/loginutils/passwd/passwd_test.go
@@ -1,0 +1,114 @@
+package passwd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GehirnInc/crypt"
+	_ "github.com/GehirnInc/crypt/sha512_crypt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "shadow")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os1, ou := shadowPath, currentUserFn
+	shadowPath = p
+	currentUserFn = func() (string, error) { return "tester", nil }
+	t.Cleanup(func() { shadowPath, currentUserFn = os1, ou })
+	return p
+}
+
+func run(t *testing.T, stdin string, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(stdin), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func hashField(t *testing.T, path, user string) string {
+	t.Helper()
+	data, _ := os.ReadFile(path)
+	for _, l := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		f := strings.Split(l, ":")
+		if f[0] == user {
+			return f[1]
+		}
+	}
+	t.Fatalf("user %s not found", user)
+	return ""
+}
+
+func TestSetPassword(t *testing.T) {
+	p := fixture(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, "newsecret\n", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	h := hashField(t, p, "alice")
+	if !strings.HasPrefix(h, "$6$") || crypt.NewFromHash(h).Verify(h, []byte("newsecret")) != nil {
+		t.Errorf("hash %q does not verify", h)
+	}
+}
+
+func TestPasswordMismatch(t *testing.T) {
+	fixture(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, "one\ntwo\n", "alice"); err == nil {
+		t.Errorf("mismatched confirmation should fail")
+	}
+}
+
+func TestLockUnlock(t *testing.T) {
+	p := fixture(t, "alice:$6$abc$def:19000:0:99999:7:::\n")
+	if err := run(t, "", "-l", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if got := hashField(t, p, "alice"); got != "!$6$abc$def" {
+		t.Errorf("locked hash = %q", got)
+	}
+	if err := run(t, "", "-u", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if got := hashField(t, p, "alice"); got != "$6$abc$def" {
+		t.Errorf("unlocked hash = %q", got)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	p := fixture(t, "alice:$6$abc$def:19000:0:99999:7:::\n")
+	if err := run(t, "", "-d", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if got := hashField(t, p, "alice"); got != "" {
+		t.Errorf("deleted password field = %q, want empty", got)
+	}
+}
+
+func TestDefaultsToCurrentUser(t *testing.T) {
+	p := fixture(t, "tester:!:19000:0:99999:7:::\n")
+	if err := run(t, "mypw\n"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(hashField(t, p, "tester"), "$6$") {
+		t.Errorf("current user's password not set")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixture(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, "x\n", "ghost"); err == nil {
+		t.Errorf("an unknown user should fail")
+	}
+	if err := run(t, "", "-l", "-u", "alice"); err == nil {
+		t.Errorf("conflicting flags should fail")
+	}
+	if err := run(t, "\n", "alice"); err == nil {
+		t.Errorf("an empty password should fail")
+	}
+}

--- a/test/it/loginutils/passwd_test.sh
+++ b/test/it/loginutils/passwd_test.sh
@@ -1,0 +1,4 @@
+# Writing /etc/shadow needs privilege; the e2e exercises the deterministic
+# conflicting-flags path. The change/lock/unlock/delete flows are unit-tested.
+TestPasswdConflict() { passwd -l -u alice 2>/dev/null; echo "rc=$?"; }
+TestPasswdHelp() { passwd --help; }

--- a/test/it/spec/passwd_spec.sh
+++ b/test/it/spec/passwd_spec.sh
@@ -1,0 +1,15 @@
+Describe 'passwd'
+    Include loginutils/passwd_test.sh
+
+    It 'rejects conflicting flags'
+        When call TestPasswdConflict
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestPasswdHelp
+        The status should be success
+        The output should include 'Usage: passwd'
+        The output should include 'password'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `passwd`, which changes a user's password in /etc/shadow. With no flag the new password is read from standard input (and, if a second line is present, must match it) and stored as a sha-512 hash; `-l` locks the account (prefix `!`), `-u` unlocks it, and `-d` clears the password field. The target defaults to the current user. Per the issue's guidance the session IO (reading the password) is separated from the backend, so the shadow path and current-user lookup are injectable and the flows are tested against fixtures. The shadow file is written atomically.

## Tests

- Unit (fixture shadow files): setting a password (a $6$ hash that verifies), rejecting a mismatched confirmation, locking then unlocking, clearing with `-d`, defaulting to the current user, and the unknown-user / conflicting-flags / empty-password errors.
- shellspec: conflicting flags are rejected, and the `--help` path (writing the real shadow needs privilege, so the flows are unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (687 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `passwd` command to change user passwords with support for locking, unlocking, and clearing account credentials
  * Includes password confirmation validation to prevent misentry

* **Tests**
  * Added comprehensive test coverage for password operations, including validation, error handling, and flag combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->