### PR TITLE
fix(inotifyd): omit empty NAME, idempotent Close, surface read errors

### DIFF
--- a/internal/applets/console-tools/inotifyd/inotifyd.go
+++ b/internal/applets/console-tools/inotifyd/inotifyd.go
@@ -6,8 +6,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
+	"io"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/nao1215/mimixbox/internal/command"
 	"golang.org/x/sys/unix"
@@ -70,7 +73,11 @@ type watch struct {
 var (
 	dialFn    = openInotify
 	handlerFn = func(stdio command.IO, prog, actions, path, name string) {
-		cmd := exec.Command(prog, actions, path, name) //nolint:gosec // running the handler is the point
+		argv := []string{actions, path}
+		if name != "" { // the NAME argument is omitted for an event on the watched file itself
+			argv = append(argv, name)
+		}
+		cmd := exec.Command(prog, argv...) //nolint:gosec // running the handler is the point
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = stdio.In, stdio.Out, stdio.Err
 		_ = cmd.Run()
 	}
@@ -117,7 +124,10 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 	for {
 		ev, err := src.Recv()
 		if err != nil {
-			return nil // closed via cancellation, or the source ended
+			if ctx.Err() != nil || errors.Is(err, io.EOF) {
+				return nil // cancelled, or the source ended cleanly
+			}
+			return command.Failuref("watch error: %v", err)
 		}
 		handlerFn(stdio, prog, maskToLetters(ev.mask), ev.path, ev.name)
 	}
@@ -157,10 +167,12 @@ func maskToLetters(mask uint32) string {
 
 // inotifySource reads events from a real inotify file descriptor.
 type inotifySource struct {
-	fd     int
-	wdPath map[int32]string
-	buf    []byte
-	queue  []event
+	fd        int
+	wdPath    map[int32]string
+	buf       []byte
+	queue     []event
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // openInotify sets up an inotify watch for each path.
@@ -210,5 +222,9 @@ func (s *inotifySource) parse(data []byte) {
 	}
 }
 
-// Close closes the inotify descriptor.
-func (s *inotifySource) Close() error { return unix.Close(s.fd) }
+// Close closes the inotify descriptor, idempotently (it is closed from both the
+// cancellation goroutine and the deferred cleanup).
+func (s *inotifySource) Close() error {
+	s.closeOnce.Do(func() { s.closeErr = unix.Close(s.fd) })
+	return s.closeErr
+}

--- a/internal/applets/console-tools/inotifyd/inotifyd_test.go
+++ b/internal/applets/console-tools/inotifyd/inotifyd_test.go
@@ -133,3 +133,20 @@ func TestErrors(t *testing.T) {
 		t.Errorf("a watch setup failure should fail")
 	}
 }
+
+// errSource returns a non-EOF error on the first Recv (a broken watcher).
+type errSource struct{}
+
+func (errSource) Recv() (event, error) { return event{}, errors.New("read error") }
+func (errSource) Close() error         { return nil }
+
+func TestRealReadErrorFails(t *testing.T) {
+	od := dialFn
+	dialFn = func([]watch) (source, error) { return errSource{}, nil }
+	defer func() { dialFn = od }()
+	io2 := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	// Not cancelled and not EOF: a real read error must surface as a failure.
+	if err := New().Run(context.Background(), io2, []string{"./h", "/etc"}); err == nil {
+		t.Errorf("an unexpected read error should fail, not exit cleanly")
+	}
+}

--- a/test/it/console-tools/inotifyd_test.sh
+++ b/test/it/console-tools/inotifyd_test.sh
@@ -5,17 +5,20 @@ TestInotifydWatchesCreate() {
     : > "$TEST_DIR/events"
     inotifyd "$TEST_DIR/h" "$d:n" &
     pid=$!
-    # Give the watch time to be established, then create a file and poll for the
-    # handler's output (more robust than fixed sleeps under CI load).
-    sleep 0.3
-    touch "$d/created.txt"
+    # Recreate the watched file each iteration until the handler logs the create
+    # event, so a create lost before the watch is fully active is retried.
+    found=missing
     for _ in $(seq 1 50); do
+        rm -f "$d/created.txt"
+        touch "$d/created.txt"
         if grep -q 'n created.txt' "$TEST_DIR/events" 2>/dev/null; then
+            found=ok
             break
         fi
         sleep 0.1
     done
     kill "$pid" 2>/dev/null
-    grep -c 'n created.txt' "$TEST_DIR/events"
+    wait "$pid" 2>/dev/null
+    echo "$found"
 }
 TestInotifydNoArgs() { inotifyd ./h 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/inotifyd_spec.sh
+++ b/test/it/spec/inotifyd_spec.sh
@@ -8,7 +8,7 @@ Describe 'inotifyd'
 
     It 'runs the handler on a create event'
         When call TestInotifydWatchesCreate
-        The output should equal '1'
+        The output should equal 'ok'
         The status should be success
     End
     It 'requires a handler and a file'


### PR DESCRIPTION
Follow-up to #458 addressing CodeRabbit findings:

- **Preserve the optional [NAME] argument (Major).** The default handler invoked PROG with an empty NAME for events on the watched file itself, breaking the 'PROG ACTIONS FILE [NAME]' contract. NAME is now omitted from argv when empty.
- **Idempotent Close (Major).** inotifySource.Close did a bare unix.Close(fd) and was called from both the cancellation goroutine and the deferred cleanup, risking closing a reused descriptor. It now uses sync.Once.
- **Surface real read errors (Major).** Run returned nil for every Recv error, hiding a broken watcher behind a clean exit. It now returns nil only for context cancellation or a clean EOF, and fails on any other error. Adds a unit test with an error-returning source.
- **De-flake the e2e (Major).** The shellspec emitted a single touch after a fixed sleep, so a create lost before the watch was active could not be recovered. It now recreates the watched file each poll iteration until the handler logs the event, and waits for the killed background process.

Part of #252