### PR TITLE
feat(loginutils): add getty applet to prompt and run login

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 303 commands. Run `mimixbox --list` to see them on the terminal.
+There are 304 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -112,6 +112,7 @@ There are 303 commands. Run `mimixbox --list` to see them on the terminal.
 | fsync | Flush a file's data to storage with fsync(2) |
 | fuser | Identify processes using a file |
 | getopt | Parse command options (enhanced, like util-linux getopt) |
+| getty | Prompt for a username and run login |
 | ghrdc | GitHub Release Download Counter |
 | grep | Print lines that match patterns |
 | groups | Print the groups to which USERNAME belongs |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -80,6 +80,7 @@ import (
 	ap_loginutils_cryptpw "github.com/nao1215/mimixbox/internal/applets/loginutils/cryptpw"
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
+	ap_loginutils_getty "github.com/nao1215/mimixbox/internal/applets/loginutils/getty"
 	ap_loginutils_login "github.com/nao1215/mimixbox/internal/applets/loginutils/login"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
@@ -290,7 +291,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 303)
+	Applets = make(map[string]Applet, 304)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -379,6 +380,7 @@ func init() {
 	register(ap_loginutils_cryptpw.New())
 	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_deluser.New())
+	register(ap_loginutils_getty.New())
 	register(ap_loginutils_login.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())

--- a/internal/applets/loginutils/getty/getty.go
+++ b/internal/applets/loginutils/getty/getty.go
@@ -1,0 +1,81 @@
+// Package getty implements the getty applet: print the login banner, read a
+// username, and hand off to login.
+package getty
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the getty applet.
+type Command struct{}
+
+// New returns a getty command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "getty" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Prompt for a username and run login" }
+
+// Injected so the banner source and the login hand-off are testable.
+var (
+	issuePath   = "/etc/issue"
+	loginExecFn = func(stdio command.IO, username string) error {
+		cmd := exec.Command("login", username) //nolint:gosec // handing off to login is the point
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		return cmd.Run()
+	}
+)
+
+// Run executes getty.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[BAUD] TTY [TERM]", stdio.Err).WithHelp(command.Help{
+		Description: "Open a terminal session: print the contents of /etc/issue (if present) and a " +
+			"'login: ' prompt, read a username, and hand off to the login program for that user. The " +
+			"BAUD, TTY, and TERM operands are accepted for compatibility; this build prompts on the " +
+			"current terminal rather than opening the named device.",
+		Examples: []command.Example{
+			{Command: "getty 38400 tty1", Explain: "Prompt on tty1 and run login."},
+		},
+		ExitStatus: "login's exit status, or 1 if no TTY was given or no username was entered.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if len(fs.Args()) == 0 {
+		return command.Failuref("a TTY argument is required")
+	}
+
+	if issue, err := os.ReadFile(issuePath); err == nil {
+		_, _ = stdio.Out.Write(issue)
+	}
+	_, _ = fmt.Fprint(stdio.Out, "login: ")
+
+	sc := bufio.NewScanner(stdio.In)
+	if !sc.Scan() {
+		return command.Failuref("no username entered")
+	}
+	username := strings.TrimSpace(sc.Text())
+	if username == "" {
+		return command.Failuref("no username entered")
+	}
+
+	if err := loginExecFn(stdio, username); err != nil {
+		var ee *exec.ExitError
+		if e, isExit := err.(*exec.ExitError); isExit {
+			ee = e
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("login: %v", err)
+	}
+	return nil
+}

--- a/internal/applets/loginutils/getty/getty_test.go
+++ b/internal/applets/loginutils/getty/getty_test.go
@@ -1,0 +1,78 @@
+package getty
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func setup(t *testing.T, issue string, loginErr error) *string {
+	t.Helper()
+	got := new(string)
+	*got = "<none>"
+	oi, ol := issuePath, loginExecFn
+	if issue != "" {
+		p := filepath.Join(t.TempDir(), "issue")
+		if err := os.WriteFile(p, []byte(issue), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		issuePath = p
+	} else {
+		issuePath = filepath.Join(t.TempDir(), "no-issue")
+	}
+	loginExecFn = func(_ command.IO, username string) error { *got = username; return loginErr }
+	t.Cleanup(func() { issuePath, loginExecFn = oi, ol })
+	return got
+}
+
+func run(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestPromptsAndHandsOff(t *testing.T) {
+	got := setup(t, "Welcome to mimixbox\n", nil)
+	out, err := run(t, "alice\n", "38400", "tty1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Welcome to mimixbox") || !strings.Contains(out, "login: ") {
+		t.Errorf("banner/prompt missing:\n%s", out)
+	}
+	if *got != "alice" {
+		t.Errorf("handed off username %q, want alice", *got)
+	}
+}
+
+func TestNoTTY(t *testing.T) {
+	setup(t, "", nil)
+	if _, err := run(t, "alice\n"); err == nil {
+		t.Errorf("a missing TTY should fail")
+	}
+}
+
+func TestEmptyUsername(t *testing.T) {
+	got := setup(t, "", nil)
+	if _, err := run(t, "\n", "tty1"); err == nil {
+		t.Errorf("an empty username should fail")
+	}
+	if *got != "<none>" {
+		t.Errorf("login must not be invoked without a username")
+	}
+}
+
+func TestLoginFailure(t *testing.T) {
+	setup(t, "", errors.New("login refused"))
+	if _, err := run(t, "alice\n", "tty1"); err == nil {
+		t.Errorf("a login failure should fail")
+	}
+}

--- a/test/it/loginutils/getty_test.sh
+++ b/test/it/loginutils/getty_test.sh
@@ -1,0 +1,5 @@
+TestGettyPrompt() {
+    # Empty username -> getty fails without invoking login, but still prints the prompt.
+    printf '\n' | getty tty1 2>/dev/null | grep -c 'login: '
+}
+TestGettyNoTTY() { printf 'alice\n' | getty 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/getty_spec.sh
+++ b/test/it/spec/getty_spec.sh
@@ -1,0 +1,14 @@
+Describe 'getty'
+    Include loginutils/getty_test.sh
+
+    It 'prints the login prompt'
+        When call TestGettyPrompt
+        The output should equal '1'
+        The status should be success
+    End
+    It 'requires a TTY argument'
+        When call TestGettyNoTTY
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `getty`, the terminal session opener. It prints /etc/issue (if present) and a `login: ` prompt, reads a username, and hands off to the login program for that user, propagating its exit status. The BAUD/TTY/TERM operands are accepted for compatibility; this build prompts on the current terminal rather than opening the named device. An empty username fails without invoking login. The banner source and the login hand-off are injectable so the flow is tested deterministically.

## Tests

- Unit (fixture issue + stubbed login): printing the banner and prompt and handing off the entered username, the missing-TTY error, an empty username failing without invoking login, and a login-failure error.
- shellspec: the `login: ` prompt is printed, and a missing TTY argument fails.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (699 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250