### PR TITLE
feat(help): document exit status in --help for 37 applets

### DIFF
--- a/internal/applets/archival/pipeprogress/pipeprogress.go
+++ b/internal/applets/archival/pipeprogress/pipeprogress.go
@@ -35,6 +35,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "tar c dir | pipe_progress | ssh host 'cat > backup.tar'", Explain: "Show progress while streaming."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred.",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/archival/pipeprogress/pipeprogress_test.go
+++ b/internal/applets/archival/pipeprogress/pipeprogress_test.go
@@ -36,4 +36,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out.String(), "Usage: pipe_progress") {
 		t.Errorf("--help = %q", out.String())
 	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section = %q", out.String())
+	}
 }

--- a/internal/applets/compat/busybox/busybox.go
+++ b/internal/applets/compat/busybox/busybox.go
@@ -52,6 +52,7 @@ func (c *Command) flagSet(stdio command.IO) *command.FlagSet {
 			{Command: "busybox --list", Explain: "List all applets."},
 			{Command: "busybox cat file.txt", Explain: "Run the cat applet."},
 		},
+		ExitStatus: "0  success.\n1  the requested applet failed or was not found.",
 	})
 }
 

--- a/internal/applets/compat/busybox/busybox_test.go
+++ b/internal/applets/compat/busybox/busybox_test.go
@@ -34,4 +34,7 @@ func TestHelpAndNoArgs(t *testing.T) {
 	if got := out(t); !strings.Contains(got, "Usage: busybox") {
 		t.Errorf("no args = %q", got)
 	}
+	if got := out(t, "--help"); !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", got)
+	}
 }

--- a/internal/applets/compat/cttyhack/cttyhack.go
+++ b/internal/applets/compat/cttyhack/cttyhack.go
@@ -37,6 +37,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		Notes: []string{
 			"The controlling-TTY allocation that BusyBox cttyhack performs is not implemented.",
 		},
+		ExitStatus: "the exit status of PROGRAM.\n1  PROGRAM could not be run (for example, the operand was missing).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/compat/cttyhack/cttyhack_test.go
+++ b/internal/applets/compat/cttyhack/cttyhack_test.go
@@ -25,6 +25,18 @@ func TestRunsProgram(t *testing.T) {
 	}
 }
 
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help missing exit status section = %q", out.String())
+	}
+}
+
 func TestMissingOperand(t *testing.T) {
 	errBuf := &bytes.Buffer{}
 	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: errBuf}

--- a/internal/applets/compat/shellfront/shellfront.go
+++ b/internal/applets/compat/shellfront/shellfront.go
@@ -49,6 +49,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 			{Command: c.Name() + " script.sh", Explain: "Run the commands in script.sh."},
 			{Command: "echo 'echo hi' | " + c.Name(), Explain: "Read commands from standard input."},
 		},
+		ExitStatus: "The exit status of the last command executed.\n2  a syntax or usage error in the shell itself.",
 		Notes: []string{
 			"This is mbsh under another name, not a full BusyBox/POSIX shell; it supports mbsh's syntax.",
 		},

--- a/internal/applets/compat/shellfront/shellfront_test.go
+++ b/internal/applets/compat/shellfront/shellfront_test.go
@@ -77,4 +77,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out.String(), "Usage: bash") {
 		t.Errorf("--help out = %q", out.String())
 	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help out missing exit status section = %q", out.String())
+	}
 }

--- a/internal/applets/console-tools/pager/pager.go
+++ b/internal/applets/console-tools/pager/pager.go
@@ -43,6 +43,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: c.Name() + " file.txt", Explain: "Page through file.txt."},
 			{Command: "ls -l | " + c.Name(), Explain: "Page command output on a terminal, or pass it through in a pipe."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred.",
 		Notes: []string{
 			"Paging keys: Enter advances one screen, a line starting with q quits. Input is line-buffered, so keys take effect on Enter; raw-mode single-key paging and backward scrolling are not implemented.",
 		},

--- a/internal/applets/console-tools/pager/pager_test.go
+++ b/internal/applets/console-tools/pager/pager_test.go
@@ -70,3 +70,23 @@ func TestIsTerminalFalseForBuffer(t *testing.T) {
 		t.Errorf("a bytes.Buffer must not be reported as a terminal")
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		cmd  *Command
+	}{
+		{"more", NewMore()},
+		{"less", NewLess()},
+	} {
+		out := &bytes.Buffer{}
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		if err := tc.cmd.Run(context.Background(), io, []string{"--help"}); err != nil {
+			t.Fatalf("%s --help err = %v", tc.name, err)
+		}
+		if !strings.Contains(out.String(), "Exit status:") {
+			t.Errorf("%s --help missing Exit status section = %q", tc.name, out.String())
+		}
+	}
+}

--- a/internal/applets/editors/ed/ed.go
+++ b/internal/applets/editors/ed/ed.go
@@ -49,6 +49,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "printf '1,$p\\nq\\n' | ed file.txt", Explain: "Print the whole file."},
 			{Command: "printf '2a\\nnew line\\n.\\nw\\nq\\n' | ed file.txt", Explain: "Insert a line after line 2 and save."},
 		},
+		ExitStatus: "0  the file was edited and written without error.\n1  an error occurred.",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/editors/ed/ed_test.go
+++ b/internal/applets/editors/ed/ed_test.go
@@ -29,6 +29,18 @@ func edit(t *testing.T, content, script string) (string, string) {
 	return out.String(), string(data)
 }
 
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help missing exit status section = %q", out.String())
+	}
+}
+
 func TestLoadAndPrint(t *testing.T) {
 	t.Parallel()
 	out, _ := edit(t, "one\ntwo\nthree\n", "1,$p\nq\n")

--- a/internal/applets/editors/vi/vi.go
+++ b/internal/applets/editors/vi/vi.go
@@ -45,6 +45,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			"Edits: i a A o O insert, x delete char, dd delete line, yy/p/P yank & paste, u undo (counts apply, e.g. 2x, 3dd).",
 			"Search: /pattern and ?pattern, then n / N for the next/previous match. Ex commands: :w :q :q! :wq and ZZ.",
 		},
+		ExitStatus: "0  the file was edited and written without error.\n1  an error occurred.",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/editors/vi/vi_test.go
+++ b/internal/applets/editors/vi/vi_test.go
@@ -126,4 +126,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: vi") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("help missing exit status section = %q", out)
+	}
 }

--- a/internal/applets/procps/iostat/iostat.go
+++ b/internal/applets/procps/iostat/iostat.go
@@ -41,6 +41,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "iostat", Explain: "Show CPU and disk I/O statistics."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/iostat/iostat_test.go
+++ b/internal/applets/procps/iostat/iostat_test.go
@@ -69,3 +69,15 @@ func TestCPUPercents(t *testing.T) {
 		t.Errorf("cpuPercents = %v %v %v %v %v %v", u, n, s, w, st, id)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/minips/minips.go
+++ b/internal/applets/procps/minips/minips.go
@@ -40,6 +40,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "minips", Explain: "List processes minimally."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/minips/minips_test.go
+++ b/internal/applets/procps/minips/minips_test.go
@@ -59,3 +59,15 @@ func TestListing(t *testing.T) {
 		t.Errorf("expected 3 process rows, got %d:\n%s", n, out)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/mpstat/mpstat.go
+++ b/internal/applets/procps/mpstat/mpstat.go
@@ -36,6 +36,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "mpstat", Explain: "Show per-CPU usage."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/mpstat/mpstat_test.go
+++ b/internal/applets/procps/mpstat/mpstat_test.go
@@ -79,3 +79,15 @@ func TestMissingStat(t *testing.T) {
 		t.Errorf("missing stat should fail")
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/nmeter/nmeter.go
+++ b/internal/applets/procps/nmeter/nmeter.go
@@ -44,6 +44,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Notes: []string{
 			"Only a single snapshot is printed; the continuous live display of real nmeter is not implemented.",
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or the FORMAT argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/nmeter/nmeter_test.go
+++ b/internal/applets/procps/nmeter/nmeter_test.go
@@ -68,3 +68,15 @@ func TestNoFormat(t *testing.T) {
 		t.Errorf("missing format should fail")
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/powertop/powertop.go
+++ b/internal/applets/procps/powertop/powertop.go
@@ -40,6 +40,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Notes: []string{
 			"The interactive power analysis and tunables of real powertop are not implemented.",
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /sys/class/power_supply could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/powertop/powertop_test.go
+++ b/internal/applets/procps/powertop/powertop_test.go
@@ -76,3 +76,15 @@ func TestMissingDir(t *testing.T) {
 		t.Errorf("missing dir should report none:\n%s", out)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/ps/ps.go
+++ b/internal/applets/procps/ps/ps.go
@@ -43,6 +43,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Notes: []string{
 			"All processes are listed; the BSD/Unix option syntax (aux, -ef) is not parsed.",
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/ps/ps_test.go
+++ b/internal/applets/procps/ps/ps_test.go
@@ -79,3 +79,15 @@ func TestCPUTime(t *testing.T) {
 		}
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/pstree/pstree.go
+++ b/internal/applets/procps/pstree/pstree.go
@@ -47,6 +47,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Notes: []string{
 			"This is the indented-tree form; the compacted classic pstree layout is not reproduced.",
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/pstree/pstree_test.go
+++ b/internal/applets/procps/pstree/pstree_test.go
@@ -90,3 +90,15 @@ func TestOrphanRoots(t *testing.T) {
 		t.Errorf("orphan should be a root: %q", out)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/smemcap/smemcap.go
+++ b/internal/applets/procps/smemcap/smemcap.go
@@ -41,6 +41,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "smemcap > capture.tar", Explain: "Capture the current memory state."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or the archive could not be written).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/smemcap/smemcap_test.go
+++ b/internal/applets/procps/smemcap/smemcap_test.go
@@ -104,3 +104,15 @@ func keys(m map[string]string) []string {
 	}
 	return out
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/top/top.go
+++ b/internal/applets/procps/top/top.go
@@ -53,6 +53,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Notes: []string{
 			"The interactive display and the %CPU/PR/NI columns of real top are not implemented.",
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	_ = fs.BoolP("batch", "b", false, "batch mode (the only supported mode)")
 	_ = fs.IntP("iterations", "n", 1, "number of iterations (only 1 is performed)")

--- a/internal/applets/procps/top/top_test.go
+++ b/internal/applets/procps/top/top_test.go
@@ -80,3 +80,15 @@ func TestSnapshot(t *testing.T) {
 		t.Errorf("%%MEM wrong:\n%s", out)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/uptime/uptime.go
+++ b/internal/applets/procps/uptime/uptime.go
@@ -48,6 +48,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "uptime", Explain: "Show the uptime summary."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/uptime/uptime_test.go
+++ b/internal/applets/procps/uptime/uptime_test.go
@@ -77,3 +77,15 @@ func TestFormatUptime(t *testing.T) {
 		}
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/procps/vmstat/vmstat.go
+++ b/internal/applets/procps/vmstat/vmstat.go
@@ -44,6 +44,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "vmstat", Explain: "Show one snapshot of system statistics."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. /proc could not be read or an argument was invalid).",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/procps/vmstat/vmstat_test.go
+++ b/internal/applets/procps/vmstat/vmstat_test.go
@@ -70,3 +70,15 @@ func TestCPUPercents(t *testing.T) {
 		t.Errorf("empty cpu idle = %d, want 100", id)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/bc/bc.go
+++ b/internal/applets/shellutils/bc/bc.go
@@ -52,6 +52,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "echo '2 + 3 * 4' | bc", Explain: "Print 14."},
 			{Command: "echo 'scale=2; 7/3' | bc", Explain: "Print 2.33."},
 		},
+		ExitStatus: "0  success.\n1  a syntax error in the expression, or a file could not be read.",
 		Notes: []string{
 			"Supported: + - * / % ^, parentheses, unary minus, variables, and the scale precision variable.",
 		},

--- a/internal/applets/shellutils/bc/bc_test.go
+++ b/internal/applets/shellutils/bc/bc_test.go
@@ -81,3 +81,15 @@ func TestDivideByZero(t *testing.T) {
 		t.Errorf("expected a divide-by-zero error, got %q", errBuf.String())
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/shellutils/dc/dc.go
+++ b/internal/applets/shellutils/dc/dc.go
@@ -52,6 +52,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "dc -e '6 3 / p'", Explain: "Print 2."},
 			{Command: "dc -e '2k 7 3 / p'", Explain: "Print 2.33 (two-digit precision)."},
 		},
+		ExitStatus: "0  success.\n1  a syntax error in the expression, or a file could not be read.",
 		Notes: []string{
 			"Commands: + - * / % ^ (arithmetic); p n f (print); c d r (stack); sX lX (registers); k K (precision); q (quit).",
 		},

--- a/internal/applets/shellutils/dc/dc_test.go
+++ b/internal/applets/shellutils/dc/dc_test.go
@@ -80,3 +80,15 @@ func TestPrintPopVsKeep(t *testing.T) {
 		t.Errorf("n -> %q", got)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/shellutils/mbsh/mbsh.go
+++ b/internal/applets/shellutils/mbsh/mbsh.go
@@ -56,6 +56,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 			{Command: "echo hi | wc -c", Explain: "Pipe one command into another."},
 			{Command: "echo hi > out.txt", Explain: "Redirect output (>, >>, < are supported)."},
 		},
+		ExitStatus: "The exit status of the last command executed.\n2  a syntax or usage error in the shell itself.",
 		Notes: []string{
 			"Tokenizing supports single/double quotes, backslash escapes, $VAR/${VAR}/$? expansion, ~ home expansion, and NAME=value prefixes.",
 			"Operators: ; sequences commands, | pipes them, and < > >> redirect I/O. A pipeline's status is its last command's; a list's is its last pipeline's.",

--- a/internal/applets/shellutils/mbsh/mbsh_test.go
+++ b/internal/applets/shellutils/mbsh/mbsh_test.go
@@ -230,6 +230,9 @@ func TestHelp(t *testing.T) {
 	if strings.Contains(out.String(), "mbsh:") {
 		t.Errorf("--help should not print a prompt: %q", out.String())
 	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help out missing exit status section = %q", out.String())
+	}
 }
 
 func requireCmd(t *testing.T, name string) {

--- a/internal/applets/shellutils/users/users.go
+++ b/internal/applets/shellutils/users/users.go
@@ -47,6 +47,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "users", Explain: "List the currently logged-in users."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred.",
 		Notes: []string{
 			"Reads the Linux utmp format; a login appears once per session.",
 		},

--- a/internal/applets/shellutils/users/users_test.go
+++ b/internal/applets/shellutils/users/users_test.go
@@ -80,3 +80,15 @@ func TestRunDefaultPath(t *testing.T) {
 		t.Errorf("default path = %q, want dave", got)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/shellutils/w/w.go
+++ b/internal/applets/shellutils/w/w.go
@@ -64,6 +64,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "w", Explain: "Show who is logged in."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred.",
 		Notes: []string{
 			"The IDLE and WHAT columns are placeholders ('-'); per-process accounting is not implemented.",
 		},

--- a/internal/applets/shellutils/w/w_test.go
+++ b/internal/applets/shellutils/w/w_test.go
@@ -110,3 +110,15 @@ func TestFormatUptime(t *testing.T) {
 		}
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/textutils/uucode/uucode.go
+++ b/internal/applets/textutils/uucode/uucode.go
@@ -54,6 +54,7 @@ func runUuencode(stdio command.IO, args []string) error {
 			{Command: "uuencode data.bin data.bin > data.uue", Explain: "Encode data.bin."},
 			{Command: "uuencode -m img.png img.png", Explain: "Encode using base64."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred.",
 	})
 	useBase64 := fs.BoolP("base64", "m", false, "use base64 encoding")
 	proceed, err := fs.Parse(stdio, args)
@@ -150,6 +151,7 @@ func runUudecode(stdio command.IO, args []string) error {
 			{Command: "uudecode data.uue", Explain: "Recreate the encoded file."},
 			{Command: "uudecode -o - data.uue", Explain: "Write the decoded bytes to standard output."},
 		},
+		ExitStatus: "0  success.\n1  an error occurred.",
 	})
 	output := fs.StringP("output-file", "o", "", "write to OUTPUT (- for standard output)")
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/textutils/uucode/uucode_test.go
+++ b/internal/applets/textutils/uucode/uucode_test.go
@@ -91,3 +91,23 @@ func TestDecodeNoBegin(t *testing.T) {
 		t.Errorf("input without a begin line should fail")
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		cmd  *Command
+	}{
+		{"uuencode", NewUuencode()},
+		{"uudecode", NewUudecode()},
+	} {
+		out := &bytes.Buffer{}
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		if err := tc.cmd.Run(context.Background(), io, []string{"--help"}); err != nil {
+			t.Fatalf("%s --help err = %v", tc.name, err)
+		}
+		if !strings.Contains(out.String(), "Exit status:") {
+			t.Errorf("%s --help missing Exit status section = %q", tc.name, out.String())
+		}
+	}
+}

--- a/internal/applets/util-linux/hexdump/hexdump.go
+++ b/internal/applets/util-linux/hexdump/hexdump.go
@@ -163,6 +163,7 @@ func (c *Command) help() command.Help {
 			{Command: c.Name() + " file.bin", Explain: "Dump the whole file."},
 			{Command: c.Name() + " -n 64 file.bin", Explain: "Dump only the first 64 bytes."},
 		},
+		ExitStatus: "0  the input was dumped successfully.\n1  a file could not be read.",
 		Notes: []string{
 			"Repeated-line squeezing (the '*' line) is not implemented; all lines are shown.",
 		},

--- a/internal/applets/util-linux/hexdump/hexdump_test.go
+++ b/internal/applets/util-linux/hexdump/hexdump_test.go
@@ -71,4 +71,12 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: hexdump") {
 		t.Errorf("--help = %q", out)
 	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", out)
+	}
+	// hd shares the parameterized command; its help also documents exit status.
+	hdOut, _ := run(t, NewHd(), "", "--help")
+	if !strings.Contains(hdOut, "Exit status:") {
+		t.Errorf("hd --help missing exit status section = %q", hdOut)
+	}
 }

--- a/internal/applets/util-linux/ipcs/ipcs.go
+++ b/internal/applets/util-linux/ipcs/ipcs.go
@@ -42,6 +42,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "ipcs", Explain: "Show all IPC objects."},
 			{Command: "ipcs -m", Explain: "Show only shared memory segments."},
 		},
+		ExitStatus: "0  the IPC status was reported successfully.\n1  an error occurred.",
 	})
 	queues := fs.BoolP("queues", "q", false, "message queues")
 	shmem := fs.BoolP("shmems", "m", false, "shared memory segments")

--- a/internal/applets/util-linux/ipcs/ipcs_test.go
+++ b/internal/applets/util-linux/ipcs/ipcs_test.go
@@ -88,3 +88,15 @@ func TestKeyFormat(t *testing.T) {
 		t.Errorf("key(0) = %q", got)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/util-linux/last/last.go
+++ b/internal/applets/util-linux/last/last.go
@@ -64,6 +64,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "last", Explain: "Show the login history."},
 			{Command: "last -n 10", Explain: "Show only the 10 most recent entries."},
 		},
+		ExitStatus: "0  the login history was listed successfully.\n1  the wtmp database could not be read.",
 	})
 	count := fs.IntP("count", "n", 0, "show only the last COUNT entries (0 = all)")
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/util-linux/last/last_test.go
+++ b/internal/applets/util-linux/last/last_test.go
@@ -102,3 +102,15 @@ func TestMissingFile(t *testing.T) {
 		t.Errorf("missing wtmp should fail")
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/util-linux/lsblk/lsblk.go
+++ b/internal/applets/util-linux/lsblk/lsblk.go
@@ -54,6 +54,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "lsblk", Explain: "List the block devices."},
 			{Command: "lsblk -a", Explain: "Include empty devices."},
 		},
+		ExitStatus: "0  the block devices were listed successfully.\n1  the block device information could not be read.",
 	})
 	all := fs.BoolP("all", "a", false, "also list empty devices")
 

--- a/internal/applets/util-linux/lsblk/lsblk_test.go
+++ b/internal/applets/util-linux/lsblk/lsblk_test.go
@@ -113,3 +113,15 @@ func TestHumanSize(t *testing.T) {
 		}
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/util-linux/lspci/lspci.go
+++ b/internal/applets/util-linux/lspci/lspci.go
@@ -38,6 +38,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "lspci", Explain: "List the PCI devices."},
 		},
+		ExitStatus: "0  the PCI devices were listed successfully.\n1  the PCI device information could not be read.",
 	})
 	_ = fs.BoolP("numeric", "n", false, "show numeric IDs (always on in this implementation)")
 

--- a/internal/applets/util-linux/lspci/lspci_test.go
+++ b/internal/applets/util-linux/lspci/lspci_test.go
@@ -86,3 +86,15 @@ func TestDisplaySlot(t *testing.T) {
 		t.Errorf("non-zero domain should be kept: %q", got)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/util-linux/lsusb/lsusb.go
+++ b/internal/applets/util-linux/lsusb/lsusb.go
@@ -47,6 +47,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "lsusb", Explain: "List the USB devices."},
 		},
+		ExitStatus: "0  the USB devices were listed successfully.\n1  the USB device information could not be read.",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/util-linux/lsusb/lsusb_test.go
+++ b/internal/applets/util-linux/lsusb/lsusb_test.go
@@ -81,3 +81,15 @@ func TestMissingDir(t *testing.T) {
 		t.Errorf("missing sysfs dir should fail")
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", out.String())
+	}
+}

--- a/internal/applets/util-linux/wall/wall.go
+++ b/internal/applets/util-linux/wall/wall.go
@@ -62,6 +62,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "wall 'system going down in 5 minutes'", Explain: "Broadcast a warning."},
 			{Command: "echo done | wall", Explain: "Broadcast a message from standard input."},
 		},
+		ExitStatus: "0  the message was written to the available terminals.\n1  an error occurred.",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/util-linux/wall/wall_test.go
+++ b/internal/applets/util-linux/wall/wall_test.go
@@ -88,3 +88,15 @@ func TestNoTerminals(t *testing.T) {
 		t.Errorf("expected no writes, got %v", *captured)
 	}
 }
+
+func TestHelpExitStatus(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help Run error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing exit status section = %q", out.String())
+	}
+}

--- a/test/it/spec/help_exit_status_spec.sh
+++ b/test/it/spec/help_exit_status_spec.sh
@@ -1,0 +1,51 @@
+Describe 'applets document their exit status in --help'
+    # GitHub issues #661-#697: every listed applet must route --help through the
+    # structured help renderer and include an "Exit status:" section, exiting 0.
+
+    Parameters
+        ash
+        bash
+        bc
+        busybox
+        cttyhack
+        dc
+        ed
+        hd
+        hexdump
+        hush
+        iostat
+        ipcs
+        last
+        less
+        lsblk
+        lspci
+        lsusb
+        mbsh
+        minips
+        more
+        mpstat
+        nmeter
+        pipe_progress
+        powertop
+        ps
+        pstree
+        sh
+        smemcap
+        top
+        uptime
+        users
+        uudecode
+        uuencode
+        vi
+        vmstat
+        w
+        wall
+    End
+
+    It "$1 --help documents its exit status"
+        When run "$1" --help
+        The status should be success
+        The output should include 'Exit status:'
+        The line 1 of output should start with "Usage: $1"
+    End
+End


### PR DESCRIPTION
## Summary

37 `[ux/help]` issues (#661–#697) asked for an `Exit status:` section in the
`--help` of applets that lacked one. This PR adds an `ExitStatus` field to each
applet's structured `command.Help` literal, with per-command wording reflecting
its real failure modes.

Covered: ash, bash, bc, busybox, cttyhack, dc, ed, hd, hexdump, hush, iostat,
ipcs, last, less, lsblk, lspci, lsusb, mbsh, minips, more, mpstat, nmeter,
pipe_progress, powertop, ps, pstree, sh, smemcap, top, uptime, users, uudecode,
uuencode, vi, vmstat, w, wall.

## Testing

- Per-package Go tests assert each applet's `--help` contains `Exit status:`.
- A parameterized ShellSpec spec (`help_exit_status_spec.sh`) asserts the same
  end-to-end for all 37 commands (37 examples, 0 failures).
- `go build ./...` and `go test` on all touched packages pass.

Closes #661, #662, #663, #664, #665, #666, #667, #668, #669, #670, #671, #672, #673, #674, #675, #676, #677, #678, #679, #680, #681, #682, #683, #684, #685, #686, #687, #688, #689, #690, #691, #692, #693, #694, #695, #696, #697