### PR TITLE
fix(shellutils): finish chroot jail identity handoff via --userspec

### DIFF
--- a/internal/applets/shellutils/chroot/chroot.go
+++ b/internal/applets/shellutils/chroot/chroot.go
@@ -3,10 +3,14 @@
 package chroot
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/nao1215/mimixbox/internal/command"
@@ -26,12 +30,60 @@ func (c *Command) Synopsis() string {
 	return "Run command or interactive shell with special root directory"
 }
 
+// indirected so tests can drive the failure-mode logic without privileges.
+var (
+	setgid    = syscall.Setgid
+	setuid    = syscall.Setuid
+	setgroups = syscall.Setgroups
+)
+
+// identity is the resolved UID/GID/supplementary-group set to apply inside the
+// jail. It is produced by resolveIdentity from the jail's account databases and
+// applied by apply after syscall.Chroot has succeeded.
+type identity struct {
+	uid    int
+	gid    int
+	groups []int
+}
+
 // Run executes chroot. It changes the root directory to NEWROOT and runs
 // COMMAND (defaulting to the shell) inside it. This requires root privileges;
 // when it cannot change the root directory it prints a GNU-style error and
 // returns command.SilentFailure().
+//
+// Identity model: by default chroot keeps the caller's UID/GID, matching GNU
+// and BusyBox. When --userspec USER[:GROUP] (and optionally --groups
+// G[,G]...) is given, the names/IDs are resolved against the JAIL's
+// /etc/passwd and /etc/group (read after entering the jail, never the host's)
+// and privileges are dropped in the order setgroups -> setgid -> setuid. If a
+// requested name cannot be resolved in the jail, or a privilege drop fails,
+// chroot reports a deterministic error and exits non-zero rather than running
+// the command with mismatched host identity.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "NEWROOT [COMMAND [ARG]...]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION] NEWROOT [COMMAND [ARG]...]", stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND (or $SHELL) with the root directory set to NEWROOT. Requires root " +
+			"privileges. With --userspec, the user/group is resolved against the JAIL's " +
+			"/etc/passwd and /etc/group and privileges are dropped after entering the jail.",
+		Examples: []command.Example{
+			{Command: "chroot /jail /bin/sh", Explain: "Run a shell inside /jail as the current user."},
+			{Command: "chroot --userspec=1000:1000 /jail /bin/sh", Explain: "Drop to uid/gid 1000 in the jail."},
+			{Command: "chroot --userspec=alice:devs /jail id", Explain: "Resolve alice/devs against the jail's databases."},
+		},
+		ExitStatus: "0    COMMAND ran successfully.\n" +
+			"1    chroot failed, an identity could not be resolved, or COMMAND failed.\n",
+		Notes: []string{
+			"USER and GROUP in --userspec may be names or numeric IDs; names are resolved against " +
+				"the jail's /etc/passwd and /etc/group, not the host's.",
+			"When GROUP is omitted from --userspec and USER is a name, the user's primary group from " +
+				"the jail's /etc/passwd is used; if USER is numeric, the gid defaults to the uid.",
+			"--groups sets the supplementary group list; with --userspec but no --groups, supplementary " +
+				"groups are cleared (matching coreutils).",
+			"Without --userspec the caller's UID/GID are kept unchanged.",
+		},
+	})
+
+	userSpec := fs.String("userspec", "", "USER[:GROUP] to switch to inside the jail (names or IDs)")
+	groupsCSV := fs.String("groups", "", "comma-separated supplementary GROUP list for inside the jail")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -58,17 +110,35 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.SilentFailure()
 	}
 
+	// Resolve and apply the requested identity against the JAIL's account
+	// databases. /etc/passwd and /etc/group are now the jail's files because
+	// the root directory has already changed.
+	if *userSpec != "" || *groupsCSV != "" {
+		passwd, _ := os.Open("/etc/passwd")
+		group, _ := os.Open("/etc/group")
+		id, ierr := resolveIdentity(*userSpec, *groupsCSV, passwd, group)
+		if passwd != nil {
+			_ = passwd.Close()
+		}
+		if group != nil {
+			_ = group.Close()
+		}
+		if ierr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "chroot: %s\n", ierr)
+			return command.SilentFailure()
+		}
+		if aerr := id.apply(); aerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "chroot: %s\n", aerr)
+			return command.SilentFailure()
+		}
+	}
+
 	name, argv := decideExecCommand(operands[1:])
 	// Reset the environment variable SHELL for the jail environment.
 	if err := os.Setenv("SHELL", name); err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "chroot: %v\n", err)
 		return command.SilentFailure()
 	}
-
-	// TODO: Reset UID and GID.
-	// "/etc/passwd (uid name resolution file)" and "/etc/group (gid name
-	// resolution file)" may be different between the original environment and
-	// the jail environment. So, reset uid and gid in the jail environment.
 
 	cmd := exec.Command(name, argv...) //nolint:gosec // running a user-named command is the whole point
 	cmd.Stdin = stdio.In
@@ -81,6 +151,192 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.SilentFailure()
 	}
 	return nil
+}
+
+// apply drops privileges to the resolved identity. The order matters:
+// supplementary groups and the primary GID must be set while still privileged,
+// before the UID is dropped (after setuid the process can no longer change its
+// groups or gid).
+func (id identity) apply() error {
+	if id.groups != nil {
+		if err := setgroups(id.groups); err != nil {
+			return fmt.Errorf("cannot set supplementary groups: %w", err)
+		}
+	}
+	if err := setgid(id.gid); err != nil {
+		return fmt.Errorf("cannot set gid to %d: %w", id.gid, err)
+	}
+	if err := setuid(id.uid); err != nil {
+		return fmt.Errorf("cannot set uid to %d: %w", id.uid, err)
+	}
+	return nil
+}
+
+// resolveIdentity turns a --userspec value and a --groups CSV into a concrete
+// uid/gid/supplementary-group set, resolving names against the passwd and group
+// sources (the jail's /etc/passwd and /etc/group). It is pure with respect to
+// the process: it performs no syscalls, so it is unit-testable without root.
+//
+// passwd or group may be nil (e.g. the file is absent in the jail); in that
+// case only numeric IDs can be resolved and a name lookup returns an error.
+func resolveIdentity(userSpec, groupsCSV string, passwd, group io.Reader) (identity, error) {
+	if userSpec == "" && groupsCSV != "" {
+		// --groups without --userspec has no deterministic identity to keep, so
+		// reject it rather than guessing the caller's uid/gid.
+		return identity{}, fmt.Errorf("--groups requires --userspec")
+	}
+
+	users := parsePasswd(passwd)
+	groups := parseGroup(group)
+
+	var id identity
+
+	if userSpec != "" {
+		userPart, groupPart, hasGroup := strings.Cut(userSpec, ":")
+		if userPart == "" {
+			return identity{}, fmt.Errorf("invalid userspec: %q", userSpec)
+		}
+
+		uid, primaryGID, uerr := lookupUser(userPart, users)
+		if uerr != nil {
+			return identity{}, uerr
+		}
+		id.uid = uid
+
+		switch {
+		case hasGroup && groupPart != "":
+			gid, gerr := lookupGroup(groupPart, groups)
+			if gerr != nil {
+				return identity{}, gerr
+			}
+			id.gid = gid
+		case hasGroup && groupPart == "":
+			return identity{}, fmt.Errorf("invalid userspec: %q", userSpec)
+		case primaryGID >= 0:
+			id.gid = primaryGID
+		default:
+			// Numeric user with no passwd entry and no group given: gid
+			// defaults to the uid, matching coreutils.
+			id.gid = uid
+		}
+	}
+
+	if groupsCSV != "" {
+		list, gerr := lookupGroups(groupsCSV, groups)
+		if gerr != nil {
+			return identity{}, gerr
+		}
+		id.groups = list
+	} else if userSpec != "" {
+		// coreutils clears supplementary groups when --userspec is given
+		// without --groups. Use an empty (non-nil) slice so apply calls
+		// setgroups with no groups rather than skipping it.
+		id.groups = []int{}
+	}
+
+	return id, nil
+}
+
+// lookupUser resolves name (a login name or numeric uid) to a uid and the
+// user's primary gid. primaryGID is -1 when it cannot be determined (numeric
+// uid with no matching passwd entry).
+func lookupUser(name string, users map[string]passwdEntry) (uid, primaryGID int, err error) {
+	if e, ok := users[name]; ok {
+		return e.uid, e.gid, nil
+	}
+	if n, perr := strconv.Atoi(name); perr == nil && n >= 0 {
+		return n, -1, nil
+	}
+	return 0, -1, fmt.Errorf("invalid user: %q", name)
+}
+
+// lookupGroup resolves name (a group name or numeric gid) to a gid.
+func lookupGroup(name string, groups map[string]int) (int, error) {
+	if gid, ok := groups[name]; ok {
+		return gid, nil
+	}
+	if n, perr := strconv.Atoi(name); perr == nil && n >= 0 {
+		return n, nil
+	}
+	return 0, fmt.Errorf("invalid group: %q", name)
+}
+
+// lookupGroups resolves a comma-separated list of group names/IDs.
+func lookupGroups(csv string, groups map[string]int) ([]int, error) {
+	parts := strings.Split(csv, ",")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		gid, err := lookupGroup(p, groups)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, gid)
+	}
+	return out, nil
+}
+
+// passwdEntry holds the fields of /etc/passwd needed for identity resolution.
+type passwdEntry struct {
+	uid int
+	gid int
+}
+
+// parsePasswd reads /etc/passwd-formatted data into a name->entry map. Numeric
+// uid/gid fields that do not parse cause the line to be skipped. A nil reader
+// yields an empty map.
+func parsePasswd(r io.Reader) map[string]passwdEntry {
+	out := map[string]passwdEntry{}
+	if r == nil {
+		return out
+	}
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		f := strings.Split(line, ":")
+		if len(f) < 4 {
+			continue
+		}
+		uid, uerr := strconv.Atoi(f[2])
+		gid, gerr := strconv.Atoi(f[3])
+		if uerr != nil || gerr != nil {
+			continue
+		}
+		out[f[0]] = passwdEntry{uid: uid, gid: gid}
+	}
+	return out
+}
+
+// parseGroup reads /etc/group-formatted data into a name->gid map. A nil reader
+// yields an empty map.
+func parseGroup(r io.Reader) map[string]int {
+	out := map[string]int{}
+	if r == nil {
+		return out
+	}
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		f := strings.Split(line, ":")
+		if len(f) < 3 {
+			continue
+		}
+		gid, err := strconv.Atoi(f[2])
+		if err != nil {
+			continue
+		}
+		out[f[0]] = gid
+	}
+	return out
 }
 
 // decideExecCommand resolves the command to run inside the jail. extra are the

--- a/internal/applets/shellutils/chroot/chroot_test.go
+++ b/internal/applets/shellutils/chroot/chroot_test.go
@@ -56,6 +56,21 @@ func TestMissingOperand(t *testing.T) {
 	}
 }
 
+// TestHelpDocumentsUserspec verifies --help advertises the identity model so
+// the documented limitations stay in sync with the implementation.
+func TestHelpDocumentsUserspec(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	for _, want := range []string{"Usage: chroot", "--userspec", "--groups", "jail's"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}
+
 // TestNonRootFails verifies that, in the (non-root) test environment, running
 // chroot against a directory yields a failure error without panicking and
 // without writing to stdout. We do not require root.

--- a/internal/applets/shellutils/chroot/identity_internal_test.go
+++ b/internal/applets/shellutils/chroot/identity_internal_test.go
@@ -1,0 +1,221 @@
+package chroot
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// jailPasswd and jailGroup model a jail whose account databases diverge from a
+// typical host: "alice" is uid 1000 with primary gid 1000, "svc" is uid 4242,
+// and the group names/ids do not line up with the host's defaults.
+const (
+	jailPasswd = `root:x:0:0:root:/root:/bin/sh
+alice:x:1000:1000:Alice:/home/alice:/bin/sh
+svc:x:4242:777:Service:/srv:/usr/sbin/nologin
+# a comment line
+
+malformed:x:notanumber:1:::
+`
+	jailGroup = `root:x:0:
+devs:x:1000:alice
+ops:x:777:svc
+extra:x:9001:alice,svc
+# comment
+broken:x:notanumber:
+`
+)
+
+func TestParsePasswd(t *testing.T) {
+	t.Parallel()
+	got := parsePasswd(strings.NewReader(jailPasswd))
+	if e, ok := got["alice"]; !ok || e.uid != 1000 || e.gid != 1000 {
+		t.Errorf("alice = %+v ok=%v, want uid=1000 gid=1000", e, ok)
+	}
+	if e, ok := got["svc"]; !ok || e.uid != 4242 || e.gid != 777 {
+		t.Errorf("svc = %+v ok=%v, want uid=4242 gid=777", e, ok)
+	}
+	if _, ok := got["malformed"]; ok {
+		t.Errorf("malformed line should be skipped")
+	}
+	if _, ok := got["#"]; ok {
+		t.Errorf("comment line should not be parsed")
+	}
+}
+
+func TestParsePasswdNil(t *testing.T) {
+	t.Parallel()
+	if got := parsePasswd(nil); len(got) != 0 {
+		t.Errorf("parsePasswd(nil) = %v, want empty", got)
+	}
+}
+
+func TestParseGroup(t *testing.T) {
+	t.Parallel()
+	got := parseGroup(strings.NewReader(jailGroup))
+	for name, want := range map[string]int{"root": 0, "devs": 1000, "ops": 777, "extra": 9001} {
+		if gid, ok := got[name]; !ok || gid != want {
+			t.Errorf("group %q = %d ok=%v, want %d", name, gid, ok, want)
+		}
+	}
+	if _, ok := got["broken"]; ok {
+		t.Errorf("broken line should be skipped")
+	}
+}
+
+func TestResolveIdentity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		userSpec  string
+		groupsCSV string
+		want      identity
+		wantErr   bool
+	}{
+		{
+			name:     "user name resolves uid and primary gid from jail",
+			userSpec: "alice",
+			want:     identity{uid: 1000, gid: 1000, groups: []int{}},
+		},
+		{
+			name:     "user:group names resolve against jail databases",
+			userSpec: "alice:ops",
+			want:     identity{uid: 1000, gid: 777, groups: []int{}},
+		},
+		{
+			name:     "svc uses divergent primary gid 777",
+			userSpec: "svc",
+			want:     identity{uid: 4242, gid: 777, groups: []int{}},
+		},
+		{
+			name:     "numeric user with no passwd entry defaults gid to uid",
+			userSpec: "5000",
+			want:     identity{uid: 5000, gid: 5000, groups: []int{}},
+		},
+		{
+			name:     "numeric user and numeric group",
+			userSpec: "5000:6000",
+			want:     identity{uid: 5000, gid: 6000, groups: []int{}},
+		},
+		{
+			name:      "userspec with supplementary groups",
+			userSpec:  "alice:devs",
+			groupsCSV: "ops,extra",
+			want:      identity{uid: 1000, gid: 1000, groups: []int{777, 9001}},
+		},
+		{
+			name:      "numeric supplementary groups",
+			userSpec:  "alice",
+			groupsCSV: "10,20",
+			want:      identity{uid: 1000, gid: 1000, groups: []int{10, 20}},
+		},
+		{
+			name:     "unknown user name is rejected",
+			userSpec: "nobodyhere",
+			wantErr:  true,
+		},
+		{
+			name:     "unknown group name is rejected",
+			userSpec: "alice:nogroup",
+			wantErr:  true,
+		},
+		{
+			name:     "empty user part is rejected",
+			userSpec: ":devs",
+			wantErr:  true,
+		},
+		{
+			name:     "trailing colon (empty group) is rejected",
+			userSpec: "alice:",
+			wantErr:  true,
+		},
+		{
+			name:      "groups without userspec is rejected",
+			groupsCSV: "devs",
+			wantErr:   true,
+		},
+		{
+			name:      "unknown supplementary group is rejected",
+			userSpec:  "alice",
+			groupsCSV: "ops,nope",
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveIdentity(
+				tt.userSpec, tt.groupsCSV,
+				strings.NewReader(jailPasswd), strings.NewReader(jailGroup),
+			)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveIdentity(%q,%q) = %+v, want error", tt.userSpec, tt.groupsCSV, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveIdentity(%q,%q) unexpected error: %v", tt.userSpec, tt.groupsCSV, err)
+			}
+			if got.uid != tt.want.uid || got.gid != tt.want.gid || !reflect.DeepEqual(got.groups, tt.want.groups) {
+				t.Errorf("resolveIdentity(%q,%q) = %+v, want %+v", tt.userSpec, tt.groupsCSV, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveIdentityNilDatabases verifies that with no jail passwd/group files
+// only numeric IDs resolve and name lookups fail deterministically.
+func TestResolveIdentityNilDatabases(t *testing.T) {
+	t.Parallel()
+	got, err := resolveIdentity("1234:5678", "", nil, nil)
+	if err != nil {
+		t.Fatalf("numeric userspec with nil databases: %v", err)
+	}
+	if got.uid != 1234 || got.gid != 5678 {
+		t.Errorf("got %+v, want uid=1234 gid=5678", got)
+	}
+	if _, err := resolveIdentity("alice", "", nil, nil); err == nil {
+		t.Errorf("name lookup with nil databases should fail")
+	}
+}
+
+// TestApplyOrder verifies apply drops privileges in the order
+// setgroups -> setgid -> setuid, since after setuid the process can no longer
+// change its gid or groups.
+func TestApplyOrder(t *testing.T) {
+	origGroups, origGid, origUid := setgroups, setgid, setuid
+	t.Cleanup(func() { setgroups, setgid, setuid = origGroups, origGid, origUid })
+
+	var order []string
+	setgroups = func(g []int) error { order = append(order, "groups"); return nil }
+	setgid = func(g int) error { order = append(order, "gid"); return nil }
+	setuid = func(u int) error { order = append(order, "uid"); return nil }
+
+	id := identity{uid: 1000, gid: 1000, groups: []int{10}}
+	if err := id.apply(); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	want := []string{"groups", "gid", "uid"}
+	if !reflect.DeepEqual(order, want) {
+		t.Errorf("apply order = %v, want %v", order, want)
+	}
+}
+
+func TestApplyNilGroupsSkipsSetgroups(t *testing.T) {
+	origGroups, origGid, origUid := setgroups, setgid, setuid
+	t.Cleanup(func() { setgroups, setgid, setuid = origGroups, origGid, origUid })
+
+	called := false
+	setgroups = func(g []int) error { called = true; return nil }
+	setgid = func(g int) error { return nil }
+	setuid = func(u int) error { return nil }
+
+	id := identity{uid: 1000, gid: 1000, groups: nil}
+	if err := id.apply(); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if called {
+		t.Errorf("setgroups should not be called when groups is nil")
+	}
+}

--- a/test/it/spec/chroot_spec.sh
+++ b/test/it/spec/chroot_spec.sh
@@ -5,6 +5,11 @@ Describe 'chroot CLI contract'
         The status should be success
         The output should include 'Usage: chroot'
     End
+    It 'documents the --userspec identity option in --help'
+        When call ChrootHelp
+        The status should be success
+        The output should include '--userspec'
+    End
     It 'fails with a message when given no operand'
         When call ChrootNoArg
         The status should be failure


### PR DESCRIPTION
## Summary

Resolves the long-standing UID/GID handoff TODO in the `chroot` applet (`internal/applets/shellutils/chroot/chroot.go`).

## Identity model chosen

A minimal, BusyBox/coreutils-compatible **`--userspec USER[:GROUP]`** model (plus an optional **`--groups G[,G]...`**), resolved against the **JAIL's** account databases:

- `--userspec` / `--groups` names and IDs are resolved against the jail's `/etc/passwd` and `/etc/group`, read **after** `syscall.Chroot` (never the host's), addressing the exact host/jail divergence the TODO warned about.
- Privileges are dropped in the correct order: `setgroups` -> `setgid` -> `setuid` (groups and gid must be set while still privileged, before the uid is dropped).
- GROUP rules match coreutils: omitted GROUP uses the user's primary gid from the jail passwd (or the uid for a numeric user with no entry); `--userspec` without `--groups` clears supplementary groups; `--groups` without `--userspec` is rejected.
- **Failure modes are deterministic**: an unresolvable name, a malformed userspec, or a failed privilege drop prints a `chroot: ...` error and exits non-zero, rather than silently running the command with host identity assumptions.
- Without `--userspec`, the caller's UID/GID are kept unchanged (default GNU/BusyBox behavior).

The TODO is removed and the model plus remaining limitations are documented in `--help` (Notes section).

## Testability

Identity resolution and mode validation are extracted into pure functions (`resolveIdentity`, `parsePasswd`, `parseGroup`, `lookup*`) and the privilege-drop sequence is indirected behind overridable `setgroups`/`setgid`/`setuid` vars, so the logic is fully unit-testable **without** `syscall.Chroot` or root.

## Tests

- `identity_internal_test.go`: passwd/group parsing, userspec resolution against a synthetic jail with **divergent** passwd/group metadata (e.g. `svc` with primary gid 777), numeric/name resolution, all rejection paths, nil-database behavior, and the `setgroups->setgid->setuid` ordering.
- `chroot_test.go`: `--help` advertises `--userspec`/`--groups` and the jail-resolution note (keeps docs in sync).
- `chroot_spec.sh`: shellspec assertion that `--help` documents `--userspec`.

## Verification

- `make generate`: no registry changes (flag-only addition)
- `gofmt -l .`: clean
- `go vet ./...`: clean
- `go build ./...`: ok
- `go test ./...`: all pass
- `make it`: chroot specs pass; the only failure is the pre-existing flaky `start-stop-daemon` spec (timing/PID-race on a backgrounded `sleep`), unrelated to this change.

Closes #472