### PR TITLE
test(help): lock in compression applets' structured --help

### DIFF
--- a/internal/applets/archival/lzopcomp/lzopcomp_test.go
+++ b/internal/applets/archival/lzopcomp/lzopcomp_test.go
@@ -155,3 +155,33 @@ func TestNames(t *testing.T) {
 		t.Fatal("unexpected applet names")
 	}
 }
+
+// TestHelpSections locks in the self-describing --help output for every lzopcomp
+// applet (GitHub issues #652/#653/#656 Examples, #701/#702/#704 purpose
+// paragraph, plus #701/#704 Notes): each command must render a purpose
+// paragraph, an Examples section, and an Exit status section.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	ctors := []func() *Command{NewLzop, NewUnlzop, NewLzopcat}
+	for _, ctor := range ctors {
+		c := ctor()
+		t.Run(c.Name(), func(t *testing.T) {
+			t.Parallel()
+			out := &bytes.Buffer{}
+			io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+			if err := c.Run(context.Background(), io, []string{"--help"}); err != nil {
+				t.Fatalf("%s --help err = %v", c.Name(), err)
+			}
+			help := out.String()
+			for _, want := range []string{"Usage: " + c.Name(), "Examples:", "Exit status:"} {
+				if !strings.Contains(help, want) {
+					t.Errorf("%s --help missing %q\n%s", c.Name(), want, help)
+				}
+			}
+			desc := help[strings.Index(help, "\n")+1:]
+			if before, _, _ := strings.Cut(desc, "\nOptions:"); strings.TrimSpace(before) == "" {
+				t.Errorf("%s --help has no purpose paragraph\n%s", c.Name(), help)
+			}
+		})
+	}
+}

--- a/internal/applets/archival/lzopcomp/lzopcomp_test.go
+++ b/internal/applets/archival/lzopcomp/lzopcomp_test.go
@@ -179,7 +179,12 @@ func TestHelpSections(t *testing.T) {
 				}
 			}
 			desc := help[strings.Index(help, "\n")+1:]
-			if before, _, _ := strings.Cut(desc, "\nOptions:"); strings.TrimSpace(before) == "" {
+			before, _, found := strings.Cut(desc, "\nOptions:")
+			if !found {
+				t.Errorf("%s --help missing Options section\n%s", c.Name(), help)
+				return
+			}
+			if strings.TrimSpace(before) == "" {
 				t.Errorf("%s --help has no purpose paragraph\n%s", c.Name(), help)
 			}
 		})

--- a/internal/applets/archival/xzcomp/xzcomp_test.go
+++ b/internal/applets/archival/xzcomp/xzcomp_test.go
@@ -116,3 +116,37 @@ func TestHelp(t *testing.T) {
 		t.Errorf("--help = %q", out)
 	}
 }
+
+// TestHelpSections locks in the self-describing --help output for every xzcomp
+// applet (GitHub issues #649-#660 Examples, #698-#708 purpose paragraph): each
+// command must render a purpose paragraph, an Examples section, and an Exit
+// status section.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	ctors := []func() *Command{
+		NewXz, NewUnxz, NewXzcat,
+		NewLzma, NewUnlzma, NewLzcat,
+		NewZcat, NewBzcat,
+	}
+	for _, ctor := range ctors {
+		c := ctor()
+		t.Run(c.Name(), func(t *testing.T) {
+			t.Parallel()
+			out, _, err := capture(t, c, nil, "--help")
+			if err != nil {
+				t.Fatalf("%s --help err = %v", c.Name(), err)
+			}
+			help := string(out)
+			for _, want := range []string{"Usage: " + c.Name(), "Examples:", "Exit status:"} {
+				if !strings.Contains(help, want) {
+					t.Errorf("%s --help missing %q\n%s", c.Name(), want, help)
+				}
+			}
+			// A purpose paragraph sits between the Usage line and Options.
+			desc := help[strings.Index(help, "\n")+1:]
+			if before, _, _ := strings.Cut(desc, "\nOptions:"); strings.TrimSpace(before) == "" {
+				t.Errorf("%s --help has no purpose paragraph\n%s", c.Name(), help)
+			}
+		})
+	}
+}

--- a/internal/applets/archival/xzcomp/xzcomp_test.go
+++ b/internal/applets/archival/xzcomp/xzcomp_test.go
@@ -144,7 +144,12 @@ func TestHelpSections(t *testing.T) {
 			}
 			// A purpose paragraph sits between the Usage line and Options.
 			desc := help[strings.Index(help, "\n")+1:]
-			if before, _, _ := strings.Cut(desc, "\nOptions:"); strings.TrimSpace(before) == "" {
+			before, _, found := strings.Cut(desc, "\nOptions:")
+			if !found {
+				t.Errorf("%s --help missing Options section\n%s", c.Name(), help)
+				return
+			}
+			if strings.TrimSpace(before) == "" {
 				t.Errorf("%s --help has no purpose paragraph\n%s", c.Name(), help)
 			}
 		})

--- a/internal/applets/compat/unit/unit.go
+++ b/internal/applets/compat/unit/unit.go
@@ -28,6 +28,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
 		Description: "BusyBox's unit applet runs its internal libbb unit tests. MimixBox does not " +
 			"embed that suite, so this applet does nothing except point at MimixBox's own tests.",
+		Examples: []command.Example{
+			{Command: "unit", Explain: "Report that MimixBox ships no embedded unit-test suite and exit 2."},
+		},
 		Notes: []string{
 			"Run 'go test ./...' for unit tests and 'make test-e2e' for the ShellSpec suite.",
 		},

--- a/internal/applets/compat/unit/unit_test.go
+++ b/internal/applets/compat/unit/unit_test.go
@@ -31,7 +31,9 @@ func TestUnitHelp(t *testing.T) {
 	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
 		t.Fatalf("--help err = %v", err)
 	}
-	if !strings.Contains(out.String(), "Usage: unit") {
-		t.Errorf("--help out = %q", out.String())
+	for _, want := range []string{"Usage: unit", "Examples:", "Exit status:", "Notes:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q; out = %q", want, out.String())
+		}
 	}
 }

--- a/test/it/spec/help_compression_spec.sh
+++ b/test/it/spec/help_compression_spec.sh
@@ -25,5 +25,9 @@ Describe 'compression applets self-describing --help'
         The output should include 'Examples:'
         The output should include 'Exit status:'
         The line 1 of output should start with "Usage: $1"
+        # A non-empty purpose paragraph sits on line 3 (line 2 is blank).
+        The line 3 of output should not equal ''
+        # At least one example command line starts with the command name.
+        The output should include "  $1 "
     End
 End

--- a/test/it/spec/help_compression_spec.sh
+++ b/test/it/spec/help_compression_spec.sh
@@ -1,0 +1,29 @@
+Describe 'compression applets self-describing --help'
+    # GitHub issues #649-#660 (Examples) and #698-#708 (purpose paragraph):
+    # every compression/decompression applet must route --help through the
+    # structured help renderer, exiting 0 with an Examples and Exit status
+    # section and an example line that starts with the command name.
+
+    Parameters
+        xz
+        unxz
+        xzcat
+        lzma
+        unlzma
+        lzcat
+        lzop
+        unlzop
+        lzopcat
+        zcat
+        bzcat
+        unit
+    End
+
+    It "$1 --help has examples and an exit-status section"
+        When run "$1" --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with "Usage: $1"
+    End
+End


### PR DESCRIPTION
## Summary

The compression/decompression applets already render structured `--help`
(purpose paragraph, `Examples:`, `Exit status:`), but nothing asserted it.
This PR adds the tests mandated by the `[ux/help]` issues' "Done when"
criteria and fixes the one genuine gap.

- **Go package tests** (`xzcomp`, `lzopcomp`): table-driven `TestHelpSections`
  assert each applet's `--help` contains a purpose paragraph, `Examples:`, and
  `Exit status:`.
- **`unit`**: added the missing `Examples:` section and strengthened its help test.
- **ShellSpec** (`help_compression_spec.sh`): a parameterized spec asserts each
  command's `--help` exits `0`, includes `Examples:`/`Exit status:`, and starts
  with `Usage: <cmd>`.

## Testing

- `go test ./internal/applets/archival/xzcomp/... ./internal/applets/archival/lzopcomp/... ./internal/applets/compat/unit/...`
- `make test-e2e` (compression spec: 12 examples, 0 failures)

Closes #649, #650, #651, #652, #653, #654, #655, #656, #657, #658, #659, #660
Closes #698, #699, #700, #701, #702, #703, #704, #705, #706, #707, #708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced help text for the `unit` applet to include usage examples and exit status information.

* **Tests**
  * Added tests to verify consistent help output structure across compression applets including gzip, xz, and lzop variants.
  * Implemented integration tests to validate help text formatting standards and required sections across utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->