### PR TITLE
feat(help): add structured --help sections to 91 applets

### DIFF
--- a/internal/applets/archival/rpm/rpm.go
+++ b/internal/applets/archival/rpm/rpm.go
@@ -28,7 +28,18 @@ func (c *Command) Synopsis() string { return "Query an RPM package file" }
 
 // Run executes rpm.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "-qp [-i] [-l] FILE.rpm", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "-qp [-i] [-l] FILE.rpm", stdio.Err).WithHelp(command.Help{
+		Description: "Query an RPM package file with -qp. By default the package identity is printed " +
+			"as name-version-release.arch; -i prints an information summary and -l lists the files " +
+			"contained in the package. Only package-file queries are supported: rpm does not " +
+			"install, remove, or query the system RPM database.",
+		Examples: []command.Example{
+			{Command: "rpm -qp pkg.rpm", Explain: "Print the package's name-version-release.arch."},
+			{Command: "rpm -qpi pkg.rpm", Explain: "Print a summary of the package information."},
+			{Command: "rpm -qpl pkg.rpm", Explain: "List the files contained in the package."},
+		},
+		ExitStatus: "0  the package file was queried successfully.\n1  the file could not be read or the query mode was not -qp.",
+	})
 	query := fs.BoolP("query", "q", false, "query mode")
 	pkgFile := fs.BoolP("package", "p", false, "query a package file")
 	info := fs.BoolP("info", "i", false, "display package information")

--- a/internal/applets/archival/rpm/rpm_test.go
+++ b/internal/applets/archival/rpm/rpm_test.go
@@ -192,7 +192,9 @@ func TestHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("help err = %v", err)
 	}
-	if !strings.Contains(out, "Usage: rpm") {
-		t.Errorf("help = %q", out)
+	for _, want := range []string{"Usage: rpm", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help missing %q\n%s", want, out)
+		}
 	}
 }

--- a/internal/applets/archival/rpm2cpio/rpm2cpio.go
+++ b/internal/applets/archival/rpm2cpio/rpm2cpio.go
@@ -27,7 +27,18 @@ func (c *Command) Synopsis() string { return "Extract the cpio payload from an R
 
 // Run executes rpm2cpio.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[FILE.rpm]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[FILE.rpm]", stdio.Err).WithHelp(command.Help{
+		Description: "Extract the cpio payload from the RPM package FILE.rpm and write it, " +
+			"decompressed, to standard output. With no FILE, or when FILE is '-', the package is " +
+			"read from standard input. The result can be piped straight into cpio to unpack the " +
+			"package contents.",
+		Examples: []command.Example{
+			{Command: "rpm2cpio pkg.rpm | cpio -idmv", Explain: "Extract every file from pkg.rpm into the current directory."},
+			{Command: "rpm2cpio pkg.rpm > pkg.cpio", Explain: "Save the decompressed cpio payload to a file."},
+			{Command: "cat pkg.rpm | rpm2cpio", Explain: "Read the package from standard input."},
+		},
+		ExitStatus: "0  the payload was extracted successfully.\n1  the file could not be opened or is not a valid RPM package.",
+	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err

--- a/internal/applets/archival/rpm2cpio/rpm2cpio_test.go
+++ b/internal/applets/archival/rpm2cpio/rpm2cpio_test.go
@@ -115,7 +115,9 @@ func TestHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("help err = %v", err)
 	}
-	if !strings.Contains(out, "Usage: rpm2cpio") {
-		t.Errorf("help = %q", out)
+	for _, want := range []string{"Usage: rpm2cpio", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help missing %q\n%s", want, out)
+		}
 	}
 }

--- a/internal/applets/archival/tar/tar.go
+++ b/internal/applets/archival/tar/tar.go
@@ -41,7 +41,17 @@ type options struct {
 
 // Run executes tar.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[-c|-x|-t] [-z] [-f ARCHIVE] [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[-c|-x|-t] [-z] [-f ARCHIVE] [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Create, list, or extract a tar archive. Exactly one of -c (create), -x (extract), " +
+			"or -t (list) selects the operation, and -z filters the archive through gzip.",
+		Examples: []command.Example{
+			{Command: "tar -cf archive.tar dir", Explain: "Create archive.tar from the contents of dir."},
+			{Command: "tar -czf archive.tar.gz dir", Explain: "Create a gzip-compressed archive of dir."},
+			{Command: "tar -xf archive.tar", Explain: "Extract the files from archive.tar."},
+			{Command: "tar -tf archive.tar", Explain: "List the contents of archive.tar."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. the archive could not be read or written).",
+	})
 	create := fs.BoolP("create", "c", false, "create a new archive")
 	extract := fs.BoolP("extract", "x", false, "extract files from an archive")
 	list := fs.BoolP("list", "t", false, "list the contents of an archive")

--- a/internal/applets/archival/tar/tar_test.go
+++ b/internal/applets/archival/tar/tar_test.go
@@ -160,4 +160,9 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: tar") {
 		t.Errorf("help = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
 }

--- a/internal/applets/archival/uncompress/uncompress.go
+++ b/internal/applets/archival/uncompress/uncompress.go
@@ -33,7 +33,16 @@ type options struct {
 
 // Run executes uncompress.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Decompress each .Z FILE produced by the classic Unix compress (LZW), replacing FILE.Z with FILE. " +
+			"With no FILE, or with -, read standard input and write to standard output.",
+		Examples: []command.Example{
+			{Command: "uncompress archive.Z", Explain: "Decompress archive.Z to archive and remove the .Z file."},
+			{Command: "uncompress -c archive.Z", Explain: "Write the decompressed data to standard output."},
+			{Command: "uncompress -k data.Z", Explain: "Decompress but keep the original .Z file."},
+		},
+		ExitStatus: "0  all files were decompressed successfully.\n1  a file was missing, had a bad stream, or could not be written.",
+	})
 	stdout := fs.BoolP("stdout", "c", false, "write on standard output, keep original files unchanged")
 	keep := fs.BoolP("keep", "k", false, "keep (don't delete) input files")
 	force := fs.BoolP("force", "f", false, "force overwrite of output file")

--- a/internal/applets/archival/uncompress/uncompress_test.go
+++ b/internal/applets/archival/uncompress/uncompress_test.go
@@ -131,4 +131,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: uncompress") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 }

--- a/internal/applets/archival/unzip/unzip.go
+++ b/internal/applets/archival/unzip/unzip.go
@@ -34,7 +34,16 @@ type options struct {
 
 // Run executes unzip.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... ARCHIVE", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... ARCHIVE", stdio.Err).WithHelp(command.Help{
+		Description: "List or extract the contents of a ZIP ARCHIVE. By default every entry is extracted into the " +
+			"current directory; -l lists entries instead, and -d chooses a destination directory.",
+		Examples: []command.Example{
+			{Command: "unzip files.zip", Explain: "Extract every entry into the current directory."},
+			{Command: "unzip -l files.zip", Explain: "List the archive contents without extracting."},
+			{Command: "unzip -d out files.zip", Explain: "Extract the archive into the out directory."},
+		},
+		ExitStatus: "0  the archive was listed or extracted successfully.\n1  the archive was missing, malformed, or could not be extracted.",
+	})
 	list := fs.BoolP("list", "l", false, "list archive contents without extracting")
 	dir := fs.StringP("dir", "d", "", "extract files into this directory")
 	verbose := fs.BoolP("verbose", "v", false, "print each file as it is extracted")

--- a/internal/applets/archival/unzip/unzip_test.go
+++ b/internal/applets/archival/unzip/unzip_test.go
@@ -135,4 +135,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: unzip") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 }

--- a/internal/applets/archival/zip/zip.go
+++ b/internal/applets/archival/zip/zip.go
@@ -33,7 +33,16 @@ type options struct {
 
 // Run executes zip.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... ARCHIVE FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... ARCHIVE FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Create the ZIP archive ARCHIVE containing the given FILE operands. Directories are " +
+			"skipped unless -r is given, in which case they are added recursively.",
+		Examples: []command.Example{
+			{Command: "zip archive.zip file1 file2", Explain: "Create archive.zip from two files."},
+			{Command: "zip -r archive.zip dir", Explain: "Recursively add a directory to the archive."},
+			{Command: "zip -v archive.zip file", Explain: "Create the archive, listing each entry as it is added."},
+		},
+		ExitStatus: "0  the archive was created.\n1  an input was missing or could not be read.",
+	})
 	recurse := fs.BoolP("recurse-paths", "r", false, "recurse into directories")
 	verbose := fs.BoolP("verbose", "v", false, "print each entry as it is added")
 

--- a/internal/applets/archival/zip/zip_test.go
+++ b/internal/applets/archival/zip/zip_test.go
@@ -153,4 +153,9 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: zip") {
 		t.Errorf("help = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 }

--- a/internal/applets/console-tools/reset/reset.go
+++ b/internal/applets/console-tools/reset/reset.go
@@ -34,7 +34,16 @@ func (c *Command) Synopsis() string { return "Reset terminal" }
 // Run executes reset: it writes the terminal-reset escape sequence to
 // stdio.Out.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Reset the terminal to its initial state by writing the standard reset escape " +
+			"sequence: it restores the default character set and display attributes, clears the " +
+			"screen, and makes the cursor visible again. Use it to recover a terminal left in a " +
+			"confused state, for example after a program emits raw binary data.",
+		Examples: []command.Example{
+			{Command: "reset", Explain: "Reset the terminal to a sane, usable state."},
+		},
+		ExitStatus: "0  the reset sequence was written successfully.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/console-tools/reset/reset_test.go
+++ b/internal/applets/console-tools/reset/reset_test.go
@@ -30,3 +30,16 @@ func TestRun(t *testing.T) {
 		t.Errorf("out = %q, want %q", out, want)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Usage: reset", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/console-tools/resize/resize.go
+++ b/internal/applets/console-tools/resize/resize.go
@@ -51,7 +51,18 @@ var winsize = func() (rows, cols uint16, err error) {
 
 // Run executes resize.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Query the controlling terminal's size and print shell commands that set the " +
+			"COLUMNS and LINES environment variables, like the xterm 'resize' utility. By default " +
+			"Bourne-shell (sh/ksh/bash) syntax is written; -c selects C-shell (csh/tcsh) syntax. " +
+			"Evaluate the output (eval `resize`) to update the current shell after the window has " +
+			"changed size.",
+		Examples: []command.Example{
+			{Command: "eval `resize`", Explain: "Update COLUMNS and LINES in the current Bourne shell."},
+			{Command: "resize -c", Explain: "Write the assignments in C-shell syntax."},
+		},
+		ExitStatus: "0  the terminal size was determined and printed.\n1  the terminal size could not be determined.",
+	})
 	sh := fs.BoolP("sh", "u", false, "write Bourne-shell (sh/ksh/bash) commands (default)")
 	csh := fs.BoolP("csh", "c", false, "write C-shell (csh/tcsh) commands")
 

--- a/internal/applets/console-tools/resize/resize_test.go
+++ b/internal/applets/console-tools/resize/resize_test.go
@@ -112,8 +112,10 @@ func TestRunHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run --help error = %v", err)
 	}
-	if !strings.Contains(out, "Usage: resize") {
-		t.Errorf("help = %q, want usage line", out)
+	for _, want := range []string{"Usage: resize", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help missing %q\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/applets/debianutils/mktemp/help_test.go
+++ b/internal/applets/debianutils/mktemp/help_test.go
@@ -1,0 +1,26 @@
+package mktemp_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/debianutils/mktemp"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := mktemp.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/debianutils/mktemp/mktemp.go
+++ b/internal/applets/debianutils/mktemp/mktemp.go
@@ -35,7 +35,14 @@ func (c *Command) Synopsis() string { return "Create a temporary file or directo
 
 // Run executes mktemp.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [TEMPLATE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [TEMPLATE]", stdio.Err).WithHelp(command.Help{
+		Description: "Create a uniquely-named temporary file (or, with -d, directory) by replacing the trailing run of at least three X's in TEMPLATE with random characters, then print its path. TEMPLATE defaults to tmp.XXXXXXXXXX.",
+		Examples: []command.Example{
+			{Command: "mktemp", Explain: "Create a temporary file and print its path, e.g. /tmp/tmp.aZ3kP9qLrt."},
+			{Command: "mktemp -d build.XXXXXX", Explain: "Create a temporary directory named build.<random> in the current directory."},
+		},
+		ExitStatus: "0  the file or directory was created and its name printed.\n1  the template was invalid or creation failed.",
+	})
 	directory := fs.BoolP("directory", "d", false, "create a directory, not a file")
 	dryRun := fs.BoolP("dry-run", "u", false, "do not create anything; merely print a name (unsafe)")
 	quiet := fs.BoolP("quiet", "q", false, "suppress diagnostics about file/dir-creation failure")

--- a/internal/applets/debianutils/remove-shell/remove-shell.go
+++ b/internal/applets/debianutils/remove-shell/remove-shell.go
@@ -46,7 +46,16 @@ func (c *Command) Synopsis() string { return "Remove shell name from /etc/shells
 
 // Run executes remove-shell.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "SHELLNAME...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "SHELLNAME...", stdio.Err).WithHelp(command.Help{
+		Description: "Remove each named SHELLNAME from the list of login shells in /etc/shells, " +
+			"rewriting the file with the remaining entries in their original order. Names that " +
+			"are not present are silently ignored.",
+		Examples: []command.Example{
+			{Command: "remove-shell /bin/zsh", Explain: "Remove /bin/zsh from /etc/shells."},
+			{Command: "remove-shell /bin/ksh /bin/tcsh", Explain: "Remove several shells at once."},
+		},
+		ExitStatus: "0  the named shells were removed (or were already absent).\n1  /etc/shells could not be rewritten or no shell name was given.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/debianutils/remove-shell/remove-shell_test.go
+++ b/internal/applets/debianutils/remove-shell/remove-shell_test.go
@@ -2,13 +2,30 @@ package removeShell_test
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	removeShell "github.com/nao1215/mimixbox/internal/applets/debianutils/remove-shell"
+	"github.com/nao1215/mimixbox/internal/command"
 )
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := removeShell.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Usage: remove-shell", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q\n%s", want, out.String())
+		}
+	}
+}
 
 func TestNew(t *testing.T) {
 	t.Parallel()

--- a/internal/applets/debianutils/valid-shell/valid-shell.go
+++ b/internal/applets/debianutils/valid-shell/valid-shell.go
@@ -47,7 +47,15 @@ func (c *Command) Synopsis() string { return "Verify if /etc/shells is valid" }
 
 // Run executes valid-shell.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Check that every shell listed in /etc/shells (or FILE, if given) exists and is " +
+			"executable, printing an \"OK:\" or \"NG:\" line for each entry. Comment and blank lines are ignored.",
+		Examples: []command.Example{
+			{Command: "valid-shell", Explain: "Validate the shells listed in /etc/shells."},
+			{Command: "valid-shell /etc/shells", Explain: "Validate the named shells file."},
+		},
+		ExitStatus: "0  every listed shell exists and is executable.\n1  a shell is missing or the file could not be read.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/debianutils/valid-shell/valid-shell_test.go
+++ b/internal/applets/debianutils/valid-shell/valid-shell_test.go
@@ -2,12 +2,14 @@ package validShell_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	validShell "github.com/nao1215/mimixbox/internal/applets/debianutils/valid-shell"
+	"github.com/nao1215/mimixbox/internal/command"
 )
 
 func TestNew(t *testing.T) {
@@ -59,5 +61,19 @@ func TestValidateShellsInvalid(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "NG: /no/such/shell") {
 		t.Errorf("output = %q, want an NG line for the missing shell", out.String())
+	}
+}
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := validShell.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
 	}
 }

--- a/internal/applets/debianutils/which/which.go
+++ b/internal/applets/debianutils/which/which.go
@@ -33,7 +33,15 @@ func (c *Command) Synopsis() string {
 // the exit status is 1, matching the Debian which behavior: nothing is written
 // for a name that cannot be resolved.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... COMMAND...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... COMMAND...", stdio.Err).WithHelp(command.Help{
+		Description: "For each COMMAND, print the absolute path that would be executed for it on the " +
+			"current $PATH. With -a, print every matching path instead of only the first.",
+		Examples: []command.Example{
+			{Command: "which ls", Explain: "Print the path of the ls command."},
+			{Command: "which -a python", Explain: "Print every python found on $PATH."},
+		},
+		ExitStatus: "0  every COMMAND was found.\n1  a COMMAND was not found, or none was given.",
+	})
 	all := fs.BoolP("all", "a", false, "print all matching pathnames of each argument")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/debianutils/which/which_test.go
+++ b/internal/applets/debianutils/which/which_test.go
@@ -128,3 +128,17 @@ func TestRunAll(t *testing.T) {
 		t.Errorf("out = %q, want to contain %q", out, bin)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := which.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/editors/patch/patch.go
+++ b/internal/applets/editors/patch/patch.go
@@ -28,7 +28,16 @@ func (c *Command) Synopsis() string { return "Apply a diff file to an original" 
 
 // Run executes patch.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [ORIGFILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [ORIGFILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Apply a unified diff (as produced by \"diff -u\") to the target files. The patch is " +
+			"read from the file given with -i, or from standard input when -i is omitted.",
+		Examples: []command.Example{
+			{Command: "patch -i changes.diff", Explain: "Apply the unified diff in changes.diff."},
+			{Command: "patch -p1 -i changes.diff", Explain: "Strip one leading path component from file names."},
+			{Command: "patch -R -i changes.diff", Explain: "Reverse a previously applied patch."},
+		},
+		ExitStatus: "0  all patches applied successfully.\n1  a patch could not be applied or the input was invalid.",
+	})
 	strip := fs.IntP("strip", "p", 0, "strip NUM leading components from file names")
 	input := fs.StringP("input", "i", "", "read patch from FILE instead of stdin")
 	reverse := fs.BoolP("reverse", "R", false, "assume patches were created with old and new swapped")

--- a/internal/applets/editors/patch/patch_test.go
+++ b/internal/applets/editors/patch/patch_test.go
@@ -206,4 +206,10 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: patch") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", out)
+	}
 }

--- a/internal/applets/editors/sed/sed.go
+++ b/internal/applets/editors/sed/sed.go
@@ -30,7 +30,21 @@ func (c *Command) Synopsis() string { return "Stream editor for filtering and tr
 
 // Run executes sed.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... {SCRIPT} [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... {SCRIPT} [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "A stream editor that applies a SCRIPT to each FILE (or to standard input) and " +
+			"writes the result to standard output. It supports a practical subset of GNU sed: the " +
+			"substitute command s/re/repl/flags, plus p (print), d (delete) and q (quit), each " +
+			"with an optional line-number, $ or /regexp/ address, given singly or as a range. The " +
+			"script is taken from -e/-f or from the first operand; -n suppresses automatic " +
+			"printing, -E/-r enable extended regular expressions, and -i edits files in place.",
+		Examples: []command.Example{
+			{Command: "sed 's/foo/bar/' file.txt", Explain: "Replace the first 'foo' on each line with 'bar'."},
+			{Command: "sed -n '2,4p' file.txt", Explain: "Print only lines 2 through 4."},
+			{Command: "sed '/^#/d' config", Explain: "Delete every comment line."},
+			{Command: "sed -i 's/old/new/g' file.txt", Explain: "Edit file.txt in place, replacing all 'old' with 'new'."},
+		},
+		ExitStatus: "0  the script ran successfully on all input.\n1  the script was invalid or a file could not be read.",
+	})
 	scripts := fs.StringArrayP("expression", "e", nil, "add the script to the commands to be executed")
 	scriptFile := fs.StringP("file", "f", "", "add the contents of FILE to the commands")
 	quiet := fs.BoolP("quiet", "n", false, "suppress automatic printing of pattern space")

--- a/internal/applets/editors/sed/sed_test.go
+++ b/internal/applets/editors/sed/sed_test.go
@@ -252,7 +252,9 @@ func TestHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("help err = %v", err)
 	}
-	if !strings.Contains(out, "Usage: sed") {
-		t.Errorf("help = %q", out)
+	for _, want := range []string{"Usage: sed", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help missing %q\n%s", want, out)
+		}
 	}
 }

--- a/internal/applets/fileutils/ln/help_test.go
+++ b/internal/applets/fileutils/ln/help_test.go
@@ -1,0 +1,26 @@
+package ln_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/ln"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := ln.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/ln/ln.go
+++ b/internal/applets/fileutils/ln/ln.go
@@ -32,7 +32,14 @@ type options struct {
 
 // Run executes ln.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... TARGET [LINK_NAME]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... TARGET [LINK_NAME]", stdio.Err).WithHelp(command.Help{
+		Description: "Create a link named LINK_NAME to TARGET. By default a hard link is made; with -s a symbolic link is made instead. With a single TARGET the link is created in the current directory; with several TARGETs the last operand must be a directory and a link to each is created there.",
+		Examples: []command.Example{
+			{Command: "ln -s /usr/bin/python3 python", Explain: "Create a symbolic link 'python' pointing to /usr/bin/python3."},
+			{Command: "ln -f foo bar", Explain: "Hard-link foo to bar, removing an existing bar first."},
+		},
+		ExitStatus: "0  every link was created.\n1  a link could not be created.",
+	})
 	symbolic := fs.BoolP("symbolic", "s", false, "make symbolic links instead of hard links")
 	force := fs.BoolP("force", "f", false, "remove existing destination files")
 	verbose := fs.BoolP("verbose", "v", false, "print name of each linked file")

--- a/internal/applets/fileutils/mkdir/help_test.go
+++ b/internal/applets/fileutils/mkdir/help_test.go
@@ -1,0 +1,26 @@
+package mkdir_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/mkdir"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := mkdir.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/mkdir/mkdir.go
+++ b/internal/applets/fileutils/mkdir/mkdir.go
@@ -25,7 +25,14 @@ func (c *Command) Synopsis() string { return "Make directories" }
 
 // Run executes mkdir.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY...", stdio.Err).WithHelp(command.Help{
+		Description: "Create each named DIRECTORY if it does not already exist. With -p, create any missing parent directories and do not error when a directory already exists.",
+		Examples: []command.Example{
+			{Command: "mkdir -p a/b/c", Explain: "Create a/b/c, making parents as needed."},
+			{Command: "mkdir -m 700 secret", Explain: "Create 'secret' with mode 0700."},
+		},
+		ExitStatus: "0  every directory was created.\n1  a directory could not be created.",
+	})
 	parents := fs.BoolP("parents", "p", false, "no error if existing, make parent directories as needed")
 	verbose := fs.BoolP("verbose", "v", false, "print a message for each created directory")
 	mode := fs.StringP("mode", "m", "", "set file mode (as in chmod), not a=rwx - umask")

--- a/internal/applets/fileutils/mkfifo/help_test.go
+++ b/internal/applets/fileutils/mkfifo/help_test.go
@@ -1,0 +1,26 @@
+package mkfifo_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/mkfifo"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := mkfifo.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/mkfifo/mkfifo.go
+++ b/internal/applets/fileutils/mkfifo/mkfifo.go
@@ -31,7 +31,14 @@ func (c *Command) Synopsis() string { return "Make FIFO (named pipe)" }
 
 // Run executes mkfifo.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME...", stdio.Err).WithHelp(command.Help{
+		Description: "Create each named FIFO (a named pipe) with permission 0644 minus umask, or with the mode given by -m. A FIFO lets two processes communicate without an intermediate file.",
+		Examples: []command.Example{
+			{Command: "mkfifo mypipe", Explain: "Create a FIFO named 'mypipe'."},
+			{Command: "mkfifo -m 600 /tmp/p", Explain: "Create /tmp/p readable and writable only by the owner."},
+		},
+		ExitStatus: "0  every FIFO was created.\n1  a FIFO could not be created (e.g. the path already exists).",
+	})
 	modeStr := fs.StringP("mode", "m", "", "set file permission bits to MODE, not a=rw - umask")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/fileutils/mountpoint/help_test.go
+++ b/internal/applets/fileutils/mountpoint/help_test.go
@@ -1,0 +1,26 @@
+package mountpoint_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/mountpoint"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := mountpoint.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/mountpoint/mountpoint.go
+++ b/internal/applets/fileutils/mountpoint/mountpoint.go
@@ -25,7 +25,14 @@ func (c *Command) Synopsis() string { return "See if a directory is a mountpoint
 
 // Run executes mountpoint.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY", stdio.Err).WithHelp(command.Help{
+		Description: "Report whether DIRECTORY is the mount point of a file system. The exit status reflects the answer, so the command is useful in shell tests; with -q it prints nothing and only sets the exit code.",
+		Examples: []command.Example{
+			{Command: "mountpoint /mnt", Explain: "Print whether /mnt is a mountpoint."},
+			{Command: "mountpoint -q /mnt && echo mounted", Explain: "Run a command only when /mnt is a mountpoint."},
+		},
+		ExitStatus: "0  DIRECTORY is a mountpoint.\n1  DIRECTORY is not a mountpoint, or an error occurred.",
+	})
 	quiet := fs.BoolP("quiet", "q", false, "be quiet, only set the exit code")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/fileutils/mv/help_test.go
+++ b/internal/applets/fileutils/mv/help_test.go
@@ -1,0 +1,26 @@
+package mv_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/mv"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := mv.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/mv/mv.go
+++ b/internal/applets/fileutils/mv/mv.go
@@ -56,7 +56,14 @@ type options struct {
 
 // Run executes mv.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... SOURCE... DEST", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... SOURCE... DEST", stdio.Err).WithHelp(command.Help{
+		Description: "Rename SOURCE to DEST, or move one or more SOURCEs into the directory DEST. Moves across file systems fall back to a copy followed by a delete. Use -i to prompt before overwriting, -n to never overwrite, -f to overwrite without prompting, and -b to back up an existing destination.",
+		Examples: []command.Example{
+			{Command: "mv old.txt new.txt", Explain: "Rename old.txt to new.txt."},
+			{Command: "mv a.txt b.txt dir/", Explain: "Move a.txt and b.txt into the directory 'dir'."},
+		},
+		ExitStatus: "0  every move succeeded.\n1  a source was missing or could not be moved.",
+	})
 	backup := fs.BoolP("backup", "b", false, "make a backup of each existing destination file")
 	force := fs.BoolP("force", "f", false, "do not prompt before overwriting")
 	interactive := fs.BoolP("interactive", "i", false, "prompt before overwrite")

--- a/internal/applets/fileutils/readlink/readlink.go
+++ b/internal/applets/fileutils/readlink/readlink.go
@@ -26,7 +26,16 @@ func (c *Command) Synopsis() string { return "Print resolved symbolic links or c
 
 // Run executes readlink.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the target of each symbolic link FILE. With -f, print the canonicalized " +
+			"absolute path, following every symlink in the chain.",
+		Examples: []command.Example{
+			{Command: "readlink /usr/bin/vi", Explain: "Print the immediate target of the symlink."},
+			{Command: "readlink -f /usr/bin/vi", Explain: "Print the fully resolved canonical path."},
+			{Command: "readlink -n link", Explain: "Print the target without a trailing newline."},
+		},
+		ExitStatus: "0  every operand was resolved.\n1  an operand was not a symlink or could not be resolved.",
+	})
 	canon := fs.BoolP("canonicalize", "f", false, "canonicalize by following every symlink")
 	quiet := fs.BoolP("no-newline", "n", false, "do not output the trailing newline")
 

--- a/internal/applets/fileutils/readlink/readlink_test.go
+++ b/internal/applets/fileutils/readlink/readlink_test.go
@@ -115,3 +115,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := readlink.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/fileutils/rm/rm.go
+++ b/internal/applets/fileutils/rm/rm.go
@@ -34,7 +34,19 @@ type options struct {
 
 // Run executes rm.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Remove each FILE. By default rm does not remove directories; use -r (or -R) to " +
+			"remove a directory and its contents recursively, or -d to remove an empty directory. " +
+			"With -f nonexistent operands are ignored and no prompt is shown, while -i prompts " +
+			"before every removal.",
+		Examples: []command.Example{
+			{Command: "rm file.txt", Explain: "Remove a single file."},
+			{Command: "rm -r dir", Explain: "Remove a directory and everything under it."},
+			{Command: "rm -f *.tmp", Explain: "Remove matching files, ignoring any that do not exist."},
+			{Command: "rm -i note.txt", Explain: "Prompt for confirmation before removing note.txt."},
+		},
+		ExitStatus: "0  all operands were removed (or ignored with -f).\n1  a file could not be removed or no operand was given.",
+	})
 	recursive := fs.BoolP("recursive", "r", false, "remove directories and their contents recursively")
 	// -R is an alias for -r in GNU rm.
 	recursiveUpper := fs.BoolP("Recursive", "R", false, "equivalent to -r")

--- a/internal/applets/fileutils/rm/rm_test.go
+++ b/internal/applets/fileutils/rm/rm_test.go
@@ -179,3 +179,16 @@ func TestMissingMiddleFileContinues(t *testing.T) {
 		t.Errorf("a and c should be removed despite the missing middle file")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, nil, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Usage: rm", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/fileutils/rmdir/rmdir.go
+++ b/internal/applets/fileutils/rmdir/rmdir.go
@@ -28,7 +28,18 @@ func (c *Command) Synopsis() string { return "Remove directory" }
 
 // Run executes rmdir.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY...", stdio.Err).WithHelp(command.Help{
+		Description: "Remove each empty DIRECTORY. With -p, also remove each now-empty ancestor of a " +
+			"DIRECTORY, so 'rmdir -p a/b/c' is like 'rmdir a/b/c a/b a'. A directory that is not " +
+			"empty, or an operand that is not a directory, is reported as an error and the exit " +
+			"status is non-zero.",
+		Examples: []command.Example{
+			{Command: "rmdir emptydir", Explain: "Remove the empty directory emptydir."},
+			{Command: "rmdir -p a/b/c", Explain: "Remove c, then b, then a if each becomes empty."},
+			{Command: "rmdir -v tmp", Explain: "Remove tmp and report what is being done."},
+		},
+		ExitStatus: "0  all directories were removed.\n1  a directory was not empty or could not be removed.",
+	})
 	parents := fs.BoolP("parents", "p", false, "remove DIRECTORY and its ancestors")
 	verbose := fs.BoolP("verbose", "v", false, "output a diagnostic for every directory processed")
 

--- a/internal/applets/fileutils/rmdir/rmdir_test.go
+++ b/internal/applets/fileutils/rmdir/rmdir_test.go
@@ -125,3 +125,16 @@ func TestRunRejectsNonDirectory(t *testing.T) {
 		t.Errorf("file must not be removed by rmdir, stat error = %v", statErr)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Usage: rmdir", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/fileutils/shred/shred.go
+++ b/internal/applets/fileutils/shred/shred.go
@@ -26,7 +26,16 @@ func (c *Command) Synopsis() string { return "Overwrite a file to hide its conte
 
 // Run executes shred.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Overwrite the specified FILE(s) repeatedly with random data to make it harder " +
+			"to recover their contents, and optionally remove them afterwards.",
+		Examples: []command.Example{
+			{Command: "shred secret.txt", Explain: "Overwrite secret.txt three times in place."},
+			{Command: "shred -u -n 5 secret.txt", Explain: "Overwrite five times, then remove the file."},
+			{Command: "shred -z secret.txt", Explain: "Overwrite, then add a final pass of zeros."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be opened or written).",
+	})
 	iterations := fs.IntP("iterations", "n", 3, "overwrite N times instead of the default 3")
 	zero := fs.BoolP("zero", "z", false, "add a final overwrite with zeros to hide shredding")
 	remove := fs.BoolP("remove", "u", false, "truncate and remove the file after overwriting")

--- a/internal/applets/fileutils/shred/shred_test.go
+++ b/internal/applets/fileutils/shred/shred_test.go
@@ -126,3 +126,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := shred.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/fileutils/stat/stat.go
+++ b/internal/applets/fileutils/stat/stat.go
@@ -28,7 +28,15 @@ func (c *Command) Synopsis() string { return "Display file or file system status
 
 // Run executes stat.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Display the status of each FILE: its size, permissions, ownership, and timestamps. " +
+			"With -c, print only the fields named by the FORMAT string.",
+		Examples: []command.Example{
+			{Command: "stat file.txt", Explain: "Show the full status of file.txt."},
+			{Command: "stat -c %s file.txt", Explain: "Print only the size of file.txt in bytes."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be stat'd).",
+	})
 	format := fs.StringP("format", "c", "", "use the specified FORMAT instead of the default")
 	deref := fs.BoolP("dereference", "L", false, "follow links")
 

--- a/internal/applets/fileutils/stat/stat_test.go
+++ b/internal/applets/fileutils/stat/stat_test.go
@@ -199,3 +199,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := stat.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/fileutils/touch/touch.go
+++ b/internal/applets/fileutils/touch/touch.go
@@ -35,7 +35,16 @@ type options struct {
 
 // Run executes touch.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Update the access and modification times of each FILE to the current time. " +
+			"A FILE that does not exist is created empty, unless -c is given.",
+		Examples: []command.Example{
+			{Command: "touch report.txt", Explain: "Create report.txt if missing, else update its timestamps."},
+			{Command: "touch -c existing.log", Explain: "Update timestamps but never create the file."},
+			{Command: "touch -m notes.md", Explain: "Change only the modification time."},
+		},
+		ExitStatus: "0  all files were touched successfully.\n1  a file could not be created or its times could not be changed.",
+	})
 	noCreate := fs.BoolP("no-create", "c", false, "do not create any files")
 	accessOnly := fs.BoolP("access", "a", false, "change only the access time")
 	modifyOnly := fs.BoolP("modify", "m", false, "change only the modification time")

--- a/internal/applets/fileutils/touch/touch_test.go
+++ b/internal/applets/fileutils/touch/touch_test.go
@@ -87,3 +87,15 @@ func TestRunMissingOperand(t *testing.T) {
 		t.Errorf("stderr = %q, want missing file operand message", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := touch.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") || !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/truncate/truncate.go
+++ b/internal/applets/fileutils/truncate/truncate.go
@@ -26,7 +26,16 @@ func (c *Command) Synopsis() string { return "Shrink or extend the size of a fil
 
 // Run executes truncate.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "-s SIZE FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "-s SIZE FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Shrink or extend the size of each FILE to SIZE. SIZE may carry a K, M, or G suffix; " +
+			"a leading + or - adjusts the size relative to its current value. A missing FILE is created, unless -c is given.",
+		Examples: []command.Example{
+			{Command: "truncate -s 1K data.bin", Explain: "Set the file size to exactly 1024 bytes."},
+			{Command: "truncate -s +10M log.txt", Explain: "Grow the file by 10 MiB."},
+			{Command: "truncate -c -s 0 existing.log", Explain: "Empty the file but do not create it if absent."},
+		},
+		ExitStatus: "0  all files were resized successfully.\n1  a size was invalid or a file could not be resized.",
+	})
 	sizeSpec := fs.StringP("size", "s", "", "set or adjust the file size by SIZE bytes")
 	noCreate := fs.BoolP("no-create", "c", false, "do not create any files")
 

--- a/internal/applets/fileutils/truncate/truncate_test.go
+++ b/internal/applets/fileutils/truncate/truncate_test.go
@@ -138,3 +138,15 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := truncate.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") || !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/unlink/unlink.go
+++ b/internal/applets/fileutils/unlink/unlink.go
@@ -23,7 +23,14 @@ func (c *Command) Synopsis() string { return "Remove a single file by calling th
 
 // Run executes unlink.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "FILE", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "FILE", stdio.Err).WithHelp(command.Help{
+		Description: "Remove the single file FILE by calling the unlink function. " +
+			"Unlike rm, it takes exactly one operand and accepts no removal options.",
+		Examples: []command.Example{
+			{Command: "unlink stale.lock", Explain: "Remove the file stale.lock."},
+		},
+		ExitStatus: "0  the file was removed successfully.\n1  no file or more than one was given, or the file could not be removed.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/fileutils/unlink/unlink_test.go
+++ b/internal/applets/fileutils/unlink/unlink_test.go
@@ -73,3 +73,15 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := unlink.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") || !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out.String())
+	}
+}

--- a/internal/applets/findutils/xargs/xargs.go
+++ b/internal/applets/findutils/xargs/xargs.go
@@ -38,7 +38,16 @@ type options struct {
 
 // Run executes xargs.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [COMMAND [INITIAL-ARGS]...]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [COMMAND [INITIAL-ARGS]...]", stdio.Err).WithHelp(command.Help{
+		Description: "Read items from standard input and run COMMAND (echo by default) once or more with " +
+			"those items appended as arguments. Items are separated by whitespace unless -0 or -d changes the delimiter.",
+		Examples: []command.Example{
+			{Command: "ls | xargs echo", Explain: "Print all file names on a single line."},
+			{Command: "find . -name '*.tmp' | xargs rm", Explain: "Delete every matching file."},
+			{Command: "xargs -n 1 -I {} echo {}", Explain: "Run the command once per input item."},
+		},
+		ExitStatus: "0  every command succeeded.\n1  the input could not be read or a command failed.",
+	})
 	maxArgs := fs.IntP("max-args", "n", 0, "use at most MAX-ARGS arguments per command line")
 	replace := fs.StringP("replace", "I", "", "replace occurrences of REPLACE-STR in the command with input")
 	null := fs.BoolP("null", "0", false, "input items are terminated by a null, not whitespace")

--- a/internal/applets/findutils/xargs/xargs_test.go
+++ b/internal/applets/findutils/xargs/xargs_test.go
@@ -134,6 +134,11 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: xargs") {
 		t.Errorf("help = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 }
 
 func TestTrueCommandRunsOnEmptyWithoutR(t *testing.T) {

--- a/internal/applets/jokeutils/nyancat/help_test.go
+++ b/internal/applets/jokeutils/nyancat/help_test.go
@@ -1,0 +1,25 @@
+package nyancat
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/jokeutils/nyancat/nyancat.go
+++ b/internal/applets/jokeutils/nyancat/nyancat.go
@@ -58,7 +58,13 @@ func Frame(trail int) string {
 
 // Run executes nyancat.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Animate the Nyan Cat trailing a rainbow across the terminal until interrupted. The animation needs a real terminal; without one (for example in a pipe or on CI) it exits immediately without drawing.",
+		Examples: []command.Example{
+			{Command: "nyancat", Explain: "Run the Nyan Cat animation until you press Ctrl-C."},
+		},
+		ExitStatus: "0  the animation ran (or was skipped for lack of a terminal) and exited cleanly.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/jokeutils/sl/sl.go
+++ b/internal/applets/jokeutils/sl/sl.go
@@ -61,7 +61,14 @@ func TrainFrame(offset int) string {
 
 // Run executes sl.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Display an animated steam locomotive that runs across the terminal. It is a playful " +
+			"reminder for when sl is typed by mistake instead of ls.",
+		Examples: []command.Example{
+			{Command: "sl", Explain: "Run the steam locomotive animation across the terminal."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/jokeutils/sl/sl_test.go
+++ b/internal/applets/jokeutils/sl/sl_test.go
@@ -74,3 +74,17 @@ func TestRunNonTTY(t *testing.T) {
 		t.Fatalf("Run() error = %v", err)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := sl.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/netutils/nc/help_test.go
+++ b/internal/applets/netutils/nc/help_test.go
@@ -1,0 +1,25 @@
+package nc
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/netutils/nc/nc.go
+++ b/internal/applets/netutils/nc/nc.go
@@ -30,7 +30,14 @@ func (c *Command) Synopsis() string { return "Read and write data across network
 
 // Run executes nc.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[-u] [-l] [-p PORT] [HOST] [PORT]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[-u] [-l] [-p PORT] [HOST] [PORT]", stdio.Err).WithHelp(command.Help{
+		Description: "Read and write data across a TCP (default) or UDP (-u) network connection. By default nc connects to HOST and PORT and shuttles data between the connection and the standard streams; with -l it listens for a single incoming connection instead.",
+		Examples: []command.Example{
+			{Command: "nc example.com 80", Explain: "Open a TCP connection to example.com on port 80."},
+			{Command: "nc -l -p 8080", Explain: "Listen on TCP port 8080 for one incoming connection."},
+		},
+		ExitStatus: "0  the connection completed normally.\n1  the connection could not be established or failed.",
+	})
 	listen := fs.BoolP("listen", "l", false, "listen for an incoming connection")
 	udp := fs.BoolP("udp", "u", false, "use UDP instead of TCP")
 	port := fs.StringP("port", "p", "", "listen on (or source from) this port")

--- a/internal/applets/netutils/netcat/netcat.go
+++ b/internal/applets/netutils/netcat/netcat.go
@@ -27,7 +27,20 @@ func (c *Command) Synopsis() string {
 	return "Read and write data across network connections (alias of nc)"
 }
 
-// Run executes netcat by forwarding to the nc implementation.
+// Run executes netcat by forwarding to the nc implementation. A leading --help
+// renders netcat-named structured help instead of nc's so the usage and example
+// lines match the invoked command.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	if command.HandleHelpVersionWith(stdio, c.Name(), "[OPTION]... [HOST] [PORT]", command.Help{
+		Description: "Read and write data across TCP or UDP network connections. netcat is an alias of " +
+			"nc: it can open a connection to HOST PORT, or listen for one with -l.",
+		Examples: []command.Example{
+			{Command: "netcat -l 8080", Explain: "Listen for a TCP connection on port 8080."},
+			{Command: "netcat example.com 80", Explain: "Connect to example.com on port 80."},
+		},
+		ExitStatus: "0  the connection completed successfully.\n1  a network or usage error occurred.",
+	}, args) {
+		return nil
+	}
 	return c.delegate.Run(ctx, stdio, args)
 }

--- a/internal/applets/netutils/netcat/netcat_test.go
+++ b/internal/applets/netutils/netcat/netcat_test.go
@@ -73,3 +73,18 @@ func TestDelegatesToNc(t *testing.T) {
 		t.Errorf("out = %q, want it to contain pong", out)
 	}
 }
+
+// TestHelpSections asserts `netcat --help` renders netcat-named structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Usage: netcat", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/internal/applets/netutils/ping/ping.go
+++ b/internal/applets/netutils/ping/ping.go
@@ -42,7 +42,16 @@ const (
 
 // Run executes ping.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... HOST", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... HOST", stdio.Err).WithHelp(command.Help{
+		Description: "Send ICMP ECHO_REQUEST packets to HOST and report the round-trip times. " +
+			"A raw socket is required, so this command needs CAP_NET_RAW or root privileges.",
+		Examples: []command.Example{
+			{Command: "ping example.com", Explain: "Send the default four echo requests to example.com."},
+			{Command: "ping -c 10 192.0.2.1", Explain: "Send ten packets to 192.0.2.1."},
+			{Command: "ping -i 0.5 -W 2 example.com", Explain: "Wait 0.5s between packets and 2s per reply."},
+		},
+		ExitStatus: "0  at least one reply was received.\n1  no reply was received, or an error occurred.",
+	})
 	count := fs.IntP("count", "c", 4, "stop after sending COUNT packets")
 	interval := fs.Float64P("interval", "i", 1.0, "seconds to wait between packets")
 	timeout := fs.Float64P("timeout", "W", 1.0, "seconds to wait for each reply")

--- a/internal/applets/netutils/ping/ping_test.go
+++ b/internal/applets/netutils/ping/ping_test.go
@@ -123,3 +123,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/netutils/whris/whris.go
+++ b/internal/applets/netutils/whris/whris.go
@@ -48,7 +48,14 @@ var asnLookup = cymruLookup
 
 // Run executes whris.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "DOMAIN", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "DOMAIN", stdio.Err).WithHelp(command.Help{
+		Description: "Resolve DOMAIN to its IPv4 addresses and print the AS number and owning " +
+			"organization for each, looked up through the Team Cymru WHOIS service.",
+		Examples: []command.Example{
+			{Command: "whris example.com", Explain: "Show the AS number and owner for example.com's IP addresses."},
+		},
+		ExitStatus: "0  the management information was printed.\n1  the domain could not be resolved or no domain was given.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/netutils/whris/whris_test.go
+++ b/internal/applets/netutils/whris/whris_test.go
@@ -163,3 +163,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/pmutils/halt/halt.go
+++ b/internal/applets/pmutils/halt/halt.go
@@ -120,7 +120,16 @@ func (c *Command) action(opts options) int {
 // Run executes halt/poweroff/reboot. It requires root; otherwise it prints a
 // permission message and returns a silent failure without touching rebootFn.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Halt, power off, or reboot the machine (this applet runs as " + c.Name() + "). It " +
+			"writes a wtmp shutdown record and then asks the kernel to stop or restart the system. " +
+			"Root privileges are required.",
+		Examples: []command.Example{
+			{Command: c.Name(), Explain: "Sync and " + c.Name() + " the system (requires root)."},
+			{Command: c.Name() + " -f", Explain: "Skip the sync and act immediately."},
+		},
+		ExitStatus: "0  the shutdown request was issued.\n1  not run as root, or the request failed.",
+	})
 	force := fs.BoolP("force", "f", false, "force immediate halt/power-off/reboot; do not sync")
 	noSync := fs.BoolP("no-sync", "n", false, "do not sync before halt or reboot")
 	wtmpOnly := fs.BoolP("wtmp-only", "w", false, "only write the wtmp shutdown record, do not stop the system")

--- a/internal/applets/pmutils/halt/halt_test.go
+++ b/internal/applets/pmutils/halt/halt_test.go
@@ -200,3 +200,20 @@ func TestRunHelp(t *testing.T) {
 		t.Errorf("stdout = %q, want usage", outBuf.String())
 	}
 }
+
+// TestHelpSections asserts reboot/poweroff/halt --help renders structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	for _, c := range []*halt.Command{halt.NewReboot(), halt.NewPoweroff(), halt.NewHalt()} {
+		out := &bytes.Buffer{}
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		if err := c.Run(context.Background(), io, []string{"--help"}); err != nil {
+			t.Fatalf("%s --help err = %v", c.Name(), err)
+		}
+		for _, want := range []string{"Usage: " + c.Name(), "Examples:", "Exit status:"} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("%s --help missing %q: %q", c.Name(), want, out.String())
+			}
+		}
+	}
+}

--- a/internal/applets/securityutils/pwcrack/pwcrack.go
+++ b/internal/applets/securityutils/pwcrack/pwcrack.go
@@ -43,7 +43,17 @@ type target struct {
 
 // Run executes pwcrack.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "-w WORDLIST [HASH | --shadow FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "-w WORDLIST [HASH | --shadow FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Audit crypt(3) password hashes against a wordlist. The hash is given as an operand, " +
+			"read from a passwd/shadow-format file with --shadow, or read from standard input. " +
+			"Use only on systems you are authorized to test.",
+		Examples: []command.Example{
+			{Command: "pwcrack -w words.txt '$6$salt$hash'", Explain: "Crack a single hash using words.txt."},
+			{Command: "pwcrack -w words.txt --shadow /etc/shadow", Explain: "Crack every entry of a shadow file."},
+			{Command: "echo '$1$salt$hash' | pwcrack -w words.txt", Explain: "Read the hash to crack from stdin."},
+		},
+		ExitStatus: "0  at least one hash was cracked.\n1  no hash was cracked, or an error occurred.",
+	})
 	wordlist := fs.StringP("wordlist", "w", "", "file of candidate passwords, one per line")
 	shadow := fs.StringP("shadow", "s", "", "crack every entry of a passwd/shadow-format file")
 

--- a/internal/applets/securityutils/pwcrack/pwcrack_test.go
+++ b/internal/applets/securityutils/pwcrack/pwcrack_test.go
@@ -153,3 +153,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/securityutils/pwgen/pwgen.go
+++ b/internal/applets/securityutils/pwgen/pwgen.go
@@ -36,7 +36,16 @@ const (
 
 // Run executes pwgen.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Generate cryptographically random passwords for authorized testing and " +
+			"password-strength auditing, printing one password per line.",
+		Examples: []command.Example{
+			{Command: "pwgen", Explain: "Generate one 16-character password."},
+			{Command: "pwgen -l 24 -n 5", Explain: "Generate five 24-character passwords."},
+			{Command: "pwgen -s -o out.txt", Explain: "Include symbols and write the result to out.txt."},
+		},
+		ExitStatus: "0  the passwords were generated.\n1  an invalid option value was given or output failed.",
+	})
 	length := fs.IntP("length", "l", 16, "length of each password")
 	count := fs.IntP("number", "n", 1, "how many passwords to generate")
 	withSymbols := fs.BoolP("symbols", "s", false, "include symbol characters")

--- a/internal/applets/securityutils/pwgen/pwgen_test.go
+++ b/internal/applets/securityutils/pwgen/pwgen_test.go
@@ -129,3 +129,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/securityutils/pwscore/pwscore.go
+++ b/internal/applets/securityutils/pwscore/pwscore.go
@@ -28,7 +28,16 @@ func (c *Command) Synopsis() string { return "Estimate the strength of a passwor
 
 // Run executes pwscore.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[PASSWORD]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[PASSWORD]", stdio.Err).WithHelp(command.Help{
+		Description: "Estimate the strength of a password on a scale of 0 to 100 and explain the reasoning, " +
+			"based on length, character-class diversity, and a common-password check. The password is " +
+			"given as an operand or read from standard input.",
+		Examples: []command.Example{
+			{Command: "pwscore 'Tr0ub4dor&3'", Explain: "Score the given password and print the reasoning."},
+			{Command: "echo 'password' | pwscore", Explain: "Read the password to score from stdin."},
+		},
+		ExitStatus: "0  a score was produced.\n1  no password was provided or input failed.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/securityutils/pwscore/pwscore_test.go
+++ b/internal/applets/securityutils/pwscore/pwscore_test.go
@@ -110,3 +110,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/securityutils/unshadow/unshadow.go
+++ b/internal/applets/securityutils/unshadow/unshadow.go
@@ -29,7 +29,15 @@ func (c *Command) Synopsis() string { return "Combine passwd and shadow files fo
 
 // Run executes unshadow.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "PASSWD SHADOW", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "PASSWD SHADOW", stdio.Err).WithHelp(command.Help{
+		Description: "Combine a PASSWD file with the hashes from a SHADOW file into a single passwd-format stream on " +
+			"standard output, the standard first step of an authorized local password audit.",
+		Examples: []command.Example{
+			{Command: "unshadow /etc/passwd /etc/shadow", Explain: "Merge the system passwd and shadow files."},
+			{Command: "unshadow /etc/passwd /etc/shadow > combined.txt", Explain: "Save the merged output for a cracker."},
+		},
+		ExitStatus: "0  the files were merged successfully.\n1  an operand was missing or a file could not be read.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/securityutils/unshadow/unshadow_test.go
+++ b/internal/applets/securityutils/unshadow/unshadow_test.go
@@ -99,3 +99,15 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") || !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out.String())
+	}
+}

--- a/internal/applets/securityutils/zippwcrack/zippwcrack.go
+++ b/internal/applets/securityutils/zippwcrack/zippwcrack.go
@@ -36,7 +36,14 @@ func (c *Command) Synopsis() string {
 
 // Run executes zip-pwcrack.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "ARCHIVE -w WORDLIST", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "ARCHIVE -w WORDLIST", stdio.Err).WithHelp(command.Help{
+		Description: "Recover the password of a ZipCrypto (traditional PKWARE) encrypted ARCHIVE by " +
+			"trying each word in WORDLIST, for authorized recovery and testing only.",
+		Examples: []command.Example{
+			{Command: "zip-pwcrack secret.zip -w words.txt", Explain: "Try each word in words.txt against secret.zip."},
+		},
+		ExitStatus: "0  the password was found and printed.\n1  the password was not in the wordlist, or an error occurred.",
+	})
 	wordlist := fs.StringP("wordlist", "w", "", "file of candidate passwords, one per line")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/securityutils/zippwcrack/zippwcrack_test.go
+++ b/internal/applets/securityutils/zippwcrack/zippwcrack_test.go
@@ -144,3 +144,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/logcollect/help_test.go
+++ b/internal/applets/shellutils/logcollect/help_test.go
@@ -1,0 +1,25 @@
+package logcollect
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/logcollect/logcollect.go
+++ b/internal/applets/shellutils/logcollect/logcollect.go
@@ -27,7 +27,14 @@ func (c *Command) Synopsis() string { return "Gather system log files into one d
 
 // Run executes log-collect.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [SOURCE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [SOURCE]", stdio.Err).WithHelp(command.Help{
+		Description: "Copy every readable regular file under SOURCE (default /var/log) into an output directory, recreating the directory layout, so the logs can be archived or inspected. Unreadable files are skipped; root is usually required to read everything under /var/log.",
+		Examples: []command.Example{
+			{Command: "log-collect", Explain: "Copy /var/log into ./collected-logs."},
+			{Command: "log-collect -o /tmp/logs /var/log/nginx", Explain: "Collect the nginx logs into /tmp/logs."},
+		},
+		ExitStatus: "0  the logs were collected.\n1  the source could not be read or the output directory could not be created.",
+	})
 	out := fs.StringP("output", "o", "collected-logs", "directory to copy the logs into")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/logname/help_test.go
+++ b/internal/applets/shellutils/logname/help_test.go
@@ -1,0 +1,25 @@
+package logname
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/logname/logname.go
+++ b/internal/applets/shellutils/logname/logname.go
@@ -28,7 +28,13 @@ var loginName = currentLogin
 
 // Run executes logname.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the login name of the current user, taken from the LOGNAME or USER environment variables, falling back to the current account name.",
+		Examples: []command.Example{
+			{Command: "logname", Explain: "Print the current login name, e.g. 'alice'."},
+		},
+		ExitStatus: "0  the login name was printed.\n1  no login name could be determined.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/mknod/help_test.go
+++ b/internal/applets/shellutils/mknod/help_test.go
@@ -1,0 +1,26 @@
+package mknod_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/mknod"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := mknod.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/mknod/mknod.go
+++ b/internal/applets/shellutils/mknod/mknod.go
@@ -27,7 +27,14 @@ func (c *Command) Synopsis() string { return "Make block or character special fi
 
 // Run executes mknod.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME TYPE [MAJOR MINOR]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME TYPE [MAJOR MINOR]", stdio.Err).WithHelp(command.Help{
+		Description: "Create the special file NAME of the given TYPE: p for a FIFO, b for a block special file, or c (or u) for a character special file. Block and character devices require MAJOR and MINOR device numbers and privileges; a FIFO can be created by any user.",
+		Examples: []command.Example{
+			{Command: "mknod mypipe p", Explain: "Create a FIFO named 'mypipe'."},
+			{Command: "mknod /dev/loop0 b 7 0", Explain: "Create a block device with major 7, minor 0."},
+		},
+		ExitStatus: "0  the special file was created.\n1  the operands were invalid or the file could not be created.",
+	})
 	modeStr := fs.StringP("mode", "m", "666", "set file permission bits to MODE, not a=rw - umask")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/nohup/help_test.go
+++ b/internal/applets/shellutils/nohup/help_test.go
@@ -1,0 +1,25 @@
+package nohup
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/nohup/nohup.go
+++ b/internal/applets/shellutils/nohup/nohup.go
@@ -42,7 +42,14 @@ var isTerminal = func(w io.Writer) bool {
 
 // Run executes nohup.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "COMMAND [ARG]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "COMMAND [ARG]...", stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND with the hang-up signal (SIGHUP) ignored, so it keeps running after the controlling terminal is closed. When standard output is a terminal it is redirected, appending to nohup.out (or $HOME/nohup.out).",
+		Examples: []command.Example{
+			{Command: "nohup ./long-job.sh &", Explain: "Run long-job.sh so it survives logout, with output in nohup.out."},
+			{Command: "nohup make build", Explain: "Run 'make build' immune to hangups."},
+		},
+		ExitStatus: "0    COMMAND ran and exited 0.\n126  COMMAND was found but could not be run.\n127  COMMAND was not found.",
+	})
 	// Stop parsing options at the command name so its flags pass through.
 	fs.SetInterspersed(false)
 

--- a/internal/applets/shellutils/nproc/help_test.go
+++ b/internal/applets/shellutils/nproc/help_test.go
@@ -1,0 +1,25 @@
+package nproc
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/nproc/nproc.go
+++ b/internal/applets/shellutils/nproc/nproc.go
@@ -27,7 +27,14 @@ var cpuCount = runtime.NumCPU
 
 // Run executes nproc.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the number of processing units available to the current process. With --ignore=N, exclude up to N units, but never print fewer than one.",
+		Examples: []command.Example{
+			{Command: "nproc", Explain: "Print the number of available CPUs, e.g. '8'."},
+			{Command: "nproc --ignore=2", Explain: "Print the CPU count minus 2 (at least 1)."},
+		},
+		ExitStatus: "0  the count was printed.\n1  the count could not be written.",
+	})
 	ignore := fs.Uint("ignore", 0, "if possible, exclude N processing units")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/od/od.go
+++ b/internal/applets/shellutils/od/od.go
@@ -30,7 +30,16 @@ func (c *Command) Synopsis() string { return "Dump files in octal and other form
 
 // Run executes od.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Write an unambiguous representation, octal bytes by default, of each FILE " +
+			"to standard output. With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "od file.bin", Explain: "Dump file.bin as 2-byte octal words."},
+			{Command: "od -A x -t x1 file.bin", Explain: "Show hexadecimal offsets and bytes."},
+			{Command: "od -c file.txt", Explain: "Display bytes as named or escaped characters."},
+		},
+		ExitStatus: "0  success.\n1  a file could not be opened or read.",
+	})
 	addr := fs.StringP("address-radix", "A", "o", "decide how file offsets are printed (o, x, d, n)")
 	typ := fs.StringP("format", "t", "", "select output format")
 	b := fs.BoolP("octal-bytes", "b", false, "same as -t o1")

--- a/internal/applets/shellutils/od/od_test.go
+++ b/internal/applets/shellutils/od/od_test.go
@@ -184,3 +184,18 @@ func TestRunHelpAndVersion(t *testing.T) {
 		t.Errorf("--version out = %q", out)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := od.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/shellutils/path/path.go
+++ b/internal/applets/shellutils/path/path.go
@@ -25,7 +25,17 @@ func (c *Command) Synopsis() string { return "Manipulate filename path" }
 
 // Run executes path.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... PATH...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... PATH...", stdio.Err).WithHelp(command.Help{
+		Description: "Manipulate a filename PATH, printing its directory, basename, extension, " +
+			"absolute form, or canonical form. With no option, the canonical (cleaned) path is printed.",
+		Examples: []command.Example{
+			{Command: "path /usr/local/bin/mimixbox", Explain: "Print the canonical (cleaned) path."},
+			{Command: "path -b /usr/local/bin/mimixbox", Explain: "Print the basename (mimixbox)."},
+			{Command: "path -d /usr/local/bin/mimixbox", Explain: "Print the directory (/usr/local/bin)."},
+			{Command: "path -e archive.tar.gz", Explain: "Print the file extension (.gz)."},
+		},
+		ExitStatus: "0  success.\n1  no operand was given or the absolute path could not be resolved.",
+	})
 	abs := fs.BoolP("absolute", "a", false, "Print absolute path")
 	base := fs.BoolP("basename", "b", false, "Print basename (filename)")
 	canonical := fs.BoolP("canonical", "c", false, "Print canonical path (default)")

--- a/internal/applets/shellutils/path/path_test.go
+++ b/internal/applets/shellutils/path/path_test.go
@@ -77,3 +77,18 @@ func TestRunMissingOperand(t *testing.T) {
 		t.Errorf("stderr = %q", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := path.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/shellutils/pidof/pidof.go
+++ b/internal/applets/shellutils/pidof/pidof.go
@@ -36,7 +36,16 @@ var listProcesses = procFromProcfs
 
 // Run executes pidof.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... PROGRAM...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... PROGRAM...", stdio.Err).WithHelp(command.Help{
+		Description: "Find the process IDs of the named running programs and print them, newest first, " +
+			"on a single line separated by spaces.",
+		Examples: []command.Example{
+			{Command: "pidof sshd", Explain: "Print the PIDs of all running sshd processes."},
+			{Command: "pidof -s nginx", Explain: "Print only one PID for nginx."},
+			{Command: "pidof bash zsh", Explain: "Print the PIDs of bash and zsh processes."},
+		},
+		ExitStatus: "0  at least one matching process was found.\n1  no matching process was found, or an error occurred.",
+	})
 	single := fs.BoolP("single-shot", "s", false, "return only one PID")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/pidof/pidof_test.go
+++ b/internal/applets/shellutils/pidof/pidof_test.go
@@ -117,3 +117,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/shellutils/posixer/posixer.go
+++ b/internal/applets/shellutils/posixer/posixer.go
@@ -35,7 +35,15 @@ var lookPath = exec.LookPath
 
 // Run executes posixer.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[check]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[check]", stdio.Err).WithHelp(command.Help{
+		Description: "Report whether the POSIX-defined utilities are installed on the system, printing a " +
+			"table of each utility's name, type, installation status, and path.",
+		Examples: []command.Example{
+			{Command: "posixer", Explain: "List every checked POSIX utility and its status."},
+			{Command: "posixer check", Explain: "Same as running posixer with no argument."},
+		},
+		ExitStatus: "0  the report was produced successfully.\n1  an unknown subcommand was given or output failed.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/posixer/posixer_test.go
+++ b/internal/applets/shellutils/posixer/posixer_test.go
@@ -103,3 +103,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/shellutils/printenv/printenv.go
+++ b/internal/applets/shellutils/printenv/printenv.go
@@ -24,7 +24,16 @@ func (c *Command) Synopsis() string { return "Print environment variable" }
 
 // Run executes printenv.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [VARIABLE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [VARIABLE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the values of the named environment VARIABLEs, one per line. With no operand, " +
+			"print every environment variable as NAME=VALUE.",
+		Examples: []command.Example{
+			{Command: "printenv", Explain: "Print all environment variables as NAME=VALUE."},
+			{Command: "printenv HOME", Explain: "Print the value of the HOME variable."},
+			{Command: "printenv -0 PATH", Explain: "Print PATH terminated by a NUL byte."},
+		},
+		ExitStatus: "0  all requested variables were set.\n1  one or more requested variables were unset.",
+	})
 	null := fs.BoolP("null", "0", false, "end each output line with NUL, not newline")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/printenv/printenv_test.go
+++ b/internal/applets/shellutils/printenv/printenv_test.go
@@ -76,3 +76,18 @@ func TestRunAllContainsSetVariable(t *testing.T) {
 		t.Errorf("out did not contain expected NAME=VALUE line: %q", out)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := printenv.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/shellutils/printf/printf.go
+++ b/internal/applets/shellutils/printf/printf.go
@@ -31,6 +31,18 @@ func (c *Command) Synopsis() string { return "Format and print data" }
 // fewer arguments than are supplied, the format is reused until the arguments
 // are exhausted, matching GNU printf.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	if command.HandleHelpVersionWith(stdio, c.Name(), "FORMAT [ARGUMENT]...", command.Help{
+		Description: "Write the ARGUMENTs under the control of FORMAT, interpreting backslash escapes " +
+			"(\\n, \\t, ...) and %-conversions (%s, %d, %x, ...). The FORMAT is reused until every " +
+			"ARGUMENT is consumed.",
+		Examples: []command.Example{
+			{Command: `printf '%s\n' hello`, Explain: "Print hello followed by a newline."},
+			{Command: `printf '%s=%d\n' x 1 y 2`, Explain: "Reuse the format for each pair of arguments."},
+		},
+		ExitStatus: "0  success.\n1  a write error or an invalid format directive.",
+	}, args) {
+		return nil
+	}
 	if len(args) == 0 {
 		_, _ = fmt.Fprintln(stdio.Err, "printf: missing operand")
 		return command.SilentFailure()

--- a/internal/applets/shellutils/printf/printf_test.go
+++ b/internal/applets/shellutils/printf/printf_test.go
@@ -67,3 +67,18 @@ func TestMissingOperand(t *testing.T) {
 		t.Errorf("stderr = %q, want it to contain %q", errOut, "printf: missing operand")
 	}
 }
+
+// TestHelpSections asserts `printf --help` renders structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := printf.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Usage: printf", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/pwd/pwd.go
+++ b/internal/applets/shellutils/pwd/pwd.go
@@ -25,7 +25,15 @@ func (c *Command) Synopsis() string { return "Print Working Directory" }
 
 // Run executes pwd.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the full filename of the current working directory. By default the logical path " +
+			"is printed, honoring $PWD; with -P all symbolic links are resolved.",
+		Examples: []command.Example{
+			{Command: "pwd", Explain: "Print the current working directory."},
+			{Command: "pwd -P", Explain: "Print the physical directory with all symlinks resolved."},
+		},
+		ExitStatus: "0  success.\n1  the working directory could not be determined.",
+	})
 	logical := fs.BoolP("logical", "L", false, "use PWD from environment, even if it contains symlinks")
 	physical := fs.BoolP("physical", "P", false, "avoid all symlinks")
 

--- a/internal/applets/shellutils/pwd/pwd_test.go
+++ b/internal/applets/shellutils/pwd/pwd_test.go
@@ -116,3 +116,18 @@ func sameDir(t *testing.T, a, b string) bool {
 	}
 	return ra == rb
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := pwd.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/shellutils/realpath/realpath.go
+++ b/internal/applets/shellutils/realpath/realpath.go
@@ -24,7 +24,18 @@ func (c *Command) Synopsis() string { return "Print the resolved absolute file n
 
 // Run executes realpath.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the resolved, absolute file name of each FILE, expanding all symbolic " +
+			"links and removing '.' and '..' components. By default every path component must " +
+			"exist; -m allows missing components, -s leaves symbolic links unexpanded, and -z " +
+			"separates results with a NUL byte instead of a newline.",
+		Examples: []command.Example{
+			{Command: "realpath ./foo/../bar", Explain: "Print the canonical absolute path of bar."},
+			{Command: "realpath -s /usr/bin/awk", Explain: "Resolve the path without expanding symlinks."},
+			{Command: "realpath -m /no/such/dir/file", Explain: "Resolve a path whose components need not exist."},
+		},
+		ExitStatus: "0  all paths were resolved successfully.\n1  a path could not be resolved or no operand was given.",
+	})
 	existing := fs.BoolP("canonicalize-existing", "e", false, "all components of the path must exist")
 	missing := fs.BoolP("canonicalize-missing", "m", false, "no path components need exist or be a directory")
 	noSymlinks := fs.BoolP("no-symlinks", "s", false, "don't expand symlinks")

--- a/internal/applets/shellutils/realpath/realpath_test.go
+++ b/internal/applets/shellutils/realpath/realpath_test.go
@@ -128,3 +128,16 @@ func TestRunMissingOperand(t *testing.T) {
 		t.Errorf("stderr = %q", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Usage: realpath", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/shellutils/sddf/sddf.go
+++ b/internal/applets/shellutils/sddf/sddf.go
@@ -65,7 +65,22 @@ type options struct {
 
 // Run executes sddf.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY...", stdio.Err).WithHelp(command.Help{
+		Description: "Search for and delete duplicated files (a MimixBox-original command). It walks " +
+			"each DIRECTORY, groups files whose byte content is identical, and by default writes " +
+			"the duplicate groups to a *.sddf report. With -d the duplicates are deleted in place, " +
+			"keeping the newest copy of each group; -n reports what would be deleted without " +
+			"removing anything, and -i prompts before each deletion. A previously written *.sddf " +
+			"report may be passed as an operand to delete the duplicates it records. System paths " +
+			"such as /bin and /etc are always excluded from the scan.",
+		Examples: []command.Example{
+			{Command: "sddf ~/Pictures", Explain: "Scan ~/Pictures and write a *.sddf report of duplicates."},
+			{Command: "sddf -d ~/Downloads", Explain: "Delete duplicates in ~/Downloads, keeping the newest copy."},
+			{Command: "sddf -n ~/Downloads", Explain: "Show which duplicates would be deleted, without removing them."},
+			{Command: "sddf duplicated-file.sddf", Explain: "Delete the duplicates recorded in a saved report."},
+		},
+		ExitStatus: "0  the scan or deletion completed successfully.\n1  a directory could not be scanned or a file could not be deleted, or no operand was given.",
+	})
 	output := fs.StringP("output", "o", "duplicated-file", "Change output file-name without extension")
 	del := fs.BoolP("delete", "d", false, "delete duplicated files in place, keeping the newest copy")
 	interactive := fs.BoolP("interactive", "i", false, "prompt before each deletion (with --delete)")

--- a/internal/applets/shellutils/sddf/sddf_test.go
+++ b/internal/applets/shellutils/sddf/sddf_test.go
@@ -151,8 +151,10 @@ func TestHelpAndVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("--help error = %v", err)
 	}
-	if !strings.Contains(out, "Usage: sddf") {
-		t.Errorf("--help out = %q", out)
+	for _, want := range []string{"Usage: sddf", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help out missing %q\n%s", want, out)
+		}
 	}
 
 	out, _, err = run(t, "", "--version")

--- a/internal/applets/shellutils/seq/seq.go
+++ b/internal/applets/shellutils/seq/seq.go
@@ -26,7 +26,20 @@ func (c *Command) Synopsis() string { return "Print a column of numbers" }
 
 // Run executes seq.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... LAST | FIRST LAST | FIRST INCREMENT LAST", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... LAST | FIRST LAST | FIRST INCREMENT LAST", stdio.Err).WithHelp(command.Help{
+		Description: "Print a column of numbers from FIRST to LAST, stepping by INCREMENT. FIRST and " +
+			"INCREMENT default to 1 when omitted, and a negative INCREMENT counts down. By default " +
+			"numbers are separated by a newline; -s sets a different separator, -w pads with " +
+			"leading zeroes so all numbers share the same width, and -f gives a printf-style " +
+			"floating-point format.",
+		Examples: []command.Example{
+			{Command: "seq 5", Explain: "Print 1 through 5, one per line."},
+			{Command: "seq 2 2 10", Explain: "Print the even numbers from 2 to 10."},
+			{Command: "seq -s , 1 5", Explain: "Print 1,2,3,4,5 separated by commas."},
+			{Command: "seq -w 1 10", Explain: "Print 01 through 10, zero-padded to equal width."},
+		},
+		ExitStatus: "0  the sequence was printed successfully.\n1  an operand was missing or not a valid number, or the increment was zero.",
+	})
 	separator := fs.StringP("separator", "s", "\n", "use STRING to separate numbers (default \\n)")
 	equalWidth := fs.BoolP("equal-width", "w", false, "equalize width by padding with leading zeroes")
 	format := fs.StringP("format", "f", "", "use printf style floating-point FORMAT")

--- a/internal/applets/shellutils/seq/seq_test.go
+++ b/internal/applets/shellutils/seq/seq_test.go
@@ -83,8 +83,10 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("--help error = %v", err)
 	}
-	if !strings.Contains(out, "Usage: seq") {
-		t.Errorf("--help out = %q", out)
+	for _, want := range []string{"Usage: seq", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help out missing %q\n%s", want, out)
+		}
 	}
 
 	out, _, err = run(t, "--version")

--- a/internal/applets/shellutils/serial/serial.go
+++ b/internal/applets/shellutils/serial/serial.go
@@ -39,7 +39,20 @@ type options struct {
 
 // Run executes serial.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... DIRECTORY", stdio.Err).WithHelp(command.Help{
+		Description: "Rename the files in DIRECTORY to names that carry a zero-padded serial number " +
+			"(a MimixBox-original command). The serial number is added as a prefix by default, or " +
+			"as a suffix with -s. With -n the renamed files share a common base name; -k keeps the " +
+			"original files by copying instead of renaming; -d prints the planned renames without " +
+			"changing anything; and -f overwrites existing files of the same name.",
+		Examples: []command.Example{
+			{Command: "serial ./photos", Explain: "Prefix every file in ./photos with a serial number."},
+			{Command: "serial -s ./photos", Explain: "Append the serial number as a suffix instead."},
+			{Command: "serial -n image ./photos", Explain: "Rename the files to image-style names with serial numbers."},
+			{Command: "serial -d ./photos", Explain: "Show the planned renames without touching the files."},
+		},
+		ExitStatus: "0  the files were renamed (or copied) successfully.\n1  the directory was missing or empty, or a file could not be renamed.",
+	})
 	dryRun := fs.BoolP("dry-run", "d", false, "Output the file renaming result to standard output (do not update the file)")
 	force := fs.BoolP("force", "f", false, "Forcibly overwrite and save even if a file with the same name exists")
 	keep := fs.BoolP("keep", "k", false, "Keep the file before renaming")

--- a/internal/applets/shellutils/serial/serial_test.go
+++ b/internal/applets/shellutils/serial/serial_test.go
@@ -164,3 +164,16 @@ func TestRunEmptyDir(t *testing.T) {
 		t.Fatal("expected error for empty directory")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Usage: serial", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/shellutils/sleep/sleep.go
+++ b/internal/applets/shellutils/sleep/sleep.go
@@ -27,7 +27,17 @@ func (c *Command) Synopsis() string { return "Pause for NUMBER seconds(minutes, 
 // sleeps for the sum of all operands, and the sleep is canceled if ctx is
 // done.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "NUMBER[smhd]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "NUMBER[smhd]...", stdio.Err).WithHelp(command.Help{
+		Description: "Pause for the amount of time given by the operands. Each NUMBER may have a suffix: " +
+			"s for seconds (the default), m for minutes, h for hours, or d for days. The total time " +
+			"slept is the sum of all operands.",
+		Examples: []command.Example{
+			{Command: "sleep 5", Explain: "Pause for five seconds."},
+			{Command: "sleep 1m", Explain: "Pause for one minute."},
+			{Command: "sleep 1h 30m", Explain: "Pause for one hour and thirty minutes."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. an operand was missing or could not be parsed).",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/sleep/sleep_test.go
+++ b/internal/applets/shellutils/sleep/sleep_test.go
@@ -110,3 +110,17 @@ func TestRunContextCancelled(t *testing.T) {
 		t.Fatal("expected context cancellation error")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/sort/sort.go
+++ b/internal/applets/shellutils/sort/sort.go
@@ -48,7 +48,16 @@ type options struct {
 
 // Run executes sort.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Write the sorted concatenation of all FILE(s) to standard output. " +
+			"With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "sort file.txt", Explain: "Sort the lines of file.txt and print them."},
+			{Command: "sort -u file.txt", Explain: "Sort lines and drop duplicates."},
+			{Command: "sort -n -k 2 file.txt", Explain: "Sort numerically on the second field."},
+		},
+		ExitStatus: "0  success.\n1  the input was not sorted (with --check).\n2  an error occurred.",
+	})
 	reverse := fs.BoolP("reverse", "r", false, "reverse the result of comparisons")
 	numeric := fs.BoolP("numeric-sort", "n", false, "compare according to string numerical value")
 	unique := fs.BoolP("unique", "u", false, "output only the first of an equal run")

--- a/internal/applets/shellutils/sort/sort_test.go
+++ b/internal/applets/shellutils/sort/sort_test.go
@@ -180,3 +180,17 @@ func TestRunHelpAndVersion(t *testing.T) {
 		t.Errorf("--version out = %q", out)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := sortcmd.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/speaker/speaker.go
+++ b/internal/applets/shellutils/speaker/speaker.go
@@ -61,7 +61,15 @@ var runEngine = func(name string, args []string) error {
 
 // Run executes speaker.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... TEXT...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... TEXT...", stdio.Err).WithHelp(command.Help{
+		Description: "Speak the given TEXT aloud using an available text-to-speech engine " +
+			"(spd-say, espeak, or say). The TEXT operands are joined with spaces.",
+		Examples: []command.Example{
+			{Command: "speaker Hello world", Explain: "Speak the phrase \"Hello world\"."},
+			{Command: "speaker -l en Good morning", Explain: "Speak using the English voice."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. no text was given or no engine was found).",
+	})
 	lang := fs.StringP("language", "l", "", "language/voice to use (engine-specific)")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/speaker/speaker_test.go
+++ b/internal/applets/shellutils/speaker/speaker_test.go
@@ -119,3 +119,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/sync/sync.go
+++ b/internal/applets/shellutils/sync/sync.go
@@ -25,7 +25,13 @@ func (c *Command) Synopsis() string { return "Synchronize cached writes to persi
 // Run executes sync. In its basic form sync takes no operands; it flushes the
 // filesystem buffers via syscall.Sync().
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Flush filesystem buffers so that cached writes are committed to persistent storage.",
+		Examples: []command.Example{
+			{Command: "sync", Explain: "Flush all pending filesystem writes to disk."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/sync/sync_test.go
+++ b/internal/applets/shellutils/sync/sync_test.go
@@ -48,3 +48,17 @@ func TestRun(t *testing.T) {
 		t.Errorf("stderr = %q, want empty", errBuf.String())
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := sync.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/tee/tee.go
+++ b/internal/applets/shellutils/tee/tee.go
@@ -28,7 +28,15 @@ func (c *Command) Synopsis() string {
 
 // Run executes tee.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Copy standard input to standard output and to each FILE. By default each FILE is " +
+			"overwritten; with -a the input is appended instead.",
+		Examples: []command.Example{
+			{Command: "tee out.txt", Explain: "Write standard input to out.txt and to standard output."},
+			{Command: "tee -a log.txt", Explain: "Append standard input to log.txt instead of overwriting it."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be written).",
+	})
 	appendMode := fs.BoolP("append", "a", false, "append to the given FILEs, do not overwrite")
 	// -i/--ignore-interrupts is accepted for GNU compatibility; in this
 	// in-memory model there is no SIGINT to ignore, so it is a no-op.

--- a/internal/applets/shellutils/tee/tee_test.go
+++ b/internal/applets/shellutils/tee/tee_test.go
@@ -137,3 +137,17 @@ func TestRunIgnoreInterruptsAccepted(t *testing.T) {
 		t.Errorf("stdout = %q, want %q", out, "x\n")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := tee.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/test/test.go
+++ b/internal/applets/shellutils/test/test.go
@@ -30,7 +30,21 @@ func (c *Command) Synopsis() string { return "Evaluate a conditional expression"
 // is the exit status only: nil for true (0), ExitError{Code: 1} for false, and
 // ExitError{Code: 2} for a malformed expression (whose message the runner prints
 // as "test: <message>").
-func (c *Command) Run(_ context.Context, _ command.IO, args []string) error {
+func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	// Like GNU test, honor --help/--version only when it is the sole argument so
+	// that `test --help = x` still evaluates a string comparison.
+	if len(args) == 1 && command.HandleHelpVersionWith(stdio, c.Name(), "EXPRESSION", command.Help{
+		Description: "Evaluate a conditional EXPRESSION and exit with its truth value. Supports the " +
+			"usual file tests (-e, -f, -d, ...), string tests (-z, -n, =, !=), integer comparisons " +
+			"(-eq, -ne, -lt, ...), and the !/-a/-o operators.",
+		Examples: []command.Example{
+			{Command: "test -f /etc/hosts", Explain: "Succeed when /etc/hosts exists and is a regular file."},
+			{Command: `test "$x" = y`, Explain: "Succeed when $x equals y."},
+		},
+		ExitStatus: "0  the expression is true.\n1  the expression is false.\n2  the expression is malformed.",
+	}, args) {
+		return nil
+	}
 	ok, err := eval(args)
 	if err != nil {
 		return &command.ExitError{Code: 2, Err: err}

--- a/internal/applets/shellutils/test/test_test.go
+++ b/internal/applets/shellutils/test/test_test.go
@@ -93,3 +93,18 @@ func TestMalformedMessage(t *testing.T) {
 		t.Errorf("stderr = %q, want prefix %q", stderr, "test: ")
 	}
 }
+
+// TestHelpSections asserts `test --help` (sole argument) renders structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := testcmd.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Usage: test", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/timeout/timeout.go
+++ b/internal/applets/shellutils/timeout/timeout.go
@@ -36,7 +36,17 @@ const (
 
 // Run executes timeout.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION] DURATION COMMAND [ARG]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION] DURATION COMMAND [ARG]...", stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND and terminate it if it is still running after DURATION. DURATION is a " +
+			"number with an optional suffix: s for seconds (the default), m for minutes, h for hours, " +
+			"or d for days.",
+		Examples: []command.Example{
+			{Command: "timeout 10 sleep 30", Explain: "Run \"sleep 30\" but kill it after ten seconds."},
+			{Command: "timeout -s KILL 5 ./worker", Explain: "Send SIGKILL instead of SIGTERM after five seconds."},
+		},
+		ExitStatus: "0    success.\n124  COMMAND timed out and was terminated.\n" +
+			"126  COMMAND was found but could not be run.\n127  COMMAND was not found.",
+	})
 	// Stop parsing options at the first operand (the DURATION) so flags meant
 	// for the wrapped command are passed through untouched.
 	fs.SetInterspersed(false)

--- a/internal/applets/shellutils/timeout/timeout_test.go
+++ b/internal/applets/shellutils/timeout/timeout_test.go
@@ -159,3 +159,17 @@ func TestInvalidKillAfter(t *testing.T) {
 		t.Errorf("err = %v", err)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/true/true.go
+++ b/internal/applets/shellutils/true/true.go
@@ -22,6 +22,14 @@ func (c *Command) Synopsis() string { return "Do nothing. Return success(0)" }
 // Run always succeeds. Like GNU true it ignores its operands, except that a
 // leading --help or --version is honored.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	command.HandleHelpVersion(stdio, c.Name(), "[IGNORED]...", args)
+	command.HandleHelpVersionWith(stdio, c.Name(), "[IGNORED]...", command.Help{
+		Description: "Do nothing and exit successfully. All operands are ignored; true exists so that " +
+			"shell scripts have a command that always succeeds.",
+		Examples: []command.Example{
+			{Command: "true && echo ok", Explain: "Print ok, because true always succeeds."},
+			{Command: "while true; do :; done", Explain: "Loop forever (true never fails)."},
+		},
+		ExitStatus: "0  always.",
+	}, args)
 	return nil
 }

--- a/internal/applets/shellutils/true/true_test.go
+++ b/internal/applets/shellutils/true/true_test.go
@@ -27,8 +27,10 @@ func TestRunHelp(t *testing.T) {
 	if code != command.ExitSuccess {
 		t.Errorf("exit code = %d, want 0", code)
 	}
-	if !strings.Contains(out.String(), "Usage: true") {
-		t.Errorf("help out = %q", out.String())
+	for _, want := range []string{"Usage: true", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("help missing %q: %q", want, out.String())
+		}
 	}
 }
 

--- a/internal/applets/shellutils/tty/tty.go
+++ b/internal/applets/shellutils/tty/tty.go
@@ -32,7 +32,15 @@ var isTerminal = term.IsTerminal
 
 // Run executes tty.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the file name of the terminal connected to standard input. " +
+			"With -s, print nothing and report the result through the exit status only.",
+		Examples: []command.Example{
+			{Command: "tty", Explain: "Print the terminal device, e.g. /dev/pts/0."},
+			{Command: "tty -s", Explain: "Silently test whether standard input is a terminal."},
+		},
+		ExitStatus: "0  standard input is a terminal.\n1  standard input is not a terminal.\n2  a usage error occurred.",
+	})
 	silent := fs.BoolP("silent", "s", false, "print nothing, only return an exit status")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/tty/tty_test.go
+++ b/internal/applets/shellutils/tty/tty_test.go
@@ -119,3 +119,15 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") || !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/uname/uname.go
+++ b/internal/applets/shellutils/uname/uname.go
@@ -38,7 +38,16 @@ var sysInfo = uts
 
 // Run executes uname.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print system information. With no option, print the kernel name. " +
+			"With -a, print everything; the other options select individual fields.",
+		Examples: []command.Example{
+			{Command: "uname", Explain: "Print the kernel name, e.g. Linux."},
+			{Command: "uname -a", Explain: "Print all available system information."},
+			{Command: "uname -sr", Explain: "Print the kernel name and release together."},
+		},
+		ExitStatus: "0  the information was printed successfully.\n1  the system information could not be obtained.",
+	})
 	all := fs.BoolP("all", "a", false, "print all information")
 	sysname := fs.BoolP("kernel-name", "s", false, "print the kernel name")
 	nodename := fs.BoolP("nodename", "n", false, "print the network node hostname")

--- a/internal/applets/shellutils/uname/uname_test.go
+++ b/internal/applets/shellutils/uname/uname_test.go
@@ -107,3 +107,15 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") || !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/uniq/uniq.go
+++ b/internal/applets/shellutils/uniq/uniq.go
@@ -35,7 +35,16 @@ type options struct {
 
 // Run executes uniq.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [INPUT [OUTPUT]]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [INPUT [OUTPUT]]", stdio.Err).WithHelp(command.Help{
+		Description: "Filter adjacent matching lines from INPUT (or standard input), writing to OUTPUT (or standard output). " +
+			"Only consecutive duplicates are collapsed, so the input is usually sorted first.",
+		Examples: []command.Example{
+			{Command: "uniq names.txt", Explain: "Collapse adjacent duplicate lines."},
+			{Command: "uniq -c names.txt", Explain: "Prefix each line with its number of occurrences."},
+			{Command: "uniq -d names.txt", Explain: "Print only lines that were repeated."},
+		},
+		ExitStatus: "0  the lines were filtered successfully.\n1  an input or output file could not be opened or read.",
+	})
 	count := fs.BoolP("count", "c", false, "prefix lines by the number of occurrences")
 	repeated := fs.BoolP("repeated", "d", false, "only print duplicate lines, one for each group")
 	unique := fs.BoolP("unique", "u", false, "only print unique lines")

--- a/internal/applets/shellutils/uniq/uniq_test.go
+++ b/internal/applets/shellutils/uniq/uniq_test.go
@@ -152,6 +152,9 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: uniq") {
 		t.Errorf("--help out = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 
 	out, _, err = runStdin(t, "", "--version")
 	if err != nil {

--- a/internal/applets/shellutils/uuidgen/uuidgen.go
+++ b/internal/applets/shellutils/uuidgen/uuidgen.go
@@ -42,7 +42,14 @@ func (c *Command) Synopsis() string { return "Print UUID (Universally Unique IDe
 // Run executes uuidgen. It generates a random (version 4) UUID and prints it
 // lowercase, followed by a newline, to stdio.Out.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Print a new random (version 4) UUID in the canonical 8-4-4-4-12 lowercase " +
+			"hexadecimal form. Each invocation prints one UUID followed by a newline.",
+		Examples: []command.Example{
+			{Command: "uuidgen", Explain: "Print a random version 4 UUID."},
+		},
+		ExitStatus: "0  a UUID was printed.\n1  a UUID could not be generated.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/uuidgen/uuidgen_test.go
+++ b/internal/applets/shellutils/uuidgen/uuidgen_test.go
@@ -48,3 +48,17 @@ func TestRunUnique(t *testing.T) {
 		t.Errorf("two runs produced the same UUID: %q", strings.TrimSpace(first))
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := uuidgen.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/watch/watch.go
+++ b/internal/applets/shellutils/watch/watch.go
@@ -33,7 +33,16 @@ const clearScreen = "\033[H\033[2J"
 // Run executes watch. It renders once immediately and then again every
 // interval until the context is cancelled (for example by Ctrl-C).
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... COMMAND [ARG]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... COMMAND [ARG]...", stdio.Err).WithHelp(command.Help{
+		Description: "Run COMMAND periodically, clearing the screen and showing its output on each run " +
+			"so changes are easy to see. By default it refreshes every two seconds until interrupted.",
+		Examples: []command.Example{
+			{Command: "watch date", Explain: "Show the current date and time, refreshing every two seconds."},
+			{Command: "watch -n 5 df -h", Explain: "Refresh disk usage every five seconds."},
+			{Command: "watch -t ls -l", Explain: "Watch a directory listing without the header line."},
+		},
+		ExitStatus: "0  watch was interrupted normally.\n1  COMMAND was missing or an error occurred.",
+	})
 	// Stop parsing options at the command name so its flags pass through.
 	fs.SetInterspersed(false)
 	interval := fs.Float64P("interval", "n", 2.0, "seconds to wait between updates")

--- a/internal/applets/shellutils/watch/watch_test.go
+++ b/internal/applets/shellutils/watch/watch_test.go
@@ -117,3 +117,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/who/who.go
+++ b/internal/applets/shellutils/who/who.go
@@ -70,7 +70,16 @@ type options struct {
 // Run executes who. With no options it reads the utmp database and prints one
 // line per logged-in user. An optional FILE operand overrides utmpFile.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Print information about users who are currently logged in, reading the login-record " +
+			"database (/var/run/utmp by default, or FILE if given), one line per user.",
+		Examples: []command.Example{
+			{Command: "who", Explain: "List the users currently logged in."},
+			{Command: "who -H", Explain: "List logged-in users with a column heading line."},
+			{Command: "who -q", Explain: "Print only the login names and a user count."},
+		},
+		ExitStatus: "0  the login records were printed.\n1  the login-record database could not be read.",
+	})
 	boot := fs.BoolP("boot", "b", false, "time of last system boot")
 	heading := fs.BoolP("heading", "H", false, "print line of column headings")
 	count := fs.BoolP("count", "q", false, "all login names and number of users logged on")

--- a/internal/applets/shellutils/who/who_test.go
+++ b/internal/applets/shellutils/who/who_test.go
@@ -163,3 +163,17 @@ func TestWhoHelp(t *testing.T) {
 		t.Errorf("--help out = %q", out)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := who.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/whoami/whoami.go
+++ b/internal/applets/shellutils/whoami/whoami.go
@@ -25,7 +25,14 @@ func (c *Command) Synopsis() string { return "Print login user name" }
 // Run executes whoami. GNU whoami takes no operands, so any extra operand is an
 // error. On success it prints the effective user name followed by a newline.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the user name associated with the current effective user ID, followed by a " +
+			"newline. This command takes no operands.",
+		Examples: []command.Example{
+			{Command: "whoami", Explain: "Print the current effective user name."},
+		},
+		ExitStatus: "0  the user name was printed.\n1  an extra operand was given or the user could not be determined.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/whoami/whoami_test.go
+++ b/internal/applets/shellutils/whoami/whoami_test.go
@@ -68,3 +68,17 @@ func exitCode(err error) int {
 	}
 	return command.ExitFailure
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := whoami.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/yes/yes.go
+++ b/internal/applets/shellutils/yes/yes.go
@@ -26,7 +26,15 @@ func (c *Command) Synopsis() string { return "Output a string repeatedly until k
 // stream reports an error (for example a closed pipe), so it terminates the way
 // the system yes does when its reader goes away.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[STRING]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[STRING]...", stdio.Err).WithHelp(command.Help{
+		Description: "Repeatedly print a line until killed, writing \"y\" by default or the STRING " +
+			"operands joined by spaces. Useful for feeding an affirmative answer to an interactive program.",
+		Examples: []command.Example{
+			{Command: "yes", Explain: "Print \"y\" repeatedly until interrupted."},
+			{Command: "yes no", Explain: "Print \"no\" repeatedly until interrupted."},
+		},
+		ExitStatus: "0  output ended normally (the reader closed the pipe).\n1  an error occurred.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/yes/yes_test.go
+++ b/internal/applets/shellutils/yes/yes_test.go
@@ -96,3 +96,17 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := yes.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/textutils/nl/help_test.go
+++ b/internal/applets/textutils/nl/help_test.go
@@ -1,0 +1,26 @@
+package nl_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/nl"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := nl.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/textutils/nl/nl.go
+++ b/internal/applets/textutils/nl/nl.go
@@ -27,7 +27,14 @@ func (c *Command) Synopsis() string {
 
 // Run executes nl.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Write each FILE (or standard input when no FILE is given, or FILE is '-') to standard output with line numbers prepended. By default only non-blank lines are numbered; -b a numbers all lines and -b n numbers none.",
+		Examples: []command.Example{
+			{Command: "nl file.txt", Explain: "Number the non-blank lines of file.txt."},
+			{Command: "nl -b a -w 4 file.txt", Explain: "Number every line in a 4-column field."},
+		},
+		ExitStatus: "0  success.\n1  a file could not be read.",
+	})
 	body := fs.StringP("body-numbering", "b", "t", "use STYLE for numbering body lines (a, t, or n)")
 	separator := fs.StringP("number-separator", "s", "\t", "add STRING after possible line number")
 	width := fs.IntP("number-width", "w", 6, "use NUMBER columns for line numbers")

--- a/internal/applets/textutils/paste/paste.go
+++ b/internal/applets/textutils/paste/paste.go
@@ -26,7 +26,16 @@ func (c *Command) Synopsis() string { return "Merge lines of files" }
 
 // Run executes paste.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Write lines consisting of the sequentially corresponding lines from each FILE, " +
+			"separated by TABs, to standard output. With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "paste a.txt b.txt", Explain: "Merge lines of a.txt and b.txt side by side."},
+			{Command: "paste -d , a.txt b.txt", Explain: "Use a comma instead of a TAB as the separator."},
+			{Command: "paste -s a.txt", Explain: "Join all lines of a.txt onto a single line."},
+		},
+		ExitStatus: "0  success.\n1  a file could not be opened or read.",
+	})
 	delims := fs.StringP("delimiters", "d", "\t", "reuse characters from LIST instead of TABs")
 	serial := fs.BoolP("serial", "s", false, "paste one file at a time instead of in parallel")
 

--- a/internal/applets/textutils/paste/paste_test.go
+++ b/internal/applets/textutils/paste/paste_test.go
@@ -110,3 +110,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := paste.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Examples:") {
+		t.Errorf("--help missing Examples section:\n%s", got)
+	}
+	if !strings.Contains(got, "Exit status:") {
+		t.Errorf("--help missing Exit status section:\n%s", got)
+	}
+}

--- a/internal/applets/textutils/rev/rev.go
+++ b/internal/applets/textutils/rev/rev.go
@@ -25,7 +25,17 @@ func (c *Command) Synopsis() string { return "Reverse the order of characters in
 
 // Run executes rev.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Copy each FILE to standard output, reversing the order of the characters in " +
+			"every line. With no FILE, or when FILE is '-', read from standard input. Reversal is " +
+			"performed on Unicode runes, so multi-byte UTF-8 characters are preserved rather than " +
+			"split.",
+		Examples: []command.Example{
+			{Command: "rev file.txt", Explain: "Reverse the characters of every line in file.txt."},
+			{Command: "echo hello | rev", Explain: "Print 'olleh'."},
+		},
+		ExitStatus: "0  all input was reversed successfully.\n1  a file could not be read.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/textutils/rev/rev_test.go
+++ b/internal/applets/textutils/rev/rev_test.go
@@ -77,7 +77,9 @@ func TestHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	if !strings.Contains(out, "Usage: rev") {
-		t.Errorf("help output = %q", out)
+	for _, want := range []string{"Usage: rev", "Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help missing %q\n%s", want, out)
+		}
 	}
 }

--- a/internal/applets/textutils/shuf/shuf.go
+++ b/internal/applets/textutils/shuf/shuf.go
@@ -28,7 +28,16 @@ func (c *Command) Synopsis() string { return "Generate a random permutation of i
 
 // Run executes shuf.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Write a random permutation of the input lines to standard output. With no FILE, " +
+			"or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "shuf file.txt", Explain: "Print the lines of file.txt in random order."},
+			{Command: "shuf -n 1 file.txt", Explain: "Pick one random line from file.txt."},
+			{Command: "shuf -i 1-100", Explain: "Print the numbers 1 through 100 in random order."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. the input could not be read or an argument was invalid).",
+	})
 	echo := fs.BoolP("echo", "e", false, "treat each ARG as an input line")
 	inputRange := fs.StringP("input-range", "i", "", "treat each number LO through HI as an input line")
 	count := fs.IntP("head-count", "n", -1, "output at most COUNT lines")

--- a/internal/applets/textutils/shuf/shuf_test.go
+++ b/internal/applets/textutils/shuf/shuf_test.go
@@ -107,3 +107,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := shuf.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/textutils/split/split.go
+++ b/internal/applets/textutils/split/split.go
@@ -28,7 +28,15 @@ func (c *Command) Synopsis() string { return "Split a file into pieces" }
 
 // Run executes split.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [INPUT [PREFIX]]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [INPUT [PREFIX]]", stdio.Err).WithHelp(command.Help{
+		Description: "Split INPUT into fixed-size output files named PREFIXaa, PREFIXab, and so on " +
+			"(PREFIX defaults to x). With no INPUT, or when INPUT is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "split -l 100 big.txt part_", Explain: "Split big.txt into files of 100 lines each, named part_aa, part_ab, ..."},
+			{Command: "split -b 1M data.bin", Explain: "Split data.bin into 1 MiB pieces named xaa, xab, ..."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. the input could not be read or an option was invalid).",
+	})
 	lines := fs.IntP("lines", "l", 1000, "put NUMBER lines per output file")
 	byteSpec := fs.StringP("bytes", "b", "", "put SIZE bytes per output file (suffixes K, M allowed)")
 

--- a/internal/applets/textutils/split/split_test.go
+++ b/internal/applets/textutils/split/split_test.go
@@ -101,3 +101,17 @@ func checkFile(t *testing.T, path, want string) {
 		t.Errorf("%s = %q, want %q", path, got, want)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := split.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/textutils/strings/strings.go
+++ b/internal/applets/textutils/strings/strings.go
@@ -25,7 +25,15 @@ func (c *Command) Synopsis() string { return "Print printable character sequence
 
 // Run executes strings.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the printable character sequences of at least a minimum length (4 by default) " +
+			"found in each FILE. With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "strings program.bin", Explain: "Print the printable strings found in program.bin."},
+			{Command: "strings -n 8 program.bin", Explain: "Print only strings of at least eight characters."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be read or -n was invalid).",
+	})
 	minLen := fs.IntP("bytes", "n", 4, "print sequences of at least N printable characters")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/textutils/strings/strings_test.go
+++ b/internal/applets/textutils/strings/strings_test.go
@@ -86,3 +86,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := cmdstrings.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/textutils/tac/tac.go
+++ b/internal/applets/textutils/tac/tac.go
@@ -25,7 +25,15 @@ func (c *Command) Synopsis() string { return "Print the file contents from the e
 
 // Run executes tac.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Concatenate each FILE to standard output, writing the lines in reverse order " +
+			"(last line first). With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "tac file.txt", Explain: "Print the lines of file.txt from last to first."},
+			{Command: "tac -s , data.txt", Explain: "Reverse records separated by commas instead of newlines."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be read).",
+	})
 	separator := fs.StringP("separator", "s", "\n", "use STRING as the record separator instead of newline")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/textutils/tac/tac_test.go
+++ b/internal/applets/textutils/tac/tac_test.go
@@ -56,3 +56,17 @@ func TestRunMissingFile(t *testing.T) {
 		t.Errorf("stderr = %q", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := tac.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/textutils/tr/tr.go
+++ b/internal/applets/textutils/tr/tr.go
@@ -32,7 +32,16 @@ type options struct {
 
 // Run executes tr.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... SET1 [SET2]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... SET1 [SET2]", stdio.Err).WithHelp(command.Help{
+		Description: "Translate, squeeze, or delete characters from standard input, writing the result to standard output. " +
+			"SET1 and SET2 may use ranges (a-z), classes ([:upper:]), and C-style escapes.",
+		Examples: []command.Example{
+			{Command: "tr a-z A-Z", Explain: "Translate lowercase letters to uppercase."},
+			{Command: "tr -d '0-9'", Explain: "Delete every digit from the input."},
+			{Command: "tr -s ' '", Explain: "Squeeze repeated spaces into a single space."},
+		},
+		ExitStatus: "0  the input was translated successfully.\n1  an operand was missing or invalid, or input could not be read.",
+	})
 	del := fs.BoolP("delete", "d", false, "delete characters in SET1, do not translate")
 	squeeze := fs.BoolP("squeeze-repeats", "s", false,
 		"replace each sequence of a repeated character that is listed in the last SET with a single occurrence of that character")

--- a/internal/applets/textutils/tr/tr_test.go
+++ b/internal/applets/textutils/tr/tr_test.go
@@ -95,4 +95,7 @@ func TestRunHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: tr") {
 		t.Errorf("--help out = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 }

--- a/internal/applets/textutils/unexpand/unexpand.go
+++ b/internal/applets/textutils/unexpand/unexpand.go
@@ -31,7 +31,16 @@ type options struct {
 
 // Run executes unexpand.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Convert runs of blanks in each FILE (or standard input) into tabs, the inverse of expand. " +
+			"By default only leading blanks are converted; -a converts blanks everywhere.",
+		Examples: []command.Example{
+			{Command: "unexpand file.txt", Explain: "Convert leading spaces to tabs, writing to standard output."},
+			{Command: "unexpand -a file.txt", Explain: "Convert every run of blanks, not just the leading ones."},
+			{Command: "unexpand -t 4 file.txt", Explain: "Treat tab stops as 4 columns apart (implies -a)."},
+		},
+		ExitStatus: "0  all input was converted successfully.\n1  a file could not be opened or read.",
+	})
 	tabs := fs.IntP("tabs", "t", 8, "have tabs N characters apart instead of 8 (enables -a)")
 	all := fs.BoolP("all", "a", false, "convert all blanks, instead of just initial blanks")
 

--- a/internal/applets/textutils/unexpand/unexpand_test.go
+++ b/internal/applets/textutils/unexpand/unexpand_test.go
@@ -77,6 +77,9 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: unexpand") {
 		t.Errorf("--help out = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 
 	out, _, err = runStdin(t, "", "--version")
 	if err != nil {

--- a/internal/applets/textutils/unix2dos/unix2dos.go
+++ b/internal/applets/textutils/unix2dos/unix2dos.go
@@ -31,7 +31,15 @@ func (c *Command) Synopsis() string { return "Change LF to CRLF" }
 // reported on stderr and makes the command exit non-zero, but the remaining
 // files are still processed.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Convert the line endings of each FILE from Unix LF to DOS CRLF, editing the file in place. " +
+			"Lines that already end in CRLF are left unchanged.",
+		Examples: []command.Example{
+			{Command: "unix2dos notes.txt", Explain: "Rewrite notes.txt with CRLF line endings."},
+			{Command: "unix2dos a.txt b.txt", Explain: "Convert several files in one invocation."},
+		},
+		ExitStatus: "0  all files were converted successfully.\n1  a file was not a regular file or could not be read or written.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/textutils/unix2dos/unix2dos_test.go
+++ b/internal/applets/textutils/unix2dos/unix2dos_test.go
@@ -160,3 +160,15 @@ func TestRunPreservesFileMode(t *testing.T) {
 		t.Errorf("content = %q", got)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := unix2dos.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("Run --help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") || !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out.String())
+	}
+}

--- a/internal/applets/textutils/wc/wc.go
+++ b/internal/applets/textutils/wc/wc.go
@@ -51,7 +51,16 @@ func (s selection) orDefault() selection {
 
 // Run executes wc.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print newline, word, and byte counts for each FILE, and a total line when more than " +
+			"one FILE is given. With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "wc -l file.txt", Explain: "Count the lines in file.txt."},
+			{Command: "wc -w file.txt", Explain: "Count the words in file.txt."},
+			{Command: "wc file1 file2", Explain: "Count lines, words, and bytes with a total line."},
+		},
+		ExitStatus: "0  all counts were printed.\n1  a file could not be read.",
+	})
 	lines := fs.BoolP("lines", "l", false, "print the newline counts")
 	words := fs.BoolP("words", "w", false, "print the word counts")
 	chars := fs.BoolP("chars", "m", false, "print the character counts")

--- a/internal/applets/textutils/wc/wc_test.go
+++ b/internal/applets/textutils/wc/wc_test.go
@@ -96,3 +96,17 @@ func TestRunMissingFile(t *testing.T) {
 		t.Errorf("stderr = %q", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := wc.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/textutils/xxd/xxd.go
+++ b/internal/applets/textutils/xxd/xxd.go
@@ -29,7 +29,15 @@ const bytesPerLine = 16
 
 // Run executes xxd.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Make a hex dump of FILE (or standard input), or with -r convert a hex dump back into " +
+			"binary. Each output line shows an offset, the bytes in hex, and their printable rendering.",
+		Examples: []command.Example{
+			{Command: "xxd file.bin", Explain: "Print a hex dump of file.bin."},
+			{Command: "xxd -r dump.txt", Explain: "Convert a hex dump back into binary."},
+		},
+		ExitStatus: "0  the dump or conversion completed.\n1  the input could not be read or the hex dump was invalid.",
+	})
 	reverse := fs.BoolP("revert", "r", false, "reverse operation: convert a hex dump into binary")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/textutils/xxd/xxd_test.go
+++ b/internal/applets/textutils/xxd/xxd_test.go
@@ -107,3 +107,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := xxd.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/command/help.go
+++ b/internal/command/help.go
@@ -28,3 +28,24 @@ func HandleHelpVersion(stdio IO, name, usage string, args []string) bool {
 	}
 	return false
 }
+
+// HandleHelpVersionWith is HandleHelpVersion for custom-parsed applets that also
+// want structured help: on a leading "--help" it renders the usage block with
+// the description, examples, exit-status and notes from help; on "--version" it
+// prints the version line. It reports whether it handled the argument so the
+// caller can return early. Like HandleHelpVersion, only the first argument is
+// inspected, so a "--help" that appears later stays an ordinary operand.
+func HandleHelpVersionWith(stdio IO, name, usage string, help Help, args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "--help":
+		NewFlagSet(name, usage, stdio.Err).WithHelp(help).WriteUsage(stdio.Out)
+		return true
+	case "--version":
+		version.Print(stdio.Out, name)
+		return true
+	}
+	return false
+}

--- a/internal/command/help_test.go
+++ b/internal/command/help_test.go
@@ -45,3 +45,32 @@ func TestHandleHelpVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleHelpVersionWith verifies the doc-aware helper renders structured
+// help on --help, prints the version on --version, and otherwise no-ops.
+func TestHandleHelpVersionWith(t *testing.T) {
+	help := command.Help{
+		Description: "do a thing",
+		Examples:    []command.Example{{Command: "demo x", Explain: "do x"}},
+		ExitStatus:  "0  always.",
+	}
+	// --help renders the sections.
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if !command.HandleHelpVersionWith(io, "demo", "[OPT]", help, []string{"--help"}) {
+		t.Fatal("--help should be handled")
+	}
+	for _, want := range []string{"Usage: demo", "Examples:", "Exit status:", "do a thing"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+	// A non-flag first argument is not handled.
+	if command.HandleHelpVersionWith(io, "demo", "[OPT]", help, []string{"file"}) {
+		t.Error("ordinary operand should not be handled")
+	}
+	// No arguments is not handled.
+	if command.HandleHelpVersionWith(io, "demo", "[OPT]", help, nil) {
+		t.Error("empty args should not be handled")
+	}
+}

--- a/internal/hashsum/hashsum.go
+++ b/internal/hashsum/hashsum.go
@@ -43,7 +43,16 @@ func (c *Command) Synopsis() string { return c.synopsis }
 // with none it digests standard input as "-". The -c/--check flag switches to
 // verifying the digest list(s) named by the operands.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print or check " + c.Name() + " message digests. With FILE operands, print " +
+			"\"<digest>  <name>\" for each; with none, digest standard input. With -c, read digest " +
+			"lists from the FILEs and verify them.",
+		Examples: []command.Example{
+			{Command: c.Name() + " file.txt", Explain: "Print the digest of file.txt."},
+			{Command: c.Name() + " -c sums.txt", Explain: "Check files against the digests in sums.txt."},
+		},
+		ExitStatus: "0  success; in -c mode every file matched.\n1  a file could not be read or a digest did not match.",
+	})
 	check := fs.BoolP("check", "c", false, "read checksums from the FILEs and check them")
 	// -b/--binary and -t/--text are accepted for GNU compatibility. The output
 	// of a Go hash is identical for both modes, so they have no observable

--- a/internal/hashsum/hashsum_test.go
+++ b/internal/hashsum/hashsum_test.go
@@ -203,3 +203,18 @@ func TestDifferentHash(t *testing.T) {
 		t.Errorf("out = %q, want %q", out.String(), want)
 	}
 }
+
+// TestHelpSections asserts a hashsum applet's --help renders structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := hashsum.New("sha256sum", "synopsis", sha256.New).Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Usage: sha256sum", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/test/it/spec/help_structured_sections_spec.sh
+++ b/test/it/spec/help_structured_sections_spec.sh
@@ -1,0 +1,144 @@
+Describe 'applets expose structured --help sections'
+    # GitHub issues: "add structured help sections for X". Each applet must
+    # route --help through the structured renderer, exit 0, and document a
+    # purpose paragraph, an Examples section, and an Exit status section.
+
+    Parameters
+        ln
+        log-collect
+        logname
+        md5sum
+        mkdir
+        mkfifo
+        mknod
+        mktemp
+        mountpoint
+        mv
+        nc
+        netcat
+        nl
+        nohup
+        nproc
+        nyancat
+        od
+        paste
+        patch
+        path
+        pidof
+        ping
+        posixer
+        poweroff
+        printenv
+        pwcrack
+        pwgen
+        pwscore
+        readlink
+        realpath
+        reboot
+        remove-shell
+        reset
+        resize
+        rev
+        rm
+        rmdir
+        rpm
+        rpm2cpio
+        sddf
+        sed
+        seq
+        serial
+        sha1sum
+        sha256sum
+        sha384sum
+        sha3sum
+        sha512sum
+        shred
+        shuf
+        sl
+        sleep
+        sort
+        speaker
+        split
+        stat
+        strings
+        sync
+        tac
+        tar
+        tee
+        timeout
+        touch
+        tr
+        truncate
+        tty
+        uname
+        uncompress
+        unexpand
+        uniq
+        unix2dos
+        unlink
+        unshadow
+        unzip
+        uuidgen
+        valid-shell
+        watch
+        wc
+        which
+        who
+        whoami
+        whris
+        xargs
+        xxd
+        yes
+        zip
+        zip-pwcrack
+    End
+
+    It "$1 --help exposes structured sections"
+        When run "$1" --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with "Usage: $1"
+        # At least one example command line starts with the command name.
+        The output should include "  $1 "
+    End
+
+    # true/test/printf/pwd are shell builtins, so run them through env to
+    # force the applet on PATH.
+    It 'true --help exposes structured sections'
+        When run env true --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with 'Usage: true'
+        The output should include '  true '
+    End
+
+    It 'test --help exposes structured sections'
+        When run env test --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with 'Usage: test'
+        The output should include '  test '
+    End
+
+    It 'printf --help exposes structured sections'
+        When run env printf --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with 'Usage: printf'
+        The output should include '  printf '
+    End
+
+    It 'pwd --help exposes structured sections'
+        When run env pwd --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with 'Usage: pwd'
+        The output should include '  pwd '
+    End
+
+End

--- a/test/it/spec/netcat_spec.sh
+++ b/test/it/spec/netcat_spec.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=sh
 # Issue #477: dedicated shell-level contract spec for the "netcat" applet.
-# netcat is an alias for the `nc` applet, so --help prints nc's usage;
-# dedicated spec per #477.
+# netcat is an alias for the `nc` applet, but it renders its own netcat-named
+# structured --help so the usage and example lines match the invoked command.
 #
 # Every MimixBox applet's --help is rendered by internal/command's
 # FlagSet.WriteUsage, so it exits 0, prints a "Usage: <cmd>" line, and writes
@@ -12,7 +12,7 @@ Describe 'netcat'
   It 'describes itself with --help'
     When run command netcat --help
     The status should be success
-    The output should include 'Usage: nc'
+    The output should include 'Usage: netcat'
     The stderr should equal ''
   End
 End


### PR DESCRIPTION
## Summary

91 `[ux/help]` "add structured help sections for X" issues asked applets to
expose a self-describing `--help`: a purpose paragraph, an `Examples:` section,
and an `Exit status:` section.

- **78 applets** chain `.WithHelp(command.Help{...})` onto their existing
  `command.NewFlagSet(...)`.
- **Shared commands**: `internal/hashsum` covers md5sum/sha1sum/sha256sum/
  sha384sum/sha512sum/sha3sum; `pmutils/halt` covers reboot/poweroff/halt.
- **Custom-parsed applets** (`true`, `test`, `printf`, `netcat`) use a new
  `command.HandleHelpVersionWith` helper that renders structured help on a
  leading `--help` while preserving each applet's argument handling. `test`
  only treats `--help` specially when it is the sole argument (matching GNU).

## Testing

- Per-package Go tests assert each `--help` contains `Examples:` and `Exit status:`;
  a unit test covers `HandleHelpVersionWith`.
- A parameterized ShellSpec spec asserts the full contract end-to-end for all 91
  commands (exit 0, `Usage:` line, `Examples:`/`Exit status:`, an example line
  starting with the command name). Shell-builtin names (`true`, `test`, `printf`,
  `pwd`) run through `env` to force the applet on PATH.
- `go build ./...`, full `go test ./...`, and `golangci-lint` (86 changed packages) all pass.

Closes #558,Closes #559 Closes #560,Closes #561 Closes #562,Closes #563 Closes #564,Closes #565 Closes #566,Closes #567 Closes #568,Closes #569 Closes #570,Closes #571 Closes #572,Closes #573 Closes #574,Closes #575 Closes #576,Closes #577 Closes #578,Closes #579 Closes #580,Closes #581 Closes #582,Closes #583 Closes #584,Closes #585 Closes #586,Closes #587 Closes #588,Closes #589 Closes #590,Closes #591 Closes #592,Closes #593 Closes #594,Closes #595 Closes #596,Closes #597 Closes #598,Closes #599 Closes #600,Closes #601 Closes #602,Closes #603 Closes #604,Closes #605 Closes #606,Closes #607 Closes #608,Closes #609 Closes #610,Closes #611 Closes #612,Closes #613 Closes #614,Closes #615 Closes #616,Closes #617 Closes #618,Closes #619 Closes #620,Closes #621 Closes #622,Closes #623 Closes #624,Closes #625 Closes #626,Closes #627 Closes #628,Closes #629 Closes #630,Closes #631 Closes #632,Closes #633 Closes #634,Closes #635 Closes #636,Closes #637 Closes #638,Closes #639 Closes #640,Closes #641 Closes #642,Closes #643 Closes #644,Closes #645 Closes #646,Closes #647 Closes #648