### PR TITLE
feat(runit): add chpst applet to run a program with changed process state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 313 commands. Run `mimixbox --list` to see them on the terminal.
+There are 314 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -53,6 +53,7 @@ There are 313 commands. Run `mimixbox --list` to see them on the terminal.
 | chmod | Change file mode bits |
 | chown | Change the owner and/or group of each FILE to OWNER and/or GROUP |
 | chpasswd | Update passwords in batch |
+| chpst | Run a program with a changed process state |
 | chroot | Run command or interactive shell with special root directory |
 | chrt | Get or set a process's real-time scheduling attributes |
 | cksum | Print CRC checksum and byte count of each file |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -122,6 +122,7 @@ import (
 	ap_procps_top "github.com/nao1215/mimixbox/internal/applets/procps/top"
 	ap_procps_uptime "github.com/nao1215/mimixbox/internal/applets/procps/uptime"
 	ap_procps_vmstat "github.com/nao1215/mimixbox/internal/applets/procps/vmstat"
+	ap_runit_chpst "github.com/nao1215/mimixbox/internal/applets/runit/chpst"
 	ap_runit_envdir "github.com/nao1215/mimixbox/internal/applets/runit/envdir"
 	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
@@ -299,7 +300,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 313)
+	Applets = make(map[string]Applet, 314)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -434,6 +435,7 @@ func init() {
 	register(ap_procps_top.New())
 	register(ap_procps_uptime.New())
 	register(ap_procps_vmstat.New())
+	register(ap_runit_chpst.New())
 	register(ap_runit_envdir.New())
 	register(ap_runit_envuidgid.New())
 	register(ap_runit_setuidgid.New())

--- a/internal/applets/runit/chpst/chpst.go
+++ b/internal/applets/runit/chpst/chpst.go
@@ -1,0 +1,202 @@
+// Package chpst implements the chpst applet: run a program with a changed
+// process state (uid/gid, environment directory, resource limits, niceness).
+package chpst
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the chpst applet.
+type Command struct{}
+
+// New returns a chpst command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "chpst" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a program with a changed process state" }
+
+// procSpec captures the requested process changes.
+type procSpec struct {
+	env      []string
+	uid, gid int
+	setCreds bool
+	nice     int
+	setNice  bool
+	prog     string
+	args     []string
+}
+
+// Injected so the database, the rlimits, and the privileged exec are testable.
+var (
+	passwdPath  = "/etc/passwd"
+	setRlimitFn = func(resource int, value uint64) error {
+		return unix.Setrlimit(resource, &unix.Rlimit{Cur: value, Max: value})
+	}
+	runFn = func(ctx context.Context, stdio command.IO, spec procSpec) error {
+		if spec.setNice {
+			_ = unix.Setpriority(unix.PRIO_PROCESS, 0, spec.nice)
+		}
+		cmd := exec.CommandContext(ctx, spec.prog, spec.args...) //nolint:gosec // running the user's program is the point
+		cmd.Env = spec.env
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		if spec.setCreds {
+			cmd.SysProcAttr = &syscall.SysProcAttr{
+				Credential: &syscall.Credential{Uid: uint32(spec.uid), Gid: uint32(spec.gid)},
+			}
+		}
+		return cmd.Run()
+	}
+)
+
+var limitFlags = []struct {
+	short    string
+	resource int
+}{
+	{"m", unix.RLIMIT_AS}, {"d", unix.RLIMIT_DATA}, {"o", unix.RLIMIT_NOFILE},
+	{"p", unix.RLIMIT_NPROC}, {"f", unix.RLIMIT_FSIZE}, {"c", unix.RLIMIT_CORE},
+	{"t", unix.RLIMIT_CPU},
+}
+
+// Run executes chpst.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-u USER] [-e DIR] [-n NICE] [limits] PROG [ARG...]", stdio.Err).WithHelp(command.Help{
+		Description: "Change the process state, then run PROG: -u USER sets the uid and gid (dropping " +
+			"privilege); -e DIR loads environment variables from a directory (as envdir); -n adds to " +
+			"the niceness; and -m/-d/-o/-p/-f/-c/-t set resource limits (as softlimit). This is the " +
+			"daemontools/runit chpst.",
+		Examples: []command.Example{
+			{Command: "chpst -u nobody -e ./env -o 64 mydaemon", Explain: "Drop to nobody, load env, cap files."},
+		},
+		ExitStatus: "PROG's exit status, or 1 on a usage error.",
+	})
+	userFlag := fs.StringP("user", "u", "", "set the uid/gid to this user's")
+	envDir := fs.StringP("envdir", "e", "", "load environment variables from this directory")
+	nice := fs.IntP("nice", "n", 0, "add this value to the niceness")
+	limits := map[int]*int64{}
+	for _, lf := range limitFlags {
+		limits[lf.resource] = fs.Int64P("limit-"+lf.short, lf.short, -1, "resource limit")
+	}
+	fs.SetInterspersed(false)
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a program is required")
+	}
+
+	spec := procSpec{env: os.Environ(), prog: rest[0], args: rest[1:]}
+
+	if *envDir != "" {
+		if spec.env, err = applyDir(spec.env, *envDir); err != nil {
+			return command.Failuref("%s: %v", *envDir, err)
+		}
+	}
+	if *userFlag != "" {
+		if spec.uid, spec.gid, err = resolve(*userFlag); err != nil {
+			return command.Failuref("%v", err)
+		}
+		spec.setCreds = true
+	}
+	if fs.Changed("nice") {
+		spec.nice = *nice
+		spec.setNice = true
+	}
+	for _, lf := range limitFlags {
+		if v := *limits[lf.resource]; v >= 0 {
+			if err := setRlimitFn(lf.resource, uint64(v)); err != nil {
+				return command.Failuref("cannot set -%s limit: %v", lf.short, err)
+			}
+		}
+	}
+
+	if err := runFn(ctx, stdio, spec); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return &command.ExitError{Code: ee.ExitCode()}
+		}
+		return command.Failuref("%v", err)
+	}
+	return nil
+}
+
+// applyDir returns env with the variables from dir's files applied.
+func applyDir(env []string, dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	vars := map[string]string{}
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok {
+			vars[k] = v
+		}
+	}
+	for _, e := range entries {
+		if e.IsDir() || strings.ContainsRune(e.Name(), '=') {
+			continue
+		}
+		data, err := os.ReadFile(dir + "/" + e.Name()) //nolint:gosec // env directory file
+		if err != nil {
+			return nil, err
+		}
+		line := string(data)
+		if i := strings.IndexByte(line, '\n'); i >= 0 {
+			line = line[:i]
+		}
+		value := strings.TrimRight(line, " \t")
+		if value == "" && len(data) == 0 {
+			delete(vars, e.Name())
+			continue
+		}
+		vars[e.Name()] = value
+	}
+	out := make([]string, 0, len(vars))
+	for k, v := range vars {
+		out = append(out, k+"="+v)
+	}
+	return out, nil
+}
+
+// resolve returns the uid and gid of the named user (USER or USER:GROUP form,
+// where GROUP if present overrides the gid).
+func resolve(spec string) (uid, gid int, err error) {
+	name, group, _ := strings.Cut(spec, ":")
+	data, err := os.ReadFile(passwdPath) //nolint:gosec // well-known passwd path
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		f := strings.Split(line, ":")
+		if len(f) < 4 || f[0] != name {
+			continue
+		}
+		u, err1 := strconv.Atoi(f[2])
+		g, err2 := strconv.Atoi(f[3])
+		if err1 != nil || err2 != nil {
+			return 0, 0, errors.New("user " + name + " has an invalid uid/gid")
+		}
+		if group != "" {
+			if g, err = strconv.Atoi(group); err != nil {
+				return 0, 0, errors.New("invalid group id: " + group)
+			}
+		}
+		return u, g, nil
+	}
+	return 0, 0, errors.New("unknown user: " + name)
+}

--- a/internal/applets/runit/chpst/chpst_test.go
+++ b/internal/applets/runit/chpst/chpst_test.go
@@ -1,0 +1,103 @@
+package chpst
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+func setup(t *testing.T) (*procSpec, map[int]uint64) {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "passwd")
+	if err := os.WriteFile(p, []byte("nobody:x:65534:65534:nobody:/:/bin/false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	spec := &procSpec{}
+	limits := map[int]uint64{}
+	op, osr, orf := passwdPath, setRlimitFn, runFn
+	passwdPath = p
+	setRlimitFn = func(resource int, value uint64) error { limits[resource] = value; return nil }
+	runFn = func(_ context.Context, _ command.IO, s procSpec) error { *spec = s; return nil }
+	t.Cleanup(func() { passwdPath, setRlimitFn, runFn = op, osr, orf })
+	return spec, limits
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestUserSetsCreds(t *testing.T) {
+	spec, _ := setup(t)
+	if err := run(t, "-u", "nobody", "mydaemon"); err != nil {
+		t.Fatal(err)
+	}
+	if !spec.setCreds || spec.uid != 65534 || spec.gid != 65534 {
+		t.Errorf("creds = %+v", *spec)
+	}
+	if spec.prog != "mydaemon" {
+		t.Errorf("prog = %q", spec.prog)
+	}
+}
+
+func TestUserGroupOverride(t *testing.T) {
+	spec, _ := setup(t)
+	if err := run(t, "-u", "nobody:100", "p"); err != nil {
+		t.Fatal(err)
+	}
+	if spec.uid != 65534 || spec.gid != 100 {
+		t.Errorf("uid/gid = %d/%d, want 65534/100", spec.uid, spec.gid)
+	}
+}
+
+func TestEnvdir(t *testing.T) {
+	spec, _ := setup(t)
+	d := t.TempDir()
+	_ = os.WriteFile(filepath.Join(d, "FOO"), []byte("bar\n"), 0o644)
+	if err := run(t, "-e", d, "p"); err != nil {
+		t.Fatal(err)
+	}
+	var has bool
+	for _, kv := range spec.env {
+		if kv == "FOO=bar" {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("env not loaded from -e dir")
+	}
+}
+
+func TestLimitsAndNice(t *testing.T) {
+	spec, limits := setup(t)
+	if err := run(t, "-o", "64", "-n", "5", "p"); err != nil {
+		t.Fatal(err)
+	}
+	if limits[unix.RLIMIT_NOFILE] != 64 {
+		t.Errorf("NOFILE limit = %d, want 64", limits[unix.RLIMIT_NOFILE])
+	}
+	if !spec.setNice || spec.nice != 5 {
+		t.Errorf("nice = %+v", *spec)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	setup(t)
+	if err := run(t, "-u", "nobody"); err == nil {
+		t.Errorf("missing program should fail")
+	}
+	if err := run(t, "-u", "ghost", "p"); err == nil {
+		t.Errorf("an unknown user should fail")
+	}
+	if err := run(t); err == nil {
+		t.Errorf("no args should fail")
+	}
+}

--- a/test/it/runit/chpst_test.sh
+++ b/test/it/runit/chpst_test.sh
@@ -1,0 +1,6 @@
+TestChpstEnvdir() {
+    mkdir -p "$TEST_DIR/env"
+    printf 'world\n' > "$TEST_DIR/env/HELLO"
+    chpst -e "$TEST_DIR/env" sh -c 'echo "$HELLO"'
+}
+TestChpstNoProg() { chpst -o 64 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/chpst_spec.sh
+++ b/test/it/spec/chpst_spec.sh
@@ -1,0 +1,19 @@
+Describe 'chpst'
+    Include runit/chpst_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/chpst; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'loads an environment directory'
+        When call TestChpstEnvdir
+        The output should equal 'world'
+        The status should be success
+    End
+    It 'requires a program'
+        When call TestChpstNoProg
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `chpst`, the daemontools/runit superset that combines the environment/uid/limit wrappers: `-u USER` (or USER:GROUP) sets the uid/gid (dropping privilege); `-e DIR` loads environment variables from a directory (as envdir, skipping '=' filenames); `-n` adjusts the niceness; and `-m/-d/-o/-p/-f/-c/-t` set resource limits (as softlimit). It then runs PROG with its arguments, passing PROG's flags through and propagating its exit status. The passwd path, the setrlimit call, and the privileged exec are injectable so the full composition is tested without root.

## Tests

- Unit (fixture passwd + stubbed setrlimit/exec): `-u` setting credentials, the USER:GROUP gid override, `-e` loading the env directory, `-o`/`-n` mapping to the right limit and niceness, and the missing-program / unknown-user / no-argument errors.
- shellspec: loading an environment directory, and requiring a program.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (716 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251