### PR TITLE
feat(loginutils): add su applet to run a shell as another user

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 300 commands. Run `mimixbox --list` to see them on the terminal.
+There are 301 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -259,6 +259,7 @@ There are 300 commands. Run `mimixbox --list` to see them on the terminal.
 | stat | Display file or file system status |
 | strings | Print printable character sequences in files |
 | stty | Print or change terminal line settings |
+| su | Run a shell as another user |
 | sum | Checksum and count the blocks in a file (BSD) |
 | swapoff | Disable a swap area |
 | swapon | Enable a swap area or list active swaps |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -87,6 +87,7 @@ import (
 	ap_loginutils_runlevel "github.com/nao1215/mimixbox/internal/applets/loginutils/runlevel"
 	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
 	ap_loginutils_startstopdaemon "github.com/nao1215/mimixbox/internal/applets/loginutils/startstopdaemon"
+	ap_loginutils_su "github.com/nao1215/mimixbox/internal/applets/loginutils/su"
 	ap_netutils_httpstatus "github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
 	ap_netutils_nc "github.com/nao1215/mimixbox/internal/applets/netutils/nc"
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
@@ -287,7 +288,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 300)
+	Applets = make(map[string]Applet, 301)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -383,6 +384,7 @@ func init() {
 	register(ap_loginutils_runlevel.New())
 	register(ap_loginutils_runparts.New())
 	register(ap_loginutils_startstopdaemon.New())
+	register(ap_loginutils_su.New())
 	register(ap_netutils_httpstatus.New())
 	register(ap_netutils_nc.New())
 	register(ap_netutils_ping.New())

--- a/internal/applets/loginutils/su/su.go
+++ b/internal/applets/loginutils/su/su.go
@@ -1,0 +1,178 @@
+// Package su implements the su applet: run a shell or command as another user
+// after authenticating.
+package su
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/auth"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the su applet.
+type Command struct{}
+
+// New returns a su command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "su" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a shell as another user" }
+
+// account is the resolved target user.
+type account struct {
+	name     string
+	uid, gid int
+	home     string
+	shell    string
+}
+
+// Injected so the password database, the privilege check, the authentication
+// backend, and the privileged exec are all testable.
+var (
+	passwdPath = "/etc/passwd"
+	isRootFn   = func() bool { return os.Geteuid() == 0 }
+	authFn     = auth.Authenticate
+	runFn = func(stdio command.IO, acc account, argv []string) error {
+		cmd := exec.Command(acc.shell) //nolint:gosec // running the user's shell is the point
+		cmd.Args = argv
+		cmd.Dir = acc.home
+		cmd.Env = append(os.Environ(), "HOME="+acc.home, "USER="+acc.name, "SHELL="+acc.shell)
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: uint32(acc.uid), Gid: uint32(acc.gid)},
+		}
+		return cmd.Run()
+	}
+)
+
+// Run executes su.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-l] [-s SHELL] [-c COMMAND] [USER]", stdio.Err).WithHelp(command.Help{
+		Description: "Run a shell as USER (root by default), after authenticating unless already root. " +
+			"-c runs a single COMMAND with the shell instead of an interactive session; -s overrides " +
+			"the shell; -l (or a bare '-' operand) starts a login shell. The password is read from " +
+			"standard input. Switching to another user requires privilege.",
+		Examples: []command.Example{
+			{Command: "su -c 'id' alice", Explain: "Run id as alice."},
+			{Command: "su - root", Explain: "Start a root login shell."},
+		},
+		ExitStatus: "the command's exit status, or 1 on authentication failure or a bad user.",
+	})
+	login := fs.BoolP("login", "l", false, "start a login shell")
+	shellOverride := fs.StringP("shell", "s", "", "shell to run instead of the user's")
+	cmdStr := fs.StringP("command", "c", "", "run COMMAND with the shell")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	operands := fs.Args()
+	// A bare "-" operand means a login shell.
+	var rest []string
+	for _, op := range operands {
+		if op == "-" {
+			*login = true
+			continue
+		}
+		rest = append(rest, op)
+	}
+	target := "root"
+	if len(rest) > 0 {
+		target = rest[0]
+	}
+
+	acc, err := resolve(target)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	if *shellOverride != "" {
+		acc.shell = *shellOverride
+	}
+	if acc.shell == "" {
+		acc.shell = "/bin/sh"
+	}
+
+	if !isRootFn() {
+		ok, err := authenticate(stdio, target)
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
+		if !ok {
+			return command.Failuref("authentication failure")
+		}
+	}
+
+	if err := runFn(stdio, acc, buildArgv(acc.shell, *login, *cmdStr)); err != nil {
+		var ee *exec.ExitError
+		if asExit(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// buildArgv constructs the shell's argv, honoring the login-shell convention
+// (argv[0] prefixed with '-') and an optional -c command.
+func buildArgv(shell string, login bool, cmdStr string) []string {
+	argv0 := filepath.Base(shell)
+	if login {
+		argv0 = "-" + argv0
+	}
+	argv := []string{argv0}
+	if cmdStr != "" {
+		argv = append(argv, "-c", cmdStr)
+	}
+	return argv
+}
+
+// resolve looks up the target user in the passwd database.
+func resolve(name string) (account, error) {
+	data, err := os.ReadFile(passwdPath) //nolint:gosec // well-known passwd path
+	if err != nil {
+		return account{}, fmt.Errorf("cannot read %s: %v", passwdPath, err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		f := strings.Split(line, ":")
+		if len(f) < 7 || f[0] != name {
+			continue
+		}
+		uid, err1 := strconv.Atoi(f[2])
+		gid, err2 := strconv.Atoi(f[3])
+		if err1 != nil || err2 != nil {
+			return account{}, fmt.Errorf("user %q has an invalid uid/gid", name)
+		}
+		return account{name: name, uid: uid, gid: gid, home: f[5], shell: f[6]}, nil
+	}
+	return account{}, fmt.Errorf("unknown user: %s", name)
+}
+
+// authenticate reads a password from stdin and verifies it for the user.
+func authenticate(stdio command.IO, user string) (bool, error) {
+	sc := bufio.NewScanner(stdio.In)
+	if !sc.Scan() {
+		return false, fmt.Errorf("no password provided")
+	}
+	return authFn(user, sc.Text())
+}
+
+// asExit reports whether err is an *exec.ExitError and stores it.
+func asExit(err error, target **exec.ExitError) bool {
+	if ee, ok := err.(*exec.ExitError); ok {
+		*target = ee
+		return true
+	}
+	return false
+}

--- a/internal/applets/loginutils/su/su_test.go
+++ b/internal/applets/loginutils/su/su_test.go
@@ -1,0 +1,125 @@
+package su
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type runCall struct {
+	acc  account
+	argv []string
+}
+
+func setup(t *testing.T, root bool, authOK bool) *runCall {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "passwd")
+	content := "root:x:0:0:root:/root:/bin/sh\nalice:x:1000:1000:alice:/home/alice:/bin/bash\n"
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	call := &runCall{}
+	op, oir, oaf, orf := passwdPath, isRootFn, authFn, runFn
+	passwdPath = p
+	isRootFn = func() bool { return root }
+	authFn = func(string, string) (bool, error) { return authOK, nil }
+	runFn = func(_ command.IO, acc account, argv []string) error {
+		*call = runCall{acc, argv}
+		return nil
+	}
+	t.Cleanup(func() { passwdPath, isRootFn, authFn, runFn = op, oir, oaf, orf })
+	return call
+}
+
+func run(t *testing.T, stdin string, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(stdin), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestRootNeedsNoAuth(t *testing.T) {
+	call := setup(t, true, false) // auth would fail, but root skips it
+	if err := run(t, "", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if call.acc.name != "alice" || call.acc.uid != 1000 || call.acc.shell != "/bin/bash" {
+		t.Errorf("target = %+v", call.acc)
+	}
+	if call.argv[0] != "bash" {
+		t.Errorf("argv0 = %q, want bash", call.argv[0])
+	}
+}
+
+func TestNonRootAuthSuccess(t *testing.T) {
+	call := setup(t, false, true)
+	if err := run(t, "password\n", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if call.acc.name != "alice" {
+		t.Errorf("should have run as alice")
+	}
+}
+
+func TestNonRootAuthFailure(t *testing.T) {
+	call := setup(t, false, false)
+	if err := run(t, "wrong\n", "alice"); err == nil {
+		t.Errorf("a failed auth should fail")
+	}
+	if call.acc.name != "" {
+		t.Errorf("runFn must not be called on auth failure")
+	}
+}
+
+func TestDefaultsToRoot(t *testing.T) {
+	call := setup(t, true, true)
+	if err := run(t, ""); err != nil {
+		t.Fatal(err)
+	}
+	if call.acc.name != "root" {
+		t.Errorf("default target = %q, want root", call.acc.name)
+	}
+}
+
+func TestCommandAndLogin(t *testing.T) {
+	call := setup(t, true, true)
+	if err := run(t, "", "-l", "-c", "id", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	// Login shell -> argv0 prefixed with '-'; -c appends the command.
+	if call.argv[0] != "-bash" || len(call.argv) != 3 || call.argv[1] != "-c" || call.argv[2] != "id" {
+		t.Errorf("argv = %v", call.argv)
+	}
+}
+
+func TestBareDashIsLogin(t *testing.T) {
+	call := setup(t, true, true)
+	if err := run(t, "", "-", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if call.argv[0] != "-bash" {
+		t.Errorf("bare '-' should give a login shell, argv0 = %q", call.argv[0])
+	}
+}
+
+func TestShellOverride(t *testing.T) {
+	call := setup(t, true, true)
+	if err := run(t, "", "-s", "/bin/zsh", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if call.acc.shell != "/bin/zsh" || call.argv[0] != "zsh" {
+		t.Errorf("shell override not applied: %+v %v", call.acc, call.argv)
+	}
+}
+
+func TestUnknownUser(t *testing.T) {
+	setup(t, true, true)
+	if err := run(t, "", "ghost"); err == nil {
+		t.Errorf("an unknown user should fail")
+	}
+}

--- a/test/it/loginutils/su_test.sh
+++ b/test/it/loginutils/su_test.sh
@@ -1,0 +1,4 @@
+# Switching users needs privilege and real auth, so the e2e exercises the
+# deterministic unknown-user path; the auth/dispatch flow is unit-tested.
+TestSuUnknownUser() { echo "" | su nonexistent_user_xyz 2>/dev/null; echo "rc=$?"; }
+TestSuHelp() { su --help; }

--- a/test/it/spec/su_spec.sh
+++ b/test/it/spec/su_spec.sh
@@ -1,0 +1,15 @@
+Describe 'su'
+    Include loginutils/su_test.sh
+
+    It 'fails for an unknown user'
+        When call TestSuUnknownUser
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestSuHelp
+        The status should be success
+        The output should include 'Usage: su'
+        The output should include 'user'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `su`, which runs a shell as USER (root by default) after authenticating unless already root. `-c` runs a single COMMAND with the shell, `-s` overrides the shell, and `-l` (or a bare `-` operand) starts a login shell (argv[0] prefixed with `-`). The target user is resolved from /etc/passwd (uid/gid/home/shell), the password is read from standard input, and the process runs with the target's credentials. Per the issue's guidance the session IO is separated from the backend: the passwd path, the privilege check, the authentication backend (defaulting to the repo's internal/auth shadow backend), and the privileged exec are all injectable, so the whole flow is tested without PAM or a real login.

## Tests

- Unit (fixture passwd + stubbed backend): root skipping authentication, non-root succeeding and failing authentication (no exec on failure), defaulting to root, the login-shell and `-c` argv construction, a bare `-` meaning login, the `-s` shell override, and the unknown-user error.
- shellspec: an unknown user fails, and the `--help` path (switching users needs privilege and real auth, so the flow is unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (693 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `su` command to switch users with optional password authentication, supporting login-shell mode and direct command execution.

* **Documentation**
  * Updated documentation and command registry to reflect the new command.

* **Tests**
  * Added unit and integration test coverage for the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->