### PR TITLE
feat(loginutils): add login applet to authenticate and start a shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 302 commands. Run `mimixbox --list` to see them on the terminal.
+There are 303 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -146,6 +146,7 @@ There are 302 commands. Run `mimixbox --list` to see them on the terminal.
 | ln | Create hard or symbolic link |
 | log-collect | Gather system log files into one directory |
 | logger | Write a message to the system log |
+| login | Authenticate a user and start their shell |
 | logname | Print the name of the current user |
 | logread | Show the system log |
 | losetup | List active loop devices |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -80,6 +80,7 @@ import (
 	ap_loginutils_cryptpw "github.com/nao1215/mimixbox/internal/applets/loginutils/cryptpw"
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
+	ap_loginutils_login "github.com/nao1215/mimixbox/internal/applets/loginutils/login"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
 	ap_loginutils_passwd "github.com/nao1215/mimixbox/internal/applets/loginutils/passwd"
@@ -289,7 +290,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 302)
+	Applets = make(map[string]Applet, 303)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -378,6 +379,7 @@ func init() {
 	register(ap_loginutils_cryptpw.New())
 	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_deluser.New())
+	register(ap_loginutils_login.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())
 	register(ap_loginutils_passwd.New())

--- a/internal/applets/loginutils/login/login.go
+++ b/internal/applets/loginutils/login/login.go
@@ -1,0 +1,155 @@
+// Package login implements the login applet: authenticate a user and start
+// their login shell.
+package login
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/auth"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the login applet.
+type Command struct{}
+
+// New returns a login command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "login" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Authenticate a user and start their shell" }
+
+// account is the resolved user.
+type account struct {
+	name     string
+	uid, gid int
+	home     string
+	shell    string
+}
+
+// Injected so the database, the auth backend, and the privileged exec are testable.
+var (
+	passwdPath = "/etc/passwd"
+	authFn     = auth.Authenticate
+	runFn      = func(stdio command.IO, acc account) error {
+		shell := acc.shell
+		if shell == "" {
+			shell = "/bin/sh"
+		}
+		cmd := exec.Command(shell) //nolint:gosec // starting the user's login shell is the point
+		cmd.Args = []string{"-" + filepath.Base(shell)}
+		cmd.Dir = acc.home
+		cmd.Env = append(os.Environ(), "HOME="+acc.home, "USER="+acc.name, "SHELL="+shell)
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: uint32(acc.uid), Gid: uint32(acc.gid)},
+		}
+		return cmd.Run()
+	}
+)
+
+// Run executes login.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-f USER] [-p] [USER]", stdio.Err).WithHelp(command.Help{
+		Description: "Authenticate a user and start their login shell with their credentials. The user " +
+			"is taken from -f (pre-authenticated, no password asked), from the USER operand (then the " +
+			"password is read from standard input), or — if neither is given — the username is read as " +
+			"the first line of standard input and the password as the second. -p preserves the " +
+			"environment. Logging in another user requires privilege.",
+		Examples: []command.Example{
+			{Command: "login alice", Explain: "Log in alice, reading the password from stdin."},
+			{Command: "login -f root", Explain: "Start root's shell without a password."},
+		},
+		ExitStatus: "the shell's exit status, or 1 on a bad login.",
+	})
+	noAuth := fs.StringP("force", "f", "", "log in this user without authenticating")
+	_ = fs.BoolP("preserve", "p", false, "preserve the environment")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	user, password, err := credentials(stdio, *noAuth, fs.Args())
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	acc, err := resolve(user)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	if *noAuth == "" {
+		ok, err := authFn(user, password)
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
+		if !ok {
+			return command.Failuref("Login incorrect")
+		}
+	}
+
+	if err := runFn(stdio, acc); err != nil {
+		var ee *exec.ExitError
+		if e, isExit := err.(*exec.ExitError); isExit {
+			ee = e
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// credentials determines the user name and password to use.
+func credentials(stdio command.IO, noAuth string, operands []string) (user, password string, err error) {
+	if noAuth != "" {
+		return noAuth, "", nil
+	}
+	sc := bufio.NewScanner(stdio.In)
+	if len(operands) > 0 {
+		user = operands[0]
+	} else {
+		_, _ = fmt.Fprint(stdio.Err, "login: ")
+		if !sc.Scan() {
+			return "", "", fmt.Errorf("no username provided")
+		}
+		user = strings.TrimSpace(sc.Text())
+	}
+	_, _ = fmt.Fprint(stdio.Err, "Password: ")
+	if !sc.Scan() {
+		return "", "", fmt.Errorf("no password provided")
+	}
+	return user, sc.Text(), nil
+}
+
+// resolve looks up the user in the passwd database.
+func resolve(name string) (account, error) {
+	data, err := os.ReadFile(passwdPath) //nolint:gosec // well-known passwd path
+	if err != nil {
+		return account{}, fmt.Errorf("cannot read %s: %v", passwdPath, err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		f := strings.Split(line, ":")
+		if len(f) < 7 || f[0] != name {
+			continue
+		}
+		uid, err1 := strconv.Atoi(f[2])
+		gid, err2 := strconv.Atoi(f[3])
+		if err1 != nil || err2 != nil {
+			return account{}, fmt.Errorf("user %q has an invalid uid/gid", name)
+		}
+		return account{name: name, uid: uid, gid: gid, home: f[5], shell: f[6]}, nil
+	}
+	return account{}, fmt.Errorf("unknown user: %s", name)
+}

--- a/internal/applets/loginutils/login/login_test.go
+++ b/internal/applets/loginutils/login/login_test.go
@@ -1,0 +1,82 @@
+package login
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T, authOK bool) *account {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "passwd")
+	content := "root:x:0:0:root:/root:/bin/sh\nalice:x:1000:1000:alice:/home/alice:/bin/bash\n"
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ran := &account{}
+	op, oa, orf := passwdPath, authFn, runFn
+	passwdPath = p
+	authFn = func(string, string) (bool, error) { return authOK, nil }
+	runFn = func(_ command.IO, acc account) error { *ran = acc; return nil }
+	t.Cleanup(func() { passwdPath, authFn, runFn = op, oa, orf })
+	return ran
+}
+
+func run(t *testing.T, stdin string, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(stdin), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestLoginWithOperand(t *testing.T) {
+	ran := setup(t, true)
+	if err := run(t, "secret\n", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if ran.name != "alice" || ran.uid != 1000 || ran.shell != "/bin/bash" {
+		t.Errorf("logged in account = %+v", *ran)
+	}
+}
+
+func TestLoginUsernameFromStdin(t *testing.T) {
+	ran := setup(t, true)
+	if err := run(t, "alice\nsecret\n"); err != nil {
+		t.Fatal(err)
+	}
+	if ran.name != "alice" {
+		t.Errorf("username from stdin = %q", ran.name)
+	}
+}
+
+func TestWrongPassword(t *testing.T) {
+	ran := setup(t, false)
+	if err := run(t, "wrong\n", "alice"); err == nil {
+		t.Errorf("a wrong password should fail")
+	}
+	if ran.name != "" {
+		t.Errorf("the shell must not start on a bad login")
+	}
+}
+
+func TestForceSkipsAuth(t *testing.T) {
+	ran := setup(t, false) // auth would fail, but -f skips it
+	if err := run(t, "", "-f", "root"); err != nil {
+		t.Fatal(err)
+	}
+	if ran.name != "root" {
+		t.Errorf("-f should log in root without auth")
+	}
+}
+
+func TestUnknownUser(t *testing.T) {
+	setup(t, true)
+	if err := run(t, "pw\n", "ghost"); err == nil {
+		t.Errorf("an unknown user should fail")
+	}
+}

--- a/test/it/loginutils/login_test.sh
+++ b/test/it/loginutils/login_test.sh
@@ -1,0 +1,5 @@
+# login authenticates and starts a shell with the user's credentials
+# (privileged); the e2e exercises the unknown-user path and --help. The flow is
+# covered by Go unit tests.
+TestLoginUnknownUser() { printf 'nope\n' | login nonexistent_user_xyz 2>/dev/null; echo "rc=$?"; }
+TestLoginHelp() { login --help; }

--- a/test/it/spec/login_spec.sh
+++ b/test/it/spec/login_spec.sh
@@ -1,0 +1,15 @@
+Describe 'login'
+    Include loginutils/login_test.sh
+
+    It 'fails for an unknown user'
+        When call TestLoginUnknownUser
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestLoginHelp
+        The status should be success
+        The output should include 'Usage: login'
+        The output should include 'login shell'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `login`, the login entry point. It determines the user from `-f` (pre-authenticated, no password), from the USER operand (then the password is read from stdin), or — if neither is given — reads the username from the first line of stdin and the password from the second. The user is resolved from /etc/passwd; on a correct password (or `-f`) it starts the user's login shell (argv[0] prefixed with `-`) with their credentials, home, and environment. A bad password fails with "Login incorrect" without starting a shell. Per the issue's guidance the session IO is separated from the backend: the passwd path, the auth backend (defaulting to internal/auth), and the privileged exec are injectable.

## Tests

- Unit (fixture passwd + stubbed backend): logging in via the USER operand, reading the username and password from stdin, rejecting a wrong password without starting the shell, `-f` skipping authentication, and the unknown-user error.
- shellspec: an unknown user fails, and the `--help` path (logging in needs privilege and real auth, so the flow is unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (697 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250