### PR TITLE
feat(console-tools): add setkeycodes applet to map scancodes to keycodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 331 commands. Run `mimixbox --list` to see them on the terminal.
+There are 332 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -258,6 +258,7 @@ There are 331 commands. Run `mimixbox --list` to see them on the terminal.
 | serial | Rename the file to the name with a serial number |
 | setarch | Run a program with a changed architecture personality |
 | setconsole | Redirect console output to a device |
+| setkeycodes | Map scancodes to keycodes |
 | setlogcons | Send kernel messages to a VT |
 | setpriv | Run a program with different privilege settings |
 | setsid | Run a program in a new session |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -36,6 +36,7 @@ import (
 	ap_console_tools_reset "github.com/nao1215/mimixbox/internal/applets/console-tools/reset"
 	ap_console_tools_resize "github.com/nao1215/mimixbox/internal/applets/console-tools/resize"
 	ap_console_tools_setconsole "github.com/nao1215/mimixbox/internal/applets/console-tools/setconsole"
+	ap_console_tools_setkeycodes "github.com/nao1215/mimixbox/internal/applets/console-tools/setkeycodes"
 	ap_console_tools_setlogcons "github.com/nao1215/mimixbox/internal/applets/console-tools/setlogcons"
 	ap_console_tools_stty "github.com/nao1215/mimixbox/internal/applets/console-tools/stty"
 	ap_console_tools_ts "github.com/nao1215/mimixbox/internal/applets/console-tools/ts"
@@ -317,7 +318,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 331)
+	Applets = make(map[string]Applet, 332)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -361,6 +362,7 @@ func init() {
 	register(ap_console_tools_reset.New())
 	register(ap_console_tools_resize.New())
 	register(ap_console_tools_setconsole.New())
+	register(ap_console_tools_setkeycodes.New())
 	register(ap_console_tools_setlogcons.New())
 	register(ap_console_tools_stty.New())
 	register(ap_console_tools_ts.New())

--- a/internal/applets/console-tools/setkeycodes/setkeycodes.go
+++ b/internal/applets/console-tools/setkeycodes/setkeycodes.go
@@ -1,0 +1,84 @@
+// Package setkeycodes implements the setkeycodes applet: map scancodes to
+// keycodes in the kernel keyboard driver.
+package setkeycodes
+
+import (
+	"context"
+	"strconv"
+	"unsafe"
+
+	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+// Command is the setkeycodes applet.
+type Command struct{}
+
+// New returns a setkeycodes command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "setkeycodes" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Map scancodes to keycodes" }
+
+// kdSetKeycode is the KDSETKEYCODE ioctl, not exported by this x/sys version.
+const kdSetKeycode = 0x4B4D
+
+// kbkeycode mirrors struct kbkeycode.
+type kbkeycode struct {
+	scancode, keycode uint32
+}
+
+// setKeycodeFn is indirected so the ioctl can be tested without a console.
+var setKeycodeFn = func(scancode, keycode int) error {
+	f, err := os.Open("/dev/console") //nolint:gosec // the system console
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	kc := kbkeycode{scancode: uint32(scancode), keycode: uint32(keycode)}
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), kdSetKeycode, uintptr(unsafe.Pointer(&kc))); errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Run executes setkeycodes.
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "SCANCODE KEYCODE...", stdio.Err).WithHelp(command.Help{
+		Description: "Map raw keyboard SCANCODEs to kernel KEYCODEs (via the KDSETKEYCODE ioctl), given " +
+			"as one or more pairs. The scancode is hexadecimal (e.g. e060) and the keycode is decimal. " +
+			"Requires privilege and a Linux console.",
+		Examples: []command.Example{
+			{Command: "setkeycodes e060 122", Explain: "Map scancode 0xe060 to keycode 122."},
+		},
+		ExitStatus: "0  the mappings were set.\n1  an odd or invalid argument, or the ioctl failed.",
+	})
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 || len(rest)%2 != 0 {
+		return command.Failuref("scancode/keycode arguments must be given in pairs")
+	}
+
+	for i := 0; i < len(rest); i += 2 {
+		scancode, err := strconv.ParseInt(rest[i], 16, 32)
+		if err != nil || scancode < 0 {
+			return command.Failuref("invalid scancode: %q", rest[i])
+		}
+		keycode, err := strconv.Atoi(rest[i+1])
+		if err != nil || keycode < 0 {
+			return command.Failuref("invalid keycode: %q", rest[i+1])
+		}
+		if err := setKeycodeFn(int(scancode), keycode); err != nil {
+			return command.Failuref("cannot set scancode %s: %v", rest[i], err)
+		}
+	}
+	return nil
+}

--- a/internal/applets/console-tools/setkeycodes/setkeycodes_test.go
+++ b/internal/applets/console-tools/setkeycodes/setkeycodes_test.go
@@ -1,0 +1,58 @@
+package setkeycodes
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+type pair struct{ scancode, keycode int }
+
+func stub(t *testing.T, err error) *[]pair {
+	t.Helper()
+	var calls []pair
+	orig := setKeycodeFn
+	setKeycodeFn = func(s, k int) error { calls = append(calls, pair{s, k}); return err }
+	t.Cleanup(func() { setKeycodeFn = orig })
+	return &calls
+}
+
+func run(t *testing.T, args ...string) error {
+	t.Helper()
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	return New().Run(context.Background(), io, args)
+}
+
+func TestSetsPairs(t *testing.T) {
+	calls := stub(t, nil)
+	if err := run(t, "e060", "122", "e061", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*calls) != 2 || (*calls)[0] != (pair{0xe060, 122}) || (*calls)[1] != (pair{0xe061, 123}) {
+		t.Errorf("calls = %v", *calls)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	stub(t, nil)
+	if err := run(t); err == nil {
+		t.Errorf("no args should fail")
+	}
+	if err := run(t, "e060"); err == nil {
+		t.Errorf("an odd number of args should fail")
+	}
+	if err := run(t, "zz", "1"); err == nil {
+		t.Errorf("a bad scancode should fail")
+	}
+	if err := run(t, "e060", "notanumber"); err == nil {
+		t.Errorf("a bad keycode should fail")
+	}
+	stub(t, errors.New("permission denied"))
+	if err := run(t, "e060", "122"); err == nil {
+		t.Errorf("an ioctl failure should fail")
+	}
+}

--- a/test/it/console-tools/setkeycodes_test.sh
+++ b/test/it/console-tools/setkeycodes_test.sh
@@ -1,0 +1,2 @@
+TestSetkeycodesOdd() { setkeycodes e060 2>/dev/null; echo "rc=$?"; }
+TestSetkeycodesBad() { setkeycodes zz 1 2>/dev/null; echo "rc=$?"; }

--- a/test/it/spec/setkeycodes_spec.sh
+++ b/test/it/spec/setkeycodes_spec.sh
@@ -1,0 +1,14 @@
+Describe 'setkeycodes'
+    Include console-tools/setkeycodes_test.sh
+
+    It 'requires arguments in pairs'
+        When call TestSetkeycodesOdd
+        The output should equal 'rc=1'
+        The status should be success
+    End
+    It 'rejects an invalid scancode'
+        When call TestSetkeycodesBad
+        The output should equal 'rc=1'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Advances the console-tools batch (#252) with `setkeycodes`, which maps raw keyboard SCANCODEs to kernel KEYCODEs (via the KDSETKEYCODE ioctl), given as one or more pairs — the scancode hexadecimal, the keycode decimal. It requires privilege and a Linux console; the ioctl is injectable so the parsing and dispatch are tested without one.

## Tests

- Unit (stubbed ioctl): setting multiple scancode/keycode pairs with the right values, and the no-args / odd-args / invalid-scancode / invalid-keycode / ioctl-failure errors.
- shellspec: arguments must be in pairs, and an invalid scancode is rejected.

## Verification

- `go test ./...` passes (race-clean); `make test-e2e` passes (751 examples, 0 failures); `golangci-lint` clean; registry/README in sync.

Part of #252