### PR TITLE
feat(console-tools): add ts applet to timestamp input lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 321 commands. Run `mimixbox --list` to see them on the terminal.
+There are 322 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -300,6 +300,7 @@ There are 321 commands. Run `mimixbox --list` to see them on the terminal.
 | tree | List directory contents in a tree-like format |
 | true | Do nothing. Return success(0) |
 | truncate | Shrink or extend the size of a file to a given size |
+| ts | Timestamp each input line |
 | tsort | Topological sort of a directed graph |
 | tty | Print the file name of the terminal connected to stdin |
 | tune2fs | Show ext2/ext3/ext4 filesystem parameters |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -30,6 +30,7 @@ import (
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
 	ap_console_tools_stty "github.com/nao1215/mimixbox/internal/applets/console-tools/stty"
+	ap_console_tools_ts "github.com/nao1215/mimixbox/internal/applets/console-tools/ts"
 	ap_debianutils_add_shell "github.com/nao1215/mimixbox/internal/applets/debianutils/add-shell"
 	ap_debianutils_ischroot "github.com/nao1215/mimixbox/internal/applets/debianutils/ischroot"
 	ap_debianutils_mktemp "github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
@@ -307,7 +308,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 321)
+	Applets = make(map[string]Applet, 322)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -345,6 +346,7 @@ func init() {
 	register(ap_console_tools_reset.New())
 	register(ap_console_tools_resize.New())
 	register(ap_console_tools_stty.New())
+	register(ap_console_tools_ts.New())
 	register(ap_debianutils_add_shell.New())
 	register(ap_debianutils_ischroot.New())
 	register(ap_debianutils_mktemp.New())

--- a/internal/applets/console-tools/ts/ts.go
+++ b/internal/applets/console-tools/ts/ts.go
@@ -1,0 +1,64 @@
+// Package ts implements the ts applet: prefix each line of standard input with a
+// timestamp.
+package ts
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the ts applet.
+type Command struct{}
+
+// New returns a ts command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ts" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Timestamp each input line" }
+
+// now is indirected so the timestamps are deterministic in tests.
+var now = time.Now
+
+const defaultLayout = "2006-01-02 15:04:05"
+
+// Run executes ts.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-r]", stdio.Err).WithHelp(command.Help{
+		Description: "Read standard input line by line and print each line prefixed with the current " +
+			"time (YYYY-MM-DD HH:MM:SS). With -r the prefix is instead the time elapsed since the " +
+			"first line, as a duration. This is the moreutils ts.",
+		Examples: []command.Example{
+			{Command: "tail -f log | ts", Explain: "Timestamp a log stream as it arrives."},
+		},
+		ExitStatus: "0  standard input reached EOF.",
+	})
+	relative := fs.BoolP("relative", "r", false, "show the time elapsed since the first line")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	var start time.Time
+	sc := bufio.NewScanner(stdio.In)
+	for sc.Scan() {
+		prefix := now().Format(defaultLayout)
+		if *relative {
+			if start.IsZero() {
+				start = now()
+			}
+			prefix = now().Sub(start).String()
+		}
+		if _, err := fmt.Fprintf(stdio.Out, "%s %s\n", prefix, sc.Text()); err != nil {
+			return command.Failuref("%v", err)
+		}
+	}
+	return sc.Err()
+}

--- a/internal/applets/console-tools/ts/ts_test.go
+++ b/internal/applets/console-tools/ts/ts_test.go
@@ -1,0 +1,57 @@
+package ts
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, stdin string, args ...string) string {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, args); err != nil {
+		t.Fatal(err)
+	}
+	return out.String()
+}
+
+func TestPrefixesTimestamp(t *testing.T) {
+	on := now
+	now = func() time.Time { return time.Date(2026, 6, 12, 14, 30, 5, 0, time.UTC) }
+	defer func() { now = on }()
+	out := run(t, "hello\nworld\n")
+	want := "2026-06-12 14:30:05 hello\n2026-06-12 14:30:05 world\n"
+	if out != want {
+		t.Errorf("ts =\n%q\nwant\n%q", out, want)
+	}
+}
+
+func TestRelative(t *testing.T) {
+	var calls int
+	on := now
+	now = func() time.Time {
+		calls++
+		// start at t=0, then +2s for the first line's print, etc.
+		return time.Unix(int64(calls), 0)
+	}
+	defer func() { now = on }()
+	out := run(t, "a\nb\n", "-r")
+	// The first line records start, so its elapsed is small; the second is later.
+	if !strings.Contains(out, " a\n") || !strings.Contains(out, " b\n") {
+		t.Errorf("relative output = %q", out)
+	}
+	if strings.Contains(out, "2026") {
+		t.Errorf("relative mode should not print absolute dates: %q", out)
+	}
+}
+
+func TestEmptyInput(t *testing.T) {
+	if out := run(t, ""); out != "" {
+		t.Errorf("empty input should produce no output, got %q", out)
+	}
+}

--- a/test/it/console-tools/ts_test.sh
+++ b/test/it/console-tools/ts_test.sh
@@ -1,0 +1,2 @@
+# Each line gets a YYYY-MM-DD HH:MM:SS prefix; check the shape, not the value.
+TestTs() { printf 'alpha\nbeta\n' | ts | grep -cE '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} (alpha|beta)$'; }

--- a/test/it/spec/ts_spec.sh
+++ b/test/it/spec/ts_spec.sh
@@ -1,0 +1,9 @@
+Describe 'ts'
+    Include console-tools/ts_test.sh
+
+    It 'prefixes each line with a timestamp'
+        When call TestTs
+        The output should equal '2'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `ts` (moreutils), which reads standard input line by line and prints each line prefixed with the current time (YYYY-MM-DD HH:MM:SS). With `-r` the prefix is instead the time elapsed since the first line. The clock is injectable so the timestamps are tested deterministically.

## Tests

- Unit (fixed clock): each line prefixed with the absolute timestamp, the `-r` relative mode (no absolute dates), and empty input producing no output.
- shellspec: each line getting a well-formed `YYYY-MM-DD HH:MM:SS` prefix.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (731 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252