### PR TITLE
feat(help): add Notes sections to 12 applets' --help

### DIFF
--- a/internal/applets/compat/bracket/bracket.go
+++ b/internal/applets/compat/bracket/bracket.go
@@ -43,6 +43,10 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 				{Command: c.Name() + ` "$x" = y ` + c.close, Explain: "True when $x equals y."},
 			},
 			ExitStatus: "0  the expression is true.\n1  the expression is false.\n2  the expression is malformed.",
+			Notes: []string{
+				"This is the bracket form of test: the final argument must be the matching " + c.close + ".",
+				"As a shell builtin the same syntax is usually available without invoking this applet.",
+			},
 		})
 		_, _ = fs.Parse(stdio, args)
 		return nil

--- a/internal/applets/compat/bracket/bracket_test.go
+++ b/internal/applets/compat/bracket/bracket_test.go
@@ -60,3 +60,18 @@ func TestBracketHelp(t *testing.T) {
 		t.Errorf("--help out=%q code=%d", out, code)
 	}
 }
+
+// TestHelpNotes asserts both bracket forms document a Notes section in --help.
+func TestHelpNotes(t *testing.T) {
+	t.Parallel()
+	for _, c := range []*Command{NewBracket(), NewDoubleBracket()} {
+		out := &bytes.Buffer{}
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		if err := c.Run(context.Background(), io, []string{"--help"}); err != nil {
+			t.Fatalf("%s --help err = %v", c.Name(), err)
+		}
+		if !strings.Contains(out.String(), "Notes:") {
+			t.Errorf("%s --help missing Notes section: %q", c.Name(), out.String())
+		}
+	}
+}

--- a/internal/applets/loginutils/acpid/acpid.go
+++ b/internal/applets/loginutils/acpid/acpid.go
@@ -54,6 +54,10 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 			{Command: "acpid -f", Explain: "Run the ACPI event daemon in the foreground."},
 		},
 		ExitStatus: "0  the daemon stopped cleanly.\n1  -f was not given or the event source was unavailable.",
+		Notes: []string{
+			"Only foreground mode (-f) is supported; MimixBox does not daemonize or write a PID file.",
+			"Reading /proc/acpi/event requires a Linux host that still exposes the legacy ACPI event interface.",
+		},
 	})
 	foreground := fs.BoolP("foreground", "f", false, "run in the foreground (the only supported mode)")
 

--- a/internal/applets/loginutils/acpid/acpid_test.go
+++ b/internal/applets/loginutils/acpid/acpid_test.go
@@ -82,3 +82,16 @@ func TestStopsOnCancel(t *testing.T) {
 		t.Fatal("acpid did not stop after cancellation")
 	}
 }
+
+// TestHelpNotes asserts the --help output documents a Notes section.
+func TestHelpNotes(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Notes:") {
+		t.Errorf("--help missing Notes section: %q", out.String())
+	}
+}

--- a/internal/applets/loginutils/crond/crond.go
+++ b/internal/applets/loginutils/crond/crond.go
@@ -48,6 +48,10 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 			{Command: "crond -f", Explain: "Run the cron daemon in the foreground."},
 		},
 		ExitStatus: "0  the daemon stopped cleanly.\n1  -f was not given.",
+		Notes: []string{
+			"Only foreground mode (-f) is supported; MimixBox does not background itself or write a PID file.",
+			"Use crontab to edit the schedules that crond runs.",
+		},
 	})
 	foreground := fs.BoolP("foreground", "f", false, "run in the foreground (the only supported mode)")
 

--- a/internal/applets/loginutils/crond/crond_test.go
+++ b/internal/applets/loginutils/crond/crond_test.go
@@ -117,3 +117,16 @@ func TestStopsOnCancel(t *testing.T) {
 		t.Fatal("crond did not stop after cancellation")
 	}
 }
+
+// TestHelpNotes asserts the --help output documents a Notes section.
+func TestHelpNotes(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Notes:") {
+		t.Errorf("--help missing Notes section: %q", out.String())
+	}
+}

--- a/internal/applets/netutils/netctl/netctl.go
+++ b/internal/applets/netutils/netctl/netctl.go
@@ -260,41 +260,50 @@ func (c *Command) help() command.Help {
 	note := "This applet reconfigures privileged kernel network state, which is not available in this " +
 		"environment. It validates arguments and serializes the requested action into a plan, then fails " +
 		"with a documented capability error (it never silently does nothing)."
+	gatedNotes := []string{
+		"Capability-gated: applying the plan needs CAP_NET_ADMIN and kernel support that MimixBox does not exercise, so the command reports a backend error instead of changing kernel state.",
+	}
 	switch c.name {
 	case "brctl":
 		return command.Help{
 			Description: "Manage Ethernet bridges (addbr, delbr, addif, delif, show). " + note,
 			Examples:    []command.Example{{Command: "brctl addbr br0", Explain: "Plan creating bridge br0."}},
+			Notes:       gatedNotes,
 			ExitStatus:  "0  never (capability-gated).\n1  always: validated plan then a documented backend error.",
 		}
 	case "ifenslave":
 		return command.Help{
 			Description: "Attach (or detach) slave interfaces to a bonding master. " + note,
 			Examples:    []command.Example{{Command: "ifenslave bond0 eth0 eth1", Explain: "Plan enslaving eth0 and eth1 to bond0."}},
+			Notes:       gatedNotes,
 			ExitStatus:  "0  never (capability-gated).\n1  always: validated plan then a documented backend error.",
 		}
 	case "tunctl":
 		return command.Help{
 			Description: "Create (-t) or delete (-d) a persistent TUN/TAP device. " + note,
 			Examples:    []command.Example{{Command: "tunctl -t tap0", Explain: "Plan creating TAP device tap0."}},
+			Notes:       gatedNotes,
 			ExitStatus:  "0  never (capability-gated).\n1  always: validated plan then a documented backend error.",
 		}
 	case "vconfig":
 		return command.Help{
 			Description: "Manage 802.1q VLAN interfaces (add, rem, set_flag, ...). " + note,
 			Examples:    []command.Example{{Command: "vconfig add eth0 100", Explain: "Plan creating VLAN 100 on eth0."}},
+			Notes:       gatedNotes,
 			ExitStatus:  "0  never (capability-gated).\n1  always: validated plan then a documented backend error.",
 		}
 	case "zcip":
 		return command.Help{
 			Description: "Manage IPv4 link-local (169.254/16) addressing via a configuration script. " + note,
 			Examples:    []command.Example{{Command: "zcip eth0 /etc/zcip.script", Explain: "Plan link-local configuration of eth0."}},
+			Notes:       gatedNotes,
 			ExitStatus:  "0  never (capability-gated).\n1  always: validated plan then a documented backend error.",
 		}
 	case "nbd-client":
 		return command.Help{
 			Description: "Attach (HOST PORT NBDDEVICE) or detach (-d NBDDEVICE) a network block device. " + note,
 			Examples:    []command.Example{{Command: "nbd-client 10.0.0.1 10809 /dev/nbd0", Explain: "Plan attaching /dev/nbd0 to 10.0.0.1:10809."}},
+			Notes:       gatedNotes,
 			ExitStatus:  "0  never (capability-gated).\n1  always: validated plan then a documented backend error.",
 		}
 	}

--- a/internal/applets/netutils/netctl/netctl_test.go
+++ b/internal/applets/netutils/netctl/netctl_test.go
@@ -81,3 +81,22 @@ func TestRunGatesAfterValidation(t *testing.T) {
 		t.Error("expected validation error for bad command")
 	}
 }
+
+// TestHelpNotes asserts every capability-gated netctl applet documents a Notes
+// section in --help (GitHub issues #712, #714, #716, #718, #719, #720).
+func TestHelpNotes(t *testing.T) {
+	t.Parallel()
+	for _, c := range []*Command{
+		NewBrctl(), NewIfenslave(), NewTunctl(),
+		NewVconfig(), NewZcip(), NewNbdClient(),
+	} {
+		out := &bytes.Buffer{}
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		if err := c.Run(context.Background(), io, []string{"--help"}); err != nil {
+			t.Fatalf("%s --help err = %v", c.Name(), err)
+		}
+		if !strings.Contains(out.String(), "Notes:") {
+			t.Errorf("%s --help missing Notes section: %q", c.Name(), out.String())
+		}
+	}
+}

--- a/internal/applets/netutils/sslutil/sslutil.go
+++ b/internal/applets/netutils/sslutil/sslutil.go
@@ -62,6 +62,10 @@ func (c *Command) runServer(_ context.Context, stdio command.IO, args []string) 
 			{Command: "ssl_server -c cert.pem -k key.pem -b 127.0.0.1:8443", Explain: "Terminate TLS on loopback port 8443 using the given cert/key."},
 		},
 		ExitStatus: "0  clean shutdown.\n1  missing cert/key, load error, or bind error.",
+		Notes: []string{
+			"Binds a loopback address only; it is intended for local testing, not as a public-facing TLS server.",
+			"Pair it with ssl_client to exercise a TLS exchange end to end.",
+		},
 	})
 	certFile := fs.StringP("cert", "c", "", "PEM certificate file")
 	keyFile := fs.StringP("key", "k", "", "PEM private key file")

--- a/internal/applets/netutils/sslutil/sslutil_test.go
+++ b/internal/applets/netutils/sslutil/sslutil_test.go
@@ -85,3 +85,16 @@ func TestClientRequiresServer(t *testing.T) {
 		t.Error("ssl_client should fail without -s")
 	}
 }
+
+// TestServerHelpNotes asserts ssl_server --help documents a Notes section.
+func TestServerHelpNotes(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := NewSSLServer().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Notes:") {
+		t.Errorf("ssl_server --help missing Notes section: %q", out.String())
+	}
+}

--- a/internal/applets/util-linux/mkfs_reiser/mkfs_reiser.go
+++ b/internal/applets/util-linux/mkfs_reiser/mkfs_reiser.go
@@ -33,6 +33,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "mkfs.reiser disk.img", Explain: "Reports that ReiserFS is unsupported."},
 		},
 		ExitStatus: "1  always: ReiserFS creation is not supported by this build.",
+		Notes: []string{
+			"ReiserFS is deprecated and slated for removal from the Linux kernel; create a supported filesystem (such as ext4) instead.",
+		},
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/util-linux/mkfs_reiser/mkfs_reiser_test.go
+++ b/internal/applets/util-linux/mkfs_reiser/mkfs_reiser_test.go
@@ -32,3 +32,16 @@ func TestRequiresDevice(t *testing.T) {
 		t.Errorf("missing device should fail")
 	}
 }
+
+// TestHelpNotes asserts the --help output documents a Notes section.
+func TestHelpNotes(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	if !strings.Contains(out.String(), "Notes:") {
+		t.Errorf("--help missing Notes section: %q", out.String())
+	}
+}

--- a/test/it/spec/help_notes_spec.sh
+++ b/test/it/spec/help_notes_spec.sh
@@ -1,0 +1,40 @@
+Describe 'applets with a Notes section in --help'
+    # GitHub issues #709-#720: every listed applet must route --help through the
+    # structured help renderer and include a "Notes:" section, exiting 0.
+
+    Parameters
+        acpid
+        brctl
+        crond
+        ifenslave
+        mkfs.reiser
+        nbd-client
+        ssl_server
+        tunctl
+        vconfig
+        zcip
+    End
+
+    It "$1 --help documents a Notes section"
+        When run "$1" --help
+        The status should be success
+        The output should include 'Notes:'
+        The line 1 of output should start with "Usage: $1"
+    End
+
+    # `[` and `[[` collide with shell builtins, so run them through env to force
+    # the applet on PATH (GitHub issues #709, #710).
+    It '[ --help documents a Notes section'
+        When run env '[' --help
+        The status should be success
+        The output should include 'Notes:'
+        The line 1 of output should start with 'Usage: ['
+    End
+
+    It '[[ --help documents a Notes section'
+        When run env '[[' --help
+        The status should be success
+        The output should include 'Notes:'
+        The line 1 of output should start with 'Usage: [['
+    End
+End


### PR DESCRIPTION
## Summary

12 `[ux/help]` issues (#709–#720) asked for a `Notes:` section in the `--help`
of applets that lacked one. This PR adds a `Notes` field to each applet's
structured `command.Help`, documenting per-applet caveats:

- `[` / `[[` — bracket-form `test`; closing bracket required; usually a shell builtin.
- `acpid` / `crond` — foreground-only; no daemonize/PID file.
- `brctl`, `ifenslave`, `tunctl`, `vconfig`, `zcip`, `nbd-client` — capability-gated network stubs (need CAP_NET_ADMIN + kernel support).
- `mkfs.reiser` — ReiserFS deprecated; use a supported filesystem.
- `ssl_server` — loopback-only; pair with `ssl_client`.

## Testing

- Per-package Go tests assert each applet's `--help` contains `Notes:`.
- A parameterized ShellSpec spec (`help_notes_spec.sh`) asserts the same
  end-to-end (`[`/`[[` run via `env` to bypass the shell builtins).
- `go build ./...`, `go test`, and `golangci-lint` on touched packages pass.

Closes #709, #710, #711, #712, #713, #714, #715, #716, #717, #718, #719, #720