### PR TITLE
feat(console-tools): add chvt applet to switch virtual terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 324 commands. Run `mimixbox --list` to see them on the terminal.
+There are 325 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -57,6 +57,7 @@ There are 324 commands. Run `mimixbox --list` to see them on the terminal.
 | chpst | Run a program with a changed process state |
 | chroot | Run command or interactive shell with special root directory |
 | chrt | Get or set a process's real-time scheduling attributes |
+| chvt | Switch to a virtual terminal |
 | cksum | Print CRC checksum and byte count of each file |
 | clear | Clear terminal |
 | cmatrix | Show the falling-glyph digital rain effect |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -25,6 +25,7 @@ import (
 	ap_compat_shellfront "github.com/nao1215/mimixbox/internal/applets/compat/shellfront"
 	ap_compat_unit "github.com/nao1215/mimixbox/internal/applets/compat/unit"
 	ap_console_tools_ascii "github.com/nao1215/mimixbox/internal/applets/console-tools/ascii"
+	ap_console_tools_chvt "github.com/nao1215/mimixbox/internal/applets/console-tools/chvt"
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
 	ap_console_tools_fgconsole "github.com/nao1215/mimixbox/internal/applets/console-tools/fgconsole"
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
@@ -310,7 +311,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 324)
+	Applets = make(map[string]Applet, 325)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -342,6 +343,7 @@ func init() {
 	register(ap_compat_shellfront.NewSh())
 	register(ap_compat_unit.New())
 	register(ap_console_tools_ascii.New())
+	register(ap_console_tools_chvt.New())
 	register(ap_console_tools_clear.New())
 	register(ap_console_tools_fgconsole.New())
 	register(ap_console_tools_pager.NewLess())

--- a/internal/applets/console-tools/chvt/chvt.go
+++ b/internal/applets/console-tools/chvt/chvt.go
@@ -1,0 +1,77 @@
+// Package chvt implements the chvt applet: switch the foreground to a given
+// virtual terminal.
+package chvt
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the chvt applet.
+type Command struct{}
+
+// New returns a chvt command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "chvt" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Switch to a virtual terminal" }
+
+// VT_ACTIVATE / VT_WAITACTIVE ioctls, not exported by this x/sys version.
+const (
+	vtActivate   = 0x5606
+	vtWaitActive = 0x5607
+)
+
+// switchFn is indirected so the VT switch can be tested without a console.
+var switchFn = func(n int) error {
+	f, err := os.Open("/dev/console") //nolint:gosec // the system console
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), vtActivate, uintptr(n)); errno != 0 {
+		return errno
+	}
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), vtWaitActive, uintptr(n)); errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes chvt.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "N", stdio.Err).WithHelp(command.Help{
+		Description: "Switch the foreground virtual terminal to N (activating it and waiting until it " +
+			"is active), via the VT_ACTIVATE/VT_WAITACTIVE ioctls on the system console. Requires a " +
+			"Linux virtual console and privilege.",
+		Examples: []command.Example{
+			{Command: "chvt 2", Explain: "Switch to tty2."},
+		},
+		ExitStatus: "0  the terminal was switched.\n1  no valid N was given or the switch failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 {
+		return command.Failuref("a virtual terminal number is required")
+	}
+	n, err := strconv.Atoi(rest[0])
+	if err != nil || n < 1 {
+		return command.Failuref("invalid virtual terminal number: %q", rest[0])
+	}
+
+	if err := switchFn(n); err != nil {
+		return command.Failuref("cannot switch to vt %d: %v", n, err)
+	}
+	return nil
+}

--- a/internal/applets/console-tools/chvt/chvt_test.go
+++ b/internal/applets/console-tools/chvt/chvt_test.go
@@ -1,0 +1,57 @@
+package chvt
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, err error) *int {
+	t.Helper()
+	got := new(int)
+	*got = -1
+	orig := switchFn
+	switchFn = func(n int) error { *got = n; return err }
+	t.Cleanup(func() { switchFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSwitchesToVT(t *testing.T) {
+	got := stub(t, nil)
+	if err := run(t, "2"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != 2 {
+		t.Errorf("switched to %d, want 2", *got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	stub(t, nil)
+	if err := run(t); err == nil {
+		t.Errorf("missing N should fail")
+	}
+	if err := run(t, "foo"); err == nil {
+		t.Errorf("a non-numeric N should fail")
+	}
+	if err := run(t, "0"); err == nil {
+		t.Errorf("a zero N should fail")
+	}
+}
+
+func TestSwitchFailure(t *testing.T) {
+	stub(t, errors.New("operation not permitted"))
+	if err := run(t, "3"); err == nil {
+		t.Errorf("a switch failure should fail")
+	}
+}

--- a/test/it/console-tools/chvt_test.sh
+++ b/test/it/console-tools/chvt_test.sh
@@ -1,0 +1,4 @@
+# Switching VTs needs a console and privilege; the e2e exercises the deterministic
+# validation paths. The ioctl dispatch is covered by unit tests.
+TestChvtBadN() { chvt notanumber 2>/dev/null; echo "rc=$?"; }
+TestChvtNoN() { chvt 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/chvt_spec.sh
+++ b/test/it/spec/chvt_spec.sh
@@ -1,0 +1,14 @@
+Describe 'chvt'
+    Include console-tools/chvt_test.sh
+
+    It 'rejects a non-numeric VT'
+        When call TestChvtBadN
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'requires a VT number'
+        When call TestChvtNoN
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `chvt`, which switches the foreground virtual terminal to N (activating it and waiting until it is active) via the VT_ACTIVATE/VT_WAITACTIVE ioctls on the system console. It requires a Linux virtual console and privilege; the VT switch is injectable so the validation and dispatch are tested without a console.

## Tests

- Unit (stubbed switch): switching to the requested VT, the missing-N / non-numeric-N / zero-N errors, and a switch-failure error.
- shellspec: a non-numeric VT and a missing VT number both fail (switching needs a console and privilege, so the dispatch is unit-tested).

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (737 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252