### PR TITLE
feat(console-tools): add deallocvt applet to deallocate a virtual terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 325 commands. Run `mimixbox --list` to see them on the terminal.
+There are 326 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -77,6 +77,7 @@ There are 325 commands. Run `mimixbox --list` to see them on the terminal.
 | date | Print or set the system date and time |
 | dc | Reverse-Polish (stack) desk calculator |
 | dd | Convert and copy a file |
+| deallocvt | Deallocate a virtual terminal |
 | delgroup | Remove a group from /etc/group |
 | deluser | Remove a user account |
 | df | Report file system disk space usage |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -27,6 +27,7 @@ import (
 	ap_console_tools_ascii "github.com/nao1215/mimixbox/internal/applets/console-tools/ascii"
 	ap_console_tools_chvt "github.com/nao1215/mimixbox/internal/applets/console-tools/chvt"
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
+	ap_console_tools_deallocvt "github.com/nao1215/mimixbox/internal/applets/console-tools/deallocvt"
 	ap_console_tools_fgconsole "github.com/nao1215/mimixbox/internal/applets/console-tools/fgconsole"
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
@@ -311,7 +312,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 325)
+	Applets = make(map[string]Applet, 326)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -345,6 +346,7 @@ func init() {
 	register(ap_console_tools_ascii.New())
 	register(ap_console_tools_chvt.New())
 	register(ap_console_tools_clear.New())
+	register(ap_console_tools_deallocvt.New())
 	register(ap_console_tools_fgconsole.New())
 	register(ap_console_tools_pager.NewLess())
 	register(ap_console_tools_pager.NewMore())

--- a/internal/applets/console-tools/deallocvt/deallocvt.go
+++ b/internal/applets/console-tools/deallocvt/deallocvt.go
@@ -1,0 +1,70 @@
+// Package deallocvt implements the deallocvt applet: deallocate unused virtual
+// terminals.
+package deallocvt
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the deallocvt applet.
+type Command struct{}
+
+// New returns a deallocvt command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "deallocvt" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Deallocate a virtual terminal" }
+
+// vtDisallocate is the VT_DISALLOCATE ioctl, not exported by this x/sys version.
+const vtDisallocate = 0x5608
+
+// deallocFn is indirected so deallocation can be tested without a console.
+var deallocFn = func(n int) error {
+	f, err := os.Open("/dev/console") //nolint:gosec // the system console
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), vtDisallocate, uintptr(n)); errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes deallocvt.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[N]", stdio.Err).WithHelp(command.Help{
+		Description: "Deallocate the unused virtual terminal N (via the VT_DISALLOCATE ioctl on the " +
+			"system console). With no argument, or 0, deallocate all unused virtual terminals. A VT " +
+			"that is in use cannot be deallocated. Requires a Linux virtual console and privilege.",
+		Examples: []command.Example{
+			{Command: "deallocvt 3", Explain: "Deallocate tty3 if it is unused."},
+			{Command: "deallocvt", Explain: "Deallocate all unused VTs."},
+		},
+		ExitStatus: "0  the terminal(s) were deallocated.\n1  an invalid N, or the ioctl failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	n := 0 // 0 means "all unused"
+	if rest := fs.Args(); len(rest) > 0 {
+		if n, err = strconv.Atoi(rest[0]); err != nil || n < 0 {
+			return command.Failuref("invalid virtual terminal number: %q", rest[0])
+		}
+	}
+
+	if err := deallocFn(n); err != nil {
+		return command.Failuref("cannot deallocate vt %d: %v", n, err)
+	}
+	return nil
+}

--- a/internal/applets/console-tools/deallocvt/deallocvt_test.go
+++ b/internal/applets/console-tools/deallocvt/deallocvt_test.go
@@ -1,0 +1,61 @@
+package deallocvt
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, err error) *int {
+	t.Helper()
+	got := new(int)
+	*got = -99
+	orig := deallocFn
+	deallocFn = func(n int) error { *got = n; return err }
+	t.Cleanup(func() { deallocFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestDeallocatesN(t *testing.T) {
+	got := stub(t, nil)
+	if err := run(t, "3"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != 3 {
+		t.Errorf("deallocated %d, want 3", *got)
+	}
+}
+
+func TestNoArgMeansAll(t *testing.T) {
+	got := stub(t, nil)
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	if *got != 0 {
+		t.Errorf("no arg should deallocate all (0), got %d", *got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	stub(t, nil)
+	if err := run(t, "foo"); err == nil {
+		t.Errorf("a non-numeric N should fail")
+	}
+	if err := run(t, "-1"); err == nil {
+		t.Errorf("a negative N should fail")
+	}
+	stub(t, errors.New("device busy"))
+	if err := run(t, "2"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/console-tools/deallocvt_test.sh
+++ b/test/it/console-tools/deallocvt_test.sh
@@ -1,0 +1,4 @@
+# Deallocating a VT needs a console and privilege; the e2e exercises the
+# deterministic invalid-arg path. The ioctl dispatch is covered by unit tests.
+TestDeallocvtBadN() { deallocvt notanumber 2>/dev/null; echo "rc=$?"; }
+TestDeallocvtHelp() { deallocvt --help; }

--- a/test/it/spec/deallocvt_spec.sh
+++ b/test/it/spec/deallocvt_spec.sh
@@ -1,0 +1,15 @@
+Describe 'deallocvt'
+    Include console-tools/deallocvt_test.sh
+
+    It 'rejects a non-numeric VT'
+        When call TestDeallocvtBadN
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestDeallocvtHelp
+        The status should be success
+        The output should include 'Usage: deallocvt'
+        The output should include 'virtual terminal'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `deallocvt`, which deallocates the unused virtual terminal N (via the VT_DISALLOCATE ioctl on the system console); with no argument, or 0, it deallocates all unused VTs. A VT in use cannot be deallocated. It requires a Linux virtual console and privilege; the ioctl is injectable so the argument handling and dispatch are tested without a console.

## Tests

- Unit (stubbed ioctl): deallocating the requested N, no argument meaning all (0), the non-numeric / negative-N errors, and an ioctl-failure error.
- shellspec: a non-numeric VT is rejected, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (739 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252