### PR TITLE
feat(console-tools): add beep applet to sound the console speaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 326 commands. Run `mimixbox --list` to see them on the terminal.
+There are 327 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -40,6 +40,7 @@ There are 326 commands. Run `mimixbox --list` to see them on the terminal.
 | basename | Print basename (PATH without "/") from file path |
 | bash | Command interpreter (MimixBox mbsh compatibility front-end) |
 | bc | An arbitrary-precision calculator language |
+| beep | Sound the console speaker |
 | blkdiscard | Discard sectors on a block device |
 | blkid | Identify the filesystem type of a device or image |
 | blockdev | Report block device properties |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -25,6 +25,7 @@ import (
 	ap_compat_shellfront "github.com/nao1215/mimixbox/internal/applets/compat/shellfront"
 	ap_compat_unit "github.com/nao1215/mimixbox/internal/applets/compat/unit"
 	ap_console_tools_ascii "github.com/nao1215/mimixbox/internal/applets/console-tools/ascii"
+	ap_console_tools_beep "github.com/nao1215/mimixbox/internal/applets/console-tools/beep"
 	ap_console_tools_chvt "github.com/nao1215/mimixbox/internal/applets/console-tools/chvt"
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
 	ap_console_tools_deallocvt "github.com/nao1215/mimixbox/internal/applets/console-tools/deallocvt"
@@ -312,7 +313,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 326)
+	Applets = make(map[string]Applet, 327)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -344,6 +345,7 @@ func init() {
 	register(ap_compat_shellfront.NewSh())
 	register(ap_compat_unit.New())
 	register(ap_console_tools_ascii.New())
+	register(ap_console_tools_beep.New())
 	register(ap_console_tools_chvt.New())
 	register(ap_console_tools_clear.New())
 	register(ap_console_tools_deallocvt.New())

--- a/internal/applets/console-tools/beep/beep.go
+++ b/internal/applets/console-tools/beep/beep.go
@@ -1,0 +1,85 @@
+// Package beep implements the beep applet: sound the console speaker.
+package beep
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the beep applet.
+type Command struct{}
+
+// New returns a beep command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "beep" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Sound the console speaker" }
+
+// KIOCSOUND drives the console speaker; the PIT runs at this clock.
+const (
+	kiocSound     = 0x4B2F
+	pitClock      = 1193180
+	defaultFreq   = 4000
+	defaultLength = 30
+)
+
+// beepFn is indirected so the speaker is not actually driven in tests.
+var beepFn = func(freq, lengthMs int) error {
+	f, err := os.Open("/dev/console") //nolint:gosec // the system console
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	tick := uintptr(0)
+	if freq > 0 {
+		tick = uintptr(pitClock / freq)
+	}
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), kiocSound, tick); errno != 0 {
+		return errno
+	}
+	time.Sleep(time.Duration(lengthMs) * time.Millisecond)
+	_, _, _ = unix.Syscall(unix.SYS_IOCTL, f.Fd(), kiocSound, 0) // silence
+	return nil
+}
+
+// Run executes beep.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-f FREQ] [-l MS] [-r N]", stdio.Err).WithHelp(command.Help{
+		Description: "Sound the console speaker. -f sets the frequency in hertz (default 4000), -l the " +
+			"length in milliseconds (default 30), and -r the number of repetitions. Requires access to " +
+			"the console and privilege.",
+		Examples: []command.Example{
+			{Command: "beep -f 1000 -l 200", Explain: "A 1 kHz tone for 200 ms."},
+			{Command: "beep -r 3", Explain: "Three default beeps."},
+		},
+		ExitStatus: "0  the speaker was sounded.\n1  invalid options or the console was inaccessible.",
+	})
+	freq := fs.IntP("frequency", "f", defaultFreq, "frequency in hertz")
+	length := fs.IntP("length", "l", defaultLength, "length in milliseconds")
+	repeats := fs.IntP("repeats", "r", 1, "number of beeps")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	if *freq <= 0 {
+		return command.Failuref("frequency must be positive")
+	}
+	if *repeats < 1 {
+		return command.Failuref("the repeat count must be at least 1")
+	}
+
+	for i := 0; i < *repeats; i++ {
+		if err := beepFn(*freq, *length); err != nil {
+			return command.Failuref("cannot sound the speaker: %v", err)
+		}
+	}
+	return nil
+}

--- a/internal/applets/console-tools/beep/beep_test.go
+++ b/internal/applets/console-tools/beep/beep_test.go
@@ -1,0 +1,70 @@
+package beep
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type beepCall struct{ freq, length int }
+
+func stub(t *testing.T, err error) *[]beepCall {
+	t.Helper()
+	var calls []beepCall
+	orig := beepFn
+	beepFn = func(freq, length int) error {
+		calls = append(calls, beepCall{freq, length})
+		return err
+	}
+	t.Cleanup(func() { beepFn = orig })
+	return &calls
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestDefaultBeep(t *testing.T) {
+	calls := stub(t, nil)
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 1 || (*calls)[0] != (beepCall{defaultFreq, defaultLength}) {
+		t.Errorf("calls = %v", *calls)
+	}
+}
+
+func TestCustomAndRepeats(t *testing.T) {
+	calls := stub(t, nil)
+	if err := run(t, "-f", "1000", "-l", "50", "-r", "3"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 3 {
+		t.Fatalf("got %d beeps, want 3", len(*calls))
+	}
+	for _, c := range *calls {
+		if c != (beepCall{1000, 50}) {
+			t.Errorf("beep = %v, want {1000 50}", c)
+		}
+	}
+}
+
+func TestErrors(t *testing.T) {
+	stub(t, nil)
+	if err := run(t, "-f", "0"); err == nil {
+		t.Errorf("a zero frequency should fail")
+	}
+	if err := run(t, "-r", "0"); err == nil {
+		t.Errorf("a zero repeat count should fail")
+	}
+	stub(t, errors.New("no console"))
+	if err := run(t); err == nil {
+		t.Errorf("a speaker failure should fail")
+	}
+}

--- a/test/it/console-tools/beep_test.sh
+++ b/test/it/console-tools/beep_test.sh
@@ -1,0 +1,4 @@
+# The console speaker needs a console and privilege; the e2e exercises the
+# deterministic invalid-option paths. The dispatch is covered by unit tests.
+TestBeepBadFreq() { beep -f 0 2>/dev/null; echo "rc=$?"; }
+TestBeepBadRepeat() { beep -r 0 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/beep_spec.sh
+++ b/test/it/spec/beep_spec.sh
@@ -1,0 +1,14 @@
+Describe 'beep'
+    Include console-tools/beep_test.sh
+
+    It 'rejects a non-positive frequency'
+        When call TestBeepBadFreq
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects a zero repeat count'
+        When call TestBeepBadRepeat
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `beep`, which sounds the console speaker via the KIOCSOUND ioctl. `-f` sets the frequency in hertz (default 4000), `-l` the length in milliseconds (default 30), and `-r` the number of repetitions. It requires console access and privilege; the speaker driver is injectable so the argument handling and dispatch are tested without sounding anything.

## Tests

- Unit (stubbed speaker): the default beep frequency/length, custom frequency/length repeated the requested number of times, and the non-positive-frequency / zero-repeat / speaker-failure errors.
- shellspec: a non-positive frequency and a zero repeat count are both rejected.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (741 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252