### PR TITLE
test(whris): fix the cymru test data race

### DIFF
--- a/internal/applets/netutils/whris/whris_test.go
+++ b/internal/applets/netutils/whris/whris_test.go
@@ -108,7 +108,9 @@ func TestParseCymruNoData(t *testing.T) {
 }
 
 func TestCymruLookupAgainstLocalServer(t *testing.T) {
-	t.Parallel()
+	// Not parallel: this test mutates the shared cymruServer global, so running it
+	// alongside another cymruServer-mutating test would race and could reach the
+	// real Cymru server.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Skipf("loopback TCP/UDP listen unavailable: %v", err)
@@ -142,7 +144,7 @@ func TestCymruLookupAgainstLocalServer(t *testing.T) {
 }
 
 func TestCymruLookupDialError(t *testing.T) {
-	t.Parallel()
+	// Not parallel: mutates the shared cymruServer global (see above).
 	orig := cymruServer
 	cymruServer = "127.0.0.1:1" // closed port
 	t.Cleanup(func() { cymruServer = orig })


### PR DESCRIPTION
The intermittent `Unit test (linux)` failure on `TestCymruLookupAgainstLocalServer` was a data race, not a timing flake: two tests (`TestCymruLookupAgainstLocalServer` and `TestCymruLookupDialError`) both ran with `t.Parallel()` while mutating the shared package global `cymruServer`. When their cleanups and lookups interleaved, the local-server test could perform its lookup while `cymruServer` had been restored to the real default, so it reached the real Cymru whois and got "CLOUDFLARENET - Cloudflare, Inc., US" instead of the mock's "CLOUDFLARENET, US".

Both tests now run serially (no `t.Parallel()`), as they mutate a shared global — the same pattern already applied to the w/users utmp tests. The parse-only tests keep their parallelism. Verified race-clean across repeated `go test -race` runs.

Part of #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adjusting parallelization behavior to prevent race conditions in related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->