### PR TITLE
feat(runit): add envdir applet to run a program with env from a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 309 commands. Run `mimixbox --list` to see them on the terminal.
+There are 310 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -87,6 +87,7 @@ There are 309 commands. Run `mimixbox --list` to see them on the terminal.
 | egrep | Search with extended regular expressions (grep -E) |
 | eject | Eject removable media |
 | env | Run a program in a modified environment / print the environment |
+| envdir | Run a program with env from a directory |
 | expand | Convert TAB to N space (default:N=8) |
 | expr | Evaluate expressions |
 | factor | Print the prime factors of each NUMBER |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -122,6 +122,7 @@ import (
 	ap_procps_top "github.com/nao1215/mimixbox/internal/applets/procps/top"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_procps_vmstat "github.com/nao1215/mimixbox/internal/applets/procps/vmstat"
+	ap_runit_envdir "github.com/nao1215/mimixbox/internal/applets/runit/envdir"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
 	ap_securityutils_pwscore "github.com/nao1215/mimixbox/internal/applets/securityutils/pwscore"
@@ -295,7 +296,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 309)
+	Applets = make(map[string]Applet, 310)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -430,6 +431,7 @@ func init() {
 	register(ap_procps_top.New())
 	register(ap_procps_uptime.New())
 	register(ap_procps_vmstat.New())
+	register(ap_runit_envdir.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())
 	register(ap_securityutils_pwscore.New())

--- a/internal/applets/runit/envdir/envdir.go
+++ b/internal/applets/runit/envdir/envdir.go
@@ -1,0 +1,120 @@
+// Package envdir implements the envdir applet: run a program with environment
+// variables set from the files of a directory.
+package envdir
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the envdir applet.
+type Command struct{}
+
+// New returns an envdir command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "envdir" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program with env from a directory" }
+
+// Run executes envdir.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DIR PROG [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Run PROG with the environment modified by the files in DIR: each file sets the " +
+			"variable named after it to its first line (with trailing whitespace removed), and an " +
+			"empty file removes that variable. This is the daemontools/runit envdir.",
+		Examples: []command.Example{
+			{Command: "envdir ./env printenv FOO", Explain: "Run printenv with FOO from ./env/FOO."},
+		},
+		ExitStatus: "PROG's exit status, or 1 on a usage or directory error.",
+	})
+	// Stop at the first operand so PROG's own flags are not parsed by envdir.
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return command.Failuref("a directory and a program are required")
+	}
+	dir, prog, progArgs := rest[0], rest[1], rest[2:]
+
+	env, err := applyDir(os.Environ(), dir)
+	if err != nil {
+		return command.Failuref("%s: %v", dir, err)
+	}
+
+	cmd := exec.Command(prog, progArgs...) //nolint:gosec // running the user's program is the point
+	cmd.Env = env
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// applyDir returns env with the variables from dir's files applied.
+func applyDir(env []string, dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	vars := toMap(env)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(dir + "/" + e.Name()) //nolint:gosec // env directory file
+		if err != nil {
+			return nil, err
+		}
+		value := strings.TrimRight(firstLine(string(data)), " \t")
+		if value == "" && len(data) == 0 {
+			delete(vars, e.Name()) // an empty file removes the variable
+			continue
+		}
+		vars[e.Name()] = value
+	}
+	return fromMap(vars), nil
+}
+
+// firstLine returns the content up to the first newline.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func toMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+func fromMap(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, k+"="+v)
+	}
+	return out
+}

--- a/internal/applets/runit/envdir/envdir_test.go
+++ b/internal/applets/runit/envdir/envdir_test.go
@@ -1,0 +1,86 @@
+package envdir
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func envDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestSetsEnvForProgram(t *testing.T) {
+	dir := envDir(t, map[string]string{"FOO": "bar\n", "MULTI": "first\nsecond\n"})
+	out, err := run(t, dir, "sh", "-c", `printf '%s|%s' "$FOO" "$MULTI"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "bar|first" {
+		t.Errorf("env = %q, want bar|first", out)
+	}
+}
+
+func TestEmptyFileRemovesVar(t *testing.T) {
+	dir := envDir(t, map[string]string{"REMOVED": ""})
+	t.Setenv("REMOVED", "present")
+	out, err := run(t, dir, "sh", "-c", `printf '[%s]' "$REMOVED"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "[]" {
+		t.Errorf("empty file should remove the var, got %q", out)
+	}
+}
+
+func TestTrailingWhitespaceTrimmed(t *testing.T) {
+	dir := envDir(t, map[string]string{"V": "value   \t\n"})
+	got, _ := applyDir([]string{}, dir)
+	found := ""
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "V=") {
+			found = kv
+		}
+	}
+	if found != "V=value" {
+		t.Errorf("trailing whitespace not trimmed: %q", found)
+	}
+}
+
+func TestExitCodePropagates(t *testing.T) {
+	dir := envDir(t, map[string]string{"X": "1"})
+	_, err := run(t, dir, "sh", "-c", "exit 4")
+	ee, ok := err.(*command.ExitError)
+	if !ok || ee.Code != 4 {
+		t.Errorf("err = %v, want exit 4", err)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	if _, err := run(t, "/only-one-arg"); err == nil {
+		t.Errorf("too few args should fail")
+	}
+	if _, err := run(t, "/no/such/dir", "true"); err == nil {
+		t.Errorf("a missing directory should fail")
+	}
+}

--- a/test/it/runit/envdir_test.sh
+++ b/test/it/runit/envdir_test.sh
@@ -1,0 +1,6 @@
+TestEnvdir() {
+    mkdir -p "$TEST_DIR/env"
+    printf 'hello\n' > "$TEST_DIR/env/GREETING"
+    envdir "$TEST_DIR/env" sh -c 'echo "$GREETING"'
+}
+TestEnvdirNoArgs() { envdir /only 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/envdir_spec.sh
+++ b/test/it/spec/envdir_spec.sh
@@ -1,0 +1,19 @@
+Describe 'envdir'
+    Include runit/envdir_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/envdir; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'sets a variable from a directory file'
+        When call TestEnvdir
+        The output should equal 'hello'
+        The status should be success
+    End
+    It 'requires a directory and a program'
+        When call TestEnvdirNoArgs
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Starts the runit batch (#251) with `envdir`, the daemontools/runit environment wrapper the issue calls out first. It runs PROG with the environment modified by the files in DIR: each file sets the variable named after it to its first line (with trailing spaces/tabs removed), and an empty file removes that variable. PROG's own flags are passed through (parsing stops at the first operand), and PROG's exit status is propagated.

## Tests

- Unit (temp env dirs + real child processes): setting a variable (first line only) for the program, an empty file removing a preset variable, trailing-whitespace trimming, exit-code propagation, and the too-few-args / missing-directory errors.
- shellspec: setting a variable from a directory file, and requiring a directory and a program.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (708 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `envdir` command to run programs with environment variables sourced from files in a specified directory.

* **Tests**
  * Added unit and integration test coverage for envdir functionality.

* **Documentation**
  * Updated command documentation to reflect envdir addition (310 total commands, up from 309).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->