### PR TITLE
refactor(lib): remove residual process-global helper surfaces (#492)

### DIFF
--- a/internal/applets/applet.go
+++ b/internal/applets/applet.go
@@ -20,7 +20,6 @@ package applets
 import (
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,9 +58,6 @@ func HasApplet(target string) bool {
 	return ok
 }
 
-// ListApplets writes the "name - description" table to os.Stdout.
-func ListApplets() { ListAppletsTo(os.Stdout) }
-
 // ListAppletsTo writes the "name - description" table to w.
 func ListAppletsTo(w io.Writer) {
 	format := "%" + strconv.Itoa(longestAppletLength()) + "s - %s\n"
@@ -69,10 +65,6 @@ func ListAppletsTo(w io.Writer) {
 		_, _ = fmt.Fprintf(w, format, key, Applets[key].Desc)
 	}
 }
-
-// ShowAppletsBySpaceSeparated writes the space-separated applet names to
-// os.Stdout.
-func ShowAppletsBySpaceSeparated() { ShowAppletsBySpaceSeparatedTo(os.Stdout) }
 
 // ShowAppletsBySpaceSeparatedTo writes the space-separated, wrapped applet
 // names to w.

--- a/internal/applets/applet_test.go
+++ b/internal/applets/applet_test.go
@@ -16,6 +16,7 @@
 package applets
 
 import (
+	"bytes"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -67,6 +68,60 @@ func TestRegistryKeyMatchesName(t *testing.T) {
 	for key, applet := range Applets {
 		if name := applet.Cmd.Name(); name != key {
 			t.Errorf("registry key %q maps to a command whose Name() is %q", key, name)
+		}
+	}
+}
+
+// TestListAppletsTo asserts the "name - description" table is written to the
+// injected writer (not os.Stdout) and that every registered applet appears with
+// its synopsis. This is the writer-injected replacement for the removed
+// process-global ListApplets wrapper (issue #492).
+func TestListAppletsTo(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	ListAppletsTo(&out)
+	got := out.String()
+
+	if len(Applets) == 0 {
+		t.Fatal("registry is empty; cannot validate the listing")
+	}
+	for name, applet := range Applets {
+		line := name + " - " + applet.Desc
+		if !strings.Contains(got, line) {
+			t.Errorf("ListAppletsTo output is missing %q", line)
+		}
+	}
+	if want := len(Applets); strings.Count(got, "\n") != want {
+		t.Errorf("ListAppletsTo wrote %d lines, want %d", strings.Count(got, "\n"), want)
+	}
+}
+
+// TestShowAppletsBySpaceSeparatedTo asserts the space-separated listing goes to
+// the injected writer, wraps at the 60-column boundary, and contains every
+// applet name exactly once. Replacement for the removed process-global wrapper.
+func TestShowAppletsBySpaceSeparatedTo(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	ShowAppletsBySpaceSeparatedTo(&out)
+	got := out.String()
+
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("output should end with a newline, got %q", got[max(0, len(got)-10):])
+	}
+	fields := strings.Fields(got)
+	if len(fields) != len(Applets) {
+		t.Errorf("output has %d names, want %d", len(fields), len(Applets))
+	}
+	for _, name := range SortApplet() {
+		if !strings.Contains(got, name) {
+			t.Errorf("output is missing applet %q", name)
+		}
+	}
+	for _, line := range strings.Split(strings.TrimRight(got, "\n"), "\n") {
+		if len(line) > 60 {
+			t.Errorf("line exceeds the 60-column wrap: %q (%d)", line, len(line))
 		}
 	}
 }

--- a/internal/applets/console-tools/resize/resize.go
+++ b/internal/applets/console-tools/resize/resize.go
@@ -25,9 +25,16 @@ func (c *Command) Name() string { return "resize" }
 // Synopsis returns the one-line description shown in the applet list.
 func (c *Command) Synopsis() string { return "Print commands to set the terminal size" }
 
-// winsize reports the current terminal size as (rows, cols). It is a package
-// var so a test can replace it with a deterministic fake instead of needing a
-// real controlling terminal.
+// winsize reports the current terminal size as (rows, cols).
+//
+// Issue #492 asked whether resize should keep probing the process file
+// descriptors directly or grow an abstraction around terminal discovery. We
+// keep the direct TIOCGWINSZ probe of the std fds on purpose: querying the
+// controlling terminal's geometry *is* the job of resize, the size cannot be
+// injected through command.IO (whose streams are plain io.Reader/io.Writer and
+// may not be terminals), and the seam below already makes the applet fully
+// unit-testable. winsize is a package var so a test can replace it with a
+// deterministic fake instead of needing a real controlling terminal.
 var winsize = func() (rows, cols uint16, err error) {
 	for _, fd := range []int{int(os.Stdout.Fd()), int(os.Stderr.Fd()), int(os.Stdin.Fd())} {
 		ws, werr := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)

--- a/internal/lib/common.go
+++ b/internal/lib/common.go
@@ -18,7 +18,6 @@ package mb
 import (
 	"fmt"
 	"io"
-	"os"
 )
 
 const (
@@ -30,9 +29,4 @@ const (
 func ShowVersionTo(w io.Writer, cmdName string, version string) {
 	description := cmdName + " version " + version + " (under Apache License version 2.0)"
 	fmt.Fprintln(w, description)
-}
-
-// ShowVersion is ShowVersionTo wired to the process stdout.
-func ShowVersion(cmdName string, version string) {
-	ShowVersionTo(os.Stdout, cmdName, version)
 }

--- a/internal/lib/crypto.go
+++ b/internal/lib/crypto.go
@@ -24,8 +24,13 @@ import (
 	"strings"
 )
 
+// CompareChecksum verifies the files listed in each checksum file against the
+// digest produced by h, writing a "<file>: OK" / "<file>: Fail" line per entry
+// to out. out is injected so the result can be captured in tests instead of
+// leaking to the process stdout.
+//
 // e.g. hash is md5.New(), md5.New(), sha512.New(), etc...
-func CompareChecksum(h hash.Hash, paths []string) error {
+func CompareChecksum(out io.Writer, h hash.Hash, paths []string) error {
 	for _, path := range paths {
 		f, err := os.Open(os.ExpandEnv(path))
 		if err != nil {
@@ -56,9 +61,9 @@ func CompareChecksum(h hash.Hash, paths []string) error {
 				return err
 			}
 			if s == data[0] {
-				fmt.Fprintf(os.Stdout, "%s: OK\n", data[1])
+				fmt.Fprintf(out, "%s: OK\n", data[1])
 			} else {
-				fmt.Fprintf(os.Stdout, "%s: Fail\n", data[1])
+				fmt.Fprintf(out, "%s: Fail\n", data[1])
 			}
 			h.Reset()
 		}
@@ -66,12 +71,15 @@ func CompareChecksum(h hash.Hash, paths []string) error {
 	return nil
 }
 
-func ChecksumOutput(hash hash.Hash, r io.Reader, path string) error {
+// ChecksumOutput writes the "<digest>  <path>" line for r to out. out is
+// injected so callers (and tests) control the destination instead of the
+// process stdout.
+func ChecksumOutput(out io.Writer, hash hash.Hash, r io.Reader, path string) error {
 	s, err := checksum(hash, r)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "%s  %s\n", s, path)
+	fmt.Fprintf(out, "%s  %s\n", s, path)
 	return nil
 }
 
@@ -82,32 +90,36 @@ func checksum(hash hash.Hash, fp io.Reader) (string, error) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
-func PrintChecksums(cmdName string, hash hash.Hash, paths []string) (int, error) {
+// PrintChecksums writes "<digest>  <path>" lines for each readable path to out
+// and per-path failure diagnostics to errw, returning a non-zero status if any
+// path could not be hashed. Both writers are injected so the command output and
+// diagnostics can be captured in tests rather than the process std streams.
+func PrintChecksums(out io.Writer, errw io.Writer, cmdName string, hash hash.Hash, paths []string) (int, error) {
 	status := 0
 	for _, path := range paths {
 		p := os.ExpandEnv(path)
 		if !Exists(p) {
-			fmt.Fprint(os.Stderr, cmdName+": "+p+": No such file or directory")
+			fmt.Fprint(errw, cmdName+": "+p+": No such file or directory")
 			status = 1
 			continue
 		}
 
 		if IsDir(p) {
-			fmt.Fprint(os.Stderr, cmdName+": "+p+": It is directory")
+			fmt.Fprint(errw, cmdName+": "+p+": It is directory")
 			status = 1
 			continue
 		}
 
 		r, err := os.Open(p)
 		if err != nil {
-			fmt.Fprint(os.Stderr, cmdName+": "+err.Error())
+			fmt.Fprint(errw, cmdName+": "+err.Error())
 			status = 1
 			continue
 		}
 		defer r.Close()
 
-		if err := ChecksumOutput(hash, r, p); err != nil {
-			fmt.Fprint(os.Stderr, cmdName+": "+err.Error())
+		if err := ChecksumOutput(out, hash, r, p); err != nil {
+			fmt.Fprint(errw, cmdName+": "+err.Error())
 			status = 1
 			continue
 		}

--- a/internal/lib/file.go
+++ b/internal/lib/file.go
@@ -17,13 +17,11 @@ package mb
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -203,63 +201,6 @@ func CopyTree(src string, dest string) error {
 	}
 	_ = os.Chmod(dest, info.Mode().Perm())
 	_ = os.Chtimes(dest, info.ModTime(), info.ModTime())
-	return nil
-}
-
-func RemoveFile(path string, interactive bool) error {
-	if !IsFile(path) {
-		return errors.New(path + " is not file")
-	}
-	if interactive && !Question("Remove "+path+"?") {
-		return nil // Skip this file
-	}
-	if err := os.Remove(path); err != nil {
-		return err
-	}
-	return nil
-}
-
-func RemoveDir(dir string, interactive bool) error {
-	if !interactive {
-		if err := os.RemoveAll(dir); err != nil {
-			return err
-		}
-		return nil
-	}
-	if err := interactiveRemoveDir(dir); err != nil {
-		return err
-	}
-	return nil
-}
-
-func interactiveRemoveDir(dir string) error {
-	dirs, files, err := Walk(dir, false)
-	if err != nil {
-		return err
-	}
-
-	// Start with the deepest directory or file
-	sort.Sort(sort.Reverse(sort.StringSlice(dirs)))
-	sort.Sort(sort.Reverse(sort.StringSlice(files)))
-
-	for _, file := range files {
-		if !Question("Remove " + file + "?") {
-			continue
-		}
-		err := os.Remove(file)
-		if err != nil {
-			return err
-		}
-	}
-	for _, dir := range dirs {
-		if !Question("Remove " + dir + "?") {
-			continue
-		}
-		err := os.Remove(dir)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/internal/lib/file_more_test.go
+++ b/internal/lib/file_more_test.go
@@ -97,37 +97,6 @@ func TestWalk(t *testing.T) {
 	}
 }
 
-func TestRemoveFileNonInteractive(t *testing.T) {
-	t.Parallel()
-	p := filepath.Join(t.TempDir(), "gone.txt")
-	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := RemoveFile(p, false); err != nil {
-		t.Fatalf("RemoveFile error = %v", err)
-	}
-	if Exists(p) {
-		t.Error("file should have been removed")
-	}
-}
-
-func TestRemoveDirNonInteractive(t *testing.T) {
-	t.Parallel()
-	dir := filepath.Join(t.TempDir(), "tree")
-	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "sub", "f.txt"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := RemoveDir(dir, false); err != nil {
-		t.Fatalf("RemoveDir error = %v", err)
-	}
-	if Exists(dir) {
-		t.Error("directory tree should have been removed")
-	}
-}
-
 func TestIsSameFileName(t *testing.T) {
 	t.Parallel()
 	if !IsSameFileName("/a/b/foo.txt", "/c/d/foo.txt") {

--- a/internal/lib/lib_more_test.go
+++ b/internal/lib/lib_more_test.go
@@ -16,6 +16,7 @@
 package mb
 
 import (
+	"bytes"
 	"crypto/md5"
 	"os"
 	"path/filepath"
@@ -167,16 +168,6 @@ func TestHasOperand(t *testing.T) {
 	}
 }
 
-func TestPrintNumberLines(t *testing.T) {
-	t.Parallel()
-	// Smoke-test the stdout printers for coverage.
-	PrintStrWithNumberLine(1, "%6d  %s", "hello")
-	PrintStrListWithNumberLine([]string{"a", "\n", "b"}, false)
-	PrintStrListWithNumberLine([]string{"a", "b"}, true)
-	Dump([]string{"x\n"}, false)
-	Dump([]string{"x"}, true)
-}
-
 func TestConcatenate(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -219,23 +210,58 @@ func TestChecksumHelpers(t *testing.T) {
 		t.Error("CalcChecksum should error on a missing file")
 	}
 
-	// PrintChecksums over a present and an absent path.
-	status, err := PrintChecksums("md5sum", md5.New(), []string{data})
+	// PrintChecksums over a present path writes "<digest>  <path>" to out and
+	// nothing to errw.
+	var out, errw bytes.Buffer
+	status, err := PrintChecksums(&out, &errw, "md5sum", md5.New(), []string{data})
 	if err != nil || status != 0 {
 		t.Errorf("PrintChecksums = %d, %v", status, err)
 	}
-	status, _ = PrintChecksums("md5sum", md5.New(), []string{"/no/such/file"})
+	if want := sum + "  " + data + "\n"; out.String() != want {
+		t.Errorf("PrintChecksums out = %q, want %q", out.String(), want)
+	}
+	if errw.Len() != 0 {
+		t.Errorf("PrintChecksums errw = %q, want empty", errw.String())
+	}
+
+	// An absent path reports status 1 and a diagnostic on errw, not out.
+	out.Reset()
+	errw.Reset()
+	status, _ = PrintChecksums(&out, &errw, "md5sum", md5.New(), []string{"/no/such/file"})
 	if status != 1 {
 		t.Errorf("PrintChecksums missing-file status = %d, want 1", status)
 	}
+	if out.Len() != 0 {
+		t.Errorf("PrintChecksums missing-file out = %q, want empty", out.String())
+	}
+	if !strings.Contains(errw.String(), "No such file or directory") {
+		t.Errorf("PrintChecksums missing-file errw = %q", errw.String())
+	}
 
-	// CompareChecksum against a valid checksum file.
+	// CompareChecksum against a valid checksum file writes "<file>: OK".
 	sumFile := filepath.Join(dir, "sums.txt")
 	if err := os.WriteFile(sumFile, []byte(sum+"  "+data+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := CompareChecksum(md5.New(), []string{sumFile}); err != nil {
+	var cmp bytes.Buffer
+	if err := CompareChecksum(&cmp, md5.New(), []string{sumFile}); err != nil {
 		t.Errorf("CompareChecksum error = %v", err)
+	}
+	if want := data + ": OK\n"; cmp.String() != want {
+		t.Errorf("CompareChecksum out = %q, want %q", cmp.String(), want)
+	}
+
+	// A tampered checksum makes CompareChecksum report "<file>: Fail".
+	badSumFile := filepath.Join(dir, "bad-sums.txt")
+	if err := os.WriteFile(badSumFile, []byte("00000000000000000000000000000000  "+data+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmp.Reset()
+	if err := CompareChecksum(&cmp, md5.New(), []string{badSumFile}); err != nil {
+		t.Errorf("CompareChecksum error = %v", err)
+	}
+	if want := data + ": Fail\n"; cmp.String() != want {
+		t.Errorf("CompareChecksum tampered out = %q, want %q", cmp.String(), want)
 	}
 }
 
@@ -279,10 +305,8 @@ func TestShadowHelpers(t *testing.T) {
 	_ = IsRootUser()
 }
 
-func TestShowVersion(t *testing.T) {
+func TestExitConstants(t *testing.T) {
 	t.Parallel()
-	// Smoke-test; writes to stdout.
-	ShowVersion("mimixbox", "1.2.3")
 	if ExitSuccess != 0 || ExitFailure != 1 {
 		t.Error("exit code constants are wrong")
 	}
@@ -299,6 +323,7 @@ func TestGroups(t *testing.T) {
 	if err != nil {
 		t.Skipf("Groups(%s) error = %v (user may not be in the user database)", u, err)
 	}
-	DumpGroups(groups, true)
-	DumpGroups(groups, false)
+	// The space-separated rendering is covered by TestDumpGroupsTo; here we just
+	// assert the lookup itself succeeds for a real user.
+	_ = groups
 }

--- a/internal/lib/shell.go
+++ b/internal/lib/shell.go
@@ -69,9 +69,6 @@ func QuestionFrom(in io.Reader, out io.Writer, ask string) bool {
 	}
 }
 
-// Question is QuestionFrom wired to the process stdin/stdout.
-func Question(ask string) bool { return QuestionFrom(os.Stdin, os.Stdout, ask) }
-
 // ParrotFrom echoes each line read from in to out, optionally with a line
 // number, until in is exhausted. Injecting in/out keeps it testable.
 func ParrotFrom(in io.Reader, out io.Writer, withNl bool) {
@@ -92,9 +89,6 @@ func ParrotFrom(in io.Reader, out io.Writer, withNl bool) {
 		}
 	}
 }
-
-// Parrot is ParrotFrom wired to the process stdin/stdout.
-func Parrot(withNl bool) { ParrotFrom(os.Stdin, os.Stdout, withNl) }
 
 func Input() (string, bool) {
 	var response string
@@ -159,17 +153,9 @@ func PrintStrListWithNumberLineTo(w io.Writer, strList []string, countEmpryLine 
 	}
 }
 
-func PrintStrListWithNumberLine(strList []string, countEmpryLine bool) {
-	PrintStrListWithNumberLineTo(os.Stdout, strList, countEmpryLine)
-}
-
 // PrintStrWithNumberLineTo writes one numbered line to w.
 func PrintStrWithNumberLineTo(w io.Writer, nl int, format string, message string) {
 	fmt.Fprintf(w, format, nl, message)
-}
-
-func PrintStrWithNumberLine(nl int, format string, message string) {
-	PrintStrWithNumberLineTo(os.Stdout, nl, format, message)
 }
 
 func FromPIPE() (string, error) {
@@ -213,8 +199,6 @@ func DumpTo(w io.Writer, lines []string, withNumber bool) {
 	}
 }
 
-func Dump(lines []string, withNumber bool) { DumpTo(os.Stdout, lines, withNumber) }
-
 func Groups(uname string) ([]user.Group, error) {
 	u, err := user.Lookup(uname)
 	if err != nil {
@@ -251,10 +235,6 @@ func DumpGroupsTo(w io.Writer, groups []user.Group, showName bool) {
 		}
 	}
 	fmt.Fprintln(w, strings.TrimSuffix(resultLine, " "))
-}
-
-func DumpGroups(groups []user.Group, showName bool) {
-	DumpGroupsTo(os.Stdout, groups, showName)
 }
 
 func HasOperand(args []string, cmdName string) bool {


### PR DESCRIPTION
## Summary

Fixes #492.

Finishes the small amount of legacy runtime/helper debt still visible in non-test library code, so pure in-memory command execution is the only path.

### Checksum helpers → injected writers (`crypto.go`)
`CompareChecksum`, `ChecksumOutput`, and `PrintChecksums` now take injected `io.Writer`(s) instead of writing to `os.Stdout` / `os.Stderr`.

### Removed dead process-global wrappers
Thin wrappers with an existing `...To`/`...From` equivalent **and zero production callers**:
- `shell.go`: `Question`, `Parrot`, `Dump`, `DumpGroups`, `PrintStrWithNumberLine`, `PrintStrListWithNumberLine`
- `common.go`: `ShowVersion`
- `applet.go`: `ListApplets`, `ShowAppletsBySpaceSeparated`

Production already calls the `...To` variant directly (`main.go` → `ShowAppletsBySpaceSeparatedTo`).

### Removed dead legacy `rm` helpers (`file.go`)
`RemoveFile` / `RemoveDir` / `interactiveRemoveDir` — the `rm` applet is self-contained and reads/writes only through its injected `command.IO`, so these `os.Stdin`/`os.Stdout`-wired functions (the only callers of `Question`) were unreachable.

### `resize.go` decision recorded
Keep the direct `TIOCGWINSZ` probe of the std fds: terminal geometry can't be injected through `command.IO`, and the existing `winsize` package-var seam already makes the applet unit-testable. Documented in the code.

## Tests
- The `...To`/`...From` variants were already asserted in `io_inject_test.go`.
- Strengthened `TestChecksumHelpers` to assert the **injected writers' contents** (OK/Fail/diagnostic routing on `out` vs `errw`).
- Added the previously missing `TestListAppletsTo` / `TestShowAppletsBySpaceSeparatedTo`.
- `go test ./...` ✅ · `make it` → **1009 examples, 0 failures** ✅ · `golangci-lint run` → **0 issues** ✅