### PR TITLE
feat(runit): add setuidgid applet to run a program as a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 310 commands. Run `mimixbox --list` to see them on the terminal.
+There are 311 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -248,6 +248,7 @@ There are 310 commands. Run `mimixbox --list` to see them on the terminal.
 | setarch | Run a program with a changed architecture personality |
 | setpriv | Run a program with different privilege settings |
 | setsid | Run a program in a new session |
+| setuidgid | Run a program as a user's uid/gid |
 | sh | Command interpreter (MimixBox mbsh compatibility front-end) |
 | sha1sum | Calculate or Check secure hash 1 algorithm |
 | sha256sum | Calculate or Check secure hash 256 algorithm |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -123,6 +123,7 @@ import (
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_procps_vmstat "github.com/nao1215/mimixbox/internal/applets/procps/vmstat"
 	ap_runit_envdir "github.com/nao1215/mimixbox/internal/applets/runit/envdir"
+	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
 	ap_securityutils_pwscore "github.com/nao1215/mimixbox/internal/applets/securityutils/pwscore"
@@ -296,7 +297,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 310)
+	Applets = make(map[string]Applet, 311)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -432,6 +433,7 @@ func init() {
 	register(ap_procps_uptime.New())
 	register(ap_procps_vmstat.New())
 	register(ap_runit_envdir.New())
+	register(ap_runit_setuidgid.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())
 	register(ap_securityutils_pwscore.New())

--- a/internal/applets/runit/setuidgid/setuidgid.go
+++ b/internal/applets/runit/setuidgid/setuidgid.go
@@ -1,0 +1,99 @@
+// Package setuidgid implements the setuidgid applet: run a program as the uid
+// and gid of a given account.
+package setuidgid
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the setuidgid applet.
+type Command struct{}
+
+// New returns a setuidgid command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "setuidgid" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program as a user's uid/gid" }
+
+// Injected so the password database and the privileged exec are testable.
+var (
+	passwdPath = "/etc/passwd"
+	runFn      = func(ctx context.Context, stdio command.IO, uid, gid int, prog string, args []string) error {
+		cmd := exec.CommandContext(ctx, prog, args...) //nolint:gosec // running the user's program is the point
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)},
+		}
+		return cmd.Run()
+	}
+)
+
+// Run executes setuidgid.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "USER PROG [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Set the real and effective uid and gid to those of USER (and the supplementary " +
+			"group list to that user's primary group), then run PROG with its arguments. This is the " +
+			"daemontools/runit setuidgid; dropping privilege requires running as root.",
+		Examples: []command.Example{
+			{Command: "setuidgid nobody mydaemon", Explain: "Run mydaemon as the nobody account."},
+		},
+		ExitStatus: "PROG's exit status, or 1 on a usage error or unknown user.",
+	})
+	// Stop at the first operand so PROG's own flags are not parsed by setuidgid.
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return command.Failuref("a user and a program are required")
+	}
+	uid, gid, err := resolve(rest[0])
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	if err := runFn(ctx, stdio, uid, gid, rest[1], rest[2:]); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// resolve returns the uid and gid of the named account from the passwd database.
+func resolve(name string) (uid, gid int, err error) {
+	data, err := os.ReadFile(passwdPath) //nolint:gosec // well-known passwd path
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		f := strings.Split(line, ":")
+		if len(f) < 4 || f[0] != name {
+			continue
+		}
+		u, err1 := strconv.Atoi(f[2])
+		g, err2 := strconv.Atoi(f[3])
+		if err1 != nil || err2 != nil {
+			return 0, 0, errors.New("user " + name + " has an invalid uid/gid")
+		}
+		return u, g, nil
+	}
+	return 0, 0, errors.New("unknown user: " + name)
+}

--- a/internal/applets/runit/setuidgid/setuidgid_test.go
+++ b/internal/applets/runit/setuidgid/setuidgid_test.go
@@ -1,0 +1,69 @@
+package setuidgid
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type runCall struct {
+	uid, gid int
+	prog     string
+	args     []string
+}
+
+func setup(t *testing.T) *runCall {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "passwd")
+	content := "root:x:0:0:root:/root:/bin/sh\nnobody:x:65534:65534:nobody:/:/usr/sbin/nologin\n"
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	call := &runCall{uid: -1}
+	op, orf := passwdPath, runFn
+	passwdPath = p
+	runFn = func(_ context.Context, _ command.IO, uid, gid int, prog string, args []string) error {
+		*call = runCall{uid, gid, prog, args}
+		return nil
+	}
+	t.Cleanup(func() { passwdPath, runFn = op, orf })
+	return call
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestRunsAsUser(t *testing.T) {
+	call := setup(t)
+	if err := run(t, "nobody", "mydaemon", "--flag", "arg"); err != nil {
+		t.Fatal(err)
+	}
+	if call.uid != 65534 || call.gid != 65534 {
+		t.Errorf("uid/gid = %d/%d, want 65534/65534", call.uid, call.gid)
+	}
+	if call.prog != "mydaemon" || len(call.args) != 2 || call.args[0] != "--flag" {
+		t.Errorf("prog/args = %q %v", call.prog, call.args)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	setup(t)
+	if err := run(t, "nobody"); err == nil {
+		t.Errorf("missing program should fail")
+	}
+	if err := run(t, "ghost", "prog"); err == nil {
+		t.Errorf("an unknown user should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("no args should fail")
+	}
+}

--- a/test/it/runit/setuidgid_test.sh
+++ b/test/it/runit/setuidgid_test.sh
@@ -1,0 +1,4 @@
+# Dropping to another user's uid/gid needs privilege; the e2e exercises the
+# deterministic unknown-user and arg-count paths. The dispatch is unit-tested.
+TestSetuidgidUnknown() { setuidgid nonexistent_user_xyz true 2>/dev/null; echo "rc=$?"; }
+TestSetuidgidNoProg() { setuidgid root 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/setuidgid_spec.sh
+++ b/test/it/spec/setuidgid_spec.sh
@@ -1,0 +1,14 @@
+Describe 'setuidgid'
+    Include runit/setuidgid_test.sh
+
+    It 'fails for an unknown user'
+        When call TestSetuidgidUnknown
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'requires a program'
+        When call TestSetuidgidNoProg
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `setuidgid`, which sets the real and effective uid/gid to those of USER (resolved from /etc/passwd) and then runs PROG with its arguments — the daemontools/runit privilege-dropping wrapper. PROG's own flags are passed through (parsing stops at the first operand) and its exit status is propagated; dropping privilege requires running as root. The passwd path and the privileged exec are injectable so the resolution and dispatch are tested without root.

## Tests

- Unit (fixture passwd + stubbed exec): running as the resolved uid/gid with the program and its args passed through, and the missing-program / unknown-user / no-argument errors.
- shellspec: an unknown user fails, and a missing program fails (dropping privilege needs root, so the dispatch is unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (710 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251