### PR TITLE
fix(envdir): honor the context and skip '=' filenames

### DIFF
--- a/internal/applets/runit/envdir/envdir.go
+++ b/internal/applets/runit/envdir/envdir.go
@@ -25,7 +25,7 @@ func (c *Command) Name() string { return "envdir" }
 func (c *Command) Synopsis() string { return "Run a program with env from a directory" }
 
 // Run executes envdir.
-func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
 	fs := command.NewFlagSet(c.Name(), "DIR PROG [ARG...]", stdio.Err).WithHelp(command.Help{
 		Description: "Run PROG with the environment modified by the files in DIR: each file sets the " +
 			"variable named after it to its first line (with trailing whitespace removed), and an " +
@@ -54,7 +54,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.Failuref("%s: %v", dir, err)
 	}
 
-	cmd := exec.Command(prog, progArgs...) //nolint:gosec // running the user's program is the point
+	cmd := exec.CommandContext(ctx, prog, progArgs...) //nolint:gosec // running the user's program is the point
 	cmd.Env = env
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
 	if err := cmd.Run(); err != nil {
@@ -76,8 +76,8 @@ func applyDir(env []string, dir string) ([]string, error) {
 
 	vars := toMap(env)
 	for _, e := range entries {
-		if e.IsDir() {
-			continue
+		if e.IsDir() || strings.ContainsRune(e.Name(), '=') {
+			continue // env keys cannot contain '=' (daemontools skips such files)
 		}
 		data, err := os.ReadFile(dir + "/" + e.Name()) //nolint:gosec // env directory file
 		if err != nil {

--- a/internal/applets/runit/envdir/envdir_test.go
+++ b/internal/applets/runit/envdir/envdir_test.go
@@ -84,3 +84,26 @@ func TestErrors(t *testing.T) {
 		t.Errorf("a missing directory should fail")
 	}
 }
+
+func TestSkipsFilenamesWithEquals(t *testing.T) {
+	dir := envDir(t, map[string]string{"A=B": "content", "OK": "value"})
+	got, err := applyDir([]string{}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "A=") {
+			t.Errorf("a filename containing '=' must be skipped, got %q", kv)
+		}
+	}
+	// The well-formed file is still applied.
+	var hasOK bool
+	for _, kv := range got {
+		if kv == "OK=value" {
+			hasOK = true
+		}
+	}
+	if !hasOK {
+		t.Errorf("the valid file should still be applied: %v", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #434 addressing CodeRabbit findings:

- **Honor the context (Major).** Run now uses exec.CommandContext so caller cancellation/timeouts stop the spawned program, instead of discarding the context.
- **Skip '=' filenames (Minor/Major).** A file whose name contains '=' cannot round-trip into a KEY=VALUE env entry (the first '=' is the delimiter), so applyDir now skips such files, matching daemontools envdir. Adds a test that an 'A=B' file is skipped while a well-formed file is still applied.

Part of #251