### PR TITLE
feat(console-tools): add kbd_mode applet to report/set the keyboard mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 327 commands. Run `mimixbox --list` to see them on the terminal.
+There are 328 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -145,6 +145,7 @@ There are 327 commands. Run `mimixbox --list` to see them on the terminal.
 | ipcrm | Remove System V IPC objects by id |
 | ipcs | Show System V IPC facilities status |
 | ischroot | Detect if running in a chroot |
+| kbd_mode | Report or set the keyboard mode |
 | kill | Kill process or send signal to process |
 | killall | Kill processes by name |
 | killall5 | Send a signal to all processes |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -30,6 +30,7 @@ import (
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
 	ap_console_tools_deallocvt "github.com/nao1215/mimixbox/internal/applets/console-tools/deallocvt"
 	ap_console_tools_fgconsole "github.com/nao1215/mimixbox/internal/applets/console-tools/fgconsole"
+	ap_console_tools_kbd_mode "github.com/nao1215/mimixbox/internal/applets/console-tools/kbd_mode"
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
@@ -313,7 +314,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 327)
+	Applets = make(map[string]Applet, 328)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -350,6 +351,7 @@ func init() {
 	register(ap_console_tools_clear.New())
 	register(ap_console_tools_deallocvt.New())
 	register(ap_console_tools_fgconsole.New())
+	register(ap_console_tools_kbd_mode.New())
 	register(ap_console_tools_pager.NewLess())
 	register(ap_console_tools_pager.NewMore())
 	register(ap_console_tools_reset.New())

--- a/internal/applets/console-tools/kbd_mode/kbd_mode.go
+++ b/internal/applets/console-tools/kbd_mode/kbd_mode.go
@@ -1,0 +1,122 @@
+// Package kbdmode implements the kbd_mode applet: report or set the console
+// keyboard mode.
+package kbdmode
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the kbd_mode applet.
+type Command struct{}
+
+// New returns a kbd_mode command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "kbd_mode" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Report or set the keyboard mode" }
+
+// Keyboard modes and the ioctls to get/set them.
+const (
+	kdgkbMode  = 0x4B44
+	kdskbMode  = 0x4B45
+	kRaw       = 0
+	kXlate     = 1
+	kMediumRaw = 2
+	kUnicode   = 3
+)
+
+// modeNames describes each keyboard mode for the report output.
+var modeNames = map[int]string{
+	kRaw:       "raw (scancode)",
+	kXlate:     "ASCII",
+	kMediumRaw: "mediumraw (keycode)",
+	kUnicode:   "Unicode (UTF-8)",
+}
+
+// Injected so the keyboard mode can be read/set without a console.
+var (
+	getModeFn = func() (int, error) {
+		f, err := os.Open("/dev/tty") //nolint:gosec // the controlling terminal
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = f.Close() }()
+		var mode int
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), kdgkbMode, uintptr(unsafe.Pointer(&mode))); errno != 0 {
+			return 0, errno
+		}
+		return mode, nil
+	}
+	setModeFn = func(mode int) error {
+		f, err := os.Open("/dev/tty") //nolint:gosec // the controlling terminal
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), kdskbMode, uintptr(mode)); errno != 0 {
+			return errno
+		}
+		return nil
+	}
+)
+
+// Run executes kbd_mode.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-a|-u|-k|-s]", stdio.Err).WithHelp(command.Help{
+		Description: "With no option, report the current keyboard mode of the console. With an option, " +
+			"set it: -a ASCII (XLATE), -u Unicode (UTF-8), -k mediumraw (keycodes), -s raw (scancodes). " +
+			"Setting the mode requires privilege and a Linux console.",
+		Examples: []command.Example{
+			{Command: "kbd_mode", Explain: "Report the current keyboard mode."},
+			{Command: "kbd_mode -u", Explain: "Switch to Unicode mode."},
+		},
+		ExitStatus: "0  the mode was reported or set.\n1  conflicting options or the console was inaccessible.",
+	})
+	ascii := fs.BoolP("ascii", "a", false, "set ASCII (XLATE) mode")
+	unicode := fs.BoolP("unicode", "u", false, "set Unicode (UTF-8) mode")
+	keycode := fs.BoolP("keycode", "k", false, "set mediumraw (keycode) mode")
+	scancode := fs.BoolP("scancode", "s", false, "set raw (scancode) mode")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	mode, set, n := -1, false, 0
+	for flag, m := range map[*bool]int{ascii: kXlate, unicode: kUnicode, keycode: kMediumRaw, scancode: kRaw} {
+		if *flag {
+			mode, set = m, true
+			n++
+		}
+	}
+	if n > 1 {
+		return command.Failuref("only one mode option may be given")
+	}
+
+	if set {
+		if err := setModeFn(mode); err != nil {
+			return command.Failuref("cannot set the keyboard mode: %v", err)
+		}
+		return nil
+	}
+
+	cur, err := getModeFn()
+	if err != nil {
+		return command.Failuref("cannot read the keyboard mode: %v", err)
+	}
+	name := modeNames[cur]
+	if name == "" {
+		name = "unknown"
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "The keyboard is in %s mode\n", name)
+	return nil
+}

--- a/internal/applets/console-tools/kbd_mode/kbd_mode_test.go
+++ b/internal/applets/console-tools/kbd_mode/kbd_mode_test.go
@@ -1,0 +1,67 @@
+package kbdmode
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, getMode int, getErr error) *int {
+	t.Helper()
+	setTo := new(int)
+	*setTo = -1
+	og, os := getModeFn, setModeFn
+	getModeFn = func() (int, error) { return getMode, getErr }
+	setModeFn = func(mode int) error { *setTo = mode; return nil }
+	t.Cleanup(func() { getModeFn, setModeFn = og, os })
+	return setTo
+}
+
+func run(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	err := New().Run(context.Background(), io, args)
+	return out.String(), err
+}
+
+func TestReportsMode(t *testing.T) {
+	stub(t, kUnicode, nil)
+	out, err := run(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Unicode") {
+		t.Errorf("report = %q", out)
+	}
+}
+
+func TestSetsMode(t *testing.T) {
+	for _, c := range []struct {
+		flag string
+		want int
+	}{{"-a", kXlate}, {"-u", kUnicode}, {"-k", kMediumRaw}, {"-s", kRaw}} {
+		setTo := stub(t, kXlate, nil)
+		if _, err := run(t, c.flag); err != nil {
+			t.Fatalf("%s: %v", c.flag, err)
+		}
+		if *setTo != c.want {
+			t.Errorf("%s set mode %d, want %d", c.flag, *setTo, c.want)
+		}
+	}
+}
+
+func TestErrors(t *testing.T) {
+	stub(t, kXlate, nil)
+	if _, err := run(t, "-a", "-u"); err == nil {
+		t.Errorf("conflicting options should fail")
+	}
+	stub(t, 0, errors.New("inappropriate ioctl"))
+	if _, err := run(t); err == nil {
+		t.Errorf("a read failure should fail")
+	}
+}

--- a/test/it/console-tools/kbd_mode_test.sh
+++ b/test/it/console-tools/kbd_mode_test.sh
@@ -1,0 +1,4 @@
+# Reading/setting the keyboard mode needs a console; the e2e exercises the
+# deterministic conflicting-options path and --help. The ioctls are unit-tested.
+TestKbdModeConflict() { kbd_mode -a -u 2>/dev/null; echo "rc=$?"; }
+TestKbdModeHelp() { kbd_mode --help; }

--- a/test/it/spec/kbd_mode_spec.sh
+++ b/test/it/spec/kbd_mode_spec.sh
@@ -1,0 +1,15 @@
+Describe 'kbd_mode'
+    Include console-tools/kbd_mode_test.sh
+
+    It 'rejects conflicting mode options'
+        When call TestKbdModeConflict
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestKbdModeHelp
+        The status should be success
+        The output should include 'Usage: kbd_mode'
+        The output should include 'keyboard'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `kbd_mode`, which with no option reports the current console keyboard mode and with an option sets it: `-a` ASCII (XLATE), `-u` Unicode (UTF-8), `-k` mediumraw (keycodes), `-s` raw (scancodes), via the KDGKBMODE/KDSKBMODE ioctls. Setting the mode requires privilege and a Linux console; the get/set ioctls are injectable so the reporting and dispatch are tested without one.

## Tests

- Unit (stubbed ioctls): reporting the current mode by name, each option setting the right mode, the conflicting-options error, and a read-failure error.
- shellspec: conflicting mode options are rejected, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (743 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252