### PR TITLE
feat(loginutils): add bootchartd applet to record boot performance samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 306 commands. Run `mimixbox --list` to see them on the terminal.
+There are 307 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -42,6 +42,7 @@ There are 306 commands. Run `mimixbox --list` to see them on the terminal.
 | blkdiscard | Discard sectors on a block device |
 | blkid | Identify the filesystem type of a device or image |
 | blockdev | Report block device properties |
+| bootchartd | Collect a bootchart performance sample |
 | bunzip2 | Decompress bzip2 (.bz2) files |
 | busybox | BusyBox-style multi-call front-end for MimixBox applets |
 | bzcat | Decompress bz2 data to standard output |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -75,6 +75,7 @@ import (
 	ap_loginutils_acpid "github.com/nao1215/mimixbox/internal/applets/loginutils/acpid"
 	ap_loginutils_addgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/addgroup"
 	ap_loginutils_adduser "github.com/nao1215/mimixbox/internal/applets/loginutils/adduser"
+	ap_loginutils_bootchartd "github.com/nao1215/mimixbox/internal/applets/loginutils/bootchartd"
 	ap_loginutils_chpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/chpasswd"
 	ap_loginutils_crond "github.com/nao1215/mimixbox/internal/applets/loginutils/crond"
 	ap_loginutils_crontab "github.com/nao1215/mimixbox/internal/applets/loginutils/crontab"
@@ -293,7 +294,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 306)
+	Applets = make(map[string]Applet, 307)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -377,6 +378,7 @@ func init() {
 	register(ap_loginutils_acpid.New())
 	register(ap_loginutils_addgroup.New())
 	register(ap_loginutils_adduser.New())
+	register(ap_loginutils_bootchartd.New())
 	register(ap_loginutils_chpasswd.New())
 	register(ap_loginutils_crond.New())
 	register(ap_loginutils_crontab.New())

--- a/internal/applets/loginutils/bootchartd/bootchartd.go
+++ b/internal/applets/loginutils/bootchartd/bootchartd.go
@@ -1,0 +1,109 @@
+// Package bootchartd implements the bootchartd applet: collect a snapshot of the
+// kernel performance counters into the bootchart log files.
+package bootchartd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the bootchartd applet.
+type Command struct{}
+
+// New returns a bootchartd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "bootchartd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Collect a bootchart performance sample" }
+
+// Injected so the kernel counters and the output location are testable.
+var (
+	statPath      = "/proc/stat"
+	diskstatsPath = "/proc/diskstats"
+	uptimePath    = "/proc/uptime"
+	outputDir     = "/var/log/bootchart"
+)
+
+// sample describes one bootchart log file and its kernel source.
+var samples = []struct {
+	logName string
+	source  func() string
+}{
+	{"proc_stat.log", func() string { return read(statPath) }},
+	{"proc_diskstats.log", func() string { return read(diskstatsPath) }},
+}
+
+// Run executes bootchartd.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-o DIR]", stdio.Err).WithHelp(command.Help{
+		Description: "Append a timestamped snapshot of the kernel performance counters (/proc/stat and " +
+			"/proc/diskstats) to the bootchart log files in DIR (default /var/log/bootchart), in the " +
+			"format the bootchart renderer reads. Run repeatedly during boot to build a profile; the " +
+			"continuous sampling loop and tarball packaging of the full bootchartd are not implemented.",
+		Examples: []command.Example{
+			{Command: "bootchartd -o /tmp/bootlog", Explain: "Record one sample into /tmp/bootlog."},
+		},
+		ExitStatus: "0  the sample was recorded.\n1  the output directory could not be written.",
+	})
+	out := fs.StringP("output", "o", "", "directory for the log files (default /var/log/bootchart)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *out != "" {
+		outputDir = *out
+	}
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return command.Failuref("cannot create %s: %v", outputDir, err)
+	}
+
+	stamp := uptimeJiffies()
+	for _, s := range samples {
+		entry := fmt.Sprintf("%d\n%s\n", stamp, strings.TrimRight(s.source(), "\n"))
+		if err := appendFile(filepath.Join(outputDir, s.logName), entry); err != nil {
+			return command.Failuref("cannot write %s: %v", s.logName, err)
+		}
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "bootchartd: sample recorded in %s\n", outputDir)
+	return nil
+}
+
+// uptimeJiffies returns the system uptime in 1/100-second jiffies, the timestamp
+// bootchart uses to separate samples.
+func uptimeJiffies() int64 {
+	fields := strings.Fields(read(uptimePath))
+	if len(fields) == 0 {
+		return 0
+	}
+	secs, _ := strconv.ParseFloat(fields[0], 64)
+	return int64(secs * 100)
+}
+
+func read(path string) string {
+	data, err := os.ReadFile(path) //nolint:gosec // /proc or test fixture path
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func appendFile(path, content string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) //nolint:gosec // log file
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.WriteString(content)
+	return err
+}

--- a/internal/applets/loginutils/bootchartd/bootchartd_test.go
+++ b/internal/applets/loginutils/bootchartd/bootchartd_test.go
@@ -1,0 +1,81 @@
+package bootchartd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixtures(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	ostat, odisk, oup, oout := statPath, diskstatsPath, uptimePath, outputDir
+	statPath = write("stat", "cpu  100 0 50 800 0 0 0 0 0 0\n")
+	diskstatsPath = write("diskstats", "8 0 sda 100 0 200 0\n")
+	uptimePath = write("uptime", "123.45 600.00\n")
+	outputDir = filepath.Join(dir, "out")
+	t.Cleanup(func() { statPath, diskstatsPath, uptimePath, outputDir = ostat, odisk, oup, oout })
+	return outputDir
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestRecordsSample(t *testing.T) {
+	out := fixtures(t)
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	stat, err := os.ReadFile(filepath.Join(out, "proc_stat.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Timestamp (uptime 123.45s -> 12345 jiffies) header followed by the content.
+	if !strings.HasPrefix(string(stat), "12345\n") || !strings.Contains(string(stat), "cpu  100 0 50 800") {
+		t.Errorf("proc_stat.log = %q", stat)
+	}
+	disk, _ := os.ReadFile(filepath.Join(out, "proc_diskstats.log"))
+	if !strings.Contains(string(disk), "sda 100 0 200") {
+		t.Errorf("proc_diskstats.log = %q", disk)
+	}
+}
+
+func TestAppendsSamples(t *testing.T) {
+	out := fixtures(t)
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	stat, _ := os.ReadFile(filepath.Join(out, "proc_stat.log"))
+	if n := strings.Count(string(stat), "12345\n"); n != 2 {
+		t.Errorf("expected 2 samples, found %d:\n%s", n, stat)
+	}
+}
+
+func TestOutputFlag(t *testing.T) {
+	fixtures(t)
+	custom := filepath.Join(t.TempDir(), "custom")
+	if err := run(t, "-o", custom); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(custom, "proc_stat.log")); err != nil {
+		t.Errorf("-o directory not used: %v", err)
+	}
+}

--- a/test/it/loginutils/bootchartd_test.sh
+++ b/test/it/loginutils/bootchartd_test.sh
@@ -1,0 +1,5 @@
+TestBootchartdSample() {
+    bootchartd -o "$TEST_DIR/bc" >/dev/null
+    # A proc_stat.log with the CPU line must have been written.
+    grep -c '^cpu ' "$TEST_DIR/bc/proc_stat.log"
+}

--- a/test/it/spec/bootchartd_spec.sh
+++ b/test/it/spec/bootchartd_spec.sh
@@ -1,0 +1,14 @@
+Describe 'bootchartd'
+    Include loginutils/bootchartd_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/bootchartd; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'records a proc_stat sample'
+        When call TestBootchartdSample
+        The output should not equal '0'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the loginutils batch (#250) with `bootchartd`, which appends a timestamped snapshot of the kernel performance counters (/proc/stat and /proc/diskstats) to the bootchart log files in DIR (`-o`, default /var/log/bootchart), in the format the bootchart renderer reads — each sample prefixed with the uptime in 1/100-second jiffies. Run repeatedly during boot to build a profile; the continuous sampling loop and tarball packaging of the full bootchartd are out of scope for this slice. The /proc paths and the output directory are injectable so the collection is tested against fixtures.

## Tests

- Unit (fixture /proc + output dir): recording a sample (the jiffy timestamp header plus the stat/diskstats content), appending a second sample to the same logs, and honoring the `-o` directory.
- shellspec: recording a real proc_stat sample containing the CPU line.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (704 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #250