### PR TITLE
feat(loginutils): add acpid applet to dispatch ACPI events

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 305 commands. Run `mimixbox --list` to see them on the terminal.
+There are 306 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
 | [ | Evaluate a conditional expression (test alias requiring ]) |
 | [[ | Evaluate a conditional expression (test alias requiring ]]) |
+| acpid | Dispatch ACPI events (foreground) |
 | add-shell | Add shell name to /etc/shells |
 | addgroup | Add a group to /etc/group |
 | adduser | Create a user account |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -72,6 +72,7 @@ import (
 	ap_jokeutils_fortune "github.com/nao1215/mimixbox/internal/applets/jokeutils/fortune"
 	ap_jokeutils_nyancat "github.com/nao1215/mimixbox/internal/applets/jokeutils/nyancat"
 	ap_jokeutils_sl "github.com/nao1215/mimixbox/internal/applets/jokeutils/sl"
+	ap_loginutils_acpid "github.com/nao1215/mimixbox/internal/applets/loginutils/acpid"
 	ap_loginutils_addgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/addgroup"
 	ap_loginutils_adduser "github.com/nao1215/mimixbox/internal/applets/loginutils/adduser"
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
@@ -292,7 +293,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 305)
+	Applets = make(map[string]Applet, 306)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -373,6 +374,7 @@ func init() {
 	register(ap_jokeutils_fortune.New())
 	register(ap_jokeutils_nyancat.New())
 	register(ap_jokeutils_sl.New())
+	register(ap_loginutils_acpid.New())
 	register(ap_loginutils_addgroup.New())
 	register(ap_loginutils_adduser.New())
 	register(ap_loginutils_chpasswd.New())

--- a/internal/applets/loginutils/acpid/acpid.go
+++ b/internal/applets/loginutils/acpid/acpid.go
@@ -1,0 +1,90 @@
+// Package acpid implements the acpid applet: a foreground ACPI event daemon that
+// reads kernel ACPI events and dispatches each to a handler.
+package acpid
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the acpid applet.
+type Command struct{}
+
+// New returns an acpid command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "acpid" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Dispatch ACPI events (foreground)" }
+
+// Injected so the event source and the handler are testable.
+var (
+	openSourceFn = func() (io.ReadCloser, error) {
+		return os.Open("/proc/acpi/event") //nolint:gosec // well-known ACPI event source
+	}
+	// handlerFn handles one event line. The default runs /etc/acpi/handler.sh with
+	// the event fields if it exists, and always reports the event.
+	handlerFn = func(stdio command.IO, event string) {
+		_, _ = fmt.Fprintf(stdio.Out, "acpid: %s\n", event)
+		const handler = "/etc/acpi/handler.sh"
+		if _, err := os.Stat(handler); err == nil {
+			cmd := exec.Command(handler, strings.Fields(event)...) //nolint:gosec // configured ACPI handler
+			cmd.Stdout, cmd.Stderr = stdio.Out, stdio.Err
+			_ = cmd.Run()
+		}
+	}
+)
+
+// Run executes acpid.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-f", stdio.Err).WithHelp(command.Help{
+		Description: "Read kernel ACPI events (from /proc/acpi/event) and dispatch each to a handler, " +
+			"running /etc/acpi/handler.sh with the event fields when it exists. Only the foreground " +
+			"mode (-f) is supported: acpid stays in the foreground until interrupted.",
+		Examples: []command.Example{
+			{Command: "acpid -f", Explain: "Run the ACPI event daemon in the foreground."},
+		},
+		ExitStatus: "0  the daemon stopped cleanly.\n1  -f was not given or the event source was unavailable.",
+	})
+	foreground := fs.BoolP("foreground", "f", false, "run in the foreground (the only supported mode)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if !*foreground {
+		_, _ = fmt.Fprintln(stdio.Err, "acpid: only the foreground mode (-f) is supported by this build")
+		return command.SilentFailure()
+	}
+
+	src, err := openSourceFn()
+	if err != nil {
+		return command.Failuref("cannot open the ACPI event source: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	// Closing the source on cancellation unblocks the read.
+	go func() {
+		<-ctx.Done()
+		_ = src.Close()
+	}()
+
+	sc := bufio.NewScanner(src)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		handlerFn(stdio, line)
+	}
+	return nil
+}

--- a/internal/applets/loginutils/acpid/acpid_test.go
+++ b/internal/applets/loginutils/acpid/acpid_test.go
@@ -1,0 +1,84 @@
+package acpid
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func withSource(t *testing.T, r io.ReadCloser, openErr error) {
+	t.Helper()
+	oo := openSourceFn
+	openSourceFn = func() (io.ReadCloser, error) {
+		if openErr != nil {
+			return nil, openErr
+		}
+		return r, nil
+	}
+	t.Cleanup(func() { openSourceFn = oo })
+}
+
+func TestDispatchesEvents(t *testing.T) {
+	withSource(t, io.NopCloser(strings.NewReader(
+		"button/power PBTN 00000080 00000000\n\nac_adapter ACAD 00000080 00000001\n")), nil)
+	out := &bytes.Buffer{}
+	io2 := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io2, []string{"-f"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "button/power PBTN") || !strings.Contains(out.String(), "ac_adapter ACAD") {
+		t.Errorf("events not dispatched:\n%s", out)
+	}
+}
+
+func TestForegroundRequired(t *testing.T) {
+	io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io2, nil); err == nil {
+		t.Errorf("acpid without -f should fail")
+	}
+}
+
+func TestOpenFailure(t *testing.T) {
+	withSource(t, nil, errors.New("no such file"))
+	io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io2, []string{"-f"}); err == nil {
+		t.Errorf("an unavailable source should fail")
+	}
+}
+
+type blockingReader struct{ closed chan struct{} }
+
+func (b *blockingReader) Read([]byte) (int, error) { <-b.closed; return 0, io.EOF }
+func (b *blockingReader) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+func TestStopsOnCancel(t *testing.T) {
+	withSource(t, &blockingReader{closed: make(chan struct{})}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		done <- New().Run(ctx, io2, []string{"-f"})
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned %v after cancel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("acpid did not stop after cancellation")
+	}
+}

--- a/test/it/loginutils/acpid_test.sh
+++ b/test/it/loginutils/acpid_test.sh
@@ -1,0 +1,4 @@
+# acpid -f reads /proc/acpi/event (often absent) and blocks; the e2e exercises
+# the no-foreground path and --help. Event dispatch is covered by Go unit tests.
+TestAcpidNoForeground() { acpid 2>/dev/null; echo "rc=$?"; }
+TestAcpidHelp() { acpid --help; }

--- a/test/it/spec/acpid_spec.sh
+++ b/test/it/spec/acpid_spec.sh
@@ -1,0 +1,15 @@
+Describe 'acpid'
+    Include loginutils/acpid_test.sh
+
+    It 'requires foreground mode'
+        When call TestAcpidNoForeground
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestAcpidHelp
+        The status should be success
+        The output should include 'Usage: acpid'
+        The output should include 'ACPI'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `acpid` in foreground mode (`-f`): it reads kernel ACPI events from /proc/acpi/event and dispatches each to a handler, running /etc/acpi/handler.sh with the event fields when it exists, until interrupted. Without `-f` it fails deterministically. The event source and the handler are injectable so the dispatch loop and cancellation are tested without a real ACPI source.

## Tests

- Unit (fake source + cancellable context): dispatching multiple ACPI events (skipping blank lines), the require-`-f` behavior, an unavailable source failing, and stopping cleanly when the context is cancelled (the blocking read is unblocked by closing the source).
- shellspec: requiring foreground mode, and the `--help` path (the loop reads a privileged/often-absent source and blocks, so dispatch is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (703 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250