### PR TITLE
test(it): add dedicated ShellSpec specs for 174 remaining commands

### DIFF
--- a/test/it/spec/[[_spec.sh
+++ b/test/it/spec/[[_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "[[" applet.
+# `[[` is the test applet requiring a closing `]]`; dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe '[['
+  It 'describes itself with --help'
+    When run command [[ --help
+    The status should be success
+    The output should include 'Usage: [['
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command [[ --help
+    The status should be success
+    The output should include 'Evaluate EXPRESSION'
+  End
+End

--- a/test/it/spec/[_spec.sh
+++ b/test/it/spec/[_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "[" applet.
+# `[` is the test applet requiring a closing `]`; dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe '['
+  It 'describes itself with --help'
+    When run command [ --help
+    The status should be success
+    The output should include 'Usage: ['
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command [ --help
+    The status should be success
+    The output should include 'Evaluate EXPRESSION'
+  End
+End

--- a/test/it/spec/addgroup_spec.sh
+++ b/test/it/spec/addgroup_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "addgroup" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'addgroup'
+  It 'describes itself with --help'
+    When run command addgroup --help
+    The status should be success
+    The output should include 'Usage: addgroup'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/adjtimex_spec.sh
+++ b/test/it/spec/adjtimex_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "adjtimex" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'adjtimex'
+  It 'describes itself with --help'
+    When run command adjtimex --help
+    The status should be success
+    The output should include 'Usage: adjtimex'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/arp_spec.sh
+++ b/test/it/spec/arp_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "arp" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'arp'
+  It 'describes itself with --help'
+    When run command arp --help
+    The status should be success
+    The output should include 'Usage: arp'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/arping_spec.sh
+++ b/test/it/spec/arping_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "arping" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'arping'
+  It 'describes itself with --help'
+    When run command arping --help
+    The status should be success
+    The output should include 'Usage: arping'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ash_spec.sh
+++ b/test/it/spec/ash_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ash" applet.
+# ash is a front-end over MimixBox's shell (mbsh); dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ash'
+  It 'describes itself with --help'
+    When run command ash --help
+    The status should be success
+    The output should include 'Usage: ash'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command ash --help
+    The status should be success
+    The output should include 'compatibility front-end over MimixBox'
+  End
+End

--- a/test/it/spec/bash_spec.sh
+++ b/test/it/spec/bash_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "bash" applet.
+# bash is a front-end over MimixBox's shell (mbsh); dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'bash'
+  It 'describes itself with --help'
+    When run command bash --help
+    The status should be success
+    The output should include 'Usage: bash'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command bash --help
+    The status should be success
+    The output should include 'compatibility front-end over MimixBox'
+  End
+End

--- a/test/it/spec/brctl_spec.sh
+++ b/test/it/spec/brctl_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "brctl" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'brctl'
+  It 'describes itself with --help'
+    When run command brctl --help
+    The status should be success
+    The output should include 'Usage: brctl'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/busybox_spec.sh
+++ b/test/it/spec/busybox_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "busybox" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'busybox'
+  It 'describes itself with --help'
+    When run command busybox --help
+    The status should be success
+    The output should include 'Usage: busybox'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command busybox --help
+    The status should be success
+    The output should include 'multi-call front-end'
+  End
+End

--- a/test/it/spec/bzcat_spec.sh
+++ b/test/it/spec/bzcat_spec.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "bzcat" applet.
+# bzcat is `bunzip2 -c`; dedicated spec per #477. Decompression behavior
+# is shared with the bzip2 family.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'bzcat'
+  It 'describes itself with --help'
+    When run command bzcat --help
+    The status should be success
+    The output should include 'Usage: bzcat'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/bzip2_spec.sh
+++ b/test/it/spec/bzip2_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "bzip2" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'bzip2'
+  It 'describes itself with --help'
+    When run command bzip2 --help
+    The status should be success
+    The output should include 'Usage: bzip2'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/chcon_spec.sh
+++ b/test/it/spec/chcon_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "chcon" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'chcon'
+  It 'describes itself with --help'
+    When run command chcon --help
+    The status should be success
+    The output should include 'Usage: chcon'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/conspy_spec.sh
+++ b/test/it/spec/conspy_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "conspy" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'conspy'
+  It 'describes itself with --help'
+    When run command conspy --help
+    The status should be success
+    The output should include 'Usage: conspy'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/crc32_spec.sh
+++ b/test/it/spec/crc32_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "crc32" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'crc32'
+  It 'describes itself with --help'
+    When run command crc32 --help
+    The status should be success
+    The output should include 'Usage: crc32'
+    The stderr should equal ''
+  End
+  It 'prints the CRC-32 of stdin'
+    Data 'hello'
+    When run command crc32
+    The status should be success
+    The output should equal '363a3020  -'
+  End
+End

--- a/test/it/spec/cttyhack_spec.sh
+++ b/test/it/spec/cttyhack_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "cttyhack" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'cttyhack'
+  It 'describes itself with --help'
+    When run command cttyhack --help
+    The status should be success
+    The output should include 'Usage: cttyhack'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/delgroup_spec.sh
+++ b/test/it/spec/delgroup_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "delgroup" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'delgroup'
+  It 'describes itself with --help'
+    When run command delgroup --help
+    The status should be success
+    The output should include 'Usage: delgroup'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/depmod_spec.sh
+++ b/test/it/spec/depmod_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "depmod" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'depmod'
+  It 'describes itself with --help'
+    When run command depmod --help
+    The status should be success
+    The output should include 'Usage: depmod'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/devmem_spec.sh
+++ b/test/it/spec/devmem_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "devmem" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'devmem'
+  It 'describes itself with --help'
+    When run command devmem --help
+    The status should be success
+    The output should include 'Usage: devmem'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/dhcprelay_spec.sh
+++ b/test/it/spec/dhcprelay_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "dhcprelay" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'dhcprelay'
+  It 'describes itself with --help'
+    When run command dhcprelay --help
+    The status should be success
+    The output should include 'Usage: dhcprelay'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/dnsd_spec.sh
+++ b/test/it/spec/dnsd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "dnsd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'dnsd'
+  It 'describes itself with --help'
+    When run command dnsd --help
+    The status should be success
+    The output should include 'Usage: dnsd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/dnsdomainname_spec.sh
+++ b/test/it/spec/dnsdomainname_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "dnsdomainname" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'dnsdomainname'
+  It 'describes itself with --help'
+    When run command dnsdomainname --help
+    The status should be success
+    The output should include 'Usage: dnsdomainname'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/dpkg-deb_spec.sh
+++ b/test/it/spec/dpkg-deb_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "dpkg-deb" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'dpkg-deb'
+  It 'describes itself with --help'
+    When run command dpkg-deb --help
+    The status should be success
+    The output should include 'Usage: dpkg-deb'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/dpkg_spec.sh
+++ b/test/it/spec/dpkg_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "dpkg" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'dpkg'
+  It 'describes itself with --help'
+    When run command dpkg --help
+    The status should be success
+    The output should include 'Usage: dpkg'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/dumpkmap_spec.sh
+++ b/test/it/spec/dumpkmap_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "dumpkmap" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'dumpkmap'
+  It 'describes itself with --help'
+    When run command dumpkmap --help
+    The status should be success
+    The output should include 'Usage: dumpkmap'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/dumpleases_spec.sh
+++ b/test/it/spec/dumpleases_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "dumpleases" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'dumpleases'
+  It 'describes itself with --help'
+    When run command dumpleases --help
+    The status should be success
+    The output should include 'Usage: dumpleases'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/egrep_spec.sh
+++ b/test/it/spec/egrep_spec.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "egrep" applet.
+# egrep is a thin alias for `grep -E`; this file is the dedicated
+# spec required by #477. Shared matching behavior is covered by the grep family.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'egrep'
+  It 'describes itself with --help'
+    When run command egrep --help
+    The status should be success
+    The output should include 'Usage: grep'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ether-wake_spec.sh
+++ b/test/it/spec/ether-wake_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ether-wake" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ether-wake'
+  It 'describes itself with --help'
+    When run command ether-wake --help
+    The status should be success
+    The output should include 'Usage: ether-wake'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/factor_spec.sh
+++ b/test/it/spec/factor_spec.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "factor" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'factor'
+  It 'describes itself with --help'
+    When run command factor --help
+    The status should be success
+    The output should include 'Usage: factor'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command factor --help
+    The status should be success
+    The output should include 'Print the prime factors'
+  End
+  It 'factors a small integer'
+    When run command factor 12
+    The status should be success
+    The output should equal '12: 2 2 3'
+  End
+  It 'fails on a non-numeric operand'
+    When run command factor notanumber
+    The status should be failure
+    The stderr should include 'factor:'
+  End
+End

--- a/test/it/spec/fakeidentd_spec.sh
+++ b/test/it/spec/fakeidentd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "fakeidentd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'fakeidentd'
+  It 'describes itself with --help'
+    When run command fakeidentd --help
+    The status should be success
+    The output should include 'Usage: fakeidentd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/fallocate_spec.sh
+++ b/test/it/spec/fallocate_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "fallocate" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'fallocate'
+  It 'describes itself with --help'
+    When run command fallocate --help
+    The status should be success
+    The output should include 'Usage: fallocate'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/fgrep_spec.sh
+++ b/test/it/spec/fgrep_spec.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "fgrep" applet.
+# fgrep is a thin alias for `grep -F`; this file is the dedicated
+# spec required by #477. Shared matching behavior is covered by the grep family.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'fgrep'
+  It 'describes itself with --help'
+    When run command fgrep --help
+    The status should be success
+    The output should include 'Usage: grep'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/fsck.minix_spec.sh
+++ b/test/it/spec/fsck.minix_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "fsck.minix" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'fsck.minix'
+  It 'describes itself with --help'
+    When run command fsck.minix --help
+    The status should be success
+    The output should include 'Usage: fsck.minix'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/fsync_spec.sh
+++ b/test/it/spec/fsync_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "fsync" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'fsync'
+  It 'describes itself with --help'
+    When run command fsync --help
+    The status should be success
+    The output should include 'Usage: fsync'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ftpd_spec.sh
+++ b/test/it/spec/ftpd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ftpd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ftpd'
+  It 'describes itself with --help'
+    When run command ftpd --help
+    The status should be success
+    The output should include 'Usage: ftpd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ftpget_spec.sh
+++ b/test/it/spec/ftpget_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ftpget" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ftpget'
+  It 'describes itself with --help'
+    When run command ftpget --help
+    The status should be success
+    The output should include 'Usage: ftpget'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ftpput_spec.sh
+++ b/test/it/spec/ftpput_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ftpput" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ftpput'
+  It 'describes itself with --help'
+    When run command ftpput --help
+    The status should be success
+    The output should include 'Usage: ftpput'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/getenforce_spec.sh
+++ b/test/it/spec/getenforce_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "getenforce" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'getenforce'
+  It 'describes itself with --help'
+    When run command getenforce --help
+    The status should be success
+    The output should include 'Usage: getenforce'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/getsebool_spec.sh
+++ b/test/it/spec/getsebool_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "getsebool" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'getsebool'
+  It 'describes itself with --help'
+    When run command getsebool --help
+    The status should be success
+    The output should include 'Usage: getsebool'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/groups_spec.sh
+++ b/test/it/spec/groups_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "groups" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'groups'
+  It 'describes itself with --help'
+    When run command groups --help
+    The status should be success
+    The output should include 'Usage: groups'
+    The stderr should equal ''
+  End
+  It 'prints the groups of a named user'
+    When run command groups root
+    The status should be success
+    The output should equal 'root'
+  End
+End

--- a/test/it/spec/hd_spec.sh
+++ b/test/it/spec/hd_spec.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "hd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'hd'
+  It 'describes itself with --help'
+    When run command hd --help
+    The status should be success
+    The output should include 'Usage: hd'
+    The stderr should equal ''
+  End
+  It 'hexdumps stdin in canonical form'
+    Data 'hi'
+    When run command hd
+    The status should be success
+    The output should include '68 69 0a'
+    The output should include '|hi.|'
+  End
+End

--- a/test/it/spec/http-status-code_spec.sh
+++ b/test/it/spec/http-status-code_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "http-status-code" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'http-status-code'
+  It 'describes itself with --help'
+    When run command http-status-code --help
+    The status should be success
+    The output should include 'Usage: http-status-code'
+    The stderr should equal ''
+  End
+  It 'looks up a status code by number'
+    When run command http-status-code search 404
+    The status should be success
+    The output should include '404 Not Found'
+  End
+End

--- a/test/it/spec/httpd_spec.sh
+++ b/test/it/spec/httpd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "httpd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'httpd'
+  It 'describes itself with --help'
+    When run command httpd --help
+    The status should be success
+    The output should include 'Usage: httpd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/hush_spec.sh
+++ b/test/it/spec/hush_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "hush" applet.
+# hush is a front-end over MimixBox's shell (mbsh); dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'hush'
+  It 'describes itself with --help'
+    When run command hush --help
+    The status should be success
+    The output should include 'Usage: hush'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command hush --help
+    The status should be success
+    The output should include 'compatibility front-end over MimixBox'
+  End
+End

--- a/test/it/spec/i2cdetect_spec.sh
+++ b/test/it/spec/i2cdetect_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "i2cdetect" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'i2cdetect'
+  It 'describes itself with --help'
+    When run command i2cdetect --help
+    The status should be success
+    The output should include 'Usage: i2cdetect'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/i2cdump_spec.sh
+++ b/test/it/spec/i2cdump_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "i2cdump" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'i2cdump'
+  It 'describes itself with --help'
+    When run command i2cdump --help
+    The status should be success
+    The output should include 'Usage: i2cdump'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/i2cget_spec.sh
+++ b/test/it/spec/i2cget_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "i2cget" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'i2cget'
+  It 'describes itself with --help'
+    When run command i2cget --help
+    The status should be success
+    The output should include 'Usage: i2cget'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/i2cset_spec.sh
+++ b/test/it/spec/i2cset_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "i2cset" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'i2cset'
+  It 'describes itself with --help'
+    When run command i2cset --help
+    The status should be success
+    The output should include 'Usage: i2cset'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/id_spec.sh
+++ b/test/it/spec/id_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "id" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'id'
+  It 'describes itself with --help'
+    When run command id --help
+    The status should be success
+    The output should include 'Usage: id'
+    The stderr should equal ''
+  End
+  It 'prints the current uid/gid line'
+    When run command id
+    The status should be success
+    The output should include 'uid='
+    The output should include 'gid='
+  End
+End

--- a/test/it/spec/ifconfig_spec.sh
+++ b/test/it/spec/ifconfig_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ifconfig" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ifconfig'
+  It 'describes itself with --help'
+    When run command ifconfig --help
+    The status should be success
+    The output should include 'Usage: ifconfig'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command ifconfig --help
+    The status should be success
+    The output should include 'network interfaces'
+  End
+End

--- a/test/it/spec/ifdown_spec.sh
+++ b/test/it/spec/ifdown_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ifdown" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ifdown'
+  It 'describes itself with --help'
+    When run command ifdown --help
+    The status should be success
+    The output should include 'Usage: ifdown'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ifenslave_spec.sh
+++ b/test/it/spec/ifenslave_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ifenslave" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ifenslave'
+  It 'describes itself with --help'
+    When run command ifenslave --help
+    The status should be success
+    The output should include 'Usage: ifenslave'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ifplugd_spec.sh
+++ b/test/it/spec/ifplugd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ifplugd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ifplugd'
+  It 'describes itself with --help'
+    When run command ifplugd --help
+    The status should be success
+    The output should include 'Usage: ifplugd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ifup_spec.sh
+++ b/test/it/spec/ifup_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ifup" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ifup'
+  It 'describes itself with --help'
+    When run command ifup --help
+    The status should be success
+    The output should include 'Usage: ifup'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/inetd_spec.sh
+++ b/test/it/spec/inetd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "inetd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'inetd'
+  It 'describes itself with --help'
+    When run command inetd --help
+    The status should be success
+    The output should include 'Usage: inetd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/insmod_spec.sh
+++ b/test/it/spec/insmod_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "insmod" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'insmod'
+  It 'describes itself with --help'
+    When run command insmod --help
+    The status should be success
+    The output should include 'Usage: insmod'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ip_spec.sh
+++ b/test/it/spec/ip_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ip" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ip'
+  It 'describes itself with --help'
+    When run command ip --help
+    The status should be success
+    The output should include 'Usage: ip'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ipaddr_spec.sh
+++ b/test/it/spec/ipaddr_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ipaddr" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ipaddr'
+  It 'describes itself with --help'
+    When run command ipaddr --help
+    The status should be success
+    The output should include 'Usage: ipaddr'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ipcalc_spec.sh
+++ b/test/it/spec/ipcalc_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ipcalc" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ipcalc'
+  It 'describes itself with --help'
+    When run command ipcalc --help
+    The status should be success
+    The output should include 'Usage: ipcalc'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command ipcalc --help
+    The status should be success
+    The output should include 'IPv4 network parameters'
+  End
+End

--- a/test/it/spec/iplink_spec.sh
+++ b/test/it/spec/iplink_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "iplink" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'iplink'
+  It 'describes itself with --help'
+    When run command iplink --help
+    The status should be success
+    The output should include 'Usage: iplink'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ipneigh_spec.sh
+++ b/test/it/spec/ipneigh_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ipneigh" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ipneigh'
+  It 'describes itself with --help'
+    When run command ipneigh --help
+    The status should be success
+    The output should include 'Usage: ipneigh'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/iproute_spec.sh
+++ b/test/it/spec/iproute_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "iproute" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'iproute'
+  It 'describes itself with --help'
+    When run command iproute --help
+    The status should be success
+    The output should include 'Usage: iproute'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/iprule_spec.sh
+++ b/test/it/spec/iprule_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "iprule" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'iprule'
+  It 'describes itself with --help'
+    When run command iprule --help
+    The status should be success
+    The output should include 'Usage: iprule'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/iptunnel_spec.sh
+++ b/test/it/spec/iptunnel_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "iptunnel" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'iptunnel'
+  It 'describes itself with --help'
+    When run command iptunnel --help
+    The status should be success
+    The output should include 'Usage: iptunnel'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/less_spec.sh
+++ b/test/it/spec/less_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "less" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'less'
+  It 'describes itself with --help'
+    When run command less --help
+    The status should be success
+    The output should include 'Usage: less'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/linux32_spec.sh
+++ b/test/it/spec/linux32_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "linux32" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'linux32'
+  It 'describes itself with --help'
+    When run command linux32 --help
+    The status should be success
+    The output should include 'Usage: linux32'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/linux64_spec.sh
+++ b/test/it/spec/linux64_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "linux64" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'linux64'
+  It 'describes itself with --help'
+    When run command linux64 --help
+    The status should be success
+    The output should include 'Usage: linux64'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/linuxrc_spec.sh
+++ b/test/it/spec/linuxrc_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "linuxrc" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'linuxrc'
+  It 'describes itself with --help'
+    When run command linuxrc --help
+    The status should be success
+    The output should include 'Usage: linuxrc'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/load_policy_spec.sh
+++ b/test/it/spec/load_policy_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "load_policy" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'load_policy'
+  It 'describes itself with --help'
+    When run command load_policy --help
+    The status should be success
+    The output should include 'Usage: load_policy'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/loadfont_spec.sh
+++ b/test/it/spec/loadfont_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "loadfont" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'loadfont'
+  It 'describes itself with --help'
+    When run command loadfont --help
+    The status should be success
+    The output should include 'Usage: loadfont'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/loadkmap_spec.sh
+++ b/test/it/spec/loadkmap_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "loadkmap" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'loadkmap'
+  It 'describes itself with --help'
+    When run command loadkmap --help
+    The status should be success
+    The output should include 'Usage: loadkmap'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/log-collect_spec.sh
+++ b/test/it/spec/log-collect_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "log-collect" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'log-collect'
+  It 'describes itself with --help'
+    When run command log-collect --help
+    The status should be success
+    The output should include 'Usage: log-collect'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lpd_spec.sh
+++ b/test/it/spec/lpd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lpd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lpd'
+  It 'describes itself with --help'
+    When run command lpd --help
+    The status should be success
+    The output should include 'Usage: lpd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lpq_spec.sh
+++ b/test/it/spec/lpq_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lpq" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lpq'
+  It 'describes itself with --help'
+    When run command lpq --help
+    The status should be success
+    The output should include 'Usage: lpq'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lpr_spec.sh
+++ b/test/it/spec/lpr_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lpr" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lpr'
+  It 'describes itself with --help'
+    When run command lpr --help
+    The status should be success
+    The output should include 'Usage: lpr'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lsmod_spec.sh
+++ b/test/it/spec/lsmod_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lsmod" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lsmod'
+  It 'describes itself with --help'
+    When run command lsmod --help
+    The status should be success
+    The output should include 'Usage: lsmod'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lzcat_spec.sh
+++ b/test/it/spec/lzcat_spec.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lzcat" applet.
+# lzcat is `unlzma -c`; dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lzcat'
+  It 'describes itself with --help'
+    When run command lzcat --help
+    The status should be success
+    The output should include 'Usage: lzcat'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lzma_spec.sh
+++ b/test/it/spec/lzma_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lzma" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lzma'
+  It 'describes itself with --help'
+    When run command lzma --help
+    The status should be success
+    The output should include 'Usage: lzma'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lzop_spec.sh
+++ b/test/it/spec/lzop_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lzop" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lzop'
+  It 'describes itself with --help'
+    When run command lzop --help
+    The status should be success
+    The output should include 'Usage: lzop'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/lzopcat_spec.sh
+++ b/test/it/spec/lzopcat_spec.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "lzopcat" applet.
+# lzopcat is `lzop -dc`; dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'lzopcat'
+  It 'describes itself with --help'
+    When run command lzopcat --help
+    The status should be success
+    The output should include 'Usage: lzopcat'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/makemime_spec.sh
+++ b/test/it/spec/makemime_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "makemime" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'makemime'
+  It 'describes itself with --help'
+    When run command makemime --help
+    The status should be success
+    The output should include 'Usage: makemime'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/matchpathcon_spec.sh
+++ b/test/it/spec/matchpathcon_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "matchpathcon" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'matchpathcon'
+  It 'describes itself with --help'
+    When run command matchpathcon --help
+    The status should be success
+    The output should include 'Usage: matchpathcon'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/microcom_spec.sh
+++ b/test/it/spec/microcom_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "microcom" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'microcom'
+  It 'describes itself with --help'
+    When run command microcom --help
+    The status should be success
+    The output should include 'Usage: microcom'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/mkdosfs_spec.sh
+++ b/test/it/spec/mkdosfs_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "mkdosfs" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'mkdosfs'
+  It 'describes itself with --help'
+    When run command mkdosfs --help
+    The status should be success
+    The output should include 'Usage: mkdosfs'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/mkfs.ext2_spec.sh
+++ b/test/it/spec/mkfs.ext2_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "mkfs.ext2" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'mkfs.ext2'
+  It 'describes itself with --help'
+    When run command mkfs.ext2 --help
+    The status should be success
+    The output should include 'Usage: mkfs.ext2'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/mkfs.minix_spec.sh
+++ b/test/it/spec/mkfs.minix_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "mkfs.minix" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'mkfs.minix'
+  It 'describes itself with --help'
+    When run command mkfs.minix --help
+    The status should be success
+    The output should include 'Usage: mkfs.minix'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/mkfs.reiser_spec.sh
+++ b/test/it/spec/mkfs.reiser_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "mkfs.reiser" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'mkfs.reiser'
+  It 'describes itself with --help'
+    When run command mkfs.reiser --help
+    The status should be success
+    The output should include 'Usage: mkfs.reiser'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/mkfs.vfat_spec.sh
+++ b/test/it/spec/mkfs.vfat_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "mkfs.vfat" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'mkfs.vfat'
+  It 'describes itself with --help'
+    When run command mkfs.vfat --help
+    The status should be success
+    The output should include 'Usage: mkfs.vfat'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/modinfo_spec.sh
+++ b/test/it/spec/modinfo_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "modinfo" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'modinfo'
+  It 'describes itself with --help'
+    When run command modinfo --help
+    The status should be success
+    The output should include 'Usage: modinfo'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/modprobe_spec.sh
+++ b/test/it/spec/modprobe_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "modprobe" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'modprobe'
+  It 'describes itself with --help'
+    When run command modprobe --help
+    The status should be success
+    The output should include 'Usage: modprobe'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/more_spec.sh
+++ b/test/it/spec/more_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "more" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'more'
+  It 'describes itself with --help'
+    When run command more --help
+    The status should be success
+    The output should include 'Usage: more'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/nameif_spec.sh
+++ b/test/it/spec/nameif_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "nameif" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'nameif'
+  It 'describes itself with --help'
+    When run command nameif --help
+    The status should be success
+    The output should include 'Usage: nameif'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/nbd-client_spec.sh
+++ b/test/it/spec/nbd-client_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "nbd-client" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'nbd-client'
+  It 'describes itself with --help'
+    When run command nbd-client --help
+    The status should be success
+    The output should include 'Usage: nbd-client'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/netcat_spec.sh
+++ b/test/it/spec/netcat_spec.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "netcat" applet.
+# netcat is an alias for the `nc` applet, so --help prints nc's usage;
+# dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'netcat'
+  It 'describes itself with --help'
+    When run command netcat --help
+    The status should be success
+    The output should include 'Usage: nc'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/netstat_spec.sh
+++ b/test/it/spec/netstat_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "netstat" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'netstat'
+  It 'describes itself with --help'
+    When run command netstat --help
+    The status should be success
+    The output should include 'Usage: netstat'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/nice_spec.sh
+++ b/test/it/spec/nice_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "nice" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'nice'
+  It 'describes itself with --help'
+    When run command nice --help
+    The status should be success
+    The output should include 'Usage: nice'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/nslookup_spec.sh
+++ b/test/it/spec/nslookup_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "nslookup" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'nslookup'
+  It 'describes itself with --help'
+    When run command nslookup --help
+    The status should be success
+    The output should include 'Usage: nslookup'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ntpd_spec.sh
+++ b/test/it/spec/ntpd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ntpd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ntpd'
+  It 'describes itself with --help'
+    When run command ntpd --help
+    The status should be success
+    The output should include 'Usage: ntpd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/openvt_spec.sh
+++ b/test/it/spec/openvt_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "openvt" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'openvt'
+  It 'describes itself with --help'
+    When run command openvt --help
+    The status should be success
+    The output should include 'Usage: openvt'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/partprobe_spec.sh
+++ b/test/it/spec/partprobe_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "partprobe" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'partprobe'
+  It 'describes itself with --help'
+    When run command partprobe --help
+    The status should be success
+    The output should include 'Usage: partprobe'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ping6_spec.sh
+++ b/test/it/spec/ping6_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ping6" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ping6'
+  It 'describes itself with --help'
+    When run command ping6 --help
+    The status should be success
+    The output should include 'Usage: ping6'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/pipe_progress_spec.sh
+++ b/test/it/spec/pipe_progress_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "pipe_progress" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'pipe_progress'
+  It 'describes itself with --help'
+    When run command pipe_progress --help
+    The status should be success
+    The output should include 'Usage: pipe_progress'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/pkill_spec.sh
+++ b/test/it/spec/pkill_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "pkill" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'pkill'
+  It 'describes itself with --help'
+    When run command pkill --help
+    The status should be success
+    The output should include 'Usage: pkill'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/popmaildir_spec.sh
+++ b/test/it/spec/popmaildir_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "popmaildir" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'popmaildir'
+  It 'describes itself with --help'
+    When run command popmaildir --help
+    The status should be success
+    The output should include 'Usage: popmaildir'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/poweroff_spec.sh
+++ b/test/it/spec/poweroff_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "poweroff" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'poweroff'
+  It 'describes itself with --help'
+    When run command poweroff --help
+    The status should be success
+    The output should include 'Usage: poweroff'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/pscan_spec.sh
+++ b/test/it/spec/pscan_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "pscan" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'pscan'
+  It 'describes itself with --help'
+    When run command pscan --help
+    The status should be success
+    The output should include 'Usage: pscan'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/pwdx_spec.sh
+++ b/test/it/spec/pwdx_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "pwdx" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'pwdx'
+  It 'describes itself with --help'
+    When run command pwdx --help
+    The status should be success
+    The output should include 'Usage: pwdx'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/raidautorun_spec.sh
+++ b/test/it/spec/raidautorun_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "raidautorun" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'raidautorun'
+  It 'describes itself with --help'
+    When run command raidautorun --help
+    The status should be success
+    The output should include 'Usage: raidautorun'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/readahead_spec.sh
+++ b/test/it/spec/readahead_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "readahead" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'readahead'
+  It 'describes itself with --help'
+    When run command readahead --help
+    The status should be success
+    The output should include 'Usage: readahead'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/reboot_spec.sh
+++ b/test/it/spec/reboot_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "reboot" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'reboot'
+  It 'describes itself with --help'
+    When run command reboot --help
+    The status should be success
+    The output should include 'Usage: reboot'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/reformime_spec.sh
+++ b/test/it/spec/reformime_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "reformime" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'reformime'
+  It 'describes itself with --help'
+    When run command reformime --help
+    The status should be success
+    The output should include 'Usage: reformime'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/restorecon_spec.sh
+++ b/test/it/spec/restorecon_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "restorecon" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'restorecon'
+  It 'describes itself with --help'
+    When run command restorecon --help
+    The status should be success
+    The output should include 'Usage: restorecon'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/resume_spec.sh
+++ b/test/it/spec/resume_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "resume" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'resume'
+  It 'describes itself with --help'
+    When run command resume --help
+    The status should be success
+    The output should include 'Usage: resume'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/rmmod_spec.sh
+++ b/test/it/spec/rmmod_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "rmmod" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'rmmod'
+  It 'describes itself with --help'
+    When run command rmmod --help
+    The status should be success
+    The output should include 'Usage: rmmod'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/route_spec.sh
+++ b/test/it/spec/route_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "route" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'route'
+  It 'describes itself with --help'
+    When run command route --help
+    The status should be success
+    The output should include 'Usage: route'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/rpm2cpio_spec.sh
+++ b/test/it/spec/rpm2cpio_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "rpm2cpio" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'rpm2cpio'
+  It 'describes itself with --help'
+    When run command rpm2cpio --help
+    The status should be success
+    The output should include 'Usage: rpm2cpio'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/run-init_spec.sh
+++ b/test/it/spec/run-init_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "run-init" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'run-init'
+  It 'describes itself with --help'
+    When run command run-init --help
+    The status should be success
+    The output should include 'Usage: run-init'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/run-parts_spec.sh
+++ b/test/it/spec/run-parts_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "run-parts" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'run-parts'
+  It 'describes itself with --help'
+    When run command run-parts --help
+    The status should be success
+    The output should include 'Usage: run-parts'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/runcon_spec.sh
+++ b/test/it/spec/runcon_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "runcon" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'runcon'
+  It 'describes itself with --help'
+    When run command runcon --help
+    The status should be success
+    The output should include 'Usage: runcon'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/rx_spec.sh
+++ b/test/it/spec/rx_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "rx" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'rx'
+  It 'describes itself with --help'
+    When run command rx --help
+    The status should be success
+    The output should include 'Usage: rx'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/scriptreplay_spec.sh
+++ b/test/it/spec/scriptreplay_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "scriptreplay" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'scriptreplay'
+  It 'describes itself with --help'
+    When run command scriptreplay --help
+    The status should be success
+    The output should include 'Usage: scriptreplay'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/seedrng_spec.sh
+++ b/test/it/spec/seedrng_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "seedrng" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'seedrng'
+  It 'describes itself with --help'
+    When run command seedrng --help
+    The status should be success
+    The output should include 'Usage: seedrng'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command seedrng --help
+    The status should be success
+    The output should include 'boot seed'
+  End
+End

--- a/test/it/spec/selinuxenabled_spec.sh
+++ b/test/it/spec/selinuxenabled_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "selinuxenabled" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'selinuxenabled'
+  It 'describes itself with --help'
+    When run command selinuxenabled --help
+    The status should be success
+    The output should include 'Usage: selinuxenabled'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/sendmail_spec.sh
+++ b/test/it/spec/sendmail_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "sendmail" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'sendmail'
+  It 'describes itself with --help'
+    When run command sendmail --help
+    The status should be success
+    The output should include 'Usage: sendmail'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/sestatus_spec.sh
+++ b/test/it/spec/sestatus_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "sestatus" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'sestatus'
+  It 'describes itself with --help'
+    When run command sestatus --help
+    The status should be success
+    The output should include 'Usage: sestatus'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/setenforce_spec.sh
+++ b/test/it/spec/setenforce_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "setenforce" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'setenforce'
+  It 'describes itself with --help'
+    When run command setenforce --help
+    The status should be success
+    The output should include 'Usage: setenforce'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/setfiles_spec.sh
+++ b/test/it/spec/setfiles_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "setfiles" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'setfiles'
+  It 'describes itself with --help'
+    When run command setfiles --help
+    The status should be success
+    The output should include 'Usage: setfiles'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/setfont_spec.sh
+++ b/test/it/spec/setfont_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "setfont" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'setfont'
+  It 'describes itself with --help'
+    When run command setfont --help
+    The status should be success
+    The output should include 'Usage: setfont'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/setsebool_spec.sh
+++ b/test/it/spec/setsebool_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "setsebool" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'setsebool'
+  It 'describes itself with --help'
+    When run command setsebool --help
+    The status should be success
+    The output should include 'Usage: setsebool'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/setsid_spec.sh
+++ b/test/it/spec/setsid_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "setsid" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'setsid'
+  It 'describes itself with --help'
+    When run command setsid --help
+    The status should be success
+    The output should include 'Usage: setsid'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/sh_spec.sh
+++ b/test/it/spec/sh_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "sh" applet.
+# sh is a front-end over MimixBox's shell (mbsh); dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'sh'
+  It 'describes itself with --help'
+    When run command sh --help
+    The status should be success
+    The output should include 'Usage: sh'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command sh --help
+    The status should be success
+    The output should include 'compatibility front-end over MimixBox'
+  End
+End

--- a/test/it/spec/sha384sum_spec.sh
+++ b/test/it/spec/sha384sum_spec.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "sha384sum" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'sha384sum'
+  It 'describes itself with --help'
+    When run command sha384sum --help
+    The status should be success
+    The output should include 'Usage: sha384sum'
+    The stderr should equal ''
+  End
+  It 'prints the SHA-384 digest of stdin'
+    Data 'hello'
+    When run command sha384sum
+    The status should be success
+    The output should equal '1d0f284efe3edea4b9ca3bd514fa134b17eae361ccc7a1eefeff801b9bd6604e01f21f6bf249ef030599f0c218f2ba8c  -'
+  End
+End

--- a/test/it/spec/sl_spec.sh
+++ b/test/it/spec/sl_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "sl" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'sl'
+  It 'describes itself with --help'
+    When run command sl --help
+    The status should be success
+    The output should include 'Usage: sl'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/slattach_spec.sh
+++ b/test/it/spec/slattach_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "slattach" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'slattach'
+  It 'describes itself with --help'
+    When run command slattach --help
+    The status should be success
+    The output should include 'Usage: slattach'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ssl_client_spec.sh
+++ b/test/it/spec/ssl_client_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ssl_client" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ssl_client'
+  It 'describes itself with --help'
+    When run command ssl_client --help
+    The status should be success
+    The output should include 'Usage: ssl_client'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/ssl_server_spec.sh
+++ b/test/it/spec/ssl_server_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "ssl_server" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'ssl_server'
+  It 'describes itself with --help'
+    When run command ssl_server --help
+    The status should be success
+    The output should include 'Usage: ssl_server'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/start-stop-daemon_spec.sh
+++ b/test/it/spec/start-stop-daemon_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "start-stop-daemon" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'start-stop-daemon'
+  It 'describes itself with --help'
+    When run command start-stop-daemon --help
+    The status should be success
+    The output should include 'Usage: start-stop-daemon'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/sum_spec.sh
+++ b/test/it/spec/sum_spec.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "sum" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'sum'
+  It 'describes itself with --help'
+    When run command sum --help
+    The status should be success
+    The output should include 'Usage: sum'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command sum --help
+    The status should be success
+    The output should include 'BSD algorithm'
+  End
+  It 'prints a BSD checksum and block count for stdin'
+    Data 'hello'
+    When run command sum
+    The status should be success
+    The output should equal '36979     1'
+  End
+End

--- a/test/it/spec/swapoff_spec.sh
+++ b/test/it/spec/swapoff_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "swapoff" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'swapoff'
+  It 'describes itself with --help'
+    When run command swapoff --help
+    The status should be success
+    The output should include 'Usage: swapoff'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/swapon_spec.sh
+++ b/test/it/spec/swapon_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "swapon" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'swapon'
+  It 'describes itself with --help'
+    When run command swapon --help
+    The status should be success
+    The output should include 'Usage: swapon'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/tc_spec.sh
+++ b/test/it/spec/tc_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "tc" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'tc'
+  It 'describes itself with --help'
+    When run command tc --help
+    The status should be success
+    The output should include 'Usage: tc'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/tcpsvd_spec.sh
+++ b/test/it/spec/tcpsvd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "tcpsvd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'tcpsvd'
+  It 'describes itself with --help'
+    When run command tcpsvd --help
+    The status should be success
+    The output should include 'Usage: tcpsvd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/telnet_spec.sh
+++ b/test/it/spec/telnet_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "telnet" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'telnet'
+  It 'describes itself with --help'
+    When run command telnet --help
+    The status should be success
+    The output should include 'Usage: telnet'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/telnetd_spec.sh
+++ b/test/it/spec/telnetd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "telnetd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'telnetd'
+  It 'describes itself with --help'
+    When run command telnetd --help
+    The status should be success
+    The output should include 'Usage: telnetd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/tftp_spec.sh
+++ b/test/it/spec/tftp_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "tftp" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'tftp'
+  It 'describes itself with --help'
+    When run command tftp --help
+    The status should be success
+    The output should include 'Usage: tftp'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/tftpd_spec.sh
+++ b/test/it/spec/tftpd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "tftpd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'tftpd'
+  It 'describes itself with --help'
+    When run command tftpd --help
+    The status should be success
+    The output should include 'Usage: tftpd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/time_spec.sh
+++ b/test/it/spec/time_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "time" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'time'
+  It 'describes itself with --help'
+    When run command time --help
+    The status should be success
+    The output should include 'Usage: time'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/traceroute6_spec.sh
+++ b/test/it/spec/traceroute6_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "traceroute6" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'traceroute6'
+  It 'describes itself with --help'
+    When run command traceroute6 --help
+    The status should be success
+    The output should include 'Usage: traceroute6'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/traceroute_spec.sh
+++ b/test/it/spec/traceroute_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "traceroute" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'traceroute'
+  It 'describes itself with --help'
+    When run command traceroute --help
+    The status should be success
+    The output should include 'Usage: traceroute'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/tsort_spec.sh
+++ b/test/it/spec/tsort_spec.sh
@@ -1,0 +1,32 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "tsort" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'tsort'
+  It 'describes itself with --help'
+    When run command tsort --help
+    The status should be success
+    The output should include 'Usage: tsort'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command tsort --help
+    The status should be success
+    The output should include 'total ordering'
+  End
+  It 'produces a topological order'
+    Data
+      #|a b
+      #|b c
+    End
+    When run command tsort
+    The status should be success
+    The output should equal 'a
+b
+c'
+  End
+End

--- a/test/it/spec/tunctl_spec.sh
+++ b/test/it/spec/tunctl_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "tunctl" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'tunctl'
+  It 'describes itself with --help'
+    When run command tunctl --help
+    The status should be success
+    The output should include 'Usage: tunctl'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/udhcpc6_spec.sh
+++ b/test/it/spec/udhcpc6_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "udhcpc6" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'udhcpc6'
+  It 'describes itself with --help'
+    When run command udhcpc6 --help
+    The status should be success
+    The output should include 'Usage: udhcpc6'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/udhcpc_spec.sh
+++ b/test/it/spec/udhcpc_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "udhcpc" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'udhcpc'
+  It 'describes itself with --help'
+    When run command udhcpc --help
+    The status should be success
+    The output should include 'Usage: udhcpc'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/udhcpd_spec.sh
+++ b/test/it/spec/udhcpd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "udhcpd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'udhcpd'
+  It 'describes itself with --help'
+    When run command udhcpd --help
+    The status should be success
+    The output should include 'Usage: udhcpd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/udpsvd_spec.sh
+++ b/test/it/spec/udpsvd_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "udpsvd" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'udpsvd'
+  It 'describes itself with --help'
+    When run command udpsvd --help
+    The status should be success
+    The output should include 'Usage: udpsvd'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/uncompress_spec.sh
+++ b/test/it/spec/uncompress_spec.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "uncompress" applet.
+# uncompress decompresses .Z streams; dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'uncompress'
+  It 'describes itself with --help'
+    When run command uncompress --help
+    The status should be success
+    The output should include 'Usage: uncompress'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/unit_spec.sh
+++ b/test/it/spec/unit_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "unit" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'unit'
+  It 'describes itself with --help'
+    When run command unit --help
+    The status should be success
+    The output should include 'Usage: unit'
+    The stderr should equal ''
+  End
+  It 'documents its purpose in --help'
+    When run command unit --help
+    The status should be success
+    The output should include 'does not embed'
+  End
+End

--- a/test/it/spec/unlzma_spec.sh
+++ b/test/it/spec/unlzma_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "unlzma" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'unlzma'
+  It 'describes itself with --help'
+    When run command unlzma --help
+    The status should be success
+    The output should include 'Usage: unlzma'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/unlzop_spec.sh
+++ b/test/it/spec/unlzop_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "unlzop" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'unlzop'
+  It 'describes itself with --help'
+    When run command unlzop --help
+    The status should be success
+    The output should include 'Usage: unlzop'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/unxz_spec.sh
+++ b/test/it/spec/unxz_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "unxz" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'unxz'
+  It 'describes itself with --help'
+    When run command unxz --help
+    The status should be success
+    The output should include 'Usage: unxz'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/unzip_spec.sh
+++ b/test/it/spec/unzip_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "unzip" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'unzip'
+  It 'describes itself with --help'
+    When run command unzip --help
+    The status should be success
+    The output should include 'Usage: unzip'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/uptime_spec.sh
+++ b/test/it/spec/uptime_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "uptime" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'uptime'
+  It 'describes itself with --help'
+    When run command uptime --help
+    The status should be success
+    The output should include 'Usage: uptime'
+    The stderr should equal ''
+  End
+  It 'prints an uptime/load line'
+    When run command uptime
+    The status should be success
+    The output should include 'load average:'
+  End
+End

--- a/test/it/spec/usleep_spec.sh
+++ b/test/it/spec/usleep_spec.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "usleep" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'usleep'
+  It 'describes itself with --help'
+    When run command usleep --help
+    The status should be success
+    The output should include 'Usage: usleep'
+    The stderr should equal ''
+  End
+  It 'rejects a non-numeric microsecond count'
+    When run command usleep notanumber
+    The status should be failure
+    The stderr should include 'usleep:'
+  End
+End

--- a/test/it/spec/uudecode_spec.sh
+++ b/test/it/spec/uudecode_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "uudecode" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'uudecode'
+  It 'describes itself with --help'
+    When run command uudecode --help
+    The status should be success
+    The output should include 'Usage: uudecode'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/uuencode_spec.sh
+++ b/test/it/spec/uuencode_spec.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "uuencode" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'uuencode'
+  It 'describes itself with --help'
+    When run command uuencode --help
+    The status should be success
+    The output should include 'Usage: uuencode'
+    The stderr should equal ''
+  End
+  It 'uuencodes stdin with a begin header'
+    Data 'hello'
+    When run command uuencode hi.txt
+    The status should be success
+    The output should include 'begin 644 hi.txt'
+    The output should include 'end'
+  End
+End

--- a/test/it/spec/vconfig_spec.sh
+++ b/test/it/spec/vconfig_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "vconfig" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'vconfig'
+  It 'describes itself with --help'
+    When run command vconfig --help
+    The status should be success
+    The output should include 'Usage: vconfig'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/volname_spec.sh
+++ b/test/it/spec/volname_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "volname" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'volname'
+  It 'describes itself with --help'
+    When run command volname --help
+    The status should be success
+    The output should include 'Usage: volname'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/watchdog_spec.sh
+++ b/test/it/spec/watchdog_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "watchdog" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'watchdog'
+  It 'describes itself with --help'
+    When run command watchdog --help
+    The status should be success
+    The output should include 'Usage: watchdog'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/whois_spec.sh
+++ b/test/it/spec/whois_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "whois" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'whois'
+  It 'describes itself with --help'
+    When run command whois --help
+    The status should be success
+    The output should include 'Usage: whois'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/xz_spec.sh
+++ b/test/it/spec/xz_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "xz" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'xz'
+  It 'describes itself with --help'
+    When run command xz --help
+    The status should be success
+    The output should include 'Usage: xz'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/xzcat_spec.sh
+++ b/test/it/spec/xzcat_spec.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "xzcat" applet.
+# xzcat is `unxz -c`; dedicated spec per #477.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'xzcat'
+  It 'describes itself with --help'
+    When run command xzcat --help
+    The status should be success
+    The output should include 'Usage: xzcat'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/zcat_spec.sh
+++ b/test/it/spec/zcat_spec.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "zcat" applet.
+# zcat decompresses to stdout; dedicated spec per #477. Behavior is shared
+# with the gzip family.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'zcat'
+  It 'describes itself with --help'
+    When run command zcat --help
+    The status should be success
+    The output should include 'Usage: zcat'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/zcip_spec.sh
+++ b/test/it/spec/zcip_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "zcip" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'zcip'
+  It 'describes itself with --help'
+    When run command zcip --help
+    The status should be success
+    The output should include 'Usage: zcip'
+    The stderr should equal ''
+  End
+End

--- a/test/it/spec/zip-pwcrack_spec.sh
+++ b/test/it/spec/zip-pwcrack_spec.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# Issue #477: dedicated shell-level contract spec for the "zip-pwcrack" applet.
+#
+# Every MimixBox applet's --help is rendered by internal/command's
+# FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
+# nothing to stderr. That universal contract is asserted here; privileged,
+# networked, and destructive applets are exercised via --help only so the
+# suite never reboots, formats, loads modules, or touches the network.
+Describe 'zip-pwcrack'
+  It 'describes itself with --help'
+    When run command zip-pwcrack --help
+    The status should be success
+    The output should include 'Usage: zip-pwcrack'
+    The stderr should equal ''
+  End
+End


### PR DESCRIPTION
## Overview

Resolves #477 by adding a dedicated `test/it/spec/<command>_spec.sh` for **all 174**
shipped commands that previously lacked one. No command is silently skipped.

## What each spec asserts

Every applet's `--help` is rendered by `internal/command`'s `FlagSet.WriteUsage`,
which guarantees: exit `0`, a `Usage: <cmd>` line on stdout, and empty stderr.
All 174 specs assert this universal, user-visible contract (verified by running
the applets under `make it`, not guessed).

Beyond `--help`, the following pure compute/text applets assert real, observed
behavior on small fixtures:

- `factor 12` -> `12: 2 2 3` (and a non-numeric operand fails with a `factor:` error)
- `tsort` of `a b` / `b c` -> `a\nb\nc`
- `sum` of `hello\n` -> `36979     1`
- `sha384sum` of `hello\n` -> known digest
- `crc32` of `hello\n` -> `363a3020  -`
- `hd` of `hi` -> canonical hexdump bytes / `|hi.|`
- `uuencode hi.txt` -> `begin 644 hi.txt` ... `end`
- `groups root` -> `root`
- `http-status-code search 404` -> `404 Not Found`
- `ipcalc -p 192.168.1.1 255.255.255.0` -> `PREFIX=24`
- `id` -> includes `uid=`/`gid=`; `uptime` -> includes `load average:`
- `usleep notanumber` -> failure with `usleep:` error

Privileged, networked, and destructive applets (`reboot`, `poweroff`, `insmod`,
`rmmod`, `modprobe`, `mkfs.*`, `swapon`/`swapoff`, `httpd`, `telnetd`, `inetd`,
`ifconfig`, `ip`, `route`, `traceroute`, `nbd-client`, etc.) are exercised via
`--help` only, so the suite never reboots, formats, loads modules, opens sockets,
or touches the network.

## Documented alias / front-end consolidations

These still get a dedicated spec file (per the issue) with a comment recording the
shared behavior:

- `egrep` / `fgrep` -> thin aliases for `grep -E` / `grep -F`; their `--help`
  prints `Usage: grep`, which the specs assert.
- `netcat` -> alias for the `nc` applet; `--help` prints `Usage: nc`, asserted.
- `sh` / `bash` / `ash` / `hush` -> front-ends over MimixBox's shell (mbsh).
- `bzcat` / `zcat` / `lzcat` / `xzcat` / `lzopcat` / `uncompress` -> decompression
  front-ends sharing their parent family's behavior.
- `[` / `[[` -> the `test` applet requiring a closing bracket.

## No documented exceptions

All 174 commands received a dedicated spec; none were omitted.

## Test result

`make it` -> **1009 examples, 0 failures**.

Closes #477
