### PR TITLE
feat(console-tools): add ascii applet to print the ASCII table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 320 commands. Run `mimixbox --list` to see them on the terminal.
+There are 321 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -31,6 +31,7 @@ There are 320 commands. Run `mimixbox --list` to see them on the terminal.
 | adduser | Create a user account |
 | ar | Create, modify and extract from archives |
 | arch | Print machine hardware name (same as uname -m) |
+| ascii | Print the ASCII code table |
 | ash | Command interpreter (MimixBox mbsh compatibility front-end) |
 | awk | Pattern scanning and processing language |
 | banner | Print a string as large ASCII-art letters |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -24,6 +24,7 @@ import (
 	ap_compat_cttyhack "github.com/nao1215/mimixbox/internal/applets/compat/cttyhack"
 	ap_compat_shellfront "github.com/nao1215/mimixbox/internal/applets/compat/shellfront"
 	ap_compat_unit "github.com/nao1215/mimixbox/internal/applets/compat/unit"
+	ap_console_tools_ascii "github.com/nao1215/mimixbox/internal/applets/console-tools/ascii"
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
@@ -306,7 +307,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 320)
+	Applets = make(map[string]Applet, 321)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -337,6 +338,7 @@ func init() {
 	register(ap_compat_shellfront.NewHush())
 	register(ap_compat_shellfront.NewSh())
 	register(ap_compat_unit.New())
+	register(ap_console_tools_ascii.New())
 	register(ap_console_tools_clear.New())
 	register(ap_console_tools_pager.NewLess())
 	register(ap_console_tools_pager.NewMore())

--- a/internal/applets/console-tools/ascii/ascii.go
+++ b/internal/applets/console-tools/ascii/ascii.go
@@ -1,0 +1,65 @@
+// Package ascii implements the ascii applet: print the table of ASCII codes and
+// their characters or control-code names.
+package ascii
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the ascii applet.
+type Command struct{}
+
+// New returns an ascii command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ascii" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the ASCII code table" }
+
+// controlNames holds the mnemonic for each control code 0-31, plus DEL at 127.
+var controlNames = []string{
+	"NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "BEL",
+	"BS", "HT", "LF", "VT", "FF", "CR", "SO", "SI",
+	"DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB",
+	"CAN", "EM", "SUB", "ESC", "FS", "GS", "RS", "US",
+}
+
+// Run executes ascii.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the 128-entry ASCII table, one code per line as decimal, hexadecimal, and " +
+			"either the printable character or the control-code mnemonic (e.g. NUL, LF, ESC, DEL).",
+		Examples: []command.Example{
+			{Command: "ascii", Explain: "Print the full ASCII table."},
+		},
+		ExitStatus: "0  always.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	for code := 0; code < 128; code++ {
+		_, _ = fmt.Fprintf(stdio.Out, "%3d  0x%02X  %s\n", code, code, repr(code))
+	}
+	return nil
+}
+
+// repr returns the printable character or control-code name for code.
+func repr(code int) string {
+	switch {
+	case code < len(controlNames):
+		return controlNames[code]
+	case code == 32:
+		return "SP"
+	case code == 127:
+		return "DEL"
+	default:
+		return string(rune(code))
+	}
+}

--- a/internal/applets/console-tools/ascii/ascii_test.go
+++ b/internal/applets/console-tools/ascii/ascii_test.go
@@ -1,0 +1,61 @@
+package ascii
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err != nil {
+		t.Fatal(err)
+	}
+	return out.String()
+}
+
+func TestPrintsFullTable(t *testing.T) {
+	lines := strings.Split(strings.TrimRight(run(t), "\n"), "\n")
+	if len(lines) != 128 {
+		t.Fatalf("printed %d lines, want 128", len(lines))
+	}
+}
+
+func TestSpecificEntries(t *testing.T) {
+	lines := strings.Split(strings.TrimRight(run(t), "\n"), "\n")
+	cases := map[int]string{
+		0:   "NUL",
+		10:  "LF",
+		27:  "ESC",
+		32:  "SP",
+		65:  "A",
+		97:  "a",
+		127: "DEL",
+	}
+	for code, want := range cases {
+		line := lines[code]
+		if !strings.HasSuffix(line, "  "+want) {
+			t.Errorf("line %d = %q, want it to end with %q", code, line, want)
+		}
+		if !strings.Contains(line, fmtHex(code)) {
+			t.Errorf("line %d = %q, missing hex %s", code, line, fmtHex(code))
+		}
+	}
+}
+
+func fmtHex(code int) string {
+	const digits = "0123456789ABCDEF"
+	return "0x" + string([]byte{digits[code>>4], digits[code&0xF]})
+}
+
+func TestReprHelper(t *testing.T) {
+	t.Parallel()
+	if repr(7) != "BEL" || repr(126) != "~" || repr(127) != "DEL" || repr(32) != "SP" {
+		t.Errorf("repr mapping wrong")
+	}
+}

--- a/test/it/console-tools/ascii_test.sh
+++ b/test/it/console-tools/ascii_test.sh
@@ -1,0 +1,3 @@
+TestAsciiLineCount() { ascii | grep -c .; }
+# Code 65 (0x41) must map to the letter A on the same line.
+TestAsciiCapitalA() { ascii | grep '0x41' | grep -c 'A'; }

--- a/test/it/spec/ascii_spec.sh
+++ b/test/it/spec/ascii_spec.sh
@@ -1,0 +1,14 @@
+Describe 'ascii'
+    Include console-tools/ascii_test.sh
+
+    It 'prints 128 entries'
+        When call TestAsciiLineCount
+        The output should equal '128'
+        The status should be success
+    End
+    It 'maps code 65 to A'
+        When call TestAsciiCapitalA
+        The output should equal '1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Starts the console-tools batch (#252) with `ascii`, which prints the 128-entry ASCII table, one code per line as decimal, hexadecimal, and either the printable character or the control-code mnemonic (NUL, LF, ESC, SP, DEL, …).

## Tests

- Unit: the table having exactly 128 lines, specific entries (0=NUL, 10=LF, 27=ESC, 32=SP, 65=A, 97=a, 127=DEL) with their hex, and the `repr` mapping helper.
- shellspec: the 128-entry count, and code 65 (0x41) mapping to A.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (730 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ascii` command that displays a character reference table showing decimal codes, hexadecimal values, and character representations for all ASCII codes 0–127.

* **Tests**
  * Added comprehensive test coverage for the new command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->