### PR TITLE
fix(runsv): record the child pid and validate the directory

### DIFF
--- a/internal/applets/runit/runsv/runsv.go
+++ b/internal/applets/runit/runsv/runsv.go
@@ -32,7 +32,13 @@ var (
 		cmd := exec.CommandContext(ctx, "./run") //nolint:gosec // running the service's run script is the point
 		cmd.Dir = dir
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
-		return cmd.Run()
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		// Record the supervised child's pid (not the supervisor's) for sv/svok.
+		_ = os.WriteFile(filepath.Join(dir, "supervise", "pid"),
+			[]byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o644)
+		return cmd.Wait()
 	}
 )
 
@@ -58,6 +64,9 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		return command.Failuref("a service directory is required")
 	}
 	dir := rest[0]
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return command.Failuref("%s: not a directory", dir)
+	}
 
 	cleanup, err := startSupervise(dir)
 	if err != nil {
@@ -95,7 +104,10 @@ func startSupervise(dir string) (func(), error) {
 	if err := os.WriteFile(okPath, nil, 0o644); err != nil {
 		return nil, err
 	}
-	_ = os.WriteFile(filepath.Join(sup, "control"), nil, 0o644)
-	_ = os.WriteFile(filepath.Join(sup, "pid"), []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644)
+	// The control file is part of the supervision contract; fail if it cannot be
+	// created. The pid file is written by each run with the child's pid.
+	if err := os.WriteFile(filepath.Join(sup, "control"), nil, 0o644); err != nil {
+		return nil, err
+	}
 	return func() { _ = os.Remove(okPath) }, nil
 }

--- a/internal/applets/runit/runsv/runsv_test.go
+++ b/internal/applets/runit/runsv/runsv_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -92,5 +94,51 @@ func TestNoDir(t *testing.T) {
 	io := command.IO{In: bytes.NewReader(nil), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	if err := New().Run(context.Background(), io, nil); err == nil {
 		t.Errorf("a missing directory should fail")
+	}
+}
+
+func TestRejectsMissingDir(t *testing.T) {
+	var count int32
+	stub(t, &count)
+	io := command.IO{In: bytes.NewReader(nil), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"/no/such/service/dir"}); err == nil {
+		t.Errorf("a nonexistent service directory should fail")
+	}
+}
+
+func TestChildPidRecorded(t *testing.T) {
+	// Use the real run step: a ./run that sleeps so we can read its pid.
+	od := restartDelay
+	restartDelay = time.Hour // the run blocks, so we only need one iteration
+	t.Cleanup(func() { restartDelay = od })
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "run"), []byte("#!/bin/sh\nsleep 5\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runAsync(ctx, dir)
+
+	pidPath := filepath.Join(dir, "supervise", "pid")
+	var pid string
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if data, err := os.ReadFile(pidPath); err == nil {
+			if pid = strings.TrimSpace(string(data)); pid != "" {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("supervise/pid was never written")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	n, err := strconv.Atoi(pid)
+	if err != nil || n == os.Getpid() {
+		t.Errorf("pid = %q, want the child's pid (not the supervisor %d)", pid, os.Getpid())
 	}
 }


### PR DESCRIPTION
Follow-up to #445 addressing three CodeRabbit Major findings:

- **supervise/pid tracked the supervisor.** It wrote os.Getpid() (the runsv process), which never changed across restarts. The pid file is now written by each run with the supervised child's pid (the run step now Start()s, records cmd.Process.Pid, then Wait()s), so sv/svok see the actual service.
- **Missing DIR was silently created.** runsv now stat()s DIR and fails with 'not a directory' before creating supervise/, instead of materializing a typoed path and looping against a missing ./run.
- **control/pid write failures were discarded.** The supervise/control creation now propagates its error (part of the supervision contract), so an unwritable filesystem fails fast instead of reporting successful supervision.

Adds unit tests for the missing-directory rejection and for the child pid being recorded (different from the supervisor's pid) via the real run step.

Part of #251