### PR TITLE
feat(runit): add svlogd applet to log stdin to a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 315 commands. Run `mimixbox --list` to see them on the terminal.
+There are 316 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -273,6 +273,7 @@ There are 315 commands. Run `mimixbox --list` to see them on the terminal.
 | su | Run a shell as another user |
 | sulogin | Single-user root login |
 | sum | Checksum and count the blocks in a file (BSD) |
+| svlogd | Log standard input to a directory |
 | svok | Check if a service is supervised |
 | swapoff | Disable a swap area |
 | swapon | Enable a swap area or list active swaps |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -127,6 +127,7 @@ import (
 	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_runit_softlimit "github.com/nao1215/mimixbox/internal/applets/runit/softlimit"
+	ap_runit_svlogd "github.com/nao1215/mimixbox/internal/applets/runit/svlogd"
 	ap_runit_svok "github.com/nao1215/mimixbox/internal/applets/runit/svok"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
 	ap_securityutils_pwgen "github.com/nao1215/mimixbox/internal/applets/securityutils/pwgen"
@@ -301,7 +302,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 315)
+	Applets = make(map[string]Applet, 316)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -441,6 +442,7 @@ func init() {
 	register(ap_runit_envuidgid.New())
 	register(ap_runit_setuidgid.New())
 	register(ap_runit_softlimit.New())
+	register(ap_runit_svlogd.New())
 	register(ap_runit_svok.New())
 	register(ap_securityutils_pwcrack.New())
 	register(ap_securityutils_pwgen.New())

--- a/internal/applets/runit/svlogd/svlogd.go
+++ b/internal/applets/runit/svlogd/svlogd.go
@@ -1,0 +1,135 @@
+// Package svlogd implements the svlogd applet: read standard input and append it
+// to a log directory's current file, rotating it by size.
+package svlogd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the svlogd applet.
+type Command struct{}
+
+// New returns a svlogd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "svlogd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Log standard input to a directory" }
+
+// Injected so the rotation size and the rotated-file timestamp are testable.
+var (
+	maxSize int64 = 1000000 // rotate the current file when it reaches this many bytes
+	now           = time.Now
+)
+
+// Run executes svlogd.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-t] DIR", stdio.Err).WithHelp(command.Help{
+		Description: "Read standard input line by line and append each line to DIR/current, rotating " +
+			"that file to a timestamped name once it grows past the size limit. With -t each line is " +
+			"prefixed with the current time. This is a single-directory subset of the runit svlogd.",
+		Examples: []command.Example{
+			{Command: "mydaemon | svlogd /var/log/mydaemon", Explain: "Log a program's output."},
+		},
+		ExitStatus: "0  standard input reached EOF.\n1  no directory was given or the log was unwritable.",
+	})
+	timestamp := fs.BoolP("timestamp", "t", false, "prefix each line with a timestamp")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a log directory is required")
+	}
+	dir := rest[0]
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return command.Failuref("cannot create %s: %v", dir, err)
+	}
+
+	w, err := newWriter(dir)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	defer func() { _ = w.close() }()
+
+	sc := bufio.NewScanner(stdio.In)
+	for sc.Scan() {
+		line := sc.Text()
+		if *timestamp {
+			line = now().UTC().Format("2006-01-02_15:04:05.000000000") + " " + line
+		}
+		if err := w.write(line + "\n"); err != nil {
+			return command.Failuref("cannot write the log: %v", err)
+		}
+	}
+	return sc.Err()
+}
+
+// writer appends to DIR/current and rotates it by size.
+type writer struct {
+	dir     string
+	current string
+	f       *os.File
+	size    int64
+}
+
+func newWriter(dir string) (*writer, error) {
+	current := filepath.Join(dir, "current")
+	f, err := os.OpenFile(current, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) //nolint:gosec // log file
+	if err != nil {
+		return nil, err
+	}
+	info, _ := f.Stat()
+	return &writer{dir: dir, current: current, f: f, size: sizeOf(info)}, nil
+}
+
+func (w *writer) write(s string) error {
+	if w.size+int64(len(s)) > maxSize && w.size > 0 {
+		if err := w.rotate(); err != nil {
+			return err
+		}
+	}
+	n, err := w.f.WriteString(s)
+	w.size += int64(n)
+	return err
+}
+
+// rotate closes the current file, renames it to a timestamped name, and opens a
+// fresh current file.
+func (w *writer) rotate() error {
+	if err := w.f.Close(); err != nil {
+		return err
+	}
+	rotated := filepath.Join(w.dir, fmt.Sprintf("@%d.s", now().UnixNano()))
+	if err := os.Rename(w.current, rotated); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(w.current, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) //nolint:gosec // log file
+	if err != nil {
+		return err
+	}
+	w.f = f
+	w.size = 0
+	return nil
+}
+
+func (w *writer) close() error { return w.f.Close() }
+
+func sizeOf(info os.FileInfo) int64 {
+	if info == nil {
+		return 0
+	}
+	return info.Size()
+}

--- a/internal/applets/runit/svlogd/svlogd_test.go
+++ b/internal/applets/runit/svlogd/svlogd_test.go
@@ -1,0 +1,85 @@
+package svlogd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(stdin), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestLogsToCurrent(t *testing.T) {
+	dir := t.TempDir()
+	if err := run(t, "line one\nline two\n", dir); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "current"))
+	if string(data) != "line one\nline two\n" {
+		t.Errorf("current = %q", data)
+	}
+}
+
+func TestTimestampPrefix(t *testing.T) {
+	on := now
+	now = func() time.Time { return time.Unix(1000, 0) }
+	defer func() { now = on }()
+	dir := t.TempDir()
+	if err := run(t, "msg\n", "-t", dir); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "current"))
+	if !strings.HasSuffix(string(data), " msg\n") || len(data) < len("msg\n")+10 {
+		t.Errorf("timestamped line = %q", data)
+	}
+}
+
+func TestRotation(t *testing.T) {
+	om, on := maxSize, now
+	maxSize = 12 // rotate after a few bytes
+	tick := int64(0)
+	now = func() time.Time { tick++; return time.Unix(tick, 0) }
+	defer func() { maxSize, now = om, on }()
+
+	dir := t.TempDir()
+	if err := run(t, "aaaa\nbbbb\ncccc\ndddd\n", dir); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(dir)
+	var rotated int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "@") {
+			rotated++
+		}
+	}
+	if rotated == 0 {
+		t.Errorf("expected at least one rotated file, got entries %v", names(entries))
+	}
+	// current must still exist and hold the most recent line(s).
+	if _, err := os.Stat(filepath.Join(dir, "current")); err != nil {
+		t.Errorf("current missing after rotation: %v", err)
+	}
+}
+
+func names(entries []os.DirEntry) []string {
+	var out []string
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+func TestNoDir(t *testing.T) {
+	if err := run(t, "x\n"); err == nil {
+		t.Errorf("a missing directory should fail")
+	}
+}

--- a/test/it/runit/svlogd_test.sh
+++ b/test/it/runit/svlogd_test.sh
@@ -1,0 +1,5 @@
+TestSvlogd() {
+    printf 'hello\nworld\n' | svlogd "$TEST_DIR/log"
+    cat "$TEST_DIR/log/current"
+}
+TestSvlogdNoDir() { echo x | svlogd 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/svlogd_spec.sh
+++ b/test/it/spec/svlogd_spec.sh
@@ -1,0 +1,20 @@
+Describe 'svlogd'
+    Include runit/svlogd_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/svlogd; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'appends stdin to the current log'
+        When call TestSvlogd
+        The line 1 of output should equal 'hello'
+        The line 2 of output should equal 'world'
+        The status should be success
+    End
+    It 'requires a directory'
+        When call TestSvlogdNoDir
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `svlogd`, which reads standard input line by line and appends each line to DIR/current, rotating that file to a timestamped name (`@<nanos>.s`) once it grows past a size limit. With `-t` each line is prefixed with the current time. This is a single-directory subset of the runit svlogd. The rotation size and the timestamp clock are injectable so the logging and rotation are tested deterministically.

## Tests

- Unit (temp log dirs): appending stdin lines to current, the `-t` timestamp prefix, size-based rotation producing a rotated `@` file while keeping a fresh current, and the missing-directory error.
- shellspec: appending stdin to the current log, and requiring a directory.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (720 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251