### PR TITLE
feat(runit): add sv applet to control or query a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 316 commands. Run `mimixbox --list` to see them on the terminal.
+There are 317 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -273,6 +273,7 @@ There are 316 commands. Run `mimixbox --list` to see them on the terminal.
 | su | Run a shell as another user |
 | sulogin | Single-user root login |
 | sum | Checksum and count the blocks in a file (BSD) |
+| sv | Control or query a runit service |
 | svlogd | Log standard input to a directory |
 | svok | Check if a service is supervised |
 | swapoff | Disable a swap area |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -127,6 +127,7 @@ import (
 	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_runit_softlimit "github.com/nao1215/mimixbox/internal/applets/runit/softlimit"
+	ap_runit_sv "github.com/nao1215/mimixbox/internal/applets/runit/sv"
 	ap_runit_svlogd "github.com/nao1215/mimixbox/internal/applets/runit/svlogd"
 	ap_runit_svok "github.com/nao1215/mimixbox/internal/applets/runit/svok"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
@@ -302,7 +303,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 316)
+	Applets = make(map[string]Applet, 317)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -442,6 +443,7 @@ func init() {
 	register(ap_runit_envuidgid.New())
 	register(ap_runit_setuidgid.New())
 	register(ap_runit_softlimit.New())
+	register(ap_runit_sv.New())
 	register(ap_runit_svlogd.New())
 	register(ap_runit_svok.New())
 	register(ap_securityutils_pwcrack.New())

--- a/internal/applets/runit/sv/sv.go
+++ b/internal/applets/runit/sv/sv.go
@@ -1,0 +1,116 @@
+// Package sv implements the sv applet: control or query a runit service by
+// writing to its supervise/control file and reading its supervise state.
+package sv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the sv applet.
+type Command struct{}
+
+// New returns a sv command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "sv" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Control or query a runit service" }
+
+// controlChars maps each sv command to the character written to the supervise
+// control file (the runit/daemontools control protocol).
+var controlChars = map[string]string{
+	"up": "u", "down": "d", "once": "o", "pause": "p", "cont": "c",
+	"hup": "h", "alarm": "a", "interrupt": "i", "term": "t", "kill": "k",
+	"quit": "q", "exit": "x", "restart": "t",
+}
+
+// Run executes sv.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "COMMAND DIR...", stdio.Err).WithHelp(command.Help{
+		Description: "Control or query the runit service(s) in each DIR. COMMAND is status, or a control " +
+			"command (up, down, once, pause, cont, hup, alarm, interrupt, term, kill, quit, exit, " +
+			"restart) that is written to DIR/supervise/control. 'status' reports whether each service " +
+			"is supervised and, if available, its pid.",
+		Examples: []command.Example{
+			{Command: "sv status /etc/service/nginx", Explain: "Show nginx's status."},
+			{Command: "sv restart /etc/service/nginx", Explain: "Restart nginx."},
+		},
+		ExitStatus: "0  the command was delivered (or status was reported).\n1  a usage or I/O error.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return command.Failuref("a command and at least one service directory are required")
+	}
+	cmd, dirs := rest[0], rest[1:]
+
+	if cmd == "status" {
+		return reportStatus(stdio, dirs)
+	}
+
+	ch, ok := controlChars[cmd]
+	if !ok {
+		return command.Failuref("unknown command: %q", cmd)
+	}
+	failed := false
+	for _, dir := range dirs {
+		if err := sendControl(dir, ch); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "sv: %s: %v\n", dir, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// sendControl writes the control character to the service's control file.
+func sendControl(dir, ch string) error {
+	control := filepath.Join(dir, "supervise", "control")
+	f, err := os.OpenFile(control, os.O_WRONLY, 0) //nolint:gosec // the supervise control fifo
+	if err != nil {
+		return fmt.Errorf("not supervised (no %s): %v", control, err)
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.WriteString(ch)
+	return err
+}
+
+// reportStatus prints the supervision state of each service directory.
+func reportStatus(stdio command.IO, dirs []string) error {
+	failed := false
+	for _, dir := range dirs {
+		if _, err := os.Stat(filepath.Join(dir, "supervise", "ok")); err != nil {
+			_, _ = fmt.Fprintf(stdio.Out, "%s: not supervised\n", dir)
+			failed = true
+			continue
+		}
+		state, detail := "run", ""
+		if pid, err := os.ReadFile(filepath.Join(dir, "supervise", "pid")); err == nil { //nolint:gosec // supervise dir
+			if p := strings.TrimSpace(string(pid)); p != "" {
+				detail = " (pid " + p + ")"
+			}
+		}
+		if _, err := os.Stat(filepath.Join(dir, "down")); err == nil {
+			state = "down"
+		}
+		_, _ = fmt.Fprintf(stdio.Out, "%s: %s%s\n", dir, state, detail)
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}

--- a/internal/applets/runit/sv/sv_test.go
+++ b/internal/applets/runit/sv/sv_test.go
@@ -1,0 +1,101 @@
+package sv
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// service creates a service dir; supervised adds supervise/ok and control.
+func service(t *testing.T, supervised bool, pid string, down bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if supervised {
+		sup := filepath.Join(dir, "supervise")
+		if err := os.MkdirAll(sup, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		_ = os.WriteFile(filepath.Join(sup, "ok"), nil, 0o644)
+		_ = os.WriteFile(filepath.Join(sup, "control"), nil, 0o644)
+		if pid != "" {
+			_ = os.WriteFile(filepath.Join(sup, "pid"), []byte(pid+"\n"), 0o644)
+		}
+	}
+	if down {
+		_ = os.WriteFile(filepath.Join(dir, "down"), nil, 0o644)
+	}
+	return dir
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestControlWritesChar(t *testing.T) {
+	dir := service(t, true, "", false)
+	for cmd, want := range map[string]string{"up": "u", "down": "d", "restart": "t", "kill": "k"} {
+		if _, err := run(t, cmd, dir); err != nil {
+			t.Fatalf("%s: %v", cmd, err)
+		}
+		got, _ := os.ReadFile(filepath.Join(dir, "supervise", "control"))
+		if string(got) != want {
+			t.Errorf("sv %s wrote %q, want %q", cmd, got, want)
+		}
+		_ = os.WriteFile(filepath.Join(dir, "supervise", "control"), nil, 0o644) // reset
+	}
+}
+
+func TestStatusRunning(t *testing.T) {
+	dir := service(t, true, "4242", false)
+	out, err := run(t, "status", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "run") || !strings.Contains(out, "pid 4242") {
+		t.Errorf("status = %q", out)
+	}
+}
+
+func TestStatusDown(t *testing.T) {
+	dir := service(t, true, "", true)
+	out, err := run(t, "status", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "down") {
+		t.Errorf("status = %q, want down", out)
+	}
+}
+
+func TestStatusNotSupervised(t *testing.T) {
+	dir := service(t, false, "", false)
+	out, err := run(t, "status", dir)
+	if err == nil {
+		t.Errorf("an unsupervised service should fail")
+	}
+	if !strings.Contains(out, "not supervised") {
+		t.Errorf("status = %q", out)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	dir := service(t, true, "", false)
+	if _, err := run(t, "bogus", dir); err == nil {
+		t.Errorf("an unknown command should fail")
+	}
+	if _, err := run(t, "up", service(t, false, "", false)); err == nil {
+		t.Errorf("controlling an unsupervised service should fail")
+	}
+	if _, err := run(t, "up"); err == nil {
+		t.Errorf("missing directory should fail")
+	}
+}

--- a/test/it/runit/sv_test.sh
+++ b/test/it/runit/sv_test.sh
@@ -1,0 +1,9 @@
+TestSvUp() {
+    d="$TEST_DIR/svc"; mkdir -p "$d/supervise"; : > "$d/supervise/control"; : > "$d/supervise/ok"
+    sv up "$d"
+    cat "$d/supervise/control"
+}
+TestSvStatus() {
+    d="$TEST_DIR/svc2"; mkdir -p "$d/supervise"; : > "$d/supervise/ok"; echo 99 > "$d/supervise/pid"
+    sv status "$d"
+}

--- a/test/it/spec/sv_spec.sh
+++ b/test/it/spec/sv_spec.sh
@@ -1,0 +1,19 @@
+Describe 'sv'
+    Include runit/sv_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/sv; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'writes the up control character'
+        When call TestSvUp
+        The output should equal 'u'
+        The status should be success
+    End
+    It 'reports a running service'
+        When call TestSvStatus
+        The output should include 'run'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `sv`, which controls or queries the runit service(s) in each DIR. COMMAND is `status`, or a control command (up, down, once, pause, cont, hup, alarm, interrupt, term, kill, quit, exit, restart) that is written as its protocol character to DIR/supervise/control. `status` reports whether each service is supervised (its supervise/ok file) and, when available, its pid and a down marker. Controlling or querying an unsupervised service fails.

## Tests

- Unit (temp service dirs): each control command writing the right character to supervise/control, status reporting a running service with its pid, status reporting a down service, status failing for an unsupervised service, and the unknown-command / unsupervised-control / missing-directory errors.
- shellspec: writing the 'up' control character, and reporting a running service.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (722 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251