### PR TITLE
feat(runit): add svok applet to check if a service is supervised

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 314 commands. Run `mimixbox --list` to see them on the terminal.
+There are 315 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -273,6 +273,7 @@ There are 314 commands. Run `mimixbox --list` to see them on the terminal.
 | su | Run a shell as another user |
 | sulogin | Single-user root login |
 | sum | Checksum and count the blocks in a file (BSD) |
+| svok | Check if a service is supervised |
 | swapoff | Disable a swap area |
 | swapon | Enable a swap area or list active swaps |
 | switch_root | Switch to another root and run init |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -127,6 +127,7 @@ import (
 	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_runit_softlimit "github.com/nao1215/mimixbox/internal/applets/runit/softlimit"
+	ap_runit_svok "github.com/nao1215/mimixbox/internal/applets/runit/svok"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
 	ap_securityutils_pwscore "github.com/nao1215/mimixbox/internal/applets/securityutils/pwscore"
@@ -300,7 +301,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 314)
+	Applets = make(map[string]Applet, 315)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -440,6 +441,7 @@ func init() {
 	register(ap_runit_envuidgid.New())
 	register(ap_runit_setuidgid.New())
 	register(ap_runit_softlimit.New())
+	register(ap_runit_svok.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())
 	register(ap_securityutils_pwscore.New())

--- a/internal/applets/runit/svok/svok.go
+++ b/internal/applets/runit/svok/svok.go
@@ -1,0 +1,50 @@
+// Package svok implements the svok applet: check whether a service directory is
+// under active supervision.
+package svok
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the svok applet.
+type Command struct{}
+
+// New returns a svok command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "svok" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Check if a service is supervised" }
+
+// Run executes svok.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DIR", stdio.Err).WithHelp(command.Help{
+		Description: "Check whether the service directory DIR is under active supervision, by testing " +
+			"for its supervise/ok control file (which runsv keeps open while supervising). Exit 0 if " +
+			"the service is supervised, or 100 if it is not.",
+		Examples: []command.Example{
+			{Command: "svok /etc/service/nginx", Explain: "Succeed if nginx is supervised."},
+		},
+		ExitStatus: "0   the service is supervised.\n100 the service is not supervised.\n1   no directory was given.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a service directory is required")
+	}
+
+	if _, err := os.Stat(filepath.Join(rest[0], "supervise", "ok")); err != nil {
+		return &command.ExitError{Code: 100}
+	}
+	return nil
+}

--- a/internal/applets/runit/svok/svok_test.go
+++ b/internal/applets/runit/svok/svok_test.go
@@ -1,0 +1,45 @@
+package svok
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSupervised(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "supervise"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "supervise", "ok"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(t, dir); err != nil {
+		t.Errorf("a supervised service should succeed, got %v", err)
+	}
+}
+
+func TestNotSupervised(t *testing.T) {
+	err := run(t, t.TempDir())
+	ee, ok := err.(*command.ExitError)
+	if !ok || ee.Code != 100 {
+		t.Errorf("err = %v, want exit 100", err)
+	}
+}
+
+func TestNoDir(t *testing.T) {
+	if err := run(t); err == nil {
+		t.Errorf("a missing directory should fail")
+	}
+}

--- a/test/it/runit/svok_test.sh
+++ b/test/it/runit/svok_test.sh
@@ -1,0 +1,9 @@
+TestSvokSupervised() {
+    mkdir -p "$TEST_DIR/svc/supervise"
+    : > "$TEST_DIR/svc/supervise/ok"
+    svok "$TEST_DIR/svc"; echo "rc=$?"
+}
+TestSvokNotSupervised() {
+    mkdir -p "$TEST_DIR/down"
+    svok "$TEST_DIR/down"; echo "rc=$?"
+}

--- a/test/it/spec/svok_spec.sh
+++ b/test/it/spec/svok_spec.sh
@@ -1,0 +1,19 @@
+Describe 'svok'
+    Include runit/svok_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/svok; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'succeeds for a supervised service'
+        When call TestSvokSupervised
+        The output should equal 'rc=0'
+        The status should be success
+    End
+    It 'returns 100 for an unsupervised service'
+        When call TestSvokNotSupervised
+        The output should equal 'rc=100'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `svok`, which checks whether a service directory is under active supervision by testing for its supervise/ok control file (which runsv keeps while supervising). It exits 0 if the service is supervised, 100 if it is not, and 1 if no directory was given.

## Tests

- Unit (temp service dirs): a service with supervise/ok succeeding, a service without it exiting 100, and the missing-directory error.
- shellspec: succeeding for a supervised service and returning 100 for an unsupervised one.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (718 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251