### PR TITLE
feat(loginutils): add sulogin applet for single-user root login

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 301 commands. Run `mimixbox --list` to see them on the terminal.
+There are 302 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -260,6 +260,7 @@ There are 301 commands. Run `mimixbox --list` to see them on the terminal.
 | strings | Print printable character sequences in files |
 | stty | Print or change terminal line settings |
 | su | Run a shell as another user |
+| sulogin | Single-user root login |
 | sum | Checksum and count the blocks in a file (BSD) |
 | swapoff | Disable a swap area |
 | swapon | Enable a swap area or list active swaps |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -88,6 +88,7 @@ import (
 	ap_loginutils_runparts "github.com/nao1215/mimixbox/internal/applets/loginutils/runparts"
 	ap_loginutils_startstopdaemon "github.com/nao1215/mimixbox/internal/applets/loginutils/startstopdaemon"
 	ap_loginutils_su "github.com/nao1215/mimixbox/internal/applets/loginutils/su"
+	ap_loginutils_sulogin "github.com/nao1215/mimixbox/internal/applets/loginutils/sulogin"
 	ap_netutils_httpstatus "github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
 	ap_netutils_nc "github.com/nao1215/mimixbox/internal/applets/netutils/nc"
 	ap_netutils_ping "github.com/nao1215/mimixbox/internal/applets/netutils/ping"
@@ -288,7 +289,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 301)
+	Applets = make(map[string]Applet, 302)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -385,6 +386,7 @@ func init() {
 	register(ap_loginutils_runparts.New())
 	register(ap_loginutils_startstopdaemon.New())
 	register(ap_loginutils_su.New())
+	register(ap_loginutils_sulogin.New())
 	register(ap_netutils_httpstatus.New())
 	register(ap_netutils_nc.New())
 	register(ap_netutils_ping.New())

--- a/internal/applets/loginutils/sulogin/sulogin.go
+++ b/internal/applets/loginutils/sulogin/sulogin.go
@@ -1,0 +1,101 @@
+// Package sulogin implements the sulogin applet: authenticate root and start a
+// single-user root shell, as used in emergency/maintenance boots.
+package sulogin
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/auth"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the sulogin applet.
+type Command struct{}
+
+// New returns a sulogin command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "sulogin" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Single-user root login" }
+
+// Injected so the authentication backend and the shell exec are testable.
+var (
+	authFn = auth.Authenticate
+	runFn  = func(stdio command.IO, shell string) error {
+		cmd := exec.Command(shell) //nolint:gosec // running the root shell is the point
+		cmd.Args = []string{"-" + baseName(shell)}
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: 0, Gid: 0},
+		}
+		return cmd.Run()
+	}
+)
+
+// Run executes sulogin.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-t SECONDS] [TTY]", stdio.Err).WithHelp(command.Help{
+		Description: "Authenticate the root user and, on success, start a single-user root shell — the " +
+			"prompt shown in emergency or maintenance boots. The root password is read from standard " +
+			"input. The shell is taken from $SHELL, or /bin/sh. Starting a root shell requires privilege.",
+		Examples: []command.Example{
+			{Command: "sulogin", Explain: "Prompt for the root password and start a root shell."},
+		},
+		ExitStatus: "the shell's exit status, or 1 on authentication failure.",
+	})
+	_ = fs.IntP("timeout", "t", 0, "seconds to wait for input (accepted for compatibility)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	_, _ = fmt.Fprint(stdio.Err, "Give root password for maintenance\n(or press Control-D to continue): ")
+	sc := bufio.NewScanner(stdio.In)
+	if !sc.Scan() {
+		return command.Failuref("no password provided")
+	}
+
+	ok, err := authFn("root", sc.Text())
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	if !ok {
+		return command.Failuref("incorrect root password")
+	}
+
+	if err := runFn(stdio, shell()); err != nil {
+		var ee *exec.ExitError
+		if e, isExit := err.(*exec.ExitError); isExit {
+			ee = e
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// shell returns the shell to start: $SHELL, or /bin/sh.
+func shell() string {
+	if s := os.Getenv("SHELL"); s != "" {
+		return s
+	}
+	return "/bin/sh"
+}
+
+func baseName(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[i+1:]
+		}
+	}
+	return path
+}

--- a/internal/applets/loginutils/sulogin/sulogin_test.go
+++ b/internal/applets/loginutils/sulogin/sulogin_test.go
@@ -1,0 +1,76 @@
+package sulogin
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T, authOK bool, authErr error) *string {
+	t.Helper()
+	ranShell := new(string)
+	*ranShell = "<none>"
+	oa, or := authFn, runFn
+	authFn = func(user, pw string) (bool, error) {
+		if user != "root" {
+			t.Errorf("sulogin must authenticate root, got %q", user)
+		}
+		return authOK, authErr
+	}
+	runFn = func(_ command.IO, shell string) error { *ranShell = shell; return nil }
+	t.Cleanup(func() { authFn, runFn = oa, or })
+	return ranShell
+}
+
+func run(t *testing.T, stdin string, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(stdin), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestStartsShellOnSuccess(t *testing.T) {
+	t.Setenv("SHELL", "/bin/bash")
+	ran := setup(t, true, nil)
+	if err := run(t, "rootpw\n"); err != nil {
+		t.Fatal(err)
+	}
+	if *ran != "/bin/bash" {
+		t.Errorf("ran shell = %q, want /bin/bash", *ran)
+	}
+}
+
+func TestRejectsWrongPassword(t *testing.T) {
+	ran := setup(t, false, nil)
+	if err := run(t, "wrong\n"); err == nil {
+		t.Errorf("a wrong password should fail")
+	}
+	if *ran != "<none>" {
+		t.Errorf("the shell must not start on auth failure")
+	}
+}
+
+func TestDefaultShell(t *testing.T) {
+	t.Setenv("SHELL", "")
+	ran := setup(t, true, nil)
+	if err := run(t, "pw\n"); err != nil {
+		t.Fatal(err)
+	}
+	if *ran != "/bin/sh" {
+		t.Errorf("default shell = %q, want /bin/sh", *ran)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	setup(t, false, errors.New("backend error"))
+	if err := run(t, "pw\n"); err == nil {
+		t.Errorf("an auth backend error should fail")
+	}
+	setup(t, true, nil)
+	if err := run(t, ""); err == nil { // no password line
+		t.Errorf("missing password should fail")
+	}
+}

--- a/test/it/loginutils/sulogin_test.sh
+++ b/test/it/loginutils/sulogin_test.sh
@@ -1,0 +1,4 @@
+# sulogin authenticates root and starts a root shell (privileged); the e2e
+# exercises the wrong-password path and --help. The flow is unit-tested.
+TestSuloginWrongPw() { echo "definitely_wrong_password" | sulogin 2>/dev/null; echo "rc=$?"; }
+TestSuloginHelp() { sulogin --help; }

--- a/test/it/spec/sulogin_spec.sh
+++ b/test/it/spec/sulogin_spec.sh
@@ -1,0 +1,15 @@
+Describe 'sulogin'
+    Include loginutils/sulogin_test.sh
+
+    It 'rejects a wrong root password'
+        When call TestSuloginWrongPw
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestSuloginHelp
+        The status should be success
+        The output should include 'Usage: sulogin'
+        The output should include 'root'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `sulogin`, the maintenance-boot prompt: it reads the root password from standard input, authenticates root, and on success starts a single-user root shell (taken from $SHELL or /bin/sh, as a login shell with root credentials). An incorrect password fails without starting a shell. `-t` is accepted for compatibility. The authentication backend (defaulting to the repo's internal/auth shadow backend) and the shell exec are injectable so the flow is tested without a real login.

## Tests

- Unit (stubbed backend): starting the shell on a correct password (honoring $SHELL), rejecting a wrong password without starting the shell, defaulting to /bin/sh, and the auth-backend-error / missing-password errors.
- shellspec: a wrong root password fails, and the `--help` path (starting a root shell needs privilege, so the flow is unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (695 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250