### PR TITLE
feat(runit): add softlimit applet to run a program under resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 312 commands. Run `mimixbox --list` to see them on the terminal.
+There are 313 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -261,6 +261,7 @@ There are 312 commands. Run `mimixbox --list` to see them on the terminal.
 | sl | Cure your bad habit of mistyping |
 | sleep | Pause for NUMBER seconds(minutes, hours, days) |
 | smemcap | Capture /proc memory data into a tar for smem |
+| softlimit | Run a program under resource limits |
 | sort | Sort lines of text files |
 | speaker | Read text aloud using an installed TTS engine |
 | split | Split a file into pieces |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -125,6 +125,7 @@ import (
 	ap_runit_envdir "github.com/nao1215/mimixbox/internal/applets/runit/envdir"
 	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
+	ap_runit_softlimit "github.com/nao1215/mimixbox/internal/applets/runit/softlimit"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
 	ap_securityutils_pwscore "github.com/nao1215/mimixbox/internal/applets/securityutils/pwscore"
@@ -298,7 +299,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 312)
+	Applets = make(map[string]Applet, 313)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -436,6 +437,7 @@ func init() {
 	register(ap_runit_envdir.New())
 	register(ap_runit_envuidgid.New())
 	register(ap_runit_setuidgid.New())
+	register(ap_runit_softlimit.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())
 	register(ap_securityutils_pwscore.New())

--- a/internal/applets/runit/softlimit/softlimit.go
+++ b/internal/applets/runit/softlimit/softlimit.go
@@ -1,0 +1,96 @@
+// Package softlimit implements the softlimit applet: run a program under a set
+// of resource limits.
+package softlimit
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the softlimit applet.
+type Command struct{}
+
+// New returns a softlimit command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "softlimit" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program under resource limits" }
+
+// setRlimitFn is indirected so the limit changes can be tested without altering
+// the test process. It sets both the soft and hard limit to value.
+var setRlimitFn = func(resource int, value uint64) error {
+	return unix.Setrlimit(resource, &unix.Rlimit{Cur: value, Max: value})
+}
+
+// limitFlag binds a command-line flag to an rlimit resource.
+type limitFlag struct {
+	short    string
+	resource int
+	help     string
+}
+
+var limitFlags = []limitFlag{
+	{"m", unix.RLIMIT_AS, "limit total address space to BYTES"},
+	{"d", unix.RLIMIT_DATA, "limit the data segment to BYTES"},
+	{"s", unix.RLIMIT_STACK, "limit the stack to BYTES"},
+	{"o", unix.RLIMIT_NOFILE, "limit open file descriptors to N"},
+	{"p", unix.RLIMIT_NPROC, "limit processes to N"},
+	{"f", unix.RLIMIT_FSIZE, "limit created file size to BYTES"},
+	{"c", unix.RLIMIT_CORE, "limit core dump size to BYTES"},
+	{"t", unix.RLIMIT_CPU, "limit CPU time to SECONDS"},
+}
+
+// Run executes softlimit.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-m BYTES] [-o N] [...] PROG [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Set resource limits, then run PROG with its arguments under them: -m total " +
+			"address space, -d data segment, -s stack, -f file size, -c core size (bytes); -o open " +
+			"files, -p processes (counts); -t CPU seconds. Each flag sets the soft (and hard) limit. " +
+			"This is the daemontools/runit softlimit.",
+		Examples: []command.Example{
+			{Command: "softlimit -m 100000000 -o 64 mydaemon", Explain: "Cap memory and open files."},
+		},
+		ExitStatus: "PROG's exit status, or 1 on a usage error or a limit that could not be set.",
+	})
+	values := make(map[int]*int64, len(limitFlags))
+	for _, lf := range limitFlags {
+		values[lf.resource] = fs.Int64P("limit-"+lf.short, lf.short, -1, lf.help)
+	}
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a program is required")
+	}
+
+	for _, lf := range limitFlags {
+		if v := *values[lf.resource]; v >= 0 {
+			if err := setRlimitFn(lf.resource, uint64(v)); err != nil {
+				return command.Failuref("cannot set -%s limit: %v", lf.short, err)
+			}
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, rest[0], rest[1:]...) //nolint:gosec // running the user's program is the point
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}

--- a/internal/applets/runit/softlimit/softlimit_test.go
+++ b/internal/applets/runit/softlimit/softlimit_test.go
@@ -1,0 +1,73 @@
+package softlimit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+func stub(t *testing.T, failResource int) map[int]uint64 {
+	t.Helper()
+	set := map[int]uint64{}
+	orig := setRlimitFn
+	setRlimitFn = func(resource int, value uint64) error {
+		if resource == failResource {
+			return errors.New("cannot set limit")
+		}
+		set[resource] = value
+		return nil
+	}
+	t.Cleanup(func() { setRlimitFn = orig })
+	return set
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSetsLimits(t *testing.T) {
+	set := stub(t, -1)
+	if err := run(t, "-m", "100000000", "-o", "64", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if set[unix.RLIMIT_AS] != 100000000 {
+		t.Errorf("RLIMIT_AS = %d, want 100000000", set[unix.RLIMIT_AS])
+	}
+	if set[unix.RLIMIT_NOFILE] != 64 {
+		t.Errorf("RLIMIT_NOFILE = %d, want 64", set[unix.RLIMIT_NOFILE])
+	}
+	// Unset flags must not set a limit.
+	if _, ok := set[unix.RLIMIT_CPU]; ok {
+		t.Errorf("RLIMIT_CPU should not be set")
+	}
+}
+
+func TestExitCodePropagates(t *testing.T) {
+	stub(t, -1)
+	err := run(t, "-o", "10", "sh", "-c", "exit 5")
+	ee, ok := err.(*command.ExitError)
+	if !ok || ee.Code != 5 {
+		t.Errorf("err = %v, want exit 5", err)
+	}
+}
+
+func TestNoProgram(t *testing.T) {
+	stub(t, -1)
+	if err := run(t, "-o", "10"); err == nil {
+		t.Errorf("a missing program should fail")
+	}
+}
+
+func TestSetLimitFailure(t *testing.T) {
+	stub(t, unix.RLIMIT_NOFILE)
+	if err := run(t, "-o", "10", "true"); err == nil {
+		t.Errorf("a failed setrlimit should fail")
+	}
+}

--- a/test/it/runit/softlimit_test.sh
+++ b/test/it/runit/softlimit_test.sh
@@ -1,0 +1,4 @@
+# mbsh has no ulimit builtin, so the e2e confirms softlimit runs a program under
+# an open-file limit (exit 0); the rlimit values are checked by Go unit tests.
+TestSoftlimitRuns() { softlimit -o 64 true; echo "rc=$?"; }
+TestSoftlimitNoProg() { softlimit -o 64 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/softlimit_spec.sh
+++ b/test/it/spec/softlimit_spec.sh
@@ -1,0 +1,14 @@
+Describe 'softlimit'
+    Include runit/softlimit_test.sh
+
+    It 'runs a program under the limits'
+        When call TestSoftlimitRuns
+        The output should equal 'rc=0'
+        The status should be success
+    End
+    It 'requires a program'
+        When call TestSoftlimitNoProg
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `softlimit`, which sets resource limits and then runs PROG under them: `-m` total address space, `-d` data segment, `-s` stack, `-f` file size, `-c` core size (bytes); `-o` open files, `-p` processes (counts); `-t` CPU seconds. Each flag sets the soft (and hard) rlimit before exec, so the child inherits them — the daemontools/runit softlimit. PROG's flags are passed through and its exit status is propagated. The setrlimit call is injectable so the limit mapping is tested without altering the test process.

## Tests

- Unit (stubbed setrlimit): `-m`/`-o` mapping to RLIMIT_AS/RLIMIT_NOFILE with the right values (and unset flags setting nothing), exit-code propagation, the missing-program error, and a setrlimit-failure error.
- shellspec: running a program under an open-file limit (exit 0), and requiring a program (mbsh has no ulimit builtin, so the rlimit values are unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (714 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251