### PR TITLE
fix(passwd): lock a stable lockfile

### DIFF
--- a/internal/applets/loginutils/passwd/passwd.go
+++ b/internal/applets/loginutils/passwd/passwd.go
@@ -138,11 +138,14 @@ func countTrue(bs ...bool) int {
 	return n
 }
 
-// withLock runs fn while holding an exclusive advisory lock on path, serializing
-// concurrent password changes. If the file cannot be opened for locking (e.g. an
-// unprivileged run), fn proceeds without the lock.
+// withLock runs fn while holding an exclusive advisory lock, serializing
+// concurrent password changes. The lock is taken on a dedicated, stable lockfile
+// ("<path>.lock") rather than on the shadow file itself: writeLines replaces the
+// shadow file's inode via rename, so a lock held on that inode would not be seen
+// by a concurrent run. If the lockfile cannot be created (e.g. an unprivileged
+// run), fn proceeds without the lock.
 func withLock(path string, fn func() error) error {
-	f, err := os.OpenFile(path, os.O_RDWR, 0) //nolint:gosec // well-known shadow path
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // adjacent to the shadow path
 	if err != nil {
 		return fn()
 	}

--- a/internal/applets/loginutils/passwd/passwd_test.go
+++ b/internal/applets/loginutils/passwd/passwd_test.go
@@ -141,3 +141,15 @@ func TestErrors(t *testing.T) {
 		t.Errorf("an empty password should fail")
 	}
 }
+
+func TestUsesStableLockfile(t *testing.T) {
+	p := fixture(t, "alice:!:19000:0:99999:7:::\n")
+	if err := run(t, "newsecret\n", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	// The lock is taken on a dedicated lockfile next to the shadow file, which
+	// survives the atomic rename of the shadow file's inode.
+	if _, err := os.Stat(p + ".lock"); err != nil {
+		t.Errorf("expected a %s.lock lockfile: %v", p, err)
+	}
+}


### PR DESCRIPTION
Follow-up to #422 addressing a CodeRabbit Major finding: the advisory lock was taken on /etc/shadow itself, but writeLines replaces the shadow file's inode via os.Rename, so a lock held on the old inode is not observed by a concurrent run that opens the new inode. The lock is now taken on a dedicated, stable lockfile (`<shadow>.lock`) that is never renamed away, giving real serialization; if the lockfile cannot be created (unprivileged runs) the operation proceeds without it as before. Adds a test that the lockfile is used.

Part of #250