### PR TITLE
feat(console-tools): add ttysize applet to print the terminal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 322 commands. Run `mimixbox --list` to see them on the terminal.
+There are 323 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -303,6 +303,7 @@ There are 322 commands. Run `mimixbox --list` to see them on the terminal.
 | ts | Timestamp each input line |
 | tsort | Topological sort of a directed graph |
 | tty | Print the file name of the terminal connected to stdin |
+| ttysize | Print the terminal width and height |
 | tune2fs | Show ext2/ext3/ext4 filesystem parameters |
 | uevent | Monitor kernel uevents |
 | umount | Unmount a filesystem |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -31,6 +31,7 @@ import (
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
 	ap_console_tools_stty "github.com/nao1215/mimixbox/internal/applets/console-tools/stty"
 	ap_console_tools_ts "github.com/nao1215/mimixbox/internal/applets/console-tools/ts"
+	ap_console_tools_ttysize "github.com/nao1215/mimixbox/internal/applets/console-tools/ttysize"
 	ap_debianutils_add_shell "github.com/nao1215/mimixbox/internal/applets/debianutils/add-shell"
 	ap_debianutils_ischroot "github.com/nao1215/mimixbox/internal/applets/debianutils/ischroot"
 	ap_debianutils_mktemp "github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
@@ -308,7 +309,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 322)
+	Applets = make(map[string]Applet, 323)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -347,6 +348,7 @@ func init() {
 	register(ap_console_tools_resize.New())
 	register(ap_console_tools_stty.New())
 	register(ap_console_tools_ts.New())
+	register(ap_console_tools_ttysize.New())
 	register(ap_debianutils_add_shell.New())
 	register(ap_debianutils_ischroot.New())
 	register(ap_debianutils_mktemp.New())

--- a/internal/applets/console-tools/ttysize/ttysize.go
+++ b/internal/applets/console-tools/ttysize/ttysize.go
@@ -1,0 +1,80 @@
+// Package ttysize implements the ttysize applet: print the terminal's width and
+// height in character cells.
+package ttysize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the ttysize applet.
+type Command struct{}
+
+// New returns a ttysize command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "ttysize" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the terminal width and height" }
+
+// Default size used when the terminal size cannot be determined.
+const (
+	defaultWidth  = 80
+	defaultHeight = 24
+)
+
+// getSizeFn is indirected so the size can be tested without a real terminal. It
+// returns the width (columns) and height (rows).
+var getSizeFn = func() (width, height int) {
+	ws, err := unix.IoctlGetWinsize(0, unix.TIOCGWINSZ)
+	if err != nil || ws.Col == 0 || ws.Row == 0 {
+		return defaultWidth, defaultHeight
+	}
+	return int(ws.Col), int(ws.Row)
+}
+
+// Run executes ttysize.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[w] [h]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the terminal width and height in character cells, separated by a space. " +
+			"Given the argument 'w' or 'h', print only the width or the height, in the order the " +
+			"arguments appear. When the size cannot be determined, 80 and 24 are used.",
+		Examples: []command.Example{
+			{Command: "ttysize", Explain: "Print 'WIDTH HEIGHT'."},
+			{Command: "ttysize w", Explain: "Print just the width."},
+		},
+		ExitStatus: "0  always.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	width, height := getSizeFn()
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		_, _ = fmt.Fprintf(stdio.Out, "%d %d\n", width, height)
+		return nil
+	}
+
+	var parts []string
+	for _, a := range rest {
+		switch a {
+		case "w":
+			parts = append(parts, fmt.Sprint(width))
+		case "h":
+			parts = append(parts, fmt.Sprint(height))
+		default:
+			return command.Failuref("unknown argument: %q (use w or h)", a)
+		}
+	}
+	_, _ = fmt.Fprintln(stdio.Out, strings.Join(parts, " "))
+	return nil
+}

--- a/internal/applets/console-tools/ttysize/ttysize_test.go
+++ b/internal/applets/console-tools/ttysize/ttysize_test.go
@@ -1,0 +1,56 @@
+package ttysize
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, w, h int) {
+	t.Helper()
+	orig := getSizeFn
+	getSizeFn = func() (int, int) { return w, h }
+	t.Cleanup(func() { getSizeFn = orig })
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestPrintsBoth(t *testing.T) {
+	stub(t, 100, 40)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "100 40" {
+		t.Errorf("ttysize = %q, want \"100 40\"", out)
+	}
+}
+
+func TestSelective(t *testing.T) {
+	stub(t, 100, 40)
+	if out, _ := run(t, "w"); out != "100" {
+		t.Errorf("ttysize w = %q", out)
+	}
+	if out, _ := run(t, "h"); out != "40" {
+		t.Errorf("ttysize h = %q", out)
+	}
+	if out, _ := run(t, "h", "w"); out != "40 100" {
+		t.Errorf("ttysize h w = %q, want \"40 100\"", out)
+	}
+}
+
+func TestUnknownArg(t *testing.T) {
+	stub(t, 80, 24)
+	if _, err := run(t, "x"); err == nil {
+		t.Errorf("an unknown argument should fail")
+	}
+}

--- a/test/it/console-tools/ttysize_test.sh
+++ b/test/it/console-tools/ttysize_test.sh
@@ -1,0 +1,3 @@
+# Run without a controlling tty, so ttysize reports the 80x24 default.
+TestTtysize() { ttysize </dev/null; }
+TestTtysizeWidth() { ttysize w </dev/null; }

--- a/test/it/spec/ttysize_spec.sh
+++ b/test/it/spec/ttysize_spec.sh
@@ -1,0 +1,14 @@
+Describe 'ttysize'
+    Include console-tools/ttysize_test.sh
+
+    It 'prints width and height'
+        When call TestTtysize
+        The output should equal '80 24'
+        The status should be success
+    End
+    It 'prints just the width with w'
+        When call TestTtysizeWidth
+        The output should equal '80'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `ttysize`, which prints the terminal width and height in character cells (via the TIOCGWINSZ ioctl), separated by a space. Given the argument 'w' or 'h' it prints only the width or height, in the order the arguments appear. When the size cannot be determined (no controlling terminal), it falls back to 80 and 24. The size lookup is injectable so the formatting is tested deterministically.

## Tests

- Unit (stubbed size): printing both dimensions, selective `w`/`h` (and their order), and the unknown-argument error.
- shellspec: printing the 80x24 default (run without a tty), and just the width with `w`.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (733 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252