### PR TITLE
feat(console-tools): add fgconsole applet to print the active VT

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 323 commands. Run `mimixbox --list` to see them on the terminal.
+There are 324 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -102,6 +102,7 @@ There are 323 commands. Run `mimixbox --list` to see them on the terminal.
 | fdflush | Flush a floppy device's buffers |
 | fdformat | Low-level format a floppy device |
 | fdisk | List the MBR partition table |
+| fgconsole | Print the active virtual terminal |
 | fgrep | Search for fixed strings (grep -F) |
 | find | Search for files in a directory hierarchy |
 | findfs | Find a filesystem by label or UUID |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -26,6 +26,7 @@ import (
 	ap_compat_unit "github.com/nao1215/mimixbox/internal/applets/compat/unit"
 	ap_console_tools_ascii "github.com/nao1215/mimixbox/internal/applets/console-tools/ascii"
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
+	ap_console_tools_fgconsole "github.com/nao1215/mimixbox/internal/applets/console-tools/fgconsole"
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
@@ -309,7 +310,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 323)
+	Applets = make(map[string]Applet, 324)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -342,6 +343,7 @@ func init() {
 	register(ap_compat_unit.New())
 	register(ap_console_tools_ascii.New())
 	register(ap_console_tools_clear.New())
+	register(ap_console_tools_fgconsole.New())
 	register(ap_console_tools_pager.NewLess())
 	register(ap_console_tools_pager.NewMore())
 	register(ap_console_tools_reset.New())

--- a/internal/applets/console-tools/fgconsole/fgconsole.go
+++ b/internal/applets/console-tools/fgconsole/fgconsole.go
@@ -1,0 +1,71 @@
+// Package fgconsole implements the fgconsole applet: print the number of the
+// active virtual terminal.
+package fgconsole
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the fgconsole applet.
+type Command struct{}
+
+// New returns a fgconsole command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "fgconsole" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Print the active virtual terminal" }
+
+// vtGetState is the VT_GETSTATE ioctl, not exported by this x/sys version.
+const vtGetState = 0x5603
+
+// vtStat mirrors struct vt_stat: the active VT and the signal/state masks.
+type vtStat struct {
+	active, signal, state uint16
+}
+
+// getActiveFn is indirected so the active VT can be tested without a console.
+var getActiveFn = func() (int, error) {
+	f, err := os.Open("/dev/tty") //nolint:gosec // the controlling terminal
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+	var vs vtStat
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), vtGetState, uintptr(unsafe.Pointer(&vs))); errno != 0 {
+		return 0, errno
+	}
+	return int(vs.active), nil
+}
+
+// Run executes fgconsole.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the number of the virtual terminal that is currently in the foreground, " +
+			"read with the VT_GETSTATE ioctl on the controlling terminal. Requires a Linux virtual " +
+			"console.",
+		Examples: []command.Example{
+			{Command: "fgconsole", Explain: "Print e.g. '1' for tty1."},
+		},
+		ExitStatus: "0  the active VT was printed.\n1  the console state could not be read.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	active, err := getActiveFn()
+	if err != nil {
+		return command.Failuref("cannot read the console state: %v", err)
+	}
+	_, _ = fmt.Fprintln(stdio.Out, active)
+	return nil
+}

--- a/internal/applets/console-tools/fgconsole/fgconsole_test.go
+++ b/internal/applets/console-tools/fgconsole/fgconsole_test.go
@@ -1,0 +1,44 @@
+package fgconsole
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, active int, err error) {
+	t.Helper()
+	orig := getActiveFn
+	getActiveFn = func() (int, error) { return active, err }
+	t.Cleanup(func() { getActiveFn = orig })
+}
+
+func run(t *testing.T) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, nil)
+	return strings.TrimSpace(out.String()), err
+}
+
+func TestPrintsActiveVT(t *testing.T) {
+	stub(t, 3, nil)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "3" {
+		t.Errorf("fgconsole = %q, want 3", out)
+	}
+}
+
+func TestFailure(t *testing.T) {
+	stub(t, 0, errors.New("inappropriate ioctl"))
+	if _, err := run(t); err == nil {
+		t.Errorf("a console read failure should fail")
+	}
+}

--- a/test/it/console-tools/fgconsole_test.sh
+++ b/test/it/console-tools/fgconsole_test.sh
@@ -1,0 +1,4 @@
+# A Linux virtual console isn't available on CI/WSL, so the e2e exercises the
+# deterministic failure path and --help; the VT read is covered by unit tests.
+TestFgconsoleNoVT() { fgconsole </dev/null 2>/dev/null; echo "rc=$?"; }
+TestFgconsoleHelp() { fgconsole --help; }

--- a/test/it/spec/fgconsole_spec.sh
+++ b/test/it/spec/fgconsole_spec.sh
@@ -1,0 +1,15 @@
+Describe 'fgconsole'
+    Include console-tools/fgconsole_test.sh
+
+    It 'fails without a virtual console'
+        When call TestFgconsoleNoVT
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestFgconsoleHelp
+        The status should be success
+        The output should include 'Usage: fgconsole'
+        The output should include 'virtual terminal'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `fgconsole`, which prints the number of the virtual terminal currently in the foreground, read with the VT_GETSTATE ioctl on the controlling terminal. It requires a Linux virtual console; the ioctl read is injectable so the output and error paths are tested without one.

## Tests

- Unit (stubbed VT read): printing the active VT number, and a console-read-failure error.
- shellspec: failing without a virtual console, and the `--help` path (a VT isn't available on CI, so the read is covered by unit tests).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (735 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252