### PR TITLE
feat(runit): add runsvdir applet, completing the runit batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 319 commands. Run `mimixbox --list` to see them on the terminal.
+There are 320 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -242,6 +242,7 @@ There are 319 commands. Run `mimixbox --list` to see them on the terminal.
 | run-parts | Run all executables in a directory |
 | runlevel | Print the previous and current runlevel |
 | runsv | Supervise a single service |
+| runsvdir | Supervise a directory of services |
 | script | Record a command's output to a typescript |
 | scriptreplay | Replay a typescript using its timing file |
 | sddf | Search & Delete Duplicated File |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -126,6 +126,7 @@ import (
 	ap_runit_envdir "github.com/nao1215/mimixbox/internal/applets/runit/envdir"
 	ap_runit_envuidgid "github.com/nao1215/mimixbox/internal/applets/runit/envuidgid"
 	ap_runit_runsv "github.com/nao1215/mimixbox/internal/applets/runit/runsv"
+	ap_runit_runsvdir "github.com/nao1215/mimixbox/internal/applets/runit/runsvdir"
 	ap_runit_setuidgid "github.com/nao1215/mimixbox/internal/applets/runit/setuidgid"
 	ap_runit_softlimit "github.com/nao1215/mimixbox/internal/applets/runit/softlimit"
 	ap_runit_sv "github.com/nao1215/mimixbox/internal/applets/runit/sv"
@@ -305,7 +306,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 319)
+	Applets = make(map[string]Applet, 320)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -444,6 +445,7 @@ func init() {
 	register(ap_runit_envdir.New())
 	register(ap_runit_envuidgid.New())
 	register(ap_runit_runsv.New())
+	register(ap_runit_runsvdir.New())
 	register(ap_runit_setuidgid.New())
 	register(ap_runit_softlimit.New())
 	register(ap_runit_sv.New())

--- a/internal/applets/runit/runsvdir/runsvdir.go
+++ b/internal/applets/runit/runsvdir/runsvdir.go
@@ -1,0 +1,89 @@
+// Package runsvdir implements the runsvdir applet: start and supervise a runsv
+// for every service directory under a directory.
+package runsvdir
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/applets/runit/runsv"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the runsvdir applet.
+type Command struct{}
+
+// New returns a runsvdir command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "runsvdir" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Supervise a directory of services" }
+
+// Injected so the per-service supervisor and the rescan interval are testable.
+var (
+	rescanInterval = 5 * time.Second
+	startRunsvFn   = func(ctx context.Context, dir string, stdio command.IO) {
+		_ = runsv.New().Run(ctx, stdio, []string{dir})
+	}
+)
+
+// Run executes runsvdir.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "DIR", stdio.Err).WithHelp(command.Help{
+		Description: "Supervise every service in DIR: start a runsv for each subdirectory and keep it " +
+			"running, rescanning periodically so newly added services are picked up, until " +
+			"interrupted. Subdirectories whose names start with a dot are ignored.",
+		Examples: []command.Example{
+			{Command: "runsvdir /etc/service", Explain: "Supervise all services under /etc/service."},
+		},
+		ExitStatus: "0  the supervisor stopped cleanly.\n1  no directory was given or it was unreadable.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a services directory is required")
+	}
+	dir := rest[0]
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return command.Failuref("%s: not a directory", dir)
+	}
+
+	started := map[string]bool{}
+	for {
+		if err := scanAndStart(ctx, dir, started, stdio); err != nil {
+			return command.Failuref("%s: %v", dir, err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(rescanInterval):
+		}
+	}
+}
+
+// scanAndStart starts a runsv for each not-yet-started service subdirectory.
+func scanAndStart(ctx context.Context, dir string, started map[string]bool, stdio command.IO) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || started[e.Name()] {
+			continue
+		}
+		started[e.Name()] = true
+		service := filepath.Join(dir, e.Name())
+		go startRunsvFn(ctx, service, stdio)
+	}
+	return nil
+}

--- a/internal/applets/runit/runsvdir/runsvdir_test.go
+++ b/internal/applets/runit/runsvdir/runsvdir_test.go
@@ -1,0 +1,82 @@
+package runsvdir
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// stub records which services were started and returns a race-safe snapshot
+// accessor.
+func stub(t *testing.T) func() []string {
+	t.Helper()
+	var mu sync.Mutex
+	var started []string
+	or, os2 := startRunsvFn, rescanInterval
+	rescanInterval = time.Millisecond
+	startRunsvFn = func(ctx context.Context, dir string, _ command.IO) {
+		mu.Lock()
+		started = append(started, filepath.Base(dir))
+		mu.Unlock()
+		<-ctx.Done()
+	}
+	t.Cleanup(func() { startRunsvFn, rescanInterval = or, os2 })
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string{}, started...)
+	}
+}
+
+func TestStartsEachService(t *testing.T) {
+	snapshot := stub(t)
+	dir := t.TempDir()
+	for _, name := range []string{"web", "db", ".hidden"} {
+		if err := os.Mkdir(filepath.Join(dir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = os.WriteFile(filepath.Join(dir, "afile"), nil, 0o644) // not a dir
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		io := command.IO{In: bytes.NewReader(nil), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		done <- New().Run(ctx, io, []string{dir})
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(snapshot()) < 2 {
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatalf("started only %v", snapshot())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	got := snapshot()
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "db" || got[1] != "web" {
+		t.Errorf("started = %v, want [db web] (hidden and files skipped)", got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	stub(t)
+	io := command.IO{In: bytes.NewReader(nil), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Errorf("missing directory should fail")
+	}
+	if err := New().Run(context.Background(), io, []string{"/no/such/dir"}); err == nil {
+		t.Errorf("a nonexistent directory should fail")
+	}
+}

--- a/test/it/runit/runsvdir_test.sh
+++ b/test/it/runit/runsvdir_test.sh
@@ -1,0 +1,4 @@
+# runsvdir supervises in the foreground until interrupted, so the e2e exercises
+# the no-directory path and --help; the per-service start is covered by unit tests.
+TestRunsvdirNoDir() { runsvdir 2>/dev/null; echo "rc=$?"; }
+TestRunsvdirHelp() { runsvdir --help; }

--- a/test/it/spec/runsvdir_spec.sh
+++ b/test/it/spec/runsvdir_spec.sh
@@ -1,0 +1,15 @@
+Describe 'runsvdir'
+    Include runit/runsvdir_test.sh
+
+    It 'requires a services directory'
+        When call TestRunsvdirNoDir
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestRunsvdirHelp
+        The status should be success
+        The output should include 'Usage: runsvdir'
+        The output should include 'service'
+    End
+End


### PR DESCRIPTION
## Summary

Adds the final applet of the runit batch (#251): `runsvdir`, which supervises every service in DIR by starting a runsv for each subdirectory and keeping it running, rescanning periodically so newly added services are picked up, until interrupted. Subdirectories whose names start with a dot, and non-directory entries, are ignored. The per-service supervisor and the rescan interval are injectable so the scanning/dispatch is tested deterministically.

With this, every command in #251's scope is now implemented (chpst, envdir, envuidgid, runsv, runsvdir, setuidgid, softlimit, sv, svc, svlogd, svok), delivered across this and the preceding PRs. The environment/uid/limit wrappers run real child processes hermetically; the supervision tools operate on temporary service directories with injectable privileged seams.

## Tests

- Unit (temp service dirs + stubbed runsv): starting a runsv for each service subdirectory while skipping hidden directories and non-directory entries, then stopping cleanly on context cancellation; and the missing-directory / non-directory errors.
- shellspec: requiring a services directory, and the `--help` path (the supervisor blocks in the foreground, so the per-service start is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (728 examples, 0 failures); `golangci-lint` clean; registry/README in sync (now 320 commands).

Closes #251