### PR TITLE
feat(loginutils): add cryptpw applet to hash a password from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 298 commands. Run `mimixbox --list` to see them on the terminal.
+There are 299 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -66,6 +66,7 @@ There are 298 commands. Run `mimixbox --list` to see them on the terminal.
 | crc32 | Print the CRC-32 checksum of each file |
 | crond | Run scheduled cron jobs (foreground) |
 | crontab | Maintain a user's crontab |
+| cryptpw | Crypt-hash a password from stdin |
 | cttyhack | Run PROGRAM with the current stdio (no controlling-TTY trick) |
 | cut | Remove sections from each line of files |
 | date | Print or set the system date and time |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -77,6 +77,7 @@ import (
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
 	ap_loginutils_crond "github.com/nao1215/mimixbox/internal/applets/loginutils/crond"
 	ap_loginutils_crontab "github.com/nao1215/mimixbox/internal/applets/loginutils/crontab"
+	ap_loginutils_cryptpw "github.com/nao1215/mimixbox/internal/applets/loginutils/cryptpw"
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
@@ -285,7 +286,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 298)
+	Applets = make(map[string]Applet, 299)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -371,6 +372,7 @@ func init() {
 	register(ap_loginutils_chpasswd.New())
 	register(ap_loginutils_crond.New())
 	register(ap_loginutils_crontab.New())
+	register(ap_loginutils_cryptpw.New())
 	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_deluser.New())
 	register(ap_loginutils_mkpasswd.New())

--- a/internal/applets/loginutils/cryptpw/cryptpw.go
+++ b/internal/applets/loginutils/cryptpw/cryptpw.go
@@ -1,0 +1,98 @@
+// Package cryptpw implements the cryptpw applet: print the crypt(3) hash of a
+// password, defaulting to reading the password from standard input.
+package cryptpw
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GehirnInc/crypt"
+	_ "github.com/GehirnInc/crypt/md5_crypt"    // register $1$
+	_ "github.com/GehirnInc/crypt/sha256_crypt" // register $5$
+	_ "github.com/GehirnInc/crypt/sha512_crypt" // register $6$
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the cryptpw applet.
+type Command struct{}
+
+// New returns a cryptpw command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "cryptpw" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Crypt-hash a password from stdin" }
+
+// methods maps the supported algorithm names to their crypt type and magic.
+var methods = map[string]struct {
+	crypt crypt.Crypt
+	magic string
+}{
+	"sha-512": {crypt.SHA512, "$6$"}, "sha512": {crypt.SHA512, "$6$"},
+	"sha-256": {crypt.SHA256, "$5$"}, "sha256": {crypt.SHA256, "$5$"},
+	"md5": {crypt.MD5, "$1$"},
+}
+
+// Run executes cryptpw.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-m METHOD] [-S SALT] [PASSWORD]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the crypt(3) hash of a password. The password is taken from PASSWORD if " +
+			"given, otherwise from standard input. -m selects the method (sha-512 by default, also " +
+			"sha-256 or md5); -S sets the salt, otherwise a random one is used. This is the same as " +
+			"mkpasswd, with the password read from stdin by default.",
+		Examples: []command.Example{
+			{Command: "echo secret | cryptpw", Explain: "Hash a password read from stdin."},
+			{Command: "cryptpw -m md5 -S abcdefgh secret", Explain: "MD5-hash with a fixed salt."},
+		},
+		ExitStatus: "0  the hash was printed.\n1  an unknown method or a hashing error.",
+	})
+	methodName := fs.StringP("method", "m", "sha-512", "hashing method: sha-512, sha-256, or md5")
+	salt := fs.StringP("salt", "S", "", "salt to use (random if unset)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	m, ok := methods[strings.ToLower(*methodName)]
+	if !ok {
+		return command.Failuref("unknown method: %q (use sha-512, sha-256, or md5)", *methodName)
+	}
+
+	password, err := readPassword(stdio, fs.Args())
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	var saltArg []byte
+	if *salt != "" {
+		saltArg = []byte(m.magic + *salt)
+	}
+	hash, err := crypt.New(m.crypt).Generate([]byte(password), saltArg)
+	if err != nil {
+		return command.Failuref("cannot hash the password: %v", err)
+	}
+	_, _ = fmt.Fprintln(stdio.Out, hash)
+	return nil
+}
+
+// readPassword returns the password from the first operand, or the first line of
+// standard input.
+func readPassword(stdio command.IO, operands []string) (string, error) {
+	if len(operands) > 0 {
+		return operands[0], nil
+	}
+	sc := bufio.NewScanner(stdio.In)
+	if !sc.Scan() {
+		if err := sc.Err(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("no password given")
+	}
+	return sc.Text(), nil
+}

--- a/internal/applets/loginutils/cryptpw/cryptpw_test.go
+++ b/internal/applets/loginutils/cryptpw/cryptpw_test.go
@@ -1,0 +1,60 @@
+package cryptpw
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GehirnInc/crypt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestStdinDefaultSHA512(t *testing.T) {
+	const want = "$6$abcdefgh$ltjgWl6579NluT/Vi1nwEvcil.G5Nbc4NiXZaNGStk8PSwGfQv72N2CKPPrVACtLtip/cZ/1GM/O6IND4WQhG."
+	got, err := run(t, "secret\n", "-S", "abcdefgh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("cryptpw =\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestOperandOverridesStdin(t *testing.T) {
+	got, err := run(t, "ignored\n", "-m", "md5", "-S", "abcdefgh", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "$1$abcdefgh$cHJi5PXp/ki/ktXzqlk6I1" {
+		t.Errorf("operand password hash = %s", got)
+	}
+}
+
+func TestVerifies(t *testing.T) {
+	got, err := run(t, "", "-S", "saltsalt", "hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if crypt.NewFromHash(got).Verify(got, []byte("hunter2")) != nil {
+		t.Errorf("hash does not verify")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t, "", "-m", "bogus", "x"); err == nil {
+		t.Errorf("unknown method should fail")
+	}
+	if _, err := run(t, ""); err == nil {
+		t.Errorf("no password should fail")
+	}
+}

--- a/test/it/loginutils/cryptpw_test.sh
+++ b/test/it/loginutils/cryptpw_test.sh
@@ -1,0 +1,2 @@
+TestCryptpwStdin() { echo secret | cryptpw -S abcdefgh; }
+TestCryptpwMd5() { echo secret | cryptpw -m md5 -S abcdefgh | head -c 12; echo; }

--- a/test/it/spec/cryptpw_spec.sh
+++ b/test/it/spec/cryptpw_spec.sh
@@ -1,0 +1,14 @@
+Describe 'cryptpw'
+    Include loginutils/cryptpw_test.sh
+
+    It 'hashes a stdin password with sha-512'
+        When call TestCryptpwStdin
+        The output should equal '$6$abcdefgh$ltjgWl6579NluT/Vi1nwEvcil.G5Nbc4NiXZaNGStk8PSwGfQv72N2CKPPrVACtLtip/cZ/1GM/O6IND4WQhG.'
+        The status should be success
+    End
+    It 'supports the md5 method'
+        When call TestCryptpwMd5
+        The output should equal '$1$abcdefgh$'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `cryptpw`, which prints the crypt(3) hash of a password — taken from the PASSWORD operand if given, otherwise from standard input (the BusyBox default that distinguishes it from mkpasswd). `-m` selects the method (sha-512 by default, also sha-256 or md5) and `-S` sets the salt. The output is byte-for-byte identical to `openssl passwd` (verified for -6 and -1).

## Tests

- Unit: the default sha-512 hash from stdin matching the openssl reference, an operand password overriding stdin (md5), a generated hash verifying against its password, and the unknown-method / no-password errors.
- shellspec: hashing a stdin password with sha-512, and the md5 method prefix.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (689 examples, 0 failures); `golangci-lint` clean; output matches `openssl passwd`; registry/README in sync.

Part of #250