### PR TITLE
feat(console-tools): add setconsole applet to redirect console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 329 commands. Run `mimixbox --list` to see them on the terminal.
+There are 330 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -256,6 +256,7 @@ There are 329 commands. Run `mimixbox --list` to see them on the terminal.
 | seq | Print a column of numbers |
 | serial | Rename the file to the name with a serial number |
 | setarch | Run a program with a changed architecture personality |
+| setconsole | Redirect console output to a device |
 | setlogcons | Send kernel messages to a VT |
 | setpriv | Run a program with different privilege settings |
 | setsid | Run a program in a new session |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -34,6 +34,7 @@ import (
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
+	ap_console_tools_setconsole "github.com/nao1215/mimixbox/internal/applets/console-tools/setconsole"
 	ap_console_tools_setlogcons "github.com/nao1215/mimixbox/internal/applets/console-tools/setlogcons"
 	ap_console_tools_stty "github.com/nao1215/mimixbox/internal/applets/console-tools/stty"
 	ap_console_tools_ts "github.com/nao1215/mimixbox/internal/applets/console-tools/ts"
@@ -315,7 +316,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 329)
+	Applets = make(map[string]Applet, 330)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -357,6 +358,7 @@ func init() {
 	register(ap_console_tools_pager.NewMore())
 	register(ap_console_tools_reset.New())
 	register(ap_console_tools_resize.New())
+	register(ap_console_tools_setconsole.New())
 	register(ap_console_tools_setlogcons.New())
 	register(ap_console_tools_stty.New())
 	register(ap_console_tools_ts.New())

--- a/internal/applets/console-tools/setconsole/setconsole.go
+++ b/internal/applets/console-tools/setconsole/setconsole.go
@@ -1,0 +1,74 @@
+// Package setconsole implements the setconsole applet: redirect system console
+// output to a given device.
+package setconsole
+
+import (
+	"context"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+// Command is the setconsole applet.
+type Command struct{}
+
+// New returns a setconsole command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "setconsole" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Redirect console output to a device" }
+
+// tioccons redirects console output to the terminal on which it is issued.
+const tioccons = 0x541D
+
+// defaultDevice resets the console to the real console.
+const defaultDevice = "/dev/console"
+
+// redirectFn is indirected so the ioctl can be tested without a console.
+var redirectFn = func(device string) error {
+	f, err := os.Open(device) //nolint:gosec // user-named console device
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), tioccons, 0); errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes setconsole.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "[-r] [DEVICE]", stdio.Err).WithHelp(command.Help{
+		Description: "Redirect kernel console output to DEVICE (the current terminal by default) using " +
+			"the TIOCCONS ioctl. With -r, reset the redirection back to /dev/console. Requires " +
+			"privilege.",
+		Examples: []command.Example{
+			{Command: "setconsole /dev/ttyS0", Explain: "Send console output to the serial port."},
+			{Command: "setconsole -r", Explain: "Reset console output to /dev/console."},
+		},
+		ExitStatus: "0  the redirection was set.\n1  the device was inaccessible or the ioctl failed.",
+	})
+	reset := fs.BoolP("reset", "r", false, "reset console output to /dev/console")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	device := defaultDevice
+	if *reset {
+		device = defaultDevice
+	} else if rest := fs.Args(); len(rest) > 0 {
+		device = rest[0]
+	}
+
+	if err := redirectFn(device); err != nil {
+		return command.Failuref("cannot redirect the console to %s: %v", device, err)
+	}
+	return nil
+}

--- a/internal/applets/console-tools/setconsole/setconsole_test.go
+++ b/internal/applets/console-tools/setconsole/setconsole_test.go
@@ -1,0 +1,60 @@
+package setconsole
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func stub(t *testing.T, err error) *string {
+	t.Helper()
+	got := new(string)
+	*got = "<unset>"
+	orig := redirectFn
+	redirectFn = func(device string) error { *got = device; return err }
+	t.Cleanup(func() { redirectFn = orig })
+	return got
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestRedirectsToDevice(t *testing.T) {
+	got := stub(t, nil)
+	if err := run(t, "/dev/ttyS0"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != "/dev/ttyS0" {
+		t.Errorf("redirected to %q, want /dev/ttyS0", *got)
+	}
+}
+
+func TestDefaultAndReset(t *testing.T) {
+	got := stub(t, nil)
+	if err := run(t); err != nil {
+		t.Fatal(err)
+	}
+	if *got != defaultDevice {
+		t.Errorf("default = %q, want %s", *got, defaultDevice)
+	}
+	if err := run(t, "-r"); err != nil {
+		t.Fatal(err)
+	}
+	if *got != defaultDevice {
+		t.Errorf("-r = %q, want %s", *got, defaultDevice)
+	}
+}
+
+func TestFailure(t *testing.T) {
+	stub(t, errors.New("permission denied"))
+	if err := run(t, "/dev/ttyS0"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/console-tools/setconsole_test.sh
+++ b/test/it/console-tools/setconsole_test.sh
@@ -1,0 +1,4 @@
+# Redirecting the console needs privilege; the e2e exercises a missing-device
+# failure and --help. The ioctl dispatch is covered by unit tests.
+TestSetconsoleBadDev() { setconsole /dev/no_such_console 2>/dev/null; echo "rc=$?"; }
+TestSetconsoleHelp() { setconsole --help; }

--- a/test/it/spec/setconsole_spec.sh
+++ b/test/it/spec/setconsole_spec.sh
@@ -1,0 +1,15 @@
+Describe 'setconsole'
+    Include console-tools/setconsole_test.sh
+
+    It 'fails on an inaccessible device'
+        When call TestSetconsoleBadDev
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'describes itself with --help'
+        When call TestSetconsoleHelp
+        The status should be success
+        The output should include 'Usage: setconsole'
+        The output should include 'console'
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `setconsole`, which redirects kernel console output to DEVICE (the current terminal by default) using the TIOCCONS ioctl; with `-r` it resets the redirection back to /dev/console. Requires privilege; the ioctl is injectable so the device selection and dispatch are tested without a console.

## Tests

- Unit (stubbed ioctl): redirecting to a named device, the default device and `-r` reset both targeting /dev/console, and an ioctl-failure error.
- shellspec: an inaccessible device fails, and the `--help` path.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (747 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252