### PR TITLE
test(it): add dedicated integration helpers and normalize conventions (#471)

### DIFF
--- a/test/it/README.md
+++ b/test/it/README.md
@@ -1,0 +1,144 @@
+# MimixBox integration-test (E2E) suite
+
+This directory holds the [ShellSpec](https://shellspec.info/) end-to-end suite
+that exercises MimixBox applets as real processes. It is split into two layers:
+
+| Layer | Location | Owns |
+| --- | --- | --- |
+| **Spec** | `spec/<command>_spec.sh` | `Describe`/`It` assertions on observable behavior. |
+| **Helper** | `<subsystem>/<command>_test.sh` | Fixtures, `Setup`/`CleanUp`, and reusable `Test*` invocations a spec `Include`s. |
+
+A spec `Include`s a helper, runs `Setup` in `BeforeEach`, calls the helper's
+`Test*` functions via `When call`, and `CleanUp` in `AfterEach`. Keeping fixture
+construction in the helper layer means a spec never re-derives temp roots,
+sample files, or invocation boilerplate.
+
+## How the suite runs
+
+```sh
+make it          # alias for "make test-e2e"
+```
+
+`make test-e2e`:
+
+1. builds `mimixbox` and stages every applet as a symlink under
+   `test/it/.mbbin` (an isolated PATH directory, git-ignored), then
+2. allocates a per-run temp root via `mktemp -d`, exports it as
+   `MIMIXBOX_IT_ROOT`, runs `shellspec`, and removes the root on exit.
+
+Because the staged PATH comes first, **bare command names resolve to MimixBox
+applets** (e.g. `cat`, `gzip`, `head`). The suite is hermetic: it does not touch
+the host's `/usr/bin`.
+
+## Helper conventions (normalized)
+
+Follow `textutils/cat_test.sh` as the canonical pattern. New helpers MUST:
+
+1. **Live at `<subsystem>/<command>_test.sh`.** The subsystem mirrors the applet
+   package tree under `internal/applets/<subsystem>/`.
+2. **Define `Setup()` and `CleanUp()`** (even if empty: `Setup() { :; }`).
+   `Setup` builds fixtures; `CleanUp` removes them.
+3. **Define `Test<Command><Case>()` functions** that invoke the applet by its
+   bare name and exercise real behavior (round-trips, file transforms, lookups).
+4. **Keep every temp file/dir under `${MIMIXBOX_IT_ROOT}`.** This is the per-run
+   root from `spec/spec_helper.sh` (env var `MIMIXBOX_IT_ROOT`, convenience
+   function `it_root()`). The established idiom is a per-command subdirectory:
+
+   ```sh
+   Setup() {
+       export TEST_DIR=${MIMIXBOX_IT_ROOT}/<command>
+       export LANG=C
+       mkdir -p "${TEST_DIR}"
+       # ...build fixtures under ${TEST_DIR}...
+   }
+   CleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/<command>"; }
+   ```
+
+   **Never hardcode `/tmp/mimixbox`** or any absolute temp path. A per-command
+   subdirectory keeps helpers idempotent and safe under repeated/parallel runs.
+5. **Set `export LANG=C`** in `Setup` when output is locale-sensitive, so
+   assertions are stable.
+6. **Re-export needed vars inside each `Test*` function** when a spec calls it
+   without `Setup` (matching the `cat_test.sh` pattern), since each ShellSpec
+   example may run in its own subshell.
+7. **Use MimixBox-compatible flags.** Inside the hermetic PATH, helper commands
+   such as `head`/`tail` are also MimixBox applets, so use portable forms
+   (`head -n 1`, not `head -1`).
+
+### Minimal template
+
+```sh
+# shellcheck shell=sh
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/foo
+    export LANG=C
+    mkdir -p "${TEST_DIR}"
+    printf 'fixture\n' > "${TEST_DIR}/in.txt"
+}
+CleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/foo"; }
+
+TestFooRoundTrip() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/foo
+    foo "${TEST_DIR}/in.txt"
+}
+```
+
+## Spec-only commands (intentionally no helper)
+
+Many shipped applets are **only safely testable via `--help` / exit-code**: they
+need root, a live network peer, real hardware, a daemon/supervisor, or perform a
+destructive system action with no deterministic, hermetic, fixture-driven
+behavior. For these a `Setup`/`CleanUp` helper would be hollow boilerplate, so
+they are **intentionally spec-only** — assert on usage text / exit status in
+`spec/<command>_spec.sh` and add no helper. This is an accepted completion of
+issue #471.
+
+Categories that are intentionally spec-only:
+
+- **Privileged daemons / supervisors:** `httpd`, `ftpd`, `tftpd`, `telnetd`,
+  `dnsd`, `inetd`, `ntpd`, `udhcpd`, `udhcpc`, `udhcpc6`, `dhcprelay`, `tcpsvd`,
+  `udpsvd`, `fakeidentd`, `lpd`, `watchdog`, `start-stop-daemon`, `ifplugd`,
+  `sendmail`, `popmaildir`.
+- **Raw network / interface configuration (root, no deterministic output):**
+  `ifconfig`, `ifup`, `ifdown`, `ifenslave`, `ip`, `ipaddr`, `iplink`,
+  `ipneigh`, `iproute`, `iprule`, `iptunnel`, `route`, `arp`, `arping`, `brctl`,
+  `vconfig`, `nameif`, `zcip`, `slattach`, `tc`, `tunctl`, `ether-wake`,
+  `ping6`, `traceroute`, `traceroute6`, `nslookup`, `whois`, `netstat`,
+  `netcat`, `nbd-client`, `ftpget`, `ftpput`, `tftp`, `telnet`, `ssl_client`,
+  `ssl_server`, `pscan`, `dumpleases`.
+- **Kernel module tooling (root / live kernel):** `insmod`, `rmmod`, `lsmod`,
+  `modprobe`, `modinfo`, `depmod`.
+- **Filesystem creation / block-device tools (root / real device):** `mkdosfs`,
+  `mkfs.ext2`, `mkfs.minix`, `mkfs.reiser`, `mkfs.vfat`, `fsck.minix`,
+  `partprobe`, `raidautorun`, `readahead`, `resume`, `swapon`, `swapoff`,
+  `volname`.
+- **System lifecycle / boot (destructive, privileged):** `reboot`, `poweroff`,
+  `run-init`, `linuxrc`, `seedrng`.
+- **SELinux state mutators (privileged, action-gated):** `chcon`, `runcon`,
+  `restorecon`, `setfiles`, `load_policy`, `setenforce`, `setsebool`,
+  `getenforce`, `getsebool`, `selinuxenabled`, `sestatus`, `matchpathcon`.
+- **Ownership mutators (require root to change owner/group):** `chgrp`, `chown`,
+  `addgroup`, `delgroup`.
+- **Console / hardware / device tools (real TTY, VT, I2C, mem):** `adjtimex`,
+  `conspy`, `microcom`, `openvt`, `loadfont`, `setfont`, `loadkmap`,
+  `dumpkmap`, `i2cdetect`, `i2cget`, `i2cset`, `i2cdump`, `devmem`, `rx`.
+- **Interactive shells / front-ends (REPL, no deterministic batch output):**
+  `sh`, `ash`, `bash`, `hush`, `cttyhack`, `linux32`, `linux64`.
+- **Trivial aliases / wrappers already covered elsewhere:** `egrep`, `fgrep`
+  (thin `grep` aliases), `busybox` (multi-call dispatcher), `unit` (prints a
+  "run go test instead" notice), `dnsdomainname` (host-dependent, may be empty),
+  `scriptreplay` (needs a recorded session), `log-collect`, `dpkg`, `dpkg-deb`,
+  `pkill`, `pwdx`, `uptime`, `time`, `usleep`, `setsid`, `fsync`, `fallocate`,
+  `sl`, `run-parts`, `more`, `less`, `pipe_progress`, `zcat`, `bzcat`, `xzcat`,
+  `lzcat`, `lzma`, `unlzma`, `xz`, `bzip2`, `unzip`, `uncompress`, `rpm2cpio`,
+  `sum`, `crc32`, `sha384sum`, `sha3sum`, `uudecode`, `uuencode` — these already
+  have behavior exercised by an existing helper (e.g. `archival/xzcomp_test.sh`,
+  `archival/bunzip2_test.sh`, `archival/compress_test.sh`, `archival/rpm_test.sh`,
+  `textutils/checksum_test.sh`, `procps/uptime_pwdx_test.sh`,
+  `procps/pgrep_test.sh`, `util-linux/setsid_fallocate_test.sh`,
+  `loginutils/run_parts_test.sh`, `console-tools/pager_test.sh`) or are covered
+  by a dedicated spec without needing a new fixture helper.
+
+When in doubt, prefer a real helper: only fall back to spec-only when there is
+no deterministic behavior reproducible under `${MIMIXBOX_IT_ROOT}` without root,
+network, hardware, or a daemon.

--- a/test/it/archival/lzop_test.sh
+++ b/test/it/archival/lzop_test.sh
@@ -1,0 +1,26 @@
+# shellcheck shell=sh
+# Integration helper for `lzop` / `lzopcat` / `unlzop`. See test/it/README.md.
+#
+# Exercises LZO compression round-trips. Fixtures live under the per-run root.
+
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/lzop
+    export LANG=C
+    mkdir -p "${TEST_DIR}"
+    printf 'lzop round trip payload\n' > "${TEST_DIR}/data.txt"
+}
+
+CleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/lzop"; }
+
+# Compress to stdout, decompress via lzopcat: must reproduce the original.
+TestLzopRoundTripPipe() {
+    printf 'lzo stream\n' | lzop | lzopcat
+}
+
+# File-based round trip: lzop creates data.txt.lzo, unlzop restores it.
+TestLzopRoundTripFile() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/lzop
+    cp "${TEST_DIR}/data.txt" "${TEST_DIR}/rt.txt"
+    lzop "${TEST_DIR}/rt.txt"
+    unlzop -c "${TEST_DIR}/rt.txt.lzo"
+}

--- a/test/it/netutils/http_status_code_test.sh
+++ b/test/it/netutils/http_status_code_test.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=sh
+# Integration helper for `http-status-code`. See test/it/README.md.
+#
+# Pure offline lookup table; no network. The helper centralises the search/list
+# subcommand invocations.
+
+Setup() { export LANG=C; }
+CleanUp() { :; }
+
+# Look up a single status code.
+TestHttpStatusSearch() {
+    http-status-code search 200
+}
+
+# Look up multiple status codes.
+TestHttpStatusSearchMultiple() {
+    http-status-code search 200 404 500
+}
+
+# List subcommand emits the full table.
+TestHttpStatusList() {
+    http-status-code list | head -n 1
+}

--- a/test/it/netutils/ipcalc_test.sh
+++ b/test/it/netutils/ipcalc_test.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=sh
+# Integration helper for `ipcalc`. See test/it/README.md.
+#
+# ipcalc is pure CIDR arithmetic with no network access, so no on-disk fixture
+# is needed; the helper centralises representative deterministic invocations.
+
+Setup() { export LANG=C; }
+CleanUp() { :; }
+
+# Full report for a /24 network.
+TestIpcalcFull() {
+    ipcalc 192.168.10.7/24
+}
+
+# Network address only.
+TestIpcalcNetwork() {
+    ipcalc -n 192.168.10.7/24
+}
+
+# Broadcast address only.
+TestIpcalcBroadcast() {
+    ipcalc -b 10.0.0.5/16
+}

--- a/test/it/shellutils/factor_test.sh
+++ b/test/it/shellutils/factor_test.sh
@@ -1,0 +1,34 @@
+# shellcheck shell=sh
+# Integration helper for `factor`.
+#
+# Convention (see test/it/README.md):
+#   - All temp state lives under ${MIMIXBOX_IT_ROOT} (per-run root from
+#     test/it/spec/spec_helper.sh); never hardcode /tmp/mimixbox.
+#   - Setup builds fixtures, CleanUp removes the per-command subdir, and
+#     Test<Command><Case> functions exercise real behavior. Idempotent and
+#     safe under repeated/parallel runs because everything is under the root.
+
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/factor
+    export LANG=C
+    mkdir -p "${TEST_DIR}"
+    # Fixture: whitespace-separated integers read from stdin.
+    printf '6 8 12\n' > "${TEST_DIR}/numbers.txt"
+}
+
+CleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/factor"; }
+
+# Single operand on the command line.
+TestFactorArg() { factor 360; }
+
+# Multiple operands.
+TestFactorMultipleArgs() { factor 7 12; }
+
+# Reads whitespace-separated numbers from stdin when no operand is given.
+TestFactorFromStdin() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/factor
+    factor < "${TEST_DIR}/numbers.txt"
+}
+
+# A prime factors to itself.
+TestFactorPrime() { factor 13; }

--- a/test/it/shellutils/groups_test.sh
+++ b/test/it/shellutils/groups_test.sh
@@ -1,0 +1,8 @@
+# shellcheck shell=sh
+# Integration helper for `groups`. See test/it/README.md.
+
+Setup() { export LANG=C; }
+CleanUp() { :; }
+
+# Current user's groups (space-separated names).
+TestGroupsCurrent() { groups; }

--- a/test/it/shellutils/id_test.sh
+++ b/test/it/shellutils/id_test.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=sh
+# Integration helper for `id`. See test/it/README.md.
+#
+# id reads the current process identity; output is environment-dependent, so
+# Test functions assert on stable structure (numeric ids, name lookups) rather
+# than absolute values.
+
+Setup() { export LANG=C; }
+CleanUp() { :; }
+
+# Default form includes uid=, gid= and groups= fields.
+TestIdDefault() { id; }
+
+# Effective user id (numeric).
+TestIdUserNumeric() { id -u; }
+
+# Effective user name.
+TestIdUserName() { id -un; }
+
+# Effective group id (numeric).
+TestIdGroupNumeric() { id -g; }

--- a/test/it/shellutils/nice_test.sh
+++ b/test/it/shellutils/nice_test.sh
@@ -1,0 +1,12 @@
+# shellcheck shell=sh
+# Integration helper for `nice`. See test/it/README.md.
+
+Setup() { export LANG=C; }
+CleanUp() { :; }
+
+# With no command, nice prints the current niceness (an integer).
+TestNiceReport() { nice; }
+
+# nice runs the given command with an adjusted niceness; the command's own
+# output passes through unchanged.
+TestNiceRunCommand() { nice -n 5 echo nice-ok; }

--- a/test/it/shellutils/tsort_test.sh
+++ b/test/it/shellutils/tsort_test.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=sh
+# Integration helper for `tsort` (topological sort). See test/it/README.md.
+
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/tsort
+    export LANG=C
+    mkdir -p "${TEST_DIR}"
+    # Fixture: dependency-graph edges "a depends-before b".
+    {
+        printf 'a b\n'
+        printf 'b c\n'
+        printf 'c d\n'
+    } > "${TEST_DIR}/graph.txt"
+}
+
+CleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/tsort"; }
+
+# Read edges from a file fixture and emit a valid topological order.
+TestTsortFromFile() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/tsort
+    tsort "${TEST_DIR}/graph.txt"
+}
+
+# Read edges from stdin.
+TestTsortFromStdin() {
+    printf 'a b\nb c\n' | tsort
+}

--- a/test/it/textutils/mime_test.sh
+++ b/test/it/textutils/mime_test.sh
@@ -1,0 +1,26 @@
+# shellcheck shell=sh
+# Integration helper for `makemime` / `reformime`. See test/it/README.md.
+#
+# Exercises a MIME encode -> reparse round trip. Fixtures live under the
+# per-run root.
+
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/mime
+    export LANG=C
+    mkdir -p "${TEST_DIR}"
+    printf 'hello mime\n' > "${TEST_DIR}/part.txt"
+}
+
+CleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/mime"; }
+
+# makemime wraps a file into a single-part MIME message.
+TestMakemimeSinglePart() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/mime
+    makemime "${TEST_DIR}/part.txt"
+}
+
+# Round trip: makemime then reformime lists the parts.
+TestMakemimeReformimeList() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/mime
+    makemime "${TEST_DIR}/part.txt" | reformime
+}

--- a/test/it/util-linux/getopt_test.sh
+++ b/test/it/util-linux/getopt_test.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=sh
+# Integration helper for `getopt`. See test/it/README.md.
+#
+# getopt is pure argument parsing (no fixtures on disk), but a dedicated helper
+# centralises the common normalised invocation so specs do not re-derive it.
+
+Setup() { export LANG=C; }
+CleanUp() { :; }
+
+# Enhanced mode: short options only, normalised output.
+TestGetoptShort() {
+    getopt -o ab: -- -a -b x file
+}
+
+# Enhanced mode with long options.
+TestGetoptLong() {
+    getopt -o a --long alpha,beta: -- -a --beta=1 operand
+}

--- a/test/it/util-linux/hd_test.sh
+++ b/test/it/util-linux/hd_test.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=sh
+# Integration helper for `hd` (hexdump in canonical mode). See test/it/README.md.
+
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/hd
+    export LANG=C
+    mkdir -p "${TEST_DIR}"
+    printf 'Hello' > "${TEST_DIR}/data.bin"
+}
+
+CleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/hd"; }
+
+# Canonical hex+ASCII dump of a small fixture file.
+TestHdFile() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/hd
+    hd "${TEST_DIR}/data.bin"
+}
+
+# hd reads stdin when no file operand is given.
+TestHdStdin() {
+    printf 'Hi' | hd
+}


### PR DESCRIPTION
## Summary

Resolves the helper-layer half of the E2E backlog from issue #471. Adds **11
dedicated `test/it/<subsystem>/<command>_test.sh` helpers** for shipped commands
whose behavior is deterministic and hermetically testable, plus a conventions
doc that normalizes the temp-root/cleanup/env contract and explicitly lists the
commands that are intentionally spec-only.

This is the **helper layer only** — distinct from the `spec/` files owned by
#477. No file under `test/it/spec/` is created or modified by this PR.

## Helpers added (11)

Each defines `Setup()`/`CleanUp()` and `Test<Command><Case>()` functions; all
fixtures live under `${MIMIXBOX_IT_ROOT}` (per-command subdir), making them
idempotent and parallel-safe.

| Subsystem | Helper | Exercises |
| --- | --- | --- |
| shellutils | `factor_test.sh` | factor: arg, multi-arg, stdin, prime |
| shellutils | `tsort_test.sh` | tsort: file fixture + stdin topo sort |
| shellutils | `id_test.sh` | id: default, `-u`, `-un`, `-g` |
| shellutils | `groups_test.sh` | groups: current user |
| shellutils | `nice_test.sh` | nice: report + run-command pass-through |
| util-linux | `getopt_test.sh` | getopt: short + long normalization |
| util-linux | `hd_test.sh` | hd: file fixture + stdin canonical dump |
| netutils | `ipcalc_test.sh` | ipcalc: full report, `-n`, `-b` |
| netutils | `http_status_code_test.sh` | http-status-code: search/list |
| archival | `lzop_test.sh` | lzop/lzopcat/unlzop round trips |
| textutils | `mime_test.sh` | makemime + reformime round trip |

## Spec-only exception list (documented, intentionally no helper)

Per the issue's own criteria, commands only safely testable via `--help`/exit
code (no deterministic, hermetic, fixture-driven behavior) get **no hollow
helper**. They are removed from the backlog by being explicitly documented in
`test/it/README.md`. Categories: privileged daemons/supervisors; raw
network/interface config; kernel-module tooling; mkfs/block-device tools;
reboot/poweroff/boot lifecycle; SELinux & ownership mutators; console/hardware
(VT/I2C/mem) tools; interactive shells; and trivial aliases or commands already
covered by an existing helper (e.g. `xzcomp_test.sh`, `bunzip2_test.sh`,
`compress_test.sh`, `rpm_test.sh`, `checksum_test.sh`, `uptime_pwdx_test.sh`,
`pgrep_test.sh`, `setsid_fallocate_test.sh`, `run_parts_test.sh`,
`pager_test.sh`). See the README for the full per-command list.

## Normalized conventions

New `test/it/README.md` documents the spec-vs-helper layering, the run-local
temp-root contract (`MIMIXBOX_IT_ROOT` / `it_root()` from `spec/spec_helper.sh`),
the mandatory rules (per-command subdir under the root, never hardcode
`/tmp/mimixbox`, `LANG=C`, re-export inside `Test*`, MimixBox-compatible flags
such as `head -n 1`), and a minimal helper template.

## Verification

- `bash -n` passes on all 11 helpers.
- `make it` (the sanctioned hermetic runner) is green: **808 examples, 0
  failures** with the helpers present.
- Each helper's `Test*` functions were exercised directly against the freshly
  built applets by `Include`-ing them from a **temporary** verification spec run
  via `make it`, then asserting `When call <Test fn>` / `The status should be
  success`. Result: **all 28 Test functions passed (0 failures)** with correct
  deterministic output (e.g. `factor 360 -> 360: 2 2 2 3 3 5`, ipcalc table,
  lzop round trip reproduces input, makemime emits a MIME message reformime
  re-lists). This caught and fixed one bug (`head -1` -> `head -n 1`, since
  `head` resolves to the MimixBox applet under the hermetic PATH). The temporary
  spec was deleted before commit; no `test/it/spec/` file is included in this PR.

Closes #471