### PR TITLE
feat(loginutils): add init and linuxrc applets, completing the batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 307 commands. Run `mimixbox --list` to see them on the terminal.
+There are 309 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -130,6 +130,7 @@ There are 307 commands. Run `mimixbox --list` to see them on the terminal.
 | hush | Command interpreter (MimixBox mbsh compatibility front-end) |
 | hwclock | Read the hardware (RTC) clock |
 | id | Print User ID and Group ID |
+| init | Run an inittab's startup actions |
 | install | Copy files and set attributes |
 | ionice | Get or set process I/O scheduling class and priority |
 | iostat | Report CPU and device I/O statistics |
@@ -146,6 +147,7 @@ There are 307 commands. Run `mimixbox --list` to see them on the terminal.
 | link | Create a hard link to a file |
 | linux32 | Run a program with a 32-bit execution domain |
 | linux64 | Run a program with a 64-bit execution domain |
+| linuxrc | Run an inittab's startup actions |
 | ln | Create hard or symbolic link |
 | log-collect | Gather system log files into one directory |
 | logger | Write a message to the system log |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -83,6 +83,7 @@ import (
 	ap_loginutils_delgroup "github.com/nao1215/mimixbox/internal/applets/loginutils/delgroup"
 	ap_loginutils_deluser "github.com/nao1215/mimixbox/internal/applets/loginutils/deluser"
 	ap_loginutils_getty "github.com/nao1215/mimixbox/internal/applets/loginutils/getty"
+	ap_loginutils_init "github.com/nao1215/mimixbox/internal/applets/loginutils/init"
 	ap_loginutils_login "github.com/nao1215/mimixbox/internal/applets/loginutils/login"
 	ap_loginutils_mkpasswd "github.com/nao1215/mimixbox/internal/applets/loginutils/mkpasswd"
 	ap_loginutils_nologin "github.com/nao1215/mimixbox/internal/applets/loginutils/nologin"
@@ -294,7 +295,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 307)
+	Applets = make(map[string]Applet, 309)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -386,6 +387,8 @@ func init() {
 	register(ap_loginutils_delgroup.New())
 	register(ap_loginutils_deluser.New())
 	register(ap_loginutils_getty.New())
+	register(ap_loginutils_init.New())
+	register(ap_loginutils_init.NewLinuxrc())
 	register(ap_loginutils_login.New())
 	register(ap_loginutils_mkpasswd.New())
 	register(ap_loginutils_nologin.New())

--- a/internal/applets/loginutils/init/init.go
+++ b/internal/applets/loginutils/init/init.go
@@ -1,0 +1,109 @@
+// Package initapplet implements the init applet (also linuxrc): run the one-shot
+// startup actions of an inittab. The full PID-1 supervision loop is not provided.
+package initapplet
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the init applet. It is also registered under the name linuxrc.
+type Command struct{ name string }
+
+// New returns an init command.
+func New() *Command { return &Command{name: "init"} }
+
+// NewLinuxrc returns the same applet under the name linuxrc.
+func NewLinuxrc() *Command { return &Command{name: "linuxrc"} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return c.name }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run an inittab's startup actions" }
+
+// inittabPath is the init configuration; tests point it at a fixture.
+var inittabPath = "/etc/inittab"
+
+// runFn runs one inittab process, waiting for it when wait is true.
+var runFn = func(stdio command.IO, process string, wait bool) error {
+	cmd := exec.Command("sh", "-c", process) //nolint:gosec // running configured init actions is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if wait {
+		return cmd.Run()
+	}
+	return cmd.Start()
+}
+
+// oneShotActions are run during startup; respawn/askfirst entries would need the
+// supervision loop and are skipped by this slice.
+var oneShotActions = map[string]bool{"sysinit": true, "wait": true, "once": true}
+
+// waitActions block until the process finishes.
+var waitActions = map[string]bool{"sysinit": true, "wait": true}
+
+// Run executes init.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-t INITTAB]", stdio.Err).WithHelp(command.Help{
+		Description: "Read an inittab and run its one-shot startup actions — sysinit and wait entries " +
+			"(run to completion) and once entries (started in the background) — in file order. The " +
+			"respawn/askfirst entries and the full PID-1 supervision loop of a real init are not run by " +
+			"this build. Each inittab line is 'id:runlevels:action:process'.",
+		Examples: []command.Example{
+			{Command: "init -t /etc/inittab", Explain: "Run the inittab's startup actions."},
+		},
+		ExitStatus: "0  the startup actions ran.\n1  the inittab could not be read.",
+	})
+	tab := fs.StringP("inittab", "t", "", "inittab file (default /etc/inittab)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *tab != "" {
+		inittabPath = *tab
+	}
+
+	data, err := os.ReadFile(inittabPath) //nolint:gosec // well-known inittab path
+	if err != nil {
+		return command.Failuref("cannot read %s: %v", inittabPath, err)
+	}
+
+	for _, entry := range parseInittab(string(data)) {
+		if !oneShotActions[entry.action] {
+			continue
+		}
+		if err := runFn(stdio, entry.process, waitActions[entry.action]); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "init: %s: %v\n", entry.process, err)
+		}
+	}
+	return nil
+}
+
+type entry struct {
+	action  string
+	process string
+}
+
+// parseInittab parses inittab text into id:runlevels:action:process entries,
+// skipping blanks and comments.
+func parseInittab(text string) []entry {
+	var entries []entry
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.SplitN(line, ":", 4)
+		if len(fields) != 4 {
+			continue
+		}
+		entries = append(entries, entry{action: fields[2], process: fields[3]})
+	}
+	return entries
+}

--- a/internal/applets/loginutils/init/init_test.go
+++ b/internal/applets/loginutils/init/init_test.go
@@ -1,0 +1,85 @@
+package initapplet
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type ranEntry struct {
+	process string
+	wait    bool
+}
+
+func setup(t *testing.T, inittab string) *[]ranEntry {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "inittab")
+	if err := os.WriteFile(p, []byte(inittab), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var ran []ranEntry
+	oi, orf := inittabPath, runFn
+	inittabPath = p
+	runFn = func(_ command.IO, process string, wait bool) error {
+		ran = append(ran, ranEntry{process, wait})
+		return nil
+	}
+	t.Cleanup(func() { inittabPath, runFn = oi, orf })
+	return &ran
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestRunsOneShotActionsInOrder(t *testing.T) {
+	ran := setup(t, "# comment\n\nsi::sysinit:mount -a\nl0::wait:run-stuff\nx::once:spawn-bg\ntty1::respawn:getty tty1\n")
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	want := []ranEntry{
+		{"mount -a", true},   // sysinit: waited
+		{"run-stuff", true},  // wait: waited
+		{"spawn-bg", false},  // once: backgrounded
+	}
+	if len(*ran) != len(want) {
+		t.Fatalf("ran %v, want %v", *ran, want)
+	}
+	for i, w := range want {
+		if (*ran)[i] != w {
+			t.Errorf("entry %d = %+v, want %+v", i, (*ran)[i], w)
+		}
+	}
+}
+
+func TestParseInittab(t *testing.T) {
+	t.Parallel()
+	entries := parseInittab("# c\n\nid:rl:action:the:process\nbad-line\nx::once:cmd\n")
+	if len(entries) != 2 {
+		t.Fatalf("parsed %d, want 2", len(entries))
+	}
+	// id:runlevels:action:process — SplitN(4) keeps colons in the process verbatim.
+	if entries[0].action != "action" || entries[0].process != "the:process" {
+		t.Errorf("entry 0 = %+v", entries[0])
+	}
+}
+
+func TestAlias(t *testing.T) {
+	if New().Name() != "init" || NewLinuxrc().Name() != "linuxrc" {
+		t.Errorf("alias names wrong")
+	}
+}
+
+func TestMissingInittab(t *testing.T) {
+	setup(t, "")
+	if err := run(t, "-t", "/no/such/inittab"); err == nil {
+		t.Errorf("a missing inittab should fail")
+	}
+}

--- a/test/it/loginutils/init_test.sh
+++ b/test/it/loginutils/init_test.sh
@@ -1,0 +1,5 @@
+TestInitRunsActions() {
+    printf 'si::sysinit:echo SYSINIT\nl::wait:echo WAIT\n' > "$TEST_DIR/inittab"
+    init -t "$TEST_DIR/inittab"
+}
+TestInitMissing() { init -t "$TEST_DIR/no_such_inittab" 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/init_spec.sh
+++ b/test/it/spec/init_spec.sh
@@ -1,0 +1,20 @@
+Describe 'init'
+    Include loginutils/init_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/init; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'runs the inittab sysinit and wait actions'
+        When call TestInitRunsActions
+        The line 1 of output should equal 'SYSINIT'
+        The line 2 of output should equal 'WAIT'
+        The status should be success
+    End
+    It 'fails on a missing inittab'
+        When call TestInitMissing
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Adds the final applets of the loginutils batch (#250): `init` (also registered as `linuxrc`). It reads an inittab (`-t`, default /etc/inittab) and runs its one-shot startup actions — sysinit and wait entries to completion, and once entries in the background — in file order. The respawn/askfirst entries and the full PID-1 supervision loop of a real init are out of scope for this slice and are skipped; each inittab line is parsed as 'id:runlevels:action:process'. The inittab path and the process runner are injectable so the parsing and dispatch are tested against fixtures.

With this, every command in #250's scope is now implemented (acpid, addgroup, adduser, bootchartd, chpasswd, crond, crontab, cryptpw, delgroup, deluser, getty, init, linuxrc, login, mkpasswd, nologin, passwd, run-init, run-parts, runlevel, start-stop-daemon, su, sulogin, vlock), delivered across this and the preceding PRs. The account-mutating applets write the passwd/shadow/group databases atomically, and the authentication-based applets (su, login, sulogin, vlock) use the repo's internal/auth backend behind an injectable seam.

## Tests

- Unit (fixture inittab + stubbed runner): running the sysinit/wait actions to completion and once in the background, in file order, while skipping respawn; the inittab parser (skipping comments/blank/malformed and keeping colons in the process); the linuxrc alias; and the missing-inittab error.
- shellspec: running the inittab's sysinit and wait actions, and failing on a missing inittab.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (706 examples, 0 failures); `golangci-lint` clean; registry/README in sync (now 309 commands).

Closes #250