### PR TITLE
feat(console-tools): add inotifyd applet to run a handler on file events

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 330 commands. Run `mimixbox --list` to see them on the terminal.
+There are 331 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -139,6 +139,7 @@ There are 330 commands. Run `mimixbox --list` to see them on the terminal.
 | hwclock | Read the hardware (RTC) clock |
 | id | Print User ID and Group ID |
 | init | Run an inittab's startup actions |
+| inotifyd | Run a handler on file inotify events |
 | install | Copy files and set attributes |
 | ionice | Get or set process I/O scheduling class and priority |
 | iostat | Report CPU and device I/O statistics |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -30,6 +30,7 @@ import (
 	ap_console_tools_clear "github.com/nao1215/mimixbox/internal/applets/console-tools/clear"
 	ap_console_tools_deallocvt "github.com/nao1215/mimixbox/internal/applets/console-tools/deallocvt"
 	ap_console_tools_fgconsole "github.com/nao1215/mimixbox/internal/applets/console-tools/fgconsole"
+	ap_console_tools_inotifyd "github.com/nao1215/mimixbox/internal/applets/console-tools/inotifyd"
 	ap_console_tools_kbd_mode "github.com/nao1215/mimixbox/internal/applets/console-tools/kbd_mode"
 	ap_console_tools_pager "github.com/nao1215/mimixbox/internal/applets/console-tools/pager"
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
@@ -316,7 +317,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 330)
+	Applets = make(map[string]Applet, 331)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -353,6 +354,7 @@ func init() {
 	register(ap_console_tools_clear.New())
 	register(ap_console_tools_deallocvt.New())
 	register(ap_console_tools_fgconsole.New())
+	register(ap_console_tools_inotifyd.New())
 	register(ap_console_tools_kbd_mode.New())
 	register(ap_console_tools_pager.NewLess())
 	register(ap_console_tools_pager.NewMore())

--- a/internal/applets/console-tools/inotifyd/inotifyd.go
+++ b/internal/applets/console-tools/inotifyd/inotifyd.go
@@ -1,0 +1,214 @@
+// Package inotifyd implements the inotifyd applet: watch files for inotify
+// events and run a handler program for each event.
+package inotifyd
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os/exec"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+// Command is the inotifyd applet.
+type Command struct{}
+
+// New returns an inotifyd command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "inotifyd" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Run a handler on file inotify events" }
+
+// maskBits maps inotify event flags to the BusyBox inotifyd event letters, in
+// bit order.
+var maskBits = []struct {
+	flag uint32
+	ch   byte
+}{
+	{unix.IN_ACCESS, 'a'}, {unix.IN_MODIFY, 'c'}, {unix.IN_ATTRIB, 'e'},
+	{unix.IN_CLOSE_WRITE, 'w'}, {unix.IN_CLOSE_NOWRITE, '0'}, {unix.IN_OPEN, 'r'},
+	{unix.IN_MOVED_FROM, 'm'}, {unix.IN_MOVED_TO, 'y'}, {unix.IN_CREATE, 'n'},
+	{unix.IN_DELETE, 'd'}, {unix.IN_DELETE_SELF, 'D'}, {unix.IN_MOVE_SELF, 'M'},
+	{unix.IN_UNMOUNT, 'u'},
+}
+
+// letterFlags is the reverse mapping, used to parse a FILE:mask spec.
+var letterFlags = func() map[byte]uint32 {
+	m := map[byte]uint32{}
+	for _, b := range maskBits {
+		m[b.ch] = b.flag
+	}
+	return m
+}()
+
+// event is one inotify event delivered for a watched path.
+type event struct {
+	mask uint32
+	path string // the watched path
+	name string // the file within a watched directory, if any
+}
+
+// source yields inotify events for the watched paths.
+type source interface {
+	Recv() (event, error)
+	Close() error
+}
+
+// watch is a parsed FILE[:mask] specification.
+type watch struct {
+	path string
+	mask uint32
+}
+
+// Injected so the watcher and the handler are testable without inotify.
+var (
+	dialFn    = openInotify
+	handlerFn = func(stdio command.IO, prog, actions, path, name string) {
+		cmd := exec.Command(prog, actions, path, name) //nolint:gosec // running the handler is the point
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
+		_ = cmd.Run()
+	}
+)
+
+// Run executes inotifyd.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "PROG FILE[:MASK]...", stdio.Err).WithHelp(command.Help{
+		Description: "Watch each FILE for inotify events and run PROG for each one, as 'PROG ACTIONS " +
+			"FILE [NAME]', where ACTIONS is the letters of the events that occurred (a access, c " +
+			"modify, e attrib, w close-write, r open, n create, d delete, y moved-to, …). A FILE may be " +
+			"suffixed with ':MASK' (those letters) to watch only those events. Runs until interrupted.",
+		Examples: []command.Example{
+			{Command: "inotifyd ./handler /etc:n /var/log/app.log:w", Explain: "Watch a dir and a file."},
+		},
+		ExitStatus: "0  the watcher stopped cleanly.\n1  a usage error or the watch could not be set up.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return command.Failuref("a handler program and at least one file are required")
+	}
+	prog := rest[0]
+	watches, err := parseWatches(rest[1:])
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+
+	src, err := dialFn(watches)
+	if err != nil {
+		return command.Failuref("cannot watch: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	go func() {
+		<-ctx.Done()
+		_ = src.Close()
+	}()
+
+	for {
+		ev, err := src.Recv()
+		if err != nil {
+			return nil // closed via cancellation, or the source ended
+		}
+		handlerFn(stdio, prog, maskToLetters(ev.mask), ev.path, ev.name)
+	}
+}
+
+// parseWatches parses the FILE[:MASK] specifications.
+func parseWatches(specs []string) ([]watch, error) {
+	watches := make([]watch, 0, len(specs))
+	for _, s := range specs {
+		path, letters, hasMask := strings.Cut(s, ":")
+		w := watch{path: path, mask: unix.IN_ALL_EVENTS}
+		if hasMask {
+			w.mask = 0
+			for i := 0; i < len(letters); i++ {
+				flag, ok := letterFlags[letters[i]]
+				if !ok {
+					return nil, command.Failuref("unknown event letter: %q", string(letters[i]))
+				}
+				w.mask |= flag
+			}
+		}
+		watches = append(watches, w)
+	}
+	return watches, nil
+}
+
+// maskToLetters renders an event mask as its BusyBox event letters.
+func maskToLetters(mask uint32) string {
+	var b strings.Builder
+	for _, mb := range maskBits {
+		if mask&mb.flag != 0 {
+			b.WriteByte(mb.ch)
+		}
+	}
+	return b.String()
+}
+
+// inotifySource reads events from a real inotify file descriptor.
+type inotifySource struct {
+	fd     int
+	wdPath map[int32]string
+	buf    []byte
+	queue  []event
+}
+
+// openInotify sets up an inotify watch for each path.
+func openInotify(watches []watch) (source, error) {
+	fd, err := unix.InotifyInit1(0)
+	if err != nil {
+		return nil, err
+	}
+	s := &inotifySource{fd: fd, wdPath: map[int32]string{}, buf: make([]byte, 8192)}
+	for _, w := range watches {
+		wd, err := unix.InotifyAddWatch(fd, w.path, w.mask)
+		if err != nil {
+			_ = unix.Close(fd)
+			return nil, err
+		}
+		s.wdPath[int32(wd)] = w.path
+	}
+	return s, nil
+}
+
+// Recv returns the next inotify event, blocking until one arrives.
+func (s *inotifySource) Recv() (event, error) {
+	for len(s.queue) == 0 {
+		n, err := unix.Read(s.fd, s.buf)
+		if err != nil {
+			return event{}, err
+		}
+		s.parse(s.buf[:n])
+	}
+	ev := s.queue[0]
+	s.queue = s.queue[1:]
+	return ev, nil
+}
+
+// parse splits a read buffer into the individual inotify_event records.
+func (s *inotifySource) parse(data []byte) {
+	for off := 0; off+16 <= len(data); {
+		wd := int32(binary.LittleEndian.Uint32(data[off:]))
+		mask := binary.LittleEndian.Uint32(data[off+4:])
+		nameLen := int(binary.LittleEndian.Uint32(data[off+12:]))
+		name := ""
+		if nameLen > 0 && off+16+nameLen <= len(data) {
+			name = string(bytes.TrimRight(data[off+16:off+16+nameLen], "\x00"))
+		}
+		s.queue = append(s.queue, event{mask: mask, path: s.wdPath[wd], name: name})
+		off += 16 + nameLen
+	}
+}
+
+// Close closes the inotify descriptor.
+func (s *inotifySource) Close() error { return unix.Close(s.fd) }

--- a/internal/applets/console-tools/inotifyd/inotifyd_test.go
+++ b/internal/applets/console-tools/inotifyd/inotifyd_test.go
@@ -1,0 +1,135 @@
+package inotifyd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+)
+
+func TestMaskToLetters(t *testing.T) {
+	t.Parallel()
+	if got := maskToLetters(unix.IN_CREATE); got != "n" {
+		t.Errorf("create = %q, want n", got)
+	}
+	if got := maskToLetters(unix.IN_CREATE | unix.IN_DELETE); got != "nd" {
+		t.Errorf("create|delete = %q, want nd", got)
+	}
+	if got := maskToLetters(unix.IN_ACCESS | unix.IN_CLOSE_WRITE); got != "aw" {
+		t.Errorf("access|close-write = %q, want aw", got)
+	}
+}
+
+func TestParseWatches(t *testing.T) {
+	t.Parallel()
+	ws, err := parseWatches([]string{"/a", "/b:nc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws[0].mask != unix.IN_ALL_EVENTS {
+		t.Errorf("no mask should watch all events")
+	}
+	if ws[1].mask != unix.IN_CREATE|unix.IN_MODIFY {
+		t.Errorf("mask 'nc' = %#x", ws[1].mask)
+	}
+	if _, err := parseWatches([]string{"/x:Z"}); err == nil {
+		t.Errorf("an unknown letter should error")
+	}
+}
+
+// queueSource yields the queued events, then reports EOF.
+type queueSource struct {
+	evs []event
+	i   int
+}
+
+func (q *queueSource) Recv() (event, error) {
+	if q.i >= len(q.evs) {
+		return event{}, io.EOF
+	}
+	e := q.evs[q.i]
+	q.i++
+	return e, nil
+}
+func (q *queueSource) Close() error { return nil }
+
+type handlerCall struct{ prog, actions, path, name string }
+
+func TestDispatchesEvents(t *testing.T) {
+	var calls []handlerCall
+	od, oh := dialFn, handlerFn
+	dialFn = func([]watch) (source, error) {
+		return &queueSource{evs: []event{
+			{mask: unix.IN_CREATE, path: "/etc", name: "new.conf"},
+			{mask: unix.IN_DELETE, path: "/etc", name: "old.conf"},
+		}}, nil
+	}
+	handlerFn = func(_ command.IO, prog, actions, path, name string) {
+		calls = append(calls, handlerCall{prog, actions, path, name})
+	}
+	defer func() { dialFn, handlerFn = od, oh }()
+
+	io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io2, []string{"./handler", "/etc"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("got %d handler calls, want 2: %+v", len(calls), calls)
+	}
+	if calls[0] != (handlerCall{"./handler", "n", "/etc", "new.conf"}) {
+		t.Errorf("first call = %+v", calls[0])
+	}
+	if calls[1] != (handlerCall{"./handler", "d", "/etc", "old.conf"}) {
+		t.Errorf("second call = %+v", calls[1])
+	}
+}
+
+type blockingSource struct{ closed chan struct{} }
+
+func (b *blockingSource) Recv() (event, error) { <-b.closed; return event{}, errors.New("closed") }
+func (b *blockingSource) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+func TestStopsOnCancel(t *testing.T) {
+	od := dialFn
+	dialFn = func([]watch) (source, error) { return &blockingSource{closed: make(chan struct{})}, nil }
+	defer func() { dialFn = od }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+		done <- New().Run(ctx, io2, []string{"./h", "/etc"})
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("inotifyd did not stop after cancellation")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io2, []string{"./h"}); err == nil {
+		t.Errorf("too few args should fail")
+	}
+	od := dialFn
+	dialFn = func([]watch) (source, error) { return nil, errors.New("no such file") }
+	defer func() { dialFn = od }()
+	if err := New().Run(context.Background(), io2, []string{"./h", "/etc"}); err == nil {
+		t.Errorf("a watch setup failure should fail")
+	}
+}

--- a/test/it/console-tools/inotifyd_test.sh
+++ b/test/it/console-tools/inotifyd_test.sh
@@ -1,0 +1,21 @@
+TestInotifydWatchesCreate() {
+    d="$TEST_DIR/w"; mkdir -p "$d"
+    printf '#!/bin/sh\necho "$1 $3" >> %s/events\n' "$TEST_DIR" > "$TEST_DIR/h"
+    chmod +x "$TEST_DIR/h"
+    : > "$TEST_DIR/events"
+    inotifyd "$TEST_DIR/h" "$d:n" &
+    pid=$!
+    # Give the watch time to be established, then create a file and poll for the
+    # handler's output (more robust than fixed sleeps under CI load).
+    sleep 0.3
+    touch "$d/created.txt"
+    for _ in $(seq 1 50); do
+        if grep -q 'n created.txt' "$TEST_DIR/events" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+    kill "$pid" 2>/dev/null
+    grep -c 'n created.txt' "$TEST_DIR/events"
+}
+TestInotifydNoArgs() { inotifyd ./h 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/inotifyd_spec.sh
+++ b/test/it/spec/inotifyd_spec.sh
@@ -1,0 +1,19 @@
+Describe 'inotifyd'
+    Include console-tools/inotifyd_test.sh
+
+    setup() { TEST_DIR=/tmp/mimixbox/it/inotifyd; mkdir -p "$TEST_DIR"; }
+    cleanup() { rm -rf "$TEST_DIR"; }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'runs the handler on a create event'
+        When call TestInotifydWatchesCreate
+        The output should equal '1'
+        The status should be success
+    End
+    It 'requires a handler and a file'
+        When call TestInotifydNoArgs
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `inotifyd`, which watches each FILE for inotify events and runs PROG for each one as 'PROG ACTIONS FILE [NAME]', where ACTIONS is the BusyBox event letters that occurred (a access, c modify, e attrib, w close-write, r open, n create, d delete, y moved-to, …). A FILE may be suffixed with ':MASK' to watch only those events. It runs until interrupted. The event source and the handler are injectable so the mask/letter mapping, the watch parsing, the dispatch, and cancellation are unit-tested without inotify, and a real create event is exercised end-to-end in the shellspec.

## Tests

- Unit: the `maskToLetters` mapping (single and combined events), `parseWatches` (default all-events, an explicit `:MASK`, and an unknown letter), dispatching queued create/delete events to the handler with the right actions/path/name, stopping cleanly on context cancellation, and the too-few-args / watch-setup-failure errors.
- shellspec: running the handler on a real file-create event (polling for robustness), and requiring a handler and a file.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (749 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `inotifyd` command to monitor specified file paths and execute a handler program in response to file system events.

* **Tests**
  * Added comprehensive test coverage including unit and integration tests for the new command.

* **Documentation**
  * Updated command documentation; command registry now includes `inotifyd` with total command count at 331.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->