### PR TITLE
feat(shellutils): add leadtime applet for GitHub PR lead-time stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MimixBox packs many Unix commands into a single binary, like BusyBox. Unlike Bus
 The list below is generated from the registered applets by `make command-list`, so it never drifts from the binary. You can also run `mimixbox --list` to print it on the terminal.
 
 <!-- COMMAND_LIST_START -->
-There are 333 commands. Run `mimixbox --list` to see them on the terminal.
+There are 334 commands. Run `mimixbox --list` to see them on the terminal.
 
 | Command | Description |
 |:--|:--|
@@ -152,6 +152,7 @@ There are 333 commands. Run `mimixbox --list` to see them on the terminal.
 | killall5 | Send a signal to all processes |
 | klogd | Forward kernel messages to the system log |
 | last | Show a listing of last logged-in users |
+| leadtime | Calculate GitHub PR lead time statistics |
 | less | Page through text one screen at a time |
 | lifegame | Life game (Conway's Game of Life) |
 | link | Create a hard link to a file |

--- a/internal/applets/applet_registry_gen.go
+++ b/internal/applets/applet_registry_gen.go
@@ -181,6 +181,7 @@ import (
 	ap_shellutils_install "github.com/nao1215/mimixbox/internal/applets/shellutils/install"
 	ap_shellutils_kill "github.com/nao1215/mimixbox/internal/applets/shellutils/kill"
 	ap_shellutils_killall "github.com/nao1215/mimixbox/internal/applets/shellutils/killall"
+	ap_shellutils_leadtime "github.com/nao1215/mimixbox/internal/applets/shellutils/leadtime"
 	ap_shellutils_logcollect "github.com/nao1215/mimixbox/internal/applets/shellutils/logcollect"
 	ap_shellutils_logname "github.com/nao1215/mimixbox/internal/applets/shellutils/logname"
 	ap_shellutils_mbsh "github.com/nao1215/mimixbox/internal/applets/shellutils/mbsh"
@@ -319,7 +320,7 @@ import (
 // init populates the applet table. Each command is registered under its own
 // Name(), so the key can never drift from the command it dispatches to.
 func init() {
-	Applets = make(map[string]Applet, 333)
+	Applets = make(map[string]Applet, 334)
 	register(ap_archival_ar.New())
 	register(ap_archival_bunzip2.New())
 	register(ap_archival_compress.New())
@@ -513,6 +514,7 @@ func init() {
 	register(ap_shellutils_install.New())
 	register(ap_shellutils_kill.New())
 	register(ap_shellutils_killall.New())
+	register(ap_shellutils_leadtime.New())
 	register(ap_shellutils_logcollect.New())
 	register(ap_shellutils_logname.New())
 	register(ap_shellutils_mbsh.New())

--- a/internal/applets/shellutils/leadtime/client.go
+++ b/internal/applets/shellutils/leadtime/client.go
@@ -1,0 +1,189 @@
+//
+// mimixbox/internal/applets/shellutils/leadtime/client.go
+//
+// Copyright 2021 Naohiro CHIKAMATSU
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leadtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// defaultBaseURL is the public GitHub REST API root.
+const defaultBaseURL = "https://api.github.com"
+
+// perPage is the page size requested from the GitHub pulls endpoint. GitHub
+// caps this at 100.
+const perPage = 100
+
+// pullRequest is the subset of the GitHub Pull Request REST representation that
+// leadtime needs to compute lead-time statistics.
+type pullRequest struct {
+	Number    int        `json:"number"`
+	State     string     `json:"state"`
+	Title     string     `json:"title"`
+	CreatedAt *time.Time `json:"created_at"`
+	MergedAt  *time.Time `json:"merged_at"`
+	User      struct {
+		Login string `json:"login"`
+		Type  string `json:"type"`
+	} `json:"user"`
+}
+
+// isMerged reports whether the Pull Request was merged (it has a merged_at
+// timestamp and a created_at to measure from).
+func (p pullRequest) isMerged() bool {
+	return p.MergedAt != nil && p.CreatedAt != nil && !p.MergedAt.IsZero() && !p.CreatedAt.IsZero()
+}
+
+// isBot reports whether the Pull Request author is a GitHub bot account. GitHub
+// marks bot accounts with a user type of "Bot"; well-known bot logins are also
+// recognized as a fallback.
+func (p pullRequest) isBot() bool {
+	if strings.EqualFold(p.User.Type, "Bot") {
+		return true
+	}
+	login := strings.ToLower(p.User.Login)
+	return strings.HasSuffix(login, "[bot]") ||
+		login == "dependabot" || login == "renovate" || login == "github-actions"
+}
+
+// leadTimeMinutes returns the lead time in minutes, from PR creation to merge.
+// It is only meaningful when isMerged reports true.
+func (p pullRequest) leadTimeMinutes() float64 {
+	return p.MergedAt.Sub(*p.CreatedAt).Minutes()
+}
+
+// client talks to the read-only GitHub REST API.
+type client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// newClient builds a client for baseURL authenticating with token. A trailing
+// slash on baseURL is trimmed so endpoint construction is predictable.
+func newClient(baseURL, token string) *client {
+	return &client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// fetchPullRequests retrieves every Pull Request (state=all) for owner/repo,
+// following pagination until an empty page is returned. It returns a
+// deterministic error on rate-limit, non-200, or malformed responses.
+func (c *client) fetchPullRequests(ctx context.Context, owner, repo string) ([]pullRequest, error) {
+	var all []pullRequest
+	for page := 1; ; page++ {
+		batch, err := c.fetchPage(ctx, owner, repo, page)
+		if err != nil {
+			return nil, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		all = append(all, batch...)
+		if len(batch) < perPage {
+			break
+		}
+	}
+	return all, nil
+}
+
+// fetchPage retrieves a single page of Pull Requests.
+func (c *client) fetchPage(ctx context.Context, owner, repo string, page int) ([]pullRequest, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/pulls?state=all&per_page=%d&page=%d",
+		c.baseURL, owner, repo, perPage, page)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("can't build request for GitHub: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("can't get response from GitHub: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("can't read response from GitHub: %w", err)
+	}
+
+	if err := checkStatus(resp, body); err != nil {
+		return nil, err
+	}
+
+	var prs []pullRequest
+	if err := json.Unmarshal(body, &prs); err != nil {
+		return nil, fmt.Errorf("can't parse GitHub response (is owner/repo correct?): %w", err)
+	}
+	return prs, nil
+}
+
+// checkStatus turns a non-success HTTP response into a deterministic error,
+// distinguishing rate-limit responses (so callers can recognize them) from
+// other failures.
+func checkStatus(resp *http.Response, body []byte) error {
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	// GitHub signals primary rate-limit exhaustion with 403/429 and an
+	// X-RateLimit-Remaining of 0.
+	remaining := resp.Header.Get("X-RateLimit-Remaining")
+	if (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests) && remaining == "0" {
+		return fmt.Errorf("GitHub API rate limit exceeded%s", resetHint(resp))
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("GitHub API authentication failed (status 401): check your token")
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("repository not found (status 404): check --owner and --repo")
+	}
+
+	msg := strings.TrimSpace(string(body))
+	if len(msg) > 200 {
+		msg = msg[:200]
+	}
+	return fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, msg)
+}
+
+// resetHint formats a human-friendly hint about when the rate limit resets,
+// derived from the X-RateLimit-Reset header (a Unix timestamp). It returns an
+// empty string when the header is absent or unparsable.
+func resetHint(resp *http.Response) string {
+	reset := resp.Header.Get("X-RateLimit-Reset")
+	if reset == "" {
+		return ""
+	}
+	sec, err := strconv.ParseInt(reset, 10, 64)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("; resets at %s", time.Unix(sec, 0).UTC().Format(time.RFC3339))
+}

--- a/internal/applets/shellutils/leadtime/format.go
+++ b/internal/applets/shellutils/leadtime/format.go
@@ -1,0 +1,135 @@
+//
+// mimixbox/internal/applets/shellutils/leadtime/format.go
+//
+// Copyright 2021 Naohiro CHIKAMATSU
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leadtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// prDetail is the per-PR view emitted with --all. Lead time is in minutes.
+type prDetail struct {
+	Number          int     `json:"number"`
+	State           string  `json:"state"`
+	Title           string  `json:"title"`
+	User            string  `json:"user"`
+	CreatedAt       string  `json:"created_at"`
+	MergedAt        string  `json:"merged_at"`
+	LeadTimeMinutes float64 `json:"lead_time_minutes"`
+}
+
+// report is the stable JSON schema emitted by --json.
+type report struct {
+	Owner      string     `json:"owner"`
+	Repo       string     `json:"repo"`
+	Statistics statistics `json:"statistics"`
+	PRs        []prDetail `json:"pull_requests,omitempty"`
+}
+
+// toDetails converts merged Pull Requests into the per-PR detail view.
+func toDetails(prs []pullRequest) []prDetail {
+	out := make([]prDetail, 0, len(prs))
+	for _, pr := range prs {
+		out = append(out, prDetail{
+			Number:          pr.Number,
+			State:           pr.State,
+			Title:           pr.Title,
+			User:            pr.User.Login,
+			CreatedAt:       fmtTime(pr.CreatedAt),
+			MergedAt:        fmtTime(pr.MergedAt),
+			LeadTimeMinutes: pr.leadTimeMinutes(),
+		})
+	}
+	return out
+}
+
+// fmtTime renders a timestamp in RFC3339 UTC, or "-" when nil.
+func fmtTime(t *time.Time) string {
+	if t == nil {
+		return "-"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// renderText writes the human-readable default output.
+func renderText(w io.Writer, opts options, s statistics, merged []pullRequest) {
+	_, _ = fmt.Fprintf(w, "Repository           : %s/%s\n", opts.owner, opts.repo)
+	_, _ = fmt.Fprintf(w, "Total PR             : %d\n", s.TotalPR)
+	_, _ = fmt.Fprintf(w, "Lead Time(Max)       : %.2f[min]\n", s.Max)
+	_, _ = fmt.Fprintf(w, "Lead Time(Min)       : %.2f[min]\n", s.Min)
+	_, _ = fmt.Fprintf(w, "Lead Time(Sum)       : %.2f[min]\n", s.Sum)
+	_, _ = fmt.Fprintf(w, "Lead Time(Ave)       : %.2f[min]\n", s.Average)
+	_, _ = fmt.Fprintf(w, "Lead Time(Median)    : %.2f[min]\n", s.Median)
+
+	if opts.all {
+		_, _ = fmt.Fprintln(w, "")
+		_, _ = fmt.Fprintln(w, "Pull Requests:")
+		for _, d := range toDetails(merged) {
+			_, _ = fmt.Fprintf(w, "  #%d [%s] %.2f[min] by %s: %s\n",
+				d.Number, d.State, d.LeadTimeMinutes, d.User, d.Title)
+		}
+	}
+}
+
+// renderJSON writes the stable JSON schema. With --all the per-PR details are
+// included.
+func renderJSON(w io.Writer, opts options, s statistics, merged []pullRequest) error {
+	r := report{
+		Owner:      opts.owner,
+		Repo:       opts.repo,
+		Statistics: s,
+	}
+	if opts.all {
+		r.PRs = toDetails(merged)
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(r); err != nil {
+		return fmt.Errorf("can't encode JSON: %w", err)
+	}
+	return nil
+}
+
+// renderMarkdown writes a Markdown table of the statistics, and a per-PR table
+// when --all is requested.
+func renderMarkdown(w io.Writer, opts options, s statistics, merged []pullRequest) error {
+	_, _ = fmt.Fprintf(w, "# Lead Time Statistics for %s/%s\n\n", opts.owner, opts.repo)
+	_, _ = fmt.Fprintln(w, "| Metric | Value |")
+	_, _ = fmt.Fprintln(w, "| --- | --- |")
+	_, _ = fmt.Fprintf(w, "| Total PR | %d |\n", s.TotalPR)
+	_, _ = fmt.Fprintf(w, "| Lead Time(Max) | %.2f[min] |\n", s.Max)
+	_, _ = fmt.Fprintf(w, "| Lead Time(Min) | %.2f[min] |\n", s.Min)
+	_, _ = fmt.Fprintf(w, "| Lead Time(Sum) | %.2f[min] |\n", s.Sum)
+	_, _ = fmt.Fprintf(w, "| Lead Time(Ave) | %.2f[min] |\n", s.Average)
+	_, _ = fmt.Fprintf(w, "| Lead Time(Median) | %.2f[min] |\n", s.Median)
+
+	if opts.all {
+		_, _ = fmt.Fprintln(w, "")
+		_, _ = fmt.Fprintln(w, "## Pull Requests")
+		_, _ = fmt.Fprintln(w, "")
+		_, _ = fmt.Fprintln(w, "| PR | State | Lead Time[min] | User | Title |")
+		_, _ = fmt.Fprintln(w, "| --- | --- | --- | --- | --- |")
+		for _, d := range toDetails(merged) {
+			_, _ = fmt.Fprintf(w, "| #%d | %s | %.2f | %s | %s |\n",
+				d.Number, d.State, d.LeadTimeMinutes, d.User, d.Title)
+		}
+	}
+	return nil
+}

--- a/internal/applets/shellutils/leadtime/leadtime.go
+++ b/internal/applets/shellutils/leadtime/leadtime.go
@@ -1,0 +1,241 @@
+//
+// mimixbox/internal/applets/shellutils/leadtime/leadtime.go
+//
+// Copyright 2021 Naohiro CHIKAMATSU
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package leadtime implements the leadtime applet: it calculates GitHub Pull
+// Request lead-time statistics for a repository. Lead time here is the elapsed
+// time, in minutes, from when a Pull Request is created until it is merged.
+// Only merged Pull Requests contribute to the statistics. The applet is a port
+// of the archived github.com/nao1215/leadtime project and talks to the
+// read-only GitHub REST API.
+package leadtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// Command is the leadtime applet.
+type Command struct{}
+
+// New returns a leadtime command.
+func New() *Command { return &Command{} }
+
+// Name returns the command name.
+func (c *Command) Name() string { return "leadtime" }
+
+// Synopsis returns the one-line description shown in the applet list.
+func (c *Command) Synopsis() string { return "Calculate GitHub PR lead time statistics" }
+
+// options collects the parsed command-line options for `leadtime stat`.
+type options struct {
+	owner       string
+	repo        string
+	all         bool
+	json        bool
+	markdown    bool
+	excludeBot  bool
+	excludePR   []int
+	excludeUser []string
+	baseURL     string
+	token       string
+}
+
+// Run executes leadtime.
+func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.Name(), "stat --owner=OWNER --repo=REPO [OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Calculate GitHub Pull Request lead-time statistics for a repository.\n\n" +
+			"Lead time is the elapsed time, in minutes, from when a Pull Request is\n" +
+			"created until it is merged. Only merged Pull Requests are counted; open and\n" +
+			"closed-but-unmerged Pull Requests are ignored. For the matching Pull\n" +
+			"Requests leadtime reports the total count and the maximum, minimum, sum,\n" +
+			"average, and median lead time. Use --all to also print per-PR details.\n\n" +
+			"The only subcommand is 'stat'. --owner and --repo are required.\n\n" +
+			"Authentication: leadtime reads a GitHub access token from the\n" +
+			"LT_GITHUB_ACCESS_TOKEN environment variable, falling back to GITHUB_TOKEN.\n" +
+			"A token is required; unauthenticated requests are rejected with a\n" +
+			"deterministic error. Only read-only REST API calls are made.\n\n" +
+			"Rate limits: the GitHub REST API limits authenticated requests (5000/hour\n" +
+			"by default). Large repositories are paginated, so a single run may issue\n" +
+			"several requests. A rate-limit response is reported as a deterministic\n" +
+			"error rather than partial output.",
+		Examples: []command.Example{
+			{Command: "leadtime stat --owner=nao1215 --repo=sqly", Explain: "Print text statistics for nao1215/sqly."},
+			{Command: "leadtime stat --owner=nao1215 --repo=sqly --all", Explain: "Also print per-PR lead-time details."},
+			{Command: "leadtime stat --owner=nao1215 --repo=sqly --json", Explain: "Emit machine-readable JSON."},
+			{Command: "leadtime stat --owner=nao1215 --repo=sqly --markdown", Explain: "Emit a Markdown table."},
+			{Command: "leadtime stat --owner=acme --repo=demo -B -P 1,3 -U bob", Explain: "Exclude bots, PR #1 and #3, and user bob."},
+			{Command: "leadtime stat --owner=acme --repo=demo --base-url=http://127.0.0.1:8080", Explain: "Target a GitHub Enterprise or test server."},
+		},
+		ExitStatus: "0  statistics were calculated and printed.\n1  bad usage, missing token, API error, or no merged Pull Requests.",
+		Notes: []string{
+			"Token is taken from LT_GITHUB_ACCESS_TOKEN, then GITHUB_TOKEN.",
+			"--base-url targets GitHub Enterprise or a local test server; it defaults to https://api.github.com.",
+			"Only read-only REST API calls are issued; leadtime never mutates GitHub state.",
+			"--json and --markdown are mutually exclusive.",
+		},
+	})
+
+	owner := fs.String("owner", "", "Repository owner (user or organization) [required]")
+	repo := fs.String("repo", "", "Repository name [required]")
+	all := fs.BoolP("all", "a", false, "Show per-PR lead-time details in addition to statistics")
+	jsonOut := fs.Bool("json", false, "Emit statistics as JSON")
+	markdownOut := fs.Bool("markdown", false, "Emit statistics as a Markdown table")
+	excludeBot := fs.BoolP("exclude-bot", "B", false, "Exclude Pull Requests opened by bots")
+	excludePR := fs.StringP("exclude-pr", "P", "", "Comma-separated PR numbers to exclude (e.g. 1,3,19)")
+	excludeUser := fs.StringP("exclude-user", "U", "", "Comma-separated user logins to exclude (e.g. alice,bob)")
+	baseURL := fs.String("base-url", defaultBaseURL, "GitHub REST API base URL (for GitHub Enterprise or test servers)")
+
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+
+	operands := fs.Args()
+	if len(operands) == 0 {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: missing subcommand: expected 'stat'\n", c.Name())
+		_, _ = fmt.Fprintf(stdio.Err, "Try '%s --help' for more information.\n", c.Name())
+		return command.SilentFailure()
+	}
+	if operands[0] != "stat" {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: unknown subcommand '%s'; only 'stat' is supported\n", c.Name(), operands[0])
+		_, _ = fmt.Fprintf(stdio.Err, "Try '%s --help' for more information.\n", c.Name())
+		return command.SilentFailure()
+	}
+	if len(operands) > 1 {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: extra operand '%s'\n", c.Name(), operands[1])
+		_, _ = fmt.Fprintf(stdio.Err, "Try '%s --help' for more information.\n", c.Name())
+		return command.SilentFailure()
+	}
+
+	if *owner == "" || *repo == "" {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: --owner and --repo are required\n", c.Name())
+		_, _ = fmt.Fprintf(stdio.Err, "Try '%s --help' for more information.\n", c.Name())
+		return command.SilentFailure()
+	}
+	if *jsonOut && *markdownOut {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: --json and --markdown are mutually exclusive\n", c.Name())
+		return command.SilentFailure()
+	}
+
+	prNumbers, err := parseExcludePR(*excludePR)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", c.Name(), err)
+		return command.SilentFailure()
+	}
+
+	opts := options{
+		owner:       *owner,
+		repo:        *repo,
+		all:         *all,
+		json:        *jsonOut,
+		markdown:    *markdownOut,
+		excludeBot:  *excludeBot,
+		excludePR:   prNumbers,
+		excludeUser: parseExcludeUser(*excludeUser),
+		baseURL:     *baseURL,
+		token:       resolveToken(),
+	}
+
+	return c.run(ctx, stdio, opts)
+}
+
+// run performs the real work once options have been validated.
+func (c *Command) run(ctx context.Context, stdio command.IO, opts options) error {
+	if opts.token == "" {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: no GitHub token found; set LT_GITHUB_ACCESS_TOKEN or GITHUB_TOKEN\n", c.Name())
+		return command.SilentFailure()
+	}
+
+	client := newClient(opts.baseURL, opts.token)
+	prs, err := client.fetchPullRequests(ctx, opts.owner, opts.repo)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", c.Name(), err)
+		return command.SilentFailure()
+	}
+
+	filtered := applyFilters(prs, opts)
+	merged := mergedOnly(filtered)
+	if len(merged) == 0 {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: no merged Pull Requests found for %s/%s\n", c.Name(), opts.owner, opts.repo)
+		return command.SilentFailure()
+	}
+
+	stats := calcStatistics(merged)
+
+	switch {
+	case opts.json:
+		return renderJSON(stdio.Out, opts, stats, merged)
+	case opts.markdown:
+		return renderMarkdown(stdio.Out, opts, stats, merged)
+	default:
+		renderText(stdio.Out, opts, stats, merged)
+		return nil
+	}
+}
+
+// resolveToken returns the GitHub access token, preferring
+// LT_GITHUB_ACCESS_TOKEN and falling back to GITHUB_TOKEN.
+func resolveToken() string {
+	if t := strings.TrimSpace(os.Getenv("LT_GITHUB_ACCESS_TOKEN")); t != "" {
+		return t
+	}
+	return strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+}
+
+// parseExcludePR parses a comma-separated list of PR numbers ("1,3,19") into a
+// slice of ints. An empty string yields nil. A non-numeric token is an error.
+func parseExcludePR(s string) ([]int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	var out []int
+	for _, tok := range strings.Split(s, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		n, err := strconv.Atoi(tok)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --exclude-pr value %q: must be a PR number", tok)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+// parseExcludeUser parses a comma-separated list of user logins ("alice,bob")
+// into a slice. An empty string yields nil.
+func parseExcludeUser(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, tok := range strings.Split(s, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok != "" {
+			out = append(out, tok)
+		}
+	}
+	return out
+}

--- a/internal/applets/shellutils/leadtime/leadtime_test.go
+++ b/internal/applets/shellutils/leadtime/leadtime_test.go
@@ -1,0 +1,555 @@
+//
+// mimixbox/internal/applets/shellutils/leadtime/leadtime_test.go
+//
+// Copyright 2021 Naohiro CHIKAMATSU
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leadtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// requireLoopback skips the test when a loopback listen socket cannot be
+// created (e.g. a sandbox without networking), since httptest needs one.
+func requireLoopback(t *testing.T) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("loopback listen unavailable: %v", err)
+	}
+	_ = ln.Close()
+}
+
+// mustTime parses an RFC3339 timestamp or fails the test.
+func mustTime(t *testing.T, s string) *time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("bad time %q: %v", s, err)
+	}
+	return &tm
+}
+
+// pr is a small helper to build a merged pull request created at create and
+// merged at merge (both RFC3339), authored by login of the given type.
+func pr(t *testing.T, number int, login, typ, create, merge string) pullRequest {
+	t.Helper()
+	p := pullRequest{Number: number, State: "closed", Title: "PR " + strconv.Itoa(number)}
+	p.User.Login = login
+	p.User.Type = typ
+	p.CreatedAt = mustTime(t, create)
+	if merge != "" {
+		p.MergedAt = mustTime(t, merge)
+	}
+	return p
+}
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestCalcStatistics(t *testing.T) {
+	// Lead times: 10, 20, 30, 40 minutes.
+	prs := []pullRequest{
+		pr(t, 1, "alice", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:10:00Z"),
+		pr(t, 2, "bob", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:20:00Z"),
+		pr(t, 3, "carol", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:30:00Z"),
+		pr(t, 4, "dave", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:40:00Z"),
+	}
+	s := calcStatistics(prs)
+	if s.TotalPR != 4 {
+		t.Errorf("TotalPR = %d, want 4", s.TotalPR)
+	}
+	if !almostEqual(s.Max, 40) {
+		t.Errorf("Max = %v, want 40", s.Max)
+	}
+	if !almostEqual(s.Min, 10) {
+		t.Errorf("Min = %v, want 10", s.Min)
+	}
+	if !almostEqual(s.Sum, 100) {
+		t.Errorf("Sum = %v, want 100", s.Sum)
+	}
+	if !almostEqual(s.Average, 25) {
+		t.Errorf("Average = %v, want 25", s.Average)
+	}
+	// Even count median: (20+30)/2 = 25.
+	if !almostEqual(s.Median, 25) {
+		t.Errorf("Median = %v, want 25", s.Median)
+	}
+}
+
+func TestMedianOdd(t *testing.T) {
+	prs := []pullRequest{
+		pr(t, 1, "a", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:10:00Z"),
+		pr(t, 2, "b", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:30:00Z"),
+		pr(t, 3, "c", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:50:00Z"),
+	}
+	s := calcStatistics(prs)
+	if !almostEqual(s.Median, 30) {
+		t.Errorf("Median = %v, want 30", s.Median)
+	}
+}
+
+func TestMedianDoesNotMutate(t *testing.T) {
+	in := []float64{30, 10, 20}
+	_ = medianOf(in)
+	if in[0] != 30 || in[1] != 10 || in[2] != 20 {
+		t.Errorf("medianOf mutated input: %v", in)
+	}
+}
+
+func TestApplyFilters(t *testing.T) {
+	prs := []pullRequest{
+		pr(t, 1, "alice", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:10:00Z"),
+		pr(t, 2, "dependabot[bot]", "Bot", "2024-01-01T00:00:00Z", "2024-01-01T00:20:00Z"),
+		pr(t, 3, "bob", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:30:00Z"),
+		pr(t, 4, "carol", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:40:00Z"),
+	}
+
+	tests := []struct {
+		name string
+		opts options
+		want []int
+	}{
+		{"no filter", options{}, []int{1, 2, 3, 4}},
+		{"exclude bot", options{excludeBot: true}, []int{1, 3, 4}},
+		{"exclude pr", options{excludePR: []int{1, 3}}, []int{2, 4}},
+		{"exclude user", options{excludeUser: []string{"bob"}}, []int{1, 2, 4}},
+		{"combined", options{excludeBot: true, excludePR: []int{4}, excludeUser: []string{"bob"}}, []int{1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyFilters(prs, tt.opts)
+			var nums []int
+			for _, p := range got {
+				nums = append(nums, p.Number)
+			}
+			if len(nums) != len(tt.want) {
+				t.Fatalf("got %v, want %v", nums, tt.want)
+			}
+			for i := range nums {
+				if nums[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", nums, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestMergedOnly(t *testing.T) {
+	prs := []pullRequest{
+		pr(t, 1, "a", "User", "2024-01-01T00:00:00Z", "2024-01-01T00:10:00Z"), // merged
+		pr(t, 2, "b", "User", "2024-01-01T00:00:00Z", ""),                     // unmerged (open/closed)
+	}
+	// PR 3 has merged_at but missing created_at -> not a valid lead time.
+	p3 := pullRequest{Number: 3, State: "closed"}
+	p3.MergedAt = mustTime(t, "2024-01-01T00:30:00Z")
+	prs = append(prs, p3)
+
+	got := mergedOnly(prs)
+	if len(got) != 1 || got[0].Number != 1 {
+		var nums []int
+		for _, p := range got {
+			nums = append(nums, p.Number)
+		}
+		t.Errorf("mergedOnly = %v, want [1]", nums)
+	}
+}
+
+func TestParseExcludePR(t *testing.T) {
+	got, err := parseExcludePR(" 1, 3 ,19 ")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := []int{1, 3, 19}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+	if _, err := parseExcludePR("1,x"); err == nil {
+		t.Error("expected error for non-numeric PR token")
+	}
+	if g, _ := parseExcludePR(""); g != nil {
+		t.Errorf("empty should be nil, got %v", g)
+	}
+}
+
+func TestIsBot(t *testing.T) {
+	tests := []struct {
+		login string
+		typ   string
+		want  bool
+	}{
+		{"alice", "User", false},
+		{"dependabot[bot]", "Bot", true},
+		{"renovate", "User", true},
+		{"github-actions", "User", true},
+		{"somebot[bot]", "User", true},
+		{"human", "User", false},
+	}
+	for _, tt := range tests {
+		p := pullRequest{}
+		p.User.Login = tt.login
+		p.User.Type = tt.typ
+		if got := p.isBot(); got != tt.want {
+			t.Errorf("isBot(%q,%q) = %v, want %v", tt.login, tt.typ, got, tt.want)
+		}
+	}
+}
+
+// --- API client tests via httptest ---
+
+// pageJSON is the canned first page: two merged PRs, one unmerged, one bot.
+const pageJSON = `[
+  {"number":1,"state":"closed","title":"feat one","created_at":"2024-01-01T00:00:00Z","merged_at":"2024-01-01T01:00:00Z","user":{"login":"alice","type":"User"}},
+  {"number":2,"state":"open","title":"wip two","created_at":"2024-01-02T00:00:00Z","merged_at":null,"user":{"login":"bob","type":"User"}},
+  {"number":3,"state":"closed","title":"deps","created_at":"2024-01-03T00:00:00Z","merged_at":"2024-01-03T00:30:00Z","user":{"login":"dependabot[bot]","type":"Bot"}},
+  {"number":4,"state":"closed","title":"feat four","created_at":"2024-01-04T00:00:00Z","merged_at":"2024-01-04T03:00:00Z","user":{"login":"carol","type":"User"}}
+]`
+
+// newServer starts an httptest server returning body with status for the pulls
+// endpoint, sets a token env, and returns the base URL.
+func newServer(t *testing.T, status int, body string) string {
+	t.Helper()
+	requireLoopback(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Page 2+ returns empty so pagination terminates.
+		if r.URL.Query().Get("page") != "1" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// runStat runs `leadtime stat` with token set and --base-url pointed at base.
+func runStat(t *testing.T, base string, args ...string) (string, string, error) {
+	t.Helper()
+	t.Setenv("LT_GITHUB_ACCESS_TOKEN", "fake-token")
+	t.Setenv("GITHUB_TOKEN", "")
+	full := append([]string{"stat", "--owner=acme", "--repo=demo", "--base-url=" + base}, args...)
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: &bytes.Buffer{}, Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, full)
+	return out.String(), errBuf.String(), err
+}
+
+func TestStatTextDefault(t *testing.T) {
+	base := newServer(t, http.StatusOK, pageJSON)
+	out, errOut, err := runStat(t, base)
+	if err != nil {
+		t.Fatalf("err = %v, stderr = %s", err, errOut)
+	}
+	// Merged PRs: #1 (60min), #3 (30min), #4 (180min). Sum=270, avg=90, median=60.
+	for _, want := range []string{
+		"Repository           : acme/demo",
+		"Total PR             : 3",
+		"Lead Time(Max)       : 180.00[min]",
+		"Lead Time(Min)       : 30.00[min]",
+		"Lead Time(Sum)       : 270.00[min]",
+		"Lead Time(Ave)       : 90.00[min]",
+		"Lead Time(Median)    : 60.00[min]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+func TestStatExcludeBot(t *testing.T) {
+	base := newServer(t, http.StatusOK, pageJSON)
+	out, _, err := runStat(t, base, "--exclude-bot")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Without the bot PR #3: merged #1 (60), #4 (180). Total 2.
+	if !strings.Contains(out, "Total PR             : 2") {
+		t.Errorf("expected 2 PRs after exclude-bot, got:\n%s", out)
+	}
+}
+
+func TestStatExcludePR(t *testing.T) {
+	base := newServer(t, http.StatusOK, pageJSON)
+	out, _, err := runStat(t, base, "-P", "1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Exclude #1: merged #3, #4 remain. Total 2.
+	if !strings.Contains(out, "Total PR             : 2") {
+		t.Errorf("expected 2 PRs after exclude-pr, got:\n%s", out)
+	}
+}
+
+func TestStatExcludeUser(t *testing.T) {
+	base := newServer(t, http.StatusOK, pageJSON)
+	out, _, err := runStat(t, base, "-U", "carol")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Exclude carol (#4): merged #1, #3 remain. Total 2.
+	if !strings.Contains(out, "Total PR             : 2") {
+		t.Errorf("expected 2 PRs after exclude-user, got:\n%s", out)
+	}
+}
+
+func TestStatJSON(t *testing.T) {
+	base := newServer(t, http.StatusOK, pageJSON)
+	out, _, err := runStat(t, base, "--json", "--all")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	var r report
+	if err := json.Unmarshal([]byte(out), &r); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if r.Owner != "acme" || r.Repo != "demo" {
+		t.Errorf("owner/repo = %s/%s", r.Owner, r.Repo)
+	}
+	if r.Statistics.TotalPR != 3 {
+		t.Errorf("TotalPR = %d, want 3", r.Statistics.TotalPR)
+	}
+	if !almostEqual(r.Statistics.Average, 90) {
+		t.Errorf("Average = %v, want 90", r.Statistics.Average)
+	}
+	if len(r.PRs) != 3 {
+		t.Errorf("with --all expected 3 PR details, got %d", len(r.PRs))
+	}
+}
+
+func TestStatJSONNoAllOmitsPRs(t *testing.T) {
+	base := newServer(t, http.StatusOK, pageJSON)
+	out, _, err := runStat(t, base, "--json")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.Contains(out, "pull_requests") {
+		t.Errorf("without --all, pull_requests must be omitted:\n%s", out)
+	}
+}
+
+func TestStatMarkdown(t *testing.T) {
+	base := newServer(t, http.StatusOK, pageJSON)
+	out, _, err := runStat(t, base, "--markdown", "--all")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	for _, want := range []string{
+		"# Lead Time Statistics for acme/demo",
+		"| Metric | Value |",
+		"| Total PR | 3 |",
+		"| Lead Time(Ave) | 90.00[min] |",
+		"## Pull Requests",
+		"| PR | State | Lead Time[min] | User | Title |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+func TestStatRateLimit(t *testing.T) {
+	requireLoopback(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1700000000")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+	}))
+	t.Cleanup(srv.Close)
+	_, errOut, err := runStat(t, srv.URL)
+	if err == nil {
+		t.Fatal("expected error on rate limit")
+	}
+	if !strings.Contains(errOut, "rate limit exceeded") {
+		t.Errorf("stderr = %q, want rate limit message", errOut)
+	}
+}
+
+func TestStatNotFound(t *testing.T) {
+	base := newServer(t, http.StatusNotFound, `{"message":"Not Found"}`)
+	_, errOut, err := runStat(t, base)
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(errOut, "not found") {
+		t.Errorf("stderr = %q, want not-found message", errOut)
+	}
+}
+
+func TestStatMalformed(t *testing.T) {
+	base := newServer(t, http.StatusOK, `this is not json`)
+	_, errOut, err := runStat(t, base)
+	if err == nil {
+		t.Fatal("expected error on malformed body")
+	}
+	if !strings.Contains(errOut, "leadtime:") {
+		t.Errorf("stderr = %q, want leadtime error prefix", errOut)
+	}
+}
+
+func TestStatEmptyRepo(t *testing.T) {
+	base := newServer(t, http.StatusOK, `[]`)
+	_, errOut, err := runStat(t, base)
+	if err == nil {
+		t.Fatal("expected error on empty repo")
+	}
+	if !strings.Contains(errOut, "no merged Pull Requests") {
+		t.Errorf("stderr = %q, want no-merged message", errOut)
+	}
+}
+
+func TestStatPagination(t *testing.T) {
+	requireLoopback(t)
+	// Page 1 returns 100 merged PRs (full page), page 2 returns 1, page 3 empty.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.WriteHeader(http.StatusOK)
+		switch page {
+		case "1":
+			_, _ = w.Write([]byte(buildPage(1, 100)))
+		case "2":
+			_, _ = w.Write([]byte(buildPage(101, 1)))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	out, _, err := runStat(t, srv.URL)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(out, "Total PR             : 101") {
+		t.Errorf("expected 101 PRs across pages, got:\n%s", out)
+	}
+}
+
+// buildPage returns a JSON array of count merged PRs starting at startNumber,
+// each with a 10-minute lead time.
+func buildPage(startNumber, count int) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		n := startNumber + i
+		b.WriteString(`{"number":`)
+		b.WriteString(strconv.Itoa(n))
+		b.WriteString(`,"state":"closed","title":"p","created_at":"2024-01-01T00:00:00Z","merged_at":"2024-01-01T00:10:00Z","user":{"login":"u","type":"User"}}`)
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+func TestStatMissingToken(t *testing.T) {
+	t.Setenv("LT_GITHUB_ACCESS_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: &bytes.Buffer{}, Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, []string{"stat", "--owner=acme", "--repo=demo"})
+	if err == nil {
+		t.Fatal("expected error when no token is set")
+	}
+	if !strings.Contains(errBuf.String(), "no GitHub token") {
+		t.Errorf("stderr = %q, want missing-token message", errBuf.String())
+	}
+}
+
+func TestTokenFallbackToGitHubToken(t *testing.T) {
+	t.Setenv("LT_GITHUB_ACCESS_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "gh-token")
+	if got := resolveToken(); got != "gh-token" {
+		t.Errorf("resolveToken = %q, want gh-token", got)
+	}
+	t.Setenv("LT_GITHUB_ACCESS_TOKEN", "lt-token")
+	if got := resolveToken(); got != "lt-token" {
+		t.Errorf("resolveToken = %q, want lt-token (LT_ takes precedence)", got)
+	}
+}
+
+func TestStatMissingOwnerRepo(t *testing.T) {
+	t.Setenv("LT_GITHUB_ACCESS_TOKEN", "x")
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: &bytes.Buffer{}, Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, []string{"stat"})
+	if err == nil {
+		t.Fatal("expected error when owner/repo missing")
+	}
+	if !strings.Contains(errBuf.String(), "--owner and --repo are required") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestUnknownSubcommand(t *testing.T) {
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: &bytes.Buffer{}, Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, []string{"bogus", "--owner=a", "--repo=b"})
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand")
+	}
+	if !strings.Contains(errBuf.String(), "unknown subcommand") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestJSONMarkdownMutuallyExclusive(t *testing.T) {
+	t.Setenv("LT_GITHUB_ACCESS_TOKEN", "x")
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: &bytes.Buffer{}, Out: out, Err: errBuf}
+	err := New().Run(context.Background(), io, []string{"stat", "--owner=a", "--repo=b", "--json", "--markdown"})
+	if err == nil {
+		t.Fatal("expected error for --json --markdown together")
+	}
+	if !strings.Contains(errBuf.String(), "mutually exclusive") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestHelp(t *testing.T) {
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: &bytes.Buffer{}, Out: out, Err: errBuf}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Usage: leadtime", "Lead time is the elapsed time", "LT_GITHUB_ACCESS_TOKEN", "rate"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q", want)
+		}
+	}
+}

--- a/internal/applets/shellutils/leadtime/stat.go
+++ b/internal/applets/shellutils/leadtime/stat.go
@@ -1,0 +1,141 @@
+//
+// mimixbox/internal/applets/shellutils/leadtime/stat.go
+//
+// Copyright 2021 Naohiro CHIKAMATSU
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leadtime
+
+import "sort"
+
+// statistics holds the aggregate lead-time metrics, all in minutes.
+type statistics struct {
+	TotalPR int     `json:"total_pr"`
+	Max     float64 `json:"max"`
+	Min     float64 `json:"min"`
+	Sum     float64 `json:"sum"`
+	Average float64 `json:"average"`
+	Median  float64 `json:"median"`
+}
+
+// applyFilters removes Pull Requests that match the exclusion options. It does
+// not filter by merged state; mergedOnly handles that so unmerged PRs can still
+// appear in --all listings when the original tool expects them. The returned
+// slice preserves input order.
+func applyFilters(prs []pullRequest, opts options) []pullRequest {
+	excludePR := make(map[int]struct{}, len(opts.excludePR))
+	for _, n := range opts.excludePR {
+		excludePR[n] = struct{}{}
+	}
+	excludeUser := make(map[string]struct{}, len(opts.excludeUser))
+	for _, u := range opts.excludeUser {
+		excludeUser[u] = struct{}{}
+	}
+
+	out := make([]pullRequest, 0, len(prs))
+	for _, pr := range prs {
+		if opts.excludeBot && pr.isBot() {
+			continue
+		}
+		if _, ok := excludePR[pr.Number]; ok {
+			continue
+		}
+		if _, ok := excludeUser[pr.User.Login]; ok {
+			continue
+		}
+		out = append(out, pr)
+	}
+	return out
+}
+
+// mergedOnly returns the Pull Requests that were actually merged (and therefore
+// have a well-defined lead time).
+func mergedOnly(prs []pullRequest) []pullRequest {
+	out := make([]pullRequest, 0, len(prs))
+	for _, pr := range prs {
+		if pr.isMerged() {
+			out = append(out, pr)
+		}
+	}
+	return out
+}
+
+// calcStatistics computes the lead-time statistics over the given merged Pull
+// Requests. The caller must ensure prs is non-empty and every element is
+// merged.
+func calcStatistics(prs []pullRequest) statistics {
+	values := make([]float64, 0, len(prs))
+	for _, pr := range prs {
+		values = append(values, pr.leadTimeMinutes())
+	}
+	return statistics{
+		TotalPR: len(values),
+		Max:     maxOf(values),
+		Min:     minOf(values),
+		Sum:     sumOf(values),
+		Average: averageOf(values),
+		Median:  medianOf(values),
+	}
+}
+
+// maxOf returns the largest value. values must be non-empty.
+func maxOf(values []float64) float64 {
+	m := values[0]
+	for _, v := range values[1:] {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// minOf returns the smallest value. values must be non-empty.
+func minOf(values []float64) float64 {
+	m := values[0]
+	for _, v := range values[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+// sumOf returns the total of values.
+func sumOf(values []float64) float64 {
+	var s float64
+	for _, v := range values {
+		s += v
+	}
+	return s
+}
+
+// averageOf returns the arithmetic mean of values. values must be non-empty.
+func averageOf(values []float64) float64 {
+	return sumOf(values) / float64(len(values))
+}
+
+// medianOf returns the median of values. For an even count it averages the two
+// middle elements. values must be non-empty. It does not mutate the input.
+func medianOf(values []float64) float64 {
+	sorted := make([]float64, len(values))
+	copy(sorted, values)
+	sort.Float64s(sorted)
+
+	n := len(sorted)
+	mid := n / 2
+	if n%2 == 1 {
+		return sorted[mid]
+	}
+	return (sorted[mid-1] + sorted[mid]) / 2
+}

--- a/test/it/shellutils/leadtime_test.sh
+++ b/test/it/shellutils/leadtime_test.sh
@@ -1,0 +1,6 @@
+LeadtimeHelp() { leadtime --help; }
+LeadtimeNoSub() { leadtime; }
+LeadtimeUnknownSub() { leadtime bogus --owner=a --repo=b; }
+LeadtimeMissingToken() { LT_GITHUB_ACCESS_TOKEN= GITHUB_TOKEN= leadtime stat --owner=acme --repo=demo; }
+LeadtimeMissingOwnerRepo() { LT_GITHUB_ACCESS_TOKEN=x leadtime stat; }
+LeadtimeJSONMarkdownConflict() { LT_GITHUB_ACCESS_TOKEN=x leadtime stat --owner=a --repo=b --json --markdown; }

--- a/test/it/spec/leadtime_spec.sh
+++ b/test/it/spec/leadtime_spec.sh
@@ -1,0 +1,34 @@
+Describe 'leadtime CLI contract'
+    Include shellutils/leadtime_test.sh
+    It 'prints usage with --help and exits 0'
+        When call LeadtimeHelp
+        The status should be success
+        The output should include 'Usage: leadtime'
+        The output should include 'LT_GITHUB_ACCESS_TOKEN'
+    End
+    It 'fails when no subcommand is given'
+        When call LeadtimeNoSub
+        The status should be failure
+        The error should include 'stat'
+    End
+    It 'fails on an unknown subcommand'
+        When call LeadtimeUnknownSub
+        The status should be failure
+        The error should include 'unknown subcommand'
+    End
+    It 'fails with a deterministic error when no token is set'
+        When call LeadtimeMissingToken
+        The status should be failure
+        The error should include 'no GitHub token'
+    End
+    It 'fails when --owner/--repo are missing'
+        When call LeadtimeMissingOwnerRepo
+        The status should be failure
+        The error should include '--owner and --repo are required'
+    End
+    It 'rejects --json with --markdown'
+        When call LeadtimeJSONMarkdownConflict
+        The status should be failure
+        The error should include 'mutually exclusive'
+    End
+End


### PR DESCRIPTION
## Summary

Ports the archived `nao1215/leadtime` project into a MimixBox applet that calculates GitHub Pull Request lead-time statistics.

**Lead time** is defined as the elapsed time, in minutes, from PR creation to merge. Only merged PRs contribute to statistics. This definition is documented in the applet's `--help`, along with the auth environment variables and GitHub rate-limit caveats.

## Added command

| Command | Description |
| --- | --- |
| `leadtime` | Calculate GitHub PR lead time statistics |

### `leadtime stat --owner=OWNER --repo=REPO`

- Statistics: total PRs, max/min/sum/average/median lead time (minutes).
- `--all` (`-a`): per-PR details in addition to statistics.
- Output modes: default text, `--json` (stable schema), `--markdown` (table). `--json`/`--markdown` are mutually exclusive.
- Filters: `--exclude-bot` (`-B`), `--exclude-pr` (`-P 1,3,19`), `--exclude-user` (`-U alice,bob`).
- `--base-url`: target GitHub Enterprise or a local test server (defaults to `https://api.github.com`).
- Auth token from `LT_GITHUB_ACCESS_TOKEN`, falling back to `GITHUB_TOKEN`.
- Read-only REST API only (`GET /repos/{owner}/{repo}/pulls?state=all`), with pagination. No mutating calls.
- Deterministic errors for: missing token, rate limit, 401/404, empty repos, malformed JSON.

## Tests

Hermetic unit tests (no real network) in `internal/applets/shellutils/leadtime/leadtime_test.go`:

- Statistics: max/min/sum/average/median, odd/even median, non-mutating median.
- Filtering: bot/PR-number/user exclusions, combined, and bot detection.
- API client via `httptest` + `--base-url`: merged/unmerged PRs, missing timestamps, pagination (101 PRs across pages), rate-limit, 404, malformed body.
- Formatters: text, JSON (schema + `--all` omission), markdown snapshot fragments.
- Token resolution + fallback, usage/validation errors, `--help`.

ShellSpec contract tests added at `test/it/spec/leadtime_spec.sh` (help, usage errors, missing-token; network paths kept out of CI for stability).

## Verification

- `go build ./...` — pass
- `go test ./...` — pass
- `golangci-lint run ./internal/applets/shellutils/leadtime/` — 0 issues
- `make generate` run; `leadtime` appears in `mimixbox --list` and the README command table.

Closes #256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `leadtime` command for computing GitHub Pull Request lead-time metrics. Supports filtering by bot authors, specific users, and PR numbers. Output available in text, JSON, and Markdown table formats. Requires `--owner` and `--repo` flags, with optional GitHub access token for authenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->