### PR TITLE
feat(loginutils): add run-init applet to switch root and run init

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 299 commands. Run `mimixbox --list` to see them on the terminal.
+There are 300 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -229,6 +229,7 @@ There are 299 commands. Run `mimixbox --list` to see them on the terminal.
 | rpm | Query an RPM package file |
 | rpm2cpio | Extract the cpio payload from an RPM package |
 | rtcwake | Arm the RTC to wake the system |
+| run-init | Switch to the real root and run init |
 | run-parts | Run all executables in a directory |
 | runlevel | Print the previous and current runlevel |
 | script | Record a command's output to a typescript |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -83,6 +83,7 @@ import (
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_loginutils_passwd "github.com/nao1215/mimixbox/internal/applets/loginutils/passwd"
+	ap_loginutils_runinit "github.com/nao1215/mimixbox/internal/applets/loginutils/runinit"
 	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
 	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
 	ap_loginutils_startstopdaemon "github.com/nao1215/mimixbox/internal/applets/loginutils/startstopdaemon"
@@ -286,7 +287,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 299)
+	Applets = make(map[string]Applet, 300)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -378,6 +379,7 @@ func init() {
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
 	register(ap_loginutils_passwd.New())
+	register(ap_loginutils_runinit.New())
 	register(ap_loginutils_runlevel.New())
 	register(ap_loginutils_runparts.New())
 	register(ap_loginutils_startstopdaemon.New())

--- a/internal/applets/loginutils/runinit/runinit.go
+++ b/internal/applets/loginutils/runinit/runinit.go
@@ -1,0 +1,82 @@
+// Package runinit implements the run-init applet: switch from an initramfs to
+// the real root filesystem and execute its init. Intended to run as PID 1.
+package runinit
+
+import (
+	"context"
+	"os"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the run-init applet.
+type Command struct{}
+
+// New returns a run-init command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "run-init" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Switch to the real root and run init" }
+
+// Injected so the privileged switch and exec are testable.
+var (
+	// switchFn makes NEW_ROOT the root of the current mount namespace.
+	switchFn = func(newRoot string) error {
+		if err := os.Chdir(newRoot); err != nil {
+			return err
+		}
+		if err := unix.Mount(newRoot, "/", "", unix.MS_MOVE, ""); err != nil {
+			return err
+		}
+		if err := unix.Chroot("."); err != nil {
+			return err
+		}
+		return os.Chdir("/")
+	}
+	// execFn replaces the current process with init; it does not return on success.
+	execFn = func(path string, argv []string) error {
+		return syscall.Exec(path, argv, os.Environ())
+	}
+)
+
+// Run executes run-init.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "NEW_ROOT INIT [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Switch the root of the current mount namespace to the NEW_ROOT directory and " +
+			"execute INIT (with any ARGs) as the new init. This is meant to run as PID 1 from an " +
+			"initramfs and requires privilege. The destructive deletion of the initramfs contents that " +
+			"the real run-init performs is intentionally not done by this build.",
+		Examples: []command.Example{
+			{Command: "run-init /sysroot /sbin/init", Explain: "Switch to /sysroot and run init."},
+		},
+		ExitStatus: "1  the arguments were wrong or the switch failed (it does not return on success).",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return command.Failuref("a NEW_ROOT directory and an INIT program are required")
+	}
+	newRoot := rest[0]
+
+	info, err := os.Stat(newRoot)
+	if err != nil || !info.IsDir() {
+		return command.Failuref("%s: not a directory", newRoot)
+	}
+
+	if err := switchFn(newRoot); err != nil {
+		return command.Failuref("cannot switch root to %s: %v", newRoot, err)
+	}
+	if err := execFn(rest[1], rest[1:]); err != nil {
+		return command.Failuref("cannot exec %s: %v", rest[1], err)
+	}
+	return nil
+}

--- a/internal/applets/loginutils/runinit/runinit_test.go
+++ b/internal/applets/loginutils/runinit/runinit_test.go
@@ -1,0 +1,65 @@
+package runinit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withStub(t *testing.T, switchErr error) (*string, *[]string) {
+	t.Helper()
+	switched := new(string)
+	*switched = "<unset>"
+	var execArgv []string
+	osw, oex := switchFn, execFn
+	switchFn = func(newRoot string) error { *switched = newRoot; return switchErr }
+	execFn = func(path string, argv []string) error { execArgv = append([]string{path}, argv...); return nil }
+	t.Cleanup(func() { switchFn, execFn = osw, oex })
+	return switched, &execArgv
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSwitchesAndExecs(t *testing.T) {
+	switched, execArgv := withStub(t, nil)
+	dir := t.TempDir()
+	if err := run(t, dir, "/sbin/init", "quiet"); err != nil {
+		t.Fatal(err)
+	}
+	if *switched != dir {
+		t.Errorf("switched to %q, want %q", *switched, dir)
+	}
+	if len(*execArgv) != 3 || (*execArgv)[1] != "/sbin/init" || (*execArgv)[2] != "quiet" {
+		t.Errorf("exec argv = %v", *execArgv)
+	}
+}
+
+func TestArgValidation(t *testing.T) {
+	withStub(t, nil)
+	dir := t.TempDir()
+	if err := run(t, dir); err == nil {
+		t.Errorf("missing init should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("no args should fail")
+	}
+	if err := run(t, "/no/such/dir", "/init"); err == nil {
+		t.Errorf("a non-directory NEW_ROOT should fail")
+	}
+}
+
+func TestSwitchFailure(t *testing.T) {
+	withStub(t, errors.New("operation not permitted"))
+	dir := t.TempDir()
+	if err := run(t, dir, "/sbin/init"); err == nil {
+		t.Errorf("a switch failure should fail")
+	}
+}

--- a/test/it/loginutils/run_init_test.sh
+++ b/test/it/loginutils/run_init_test.sh
@@ -1,0 +1,4 @@
+# run-init needs to run as PID 1 with privilege, so the e2e exercises the
+# deterministic validation paths; the switch and exec are unit-tested.
+TestRunInitMissingInit() { run-init /tmp 2>/dev/null; echo "rc=$?"; }
+TestRunInitBadDir() { run-init /no/such/dir /init 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/run_init_spec.sh
+++ b/test/it/spec/run_init_spec.sh
@@ -1,0 +1,14 @@
+Describe 'run-init'
+    Include loginutils/run_init_test.sh
+
+    It 'requires NEW_ROOT and INIT'
+        When call TestRunInitMissingInit
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects a non-directory NEW_ROOT'
+        When call TestRunInitBadDir
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `run-init`, the initramfs root-switch tool. It makes NEW_ROOT the root of the current mount namespace (chdir → mount --move onto / → chroot) and execs INIT (with any ARGs) as the new init. It validates that exactly two-plus arguments are given and that NEW_ROOT is a directory. It is meant to run as PID 1 from an initramfs and requires privilege; the destructive deletion of the initramfs contents that the real run-init performs is intentionally not done by this build. The switch and the exec are injectable so the validation and dispatch are tested without privilege.

## Tests

- Unit (stubbed switch + exec): switching to NEW_ROOT and exec'ing INIT with its args, the missing-INIT / no-argument / non-directory errors, and a switch-failure error.
- shellspec: a missing INIT and a non-directory NEW_ROOT both fail.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (691 examples, 0 failures); `golangci-lint` clean; registry/README in sync (now 300 commands).

Part of #250