### PR TITLE
feat(console-tools): add setlogcons applet to set the kernel-log VT

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 328 commands. Run `mimixbox --list` to see them on the terminal.
+There are 329 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -256,6 +256,7 @@ There are 328 commands. Run `mimixbox --list` to see them on the terminal.
 | seq | Print a column of numbers |
 | serial | Rename the file to the name with a serial number |
 | setarch | Run a program with a changed architecture personality |
+| setlogcons | Send kernel messages to a VT |
 | setpriv | Run a program with different privilege settings |
 | setsid | Run a program in a new session |
 | setuidgid | Run a program as a user's uid/gid |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -34,6 +34,7 @@ import (
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
+	ap_console_tools_setlogcons "github.com/nao1215/mimixbox/internal/applets/console-tools/setlogcons"
 	ap_console_tools_stty "github.com/nao1215/mimixbox/internal/applets/console-tools/stty"
 	ap_console_tools_ts "github.com/nao1215/mimixbox/internal/applets/console-tools/ts"
 	ap_console_tools_ttysize "github.com/nao1215/mimixbox/internal/applets/console-tools/ttysize"
@@ -314,7 +315,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 328)
+	Applets = make(map[string]Applet, 329)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -356,6 +357,7 @@ func init() {
 	register(ap_console_tools_pager.NewMore())
 	register(ap_console_tools_reset.New())
 	register(ap_console_tools_resize.New())
+	register(ap_console_tools_setlogcons.New())
 	register(ap_console_tools_stty.New())
 	register(ap_console_tools_ts.New())
 	register(ap_console_tools_ttysize.New())

--- a/internal/applets/console-tools/setlogcons/setlogcons.go
+++ b/internal/applets/console-tools/setlogcons/setlogcons.go
@@ -1,0 +1,74 @@
+// Package setlogcons implements the setlogcons applet: send kernel messages to a
+// given virtual terminal.
+package setlogcons
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the setlogcons applet.
+type Command struct{}
+
+// New returns a setlogcons command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "setlogcons" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Send kernel messages to a VT" }
+
+// TIOCLINUX subcommand 11 sets the console that receives kernel messages.
+const (
+	tioclinux    = 0x541C
+	setLogSubcmd = 11
+)
+
+// setFn is indirected so the ioctl can be tested without a console.
+var setFn = func(n int) error {
+	f, err := os.Open("/dev/console") //nolint:gosec // the system console
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	arg := [2]byte{setLogSubcmd, byte(n)}
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), tioclinux, uintptr(unsafe.Pointer(&arg))); errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes setlogcons.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[N]", stdio.Err).WithHelp(command.Help{
+		Description: "Direct kernel log messages to virtual terminal N (via the TIOCLINUX ioctl). With " +
+			"no argument, or 0, send them to the current foreground terminal. Requires privilege and a " +
+			"Linux console.",
+		Examples: []command.Example{
+			{Command: "setlogcons 12", Explain: "Send kernel messages to tty12."},
+		},
+		ExitStatus: "0  the log console was set.\n1  an invalid N, or the ioctl failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	n := 0
+	if rest := fs.Args(); len(rest) > 0 {
+		if n, err = strconv.Atoi(rest[0]); err != nil || n < 0 {
+			return command.Failuref("invalid virtual terminal number: %q", rest[0])
+		}
+	}
+
+	if err := setFn(n); err != nil {
+		return command.Failuref("cannot set the log console: %v", err)
+	}
+	return nil
+}

--- a/internal/applets/console-tools/setlogcons/setlogcons_test.go
+++ b/internal/applets/console-tools/setlogcons/setlogcons_test.go
@@ -1,0 +1,61 @@
+package setlogcons
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, err error) *int {
+	t.Helper()
+	got := new(int)
+	*got = -99
+	orig := setFn
+	setFn = func(n int) error { *got = n; return err }
+	t.Cleanup(func() { setFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSetsLogConsole(t *testing.T) {
+	got := stub(t, nil)
+	if err := run(t, "12"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != 12 {
+		t.Errorf("set to %d, want 12", *got)
+	}
+}
+
+func TestNoArgMeansCurrent(t *testing.T) {
+	got := stub(t, nil)
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	if *got != 0 {
+		t.Errorf("no arg should be 0 (current), got %d", *got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	stub(t, nil)
+	if err := run(t, "foo"); err == nil {
+		t.Errorf("a non-numeric N should fail")
+	}
+	if err := run(t, "-1"); err == nil {
+		t.Errorf("a negative N should fail")
+	}
+	stub(t, errors.New("permission denied"))
+	if err := run(t, "1"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/console-tools/setlogcons_test.sh
+++ b/test/it/console-tools/setlogcons_test.sh
@@ -1,0 +1,2 @@
+TestSetlogconsBadN() { setlogcons notanumber 2>/dev/null; echo "rc=$?"; }
+TestSetlogconsHelp() { setlogcons --help; }

--- a/test/it/spec/setlogcons_spec.sh
+++ b/test/it/spec/setlogcons_spec.sh
@@ -1,0 +1,15 @@
+Describe 'setlogcons'
+    Include console-tools/setlogcons_test.sh
+
+    It 'rejects a non-numeric VT'
+        When call TestSetlogconsBadN
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestSetlogconsHelp
+        The status should be success
+        The output should include 'Usage: setlogcons'
+        The output should include 'kernel'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `setlogcons`, which directs kernel log messages to virtual terminal N (via the TIOCLINUX ioctl, subcommand 11); with no argument, or 0, it sends them to the current foreground terminal. It requires privilege and a Linux console; the ioctl is injectable so the argument handling and dispatch are tested without one.

## Tests

- Unit (stubbed ioctl): setting the log console to N, no argument meaning the current VT (0), the non-numeric / negative-N errors, and an ioctl-failure error.
- shellspec: a non-numeric VT is rejected, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (745 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252