### PR TITLE
feat(runit): add runsv applet to supervise a single service

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 318 commands. Run `mimixbox --list` to see them on the terminal.
+There are 319 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -241,6 +241,7 @@ There are 318 commands. Run `mimixbox --list` to see them on the terminal.
 | run-init | Switch to the real root and run init |
 | run-parts | Run all executables in a directory |
 | runlevel | Print the previous and current runlevel |
+| runsv | Supervise a single service |
 | script | Record a command's output to a typescript |
 | scriptreplay | Replay a typescript using its timing file |
 | sddf | Search & Delete Duplicated File |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -125,6 +125,7 @@ import (
 	ap_runit_chpst "github.com/nao1215/mimixbox/internal/applets/runit/chpst"
 	ap_runit_envdir "github.com/nao1215/mimixbox/internal/applets/runit/envdir"
 	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
+	ap_runit_runsv "github.com/nao1215/mimixbox/internal/applets/runit/runsv"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_runit_softlimit "github.com/nao1215/mimixbox/internal/applets/runit/softlimit"
 	ap_runit_sv "github.com/nao1215/mimixbox/internal/applets/runit/sv"
@@ -304,7 +305,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 318)
+	Applets = make(map[string]Applet, 319)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -442,6 +443,7 @@ func init() {
 	register(ap_runit_chpst.New())
 	register(ap_runit_envdir.New())
 	register(ap_runit_envuidgid.New())
+	register(ap_runit_runsv.New())
 	register(ap_runit_setuidgid.New())
 	register(ap_runit_softlimit.New())
 	register(ap_runit_sv.New())

--- a/internal/applets/runit/runsv/runsv.go
+++ b/internal/applets/runit/runsv/runsv.go
@@ -1,0 +1,101 @@
+// Package runsv implements the runsv applet: supervise a single service by
+// running its ./run script and restarting it when it exits.
+package runsv
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the runsv applet.
+type Command struct{}
+
+// New returns a runsv command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "runsv" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Supervise a single service" }
+
+// Injected so the run step and the restart delay are testable.
+var (
+	restartDelay = time.Second
+	runOnceFn    = func(ctx context.Context, dir string, stdio command.IO) error {
+		cmd := exec.CommandContext(ctx, "./run") //nolint:gosec // running the service's run script is the point
+		cmd.Dir = dir
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		return cmd.Run()
+	}
+)
+
+// Run executes runsv.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DIR", stdio.Err).WithHelp(command.Help{
+		Description: "Supervise the service directory DIR: run its ./run script and restart it whenever " +
+			"it exits, until interrupted. While supervising, it maintains DIR/supervise/ok and the " +
+			"control file so that sv/svok can see the service. If DIR/down exists, the service is left " +
+			"stopped (but still supervised).",
+		Examples: []command.Example{
+			{Command: "runsv /etc/service/nginx", Explain: "Supervise the nginx service."},
+		},
+		ExitStatus: "0  the supervisor stopped cleanly.\n1  no directory was given or it was unwritable.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a service directory is required")
+	}
+	dir := rest[0]
+
+	cleanup, err := startSupervise(dir)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	defer cleanup()
+
+	// A "down" file means the service should not be started, only supervised.
+	if _, err := os.Stat(filepath.Join(dir, "down")); err == nil {
+		<-ctx.Done()
+		return nil
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		_ = runOnceFn(ctx, dir, stdio)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(restartDelay):
+		}
+	}
+}
+
+// startSupervise creates the supervise directory and its ok/control files,
+// returning a cleanup that removes the ok file when supervision ends.
+func startSupervise(dir string) (func(), error) {
+	sup := filepath.Join(dir, "supervise")
+	if err := os.MkdirAll(sup, 0o755); err != nil {
+		return nil, err
+	}
+	okPath := filepath.Join(sup, "ok")
+	if err := os.WriteFile(okPath, nil, 0o644); err != nil {
+		return nil, err
+	}
+	_ = os.WriteFile(filepath.Join(sup, "control"), nil, 0o644)
+	_ = os.WriteFile(filepath.Join(sup, "pid"), []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644)
+	return func() { _ = os.Remove(okPath) }, nil
+}

--- a/internal/applets/runit/runsv/runsv_test.go
+++ b/internal/applets/runit/runsv/runsv_test.go
@@ -1,0 +1,96 @@
+package runsv
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, counter *int32) {
+	t.Helper()
+	od, of := restartDelay, runOnceFn
+	restartDelay = time.Millisecond
+	runOnceFn = func(_ context.Context, _ string, _ command.IO) error {
+		atomic.AddInt32(counter, 1)
+		return nil
+	}
+	t.Cleanup(func() { restartDelay, runOnceFn = od, of })
+}
+
+func runAsync(ctx context.Context, dir string) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		io := command.IO{In: bytes.NewReader(nil), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		done <- New().Run(ctx, io, []string{dir})
+	}()
+	return done
+}
+
+func TestRestartsUntilCancelled(t *testing.T) {
+	var count int32
+	stub(t, &count)
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, dir)
+
+	// Wait until ./run has been started several times (restart loop).
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&count) < 3 {
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatalf("run started only %d times", atomic.LoadInt32(&count))
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runsv did not stop after cancellation")
+	}
+
+	// The supervise/ok file must have been created during supervision.
+	if _, err := os.Stat(filepath.Join(dir, "supervise", "control")); err != nil {
+		t.Errorf("control file not created: %v", err)
+	}
+}
+
+func TestDownFileLeavesServiceStopped(t *testing.T) {
+	var count int32
+	stub(t, &count)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "down"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, dir)
+	time.Sleep(20 * time.Millisecond)
+	if c := atomic.LoadInt32(&count); c != 0 {
+		t.Errorf("a down service must not be started, ran %d times", c)
+	}
+	// It is still supervised (ok file exists).
+	if _, err := os.Stat(filepath.Join(dir, "supervise", "ok")); err != nil {
+		t.Errorf("a down service should still be supervised: %v", err)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runsv did not stop after cancellation")
+	}
+}
+
+func TestNoDir(t *testing.T) {
+	io := command.IO{In: bytes.NewReader(nil), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("a missing directory should fail")
+	}
+}

--- a/test/it/runit/runsv_test.sh
+++ b/test/it/runit/runsv_test.sh
@@ -1,0 +1,4 @@
+# runsv supervises in the foreground until interrupted, so the e2e exercises the
+# no-directory path and --help; the restart loop is covered by Go unit tests.
+TestRunsvNoDir() { runsv 2>/dev/null; echo "rc=$?"; }
+TestRunsvHelp() { runsv --help; }

--- a/test/it/spec/runsv_spec.sh
+++ b/test/it/spec/runsv_spec.sh
@@ -1,0 +1,15 @@
+Describe 'runsv'
+    Include runit/runsv_test.sh
+
+    It 'requires a service directory'
+        When call TestRunsvNoDir
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestRunsvHelp
+        The status should be success
+        The output should include 'Usage: runsv'
+        The output should include 'service'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the runit batch (#251) with `runsv`, which supervises the service directory DIR: it runs the ./run script and restarts it whenever it exits, until interrupted. While supervising it maintains DIR/supervise/ok, control, and pid so that sv/svok can see the service. If DIR/down exists the service is left stopped but still supervised. The run step and the restart delay are injectable so the supervision loop is tested deterministically.

## Tests

- Unit (temp service dirs + stubbed run): restarting ./run repeatedly until the context is cancelled (then stopping cleanly) while creating the supervise control file, a down file leaving the service stopped but still supervised (supervise/ok present), and the missing-directory error.
- shellspec: requiring a service directory, and the `--help` path (the supervisor blocks in the foreground, so the restart loop is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (726 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `runsv` applet to supervise a single service directory, running and automatically restarting the service whenever it exits until the command is interrupted.

* **Tests**
  * Added comprehensive unit and integration tests for the new `runsv` applet functionality, covering supervision and control scenarios.

* **Documentation**
  * Updated README to reflect the addition of the new applet (319 total applets available).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->