### PR TITLE
feat(runit): add svc applet to send control commands to a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 317 commands. Run `mimixbox --list` to see them on the terminal.
+There are 318 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -274,6 +274,7 @@ There are 317 commands. Run `mimixbox --list` to see them on the terminal.
 | sulogin | Single-user root login |
 | sum | Checksum and count the blocks in a file (BSD) |
 | sv | Control or query a runit service |
+| svc | Send control commands to a service |
 | svlogd | Log standard input to a directory |
 | svok | Check if a service is supervised |
 | swapoff | Disable a swap area |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -128,6 +128,7 @@ import (
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_runit_softlimit "github.com/nao1215/mimixbox/internal/applets/runit/softlimit"
 	ap_runit_sv "github.com/nao1215/mimixbox/internal/applets/runit/sv"
+	ap_runit_svc "github.com/nao1215/mimixbox/internal/applets/runit/svc"
 	ap_runit_svlogd "github.com/nao1215/mimixbox/internal/applets/runit/svlogd"
 	ap_runit_svok "github.com/nao1215/mimixbox/internal/applets/runit/svok"
 	ap_securityutils_pwcrack "github.com/nao1215/mimixbox/internal/applets/securityutils/pwcrack"
@@ -303,7 +304,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 317)
+	Applets = make(map[string]Applet, 318)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -444,6 +445,7 @@ func init() {
 	register(ap_runit_setuidgid.New())
 	register(ap_runit_softlimit.New())
 	register(ap_runit_sv.New())
+	register(ap_runit_svc.New())
 	register(ap_runit_svlogd.New())
 	register(ap_runit_svok.New())
 	register(ap_securityutils_pwcrack.New())

--- a/internal/applets/runit/svc/svc.go
+++ b/internal/applets/runit/svc/svc.go
@@ -1,0 +1,111 @@
+// Package svc implements the svc applet: send control commands to a daemontools
+// service by writing to its supervise/control file.
+package svc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the svc applet.
+type Command struct{}
+
+// New returns a svc command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "svc" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Send control commands to a service" }
+
+// controlFlag binds a command-line flag to a supervise control character.
+type controlFlag struct {
+	short string
+	ch    byte
+	help  string
+}
+
+// flags are applied in this order — signal commands before the up/down/exit
+// state commands — so a combination like -t -u sends "tu" (terminate, then keep
+// the service up), the conventional restart.
+var flags = []controlFlag{
+	{"t", 't', "terminate (SIGTERM)"},
+	{"k", 'k', "kill (SIGKILL)"},
+	{"p", 'p', "pause (SIGSTOP)"},
+	{"c", 'c', "continue (SIGCONT)"},
+	{"h", 'h', "hangup (SIGHUP)"},
+	{"a", 'a', "alarm (SIGALRM)"},
+	{"i", 'i', "interrupt (SIGINT)"},
+	{"o", 'o', "once: start, but do not restart"},
+	{"u", 'u', "up: start and restart on exit"},
+	{"d", 'd', "down: stop and do not restart"},
+	{"x", 'x', "exit: ask the supervisor to exit"},
+}
+
+// Run executes svc.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "-{udopchaitkx} DIR...", stdio.Err).WithHelp(command.Help{
+		Description: "Send control commands to the daemontools service(s) in each DIR by writing the " +
+			"corresponding characters to DIR/supervise/control: -u up, -d down, -o once, -p pause, " +
+			"-c continue, -h hup, -a alarm, -i interrupt, -t term, -k kill, -x exit. Multiple commands " +
+			"may be combined.",
+		Examples: []command.Example{
+			{Command: "svc -d /service/nginx", Explain: "Stop nginx and keep it down."},
+			{Command: "svc -t -u /service/nginx", Explain: "Restart nginx (term, then up)."},
+		},
+		ExitStatus: "0  the commands were delivered.\n1  no command/dir was given, or an I/O error.",
+	})
+	set := make(map[string]*bool, len(flags))
+	for _, f := range flags {
+		set[f.short] = fs.BoolP("cmd-"+f.short, f.short, false, f.help)
+	}
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	var control []byte
+	for _, f := range flags {
+		if *set[f.short] {
+			control = append(control, f.ch)
+		}
+	}
+	if len(control) == 0 {
+		return command.Failuref("at least one control command is required")
+	}
+
+	dirs := fs.Args()
+	if len(dirs) == 0 {
+		return command.Failuref("at least one service directory is required")
+	}
+
+	failed := false
+	for _, dir := range dirs {
+		if err := sendControl(dir, control); err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "svc: %s: %v\n", dir, err)
+			failed = true
+		}
+	}
+	if failed {
+		return command.SilentFailure()
+	}
+	return nil
+}
+
+// sendControl writes the control bytes to the service's control file.
+func sendControl(dir string, control []byte) error {
+	path := filepath.Join(dir, "supervise", "control")
+	f, err := os.OpenFile(path, os.O_WRONLY, 0) //nolint:gosec // the supervise control fifo
+	if err != nil {
+		return fmt.Errorf("not supervised (no %s): %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.Write(control)
+	return err
+}

--- a/internal/applets/runit/svc/svc_test.go
+++ b/internal/applets/runit/svc/svc_test.go
@@ -1,0 +1,81 @@
+package svc
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func service(t *testing.T, supervised bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if supervised {
+		sup := filepath.Join(dir, "supervise")
+		if err := os.MkdirAll(sup, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		_ = os.WriteFile(filepath.Join(sup, "control"), nil, 0o644)
+	}
+	return dir
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func control(t *testing.T, dir string) string {
+	t.Helper()
+	data, _ := os.ReadFile(filepath.Join(dir, "supervise", "control"))
+	return string(data)
+}
+
+func TestSingleCommand(t *testing.T) {
+	dir := service(t, true)
+	if err := run(t, "-d", dir); err != nil {
+		t.Fatal(err)
+	}
+	if control(t, dir) != "d" {
+		t.Errorf("control = %q, want d", control(t, dir))
+	}
+}
+
+func TestCombinedCommandsInOrder(t *testing.T) {
+	dir := service(t, true)
+	// -u given before -t on the line, but the canonical order sends "tu".
+	if err := run(t, "-u", "-t", dir); err != nil {
+		t.Fatal(err)
+	}
+	if control(t, dir) != "tu" {
+		t.Errorf("control = %q, want tu", control(t, dir))
+	}
+}
+
+func TestMultipleDirs(t *testing.T) {
+	a, b := service(t, true), service(t, true)
+	if err := run(t, "-x", a, b); err != nil {
+		t.Fatal(err)
+	}
+	if control(t, a) != "x" || control(t, b) != "x" {
+		t.Errorf("control a=%q b=%q", control(t, a), control(t, b))
+	}
+}
+
+func TestErrors(t *testing.T) {
+	dir := service(t, true)
+	if err := run(t, dir); err == nil {
+		t.Errorf("no command should fail")
+	}
+	if err := run(t, "-u"); err == nil {
+		t.Errorf("no directory should fail")
+	}
+	if err := run(t, "-u", service(t, false)); err == nil {
+		t.Errorf("an unsupervised service should fail")
+	}
+}

--- a/test/it/runit/svc_test.sh
+++ b/test/it/runit/svc_test.sh
@@ -1,0 +1,6 @@
+TestSvc() {
+    d="$TEST_DIR/svc"; mkdir -p "$d/supervise"; : > "$d/supervise/control"
+    svc -d "$d"
+    cat "$d/supervise/control"
+}
+TestSvcNoCmd() { d="$TEST_DIR/s2"; mkdir -p "$d/supervise"; : > "$d/supervise/control"; svc "$d" 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/svc_spec.sh
+++ b/test/it/spec/svc_spec.sh
@@ -1,0 +1,19 @@
+Describe 'svc'
+    Include runit/svc_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/svc; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'writes the down control character'
+        When call TestSvc
+        The output should equal 'd'
+        The status should be success
+    End
+    It 'requires a control command'
+        When call TestSvcNoCmd
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `svc`, the daemontools service-control tool. It sends control commands to the service(s) in each DIR by writing the corresponding characters to DIR/supervise/control: `-u` up, `-d` down, `-o` once, `-p` pause, `-c` continue, `-h` hup, `-a` alarm, `-i` interrupt, `-t` term, `-k` kill, `-x` exit. Multiple commands combine, with signal commands sent before the up/down/exit state commands so e.g. `-t -u` sends "tu" (the conventional restart). Sending to an unsupervised service fails.

## Tests

- Unit (temp service dirs): a single command writing its character, combined commands written in the canonical order regardless of command-line order, delivery to multiple directories, and the no-command / no-directory / unsupervised errors.
- shellspec: writing the 'down' control character, and requiring a control command.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (724 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251