### PR TITLE
feat(runit): add envuidgid applet to export a user's uid/gid

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 311 commands. Run `mimixbox --list` to see them on the terminal.
+There are 312 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -88,6 +88,7 @@ There are 311 commands. Run `mimixbox --list` to see them on the terminal.
 | eject | Eject removable media |
 | env | Run a program in a modified environment / print the environment |
 | envdir | Run a program with env from a directory |
+| envuidgid | Run a program with $UID/$GID from a user |
 | expand | Convert TAB to N space (default:N=8) |
 | expr | Evaluate expressions |
 | factor | Print the prime factors of each NUMBER |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -123,6 +123,7 @@ import (
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_procps_vmstat "github.com/nao1215/mimixbox/internal/applets/procps/vmstat"
 	ap_runit_envdir "github.com/nao1215/mimixbox/internal/applets/runit/envdir"
+	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
@@ -297,7 +298,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 311)
+	Applets = make(map[string]Applet, 312)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -433,6 +434,7 @@ func init() {
 	register(ap_procps_uptime.New())
 	register(ap_procps_vmstat.New())
 	register(ap_runit_envdir.New())
+	register(ap_runit_envuidgid.New())
 	register(ap_runit_setuidgid.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())

--- a/internal/applets/runit/envuidgid/envuidgid.go
+++ b/internal/applets/runit/envuidgid/envuidgid.go
@@ -1,0 +1,91 @@
+// Package envuidgid implements the envuidgid applet: run a program with $UID and
+// $GID set from a given account, without changing privilege.
+package envuidgid
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the envuidgid applet.
+type Command struct{}
+
+// New returns an envuidgid command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "envuidgid" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program with $UID/$GID from a user" }
+
+// passwdPath is the password database; tests point it at a fixture.
+var passwdPath = "/etc/passwd"
+
+// Run executes envuidgid.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "USER PROG [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Set the environment variables $UID and $GID to the numeric uid and gid of USER " +
+			"(from /etc/passwd), then run PROG with its arguments. Unlike setuidgid it does not change " +
+			"privilege; it only exports the ids, as the daemontools/runit envuidgid does.",
+		Examples: []command.Example{
+			{Command: "envuidgid nobody printenv UID GID", Explain: "Run printenv with nobody's ids."},
+		},
+		ExitStatus: "PROG's exit status, or 1 on a usage error or unknown user.",
+	})
+	// Stop at the first operand so PROG's own flags are not parsed by envuidgid.
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return command.Failuref("a user and a program are required")
+	}
+	uid, gid, err := resolve(rest[0])
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	cmd := exec.CommandContext(ctx, rest[1], rest[2:]...) //nolint:gosec // running the user's program is the point
+	cmd.Env = append(os.Environ(), "UID="+strconv.Itoa(uid), "GID="+strconv.Itoa(gid))
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// resolve returns the uid and gid of the named account.
+func resolve(name string) (uid, gid int, err error) {
+	data, err := os.ReadFile(passwdPath) //nolint:gosec // well-known passwd path
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		f := strings.Split(line, ":")
+		if len(f) < 4 || f[0] != name {
+			continue
+		}
+		u, err1 := strconv.Atoi(f[2])
+		g, err2 := strconv.Atoi(f[3])
+		if err1 != nil || err2 != nil {
+			return 0, 0, errors.New("user " + name + " has an invalid uid/gid")
+		}
+		return u, g, nil
+	}
+	return 0, 0, errors.New("unknown user: " + name)
+}

--- a/internal/applets/runit/envuidgid/envuidgid_test.go
+++ b/internal/applets/runit/envuidgid/envuidgid_test.go
@@ -1,0 +1,63 @@
+package envuidgid
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func fixture(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "passwd")
+	content := "root:x:0:0:root:/root:/bin/sh\nnobody:x:65534:65533:nobody:/:/usr/sbin/nologin\n"
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := passwdPath
+	passwdPath = p
+	t.Cleanup(func() { passwdPath = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestSetsUIDGID(t *testing.T) {
+	fixture(t)
+	out, err := run(t, "nobody", "sh", "-c", `printf '%s:%s' "$UID" "$GID"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "65534:65533" {
+		t.Errorf("UID:GID = %q, want 65534:65533", out)
+	}
+}
+
+func TestExitCodePropagates(t *testing.T) {
+	fixture(t)
+	_, err := run(t, "root", "sh", "-c", "exit 7")
+	ee, ok := err.(*command.ExitError)
+	if !ok || ee.Code != 7 {
+		t.Errorf("err = %v, want exit 7", err)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	fixture(t)
+	if _, err := run(t, "root"); err == nil {
+		t.Errorf("missing program should fail")
+	}
+	if _, err := run(t, "ghost", "true"); err == nil {
+		t.Errorf("an unknown user should fail")
+	}
+}

--- a/test/it/runit/envuidgid_test.sh
+++ b/test/it/runit/envuidgid_test.sh
@@ -1,0 +1,3 @@
+# envuidgid sets $UID/$GID from /etc/passwd; root is always present (0:0).
+TestEnvuidgidRoot() { envuidgid root sh -c 'echo "$UID:$GID"'; }
+TestEnvuidgidUnknown() { envuidgid nonexistent_xyz true 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/envuidgid_spec.sh
+++ b/test/it/spec/envuidgid_spec.sh
@@ -1,0 +1,14 @@
+Describe 'envuidgid'
+    Include runit/envuidgid_test.sh
+
+    It 'exports root uid and gid'
+        When call TestEnvuidgidRoot
+        The output should equal '0:0'
+        The status should be success
+    End
+    It 'fails for an unknown user'
+        When call TestEnvuidgidUnknown
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `envuidgid`, which sets the environment variables $UID and $GID to the numeric uid/gid of USER (from /etc/passwd) and then runs PROG with its arguments. Unlike setuidgid it does not change privilege — it only exports the ids, as the daemontools/runit envuidgid does. PROG's flags are passed through and its exit status is propagated. The passwd path is injectable.

## Tests

- Unit (fixture passwd + real child process): exporting $UID/$GID to the program, exit-code propagation, and the missing-program / unknown-user errors.
- shellspec: exporting root's uid/gid (0:0), and failing for an unknown user.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (712 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251