### PR TITLE
feat(help): add structured --help sections to 60 more applets

### DIFF
--- a/internal/applets/archival/ar/ar.go
+++ b/internal/applets/archival/ar/ar.go
@@ -37,7 +37,18 @@ func (c *Command) Synopsis() string { return "Create, modify and extract from ar
 // Run executes ar. The first operand is a key letter (r, t or x) optionally
 // preceded by a dash, matching ar's traditional calling convention.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "{rtx}[v] ARCHIVE [MEMBER]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "{rtx}[v] ARCHIVE [MEMBER]...", stdio.Err).WithHelp(command.Help{
+		Description: "Create, list and extract members of a Unix \"common\" (System V/GNU) ar\n" +
+			"archive. The first operand is a key letter: r replaces or creates the\n" +
+			"archive from the named files, t lists its members, and x extracts them.\n" +
+			"Append v to the key for verbose output.",
+		Examples: []command.Example{
+			{Command: "ar rv libfoo.a foo.o bar.o", Explain: "create libfoo.a from the object files"},
+			{Command: "ar t libfoo.a", Explain: "list the members of libfoo.a"},
+			{Command: "ar x libfoo.a foo.o", Explain: "extract foo.o into the current directory"},
+		},
+		ExitStatus: "0  success.\n1  an invalid key was given, or the archive could not be read or written.",
+	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err

--- a/internal/applets/archival/ar/ar.go
+++ b/internal/applets/archival/ar/ar.go
@@ -41,7 +41,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Description: "Create, list and extract members of a Unix \"common\" (System V/GNU) ar\n" +
 			"archive. The first operand is a key letter: r replaces or creates the\n" +
 			"archive from the named files, t lists its members, and x extracts them.\n" +
-			"Append v to the key for verbose output.",
+			"Append v to r or x for verbose output.",
 		Examples: []command.Example{
 			{Command: "ar rv libfoo.a foo.o bar.o", Explain: "create libfoo.a from the object files"},
 			{Command: "ar t libfoo.a", Explain: "list the members of libfoo.a"},

--- a/internal/applets/archival/ar/ar_test.go
+++ b/internal/applets/archival/ar/ar_test.go
@@ -189,4 +189,10 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: ar") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("help missing Exit status: %q", out)
+	}
 }

--- a/internal/applets/archival/bunzip2/bunzip2.go
+++ b/internal/applets/archival/bunzip2/bunzip2.go
@@ -34,7 +34,17 @@ type options struct {
 
 // Run executes bunzip2.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Decompress each bzip2 (.bz2) FILE, or standard input when no FILE (or\n" +
+			"\"-\") is given. A decompressed file replaces its .bz2 original unless -k is\n" +
+			"given to keep it, or -c is given to write to standard output instead.",
+		Examples: []command.Example{
+			{Command: "bunzip2 archive.tar.bz2", Explain: "decompress to archive.tar and remove the .bz2"},
+			{Command: "bunzip2 -k data.bz2", Explain: "decompress but keep the original"},
+			{Command: "bunzip2 -c data.bz2", Explain: "write the decompressed data to standard output"},
+		},
+		ExitStatus: "0  success.\n1  a file lacked a known suffix, could not be read, or the output already exists without -f.",
+	})
 	keep := fs.BoolP("keep", "k", false, "keep (don't delete) input files")
 	stdout := fs.BoolP("stdout", "c", false, "write on standard output, keep original files unchanged")
 	force := fs.BoolP("force", "f", false, "force overwrite of output file")

--- a/internal/applets/archival/bunzip2/bunzip2_test.go
+++ b/internal/applets/archival/bunzip2/bunzip2_test.go
@@ -160,4 +160,10 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: bunzip2") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("help missing Exit status: %q", out)
+	}
 }

--- a/internal/applets/archival/compress/compress.go
+++ b/internal/applets/archival/compress/compress.go
@@ -34,7 +34,16 @@ type options struct {
 
 // Run executes compress.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Compress each FILE in place with the classic Unix LZW algorithm, replacing it with FILE.Z. " +
+			"With -c write to standard output and keep the input. With no FILE (or FILE '-') read standard input.",
+		Examples: []command.Example{
+			{Command: "compress file.txt", Explain: "Replace file.txt with the compressed file.txt.Z."},
+			{Command: "compress -k file.txt", Explain: "Create file.txt.Z but keep the original file.txt."},
+			{Command: "compress -c file.txt > file.Z", Explain: "Write the compressed data to standard output."},
+		},
+		ExitStatus: "0  all files were compressed successfully.\n1  one or more files could not be compressed.",
+	})
 	stdout := fs.BoolP("stdout", "c", false, "write on standard output, keep original files unchanged")
 	keep := fs.BoolP("keep", "k", false, "keep (don't delete) input files")
 	force := fs.BoolP("force", "f", false, "force overwrite of output file")

--- a/internal/applets/archival/compress/compress_test.go
+++ b/internal/applets/archival/compress/compress_test.go
@@ -178,4 +178,9 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: compress") {
 		t.Errorf("help = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
 }

--- a/internal/applets/archival/cpio/cpio.go
+++ b/internal/applets/archival/cpio/cpio.go
@@ -43,7 +43,16 @@ type options struct {
 
 // Run executes cpio.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "{-o|-i|-t} [-v] [-H newc]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "{-o|-i|-t} [-v] [-H newc]", stdio.Err).WithHelp(command.Help{
+		Description: "Copy files to and from a cpio archive in the portable \"new ASCII\" (newc) format. " +
+			"Exactly one of -o (copy-out), -i (copy-in), or -t (list, with -i) selects the operation.",
+		Examples: []command.Example{
+			{Command: "ls | cpio -o > archive.cpio", Explain: "Create an archive from the names read on stdin."},
+			{Command: "cpio -i < archive.cpio", Explain: "Extract every file from the archive read on stdin."},
+			{Command: "cpio -it < archive.cpio", Explain: "List the contents of the archive."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. the archive could not be read or written).",
+	})
 	create := fs.BoolP("create", "o", false, "copy-out: read file names from stdin, write archive to stdout")
 	extract := fs.BoolP("extract", "i", false, "copy-in: read archive from stdin and extract")
 	list := fs.BoolP("list", "t", false, "list the contents of the archive (with -i)")

--- a/internal/applets/archival/cpio/cpio_test.go
+++ b/internal/applets/archival/cpio/cpio_test.go
@@ -151,4 +151,9 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: cpio") {
 		t.Errorf("help = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 }

--- a/internal/applets/archival/gunzip/gunzip.go
+++ b/internal/applets/archival/gunzip/gunzip.go
@@ -34,7 +34,16 @@ type options struct {
 
 // Run executes gunzip.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Decompress each gzip (.gz) FILE, replacing FILE.gz with FILE. With no FILE, or with -, read " +
+			"standard input and write the decompressed data to standard output.",
+		Examples: []command.Example{
+			{Command: "gunzip archive.gz", Explain: "Decompress archive.gz to archive and remove the .gz file."},
+			{Command: "gunzip -c archive.gz", Explain: "Write the decompressed data to standard output."},
+			{Command: "gunzip -k archive.gz", Explain: "Decompress but keep the original .gz file."},
+		},
+		ExitStatus: "0  all files were decompressed successfully.\n1  a file was missing, had a bad stream, or could not be written.",
+	})
 	keep := fs.BoolP("keep", "k", false, "keep (don't delete) input files")
 	stdout := fs.BoolP("stdout", "c", false, "write on standard output, keep original files unchanged")
 	force := fs.BoolP("force", "f", false, "force overwrite of output file")

--- a/internal/applets/archival/gunzip/gunzip_test.go
+++ b/internal/applets/archival/gunzip/gunzip_test.go
@@ -175,4 +175,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: gunzip") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 }

--- a/internal/applets/archival/gzip/gzip.go
+++ b/internal/applets/archival/gzip/gzip.go
@@ -38,7 +38,16 @@ type options struct {
 
 // Run executes gzip.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Compress each FILE in place using DEFLATE, replacing FILE with FILE.gz. With -d, decompress " +
+			"FILE.gz back to FILE. With no FILE, or with -, read standard input and write to standard output.",
+		Examples: []command.Example{
+			{Command: "gzip notes.txt", Explain: "Compress notes.txt to notes.txt.gz and remove the original."},
+			{Command: "gzip -d notes.txt.gz", Explain: "Decompress notes.txt.gz back to notes.txt."},
+			{Command: "gzip -c notes.txt", Explain: "Write the compressed data to standard output, keeping the original."},
+		},
+		ExitStatus: "0  all files were processed successfully.\n1  a file was missing, had a bad stream, or could not be written.",
+	})
 	decompress := fs.BoolP("decompress", "d", false, "decompress")
 	keep := fs.BoolP("keep", "k", false, "keep (don't delete) input files")
 	stdout := fs.BoolP("stdout", "c", false, "write on standard output, keep original files unchanged")

--- a/internal/applets/archival/gzip/gzip_test.go
+++ b/internal/applets/archival/gzip/gzip_test.go
@@ -148,3 +148,13 @@ func TestMissingFile(t *testing.T) {
 		t.Errorf("stderr = %q, want gzip error prefix", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/internal/applets/console-tools/clear/clear.go
+++ b/internal/applets/console-tools/clear/clear.go
@@ -27,7 +27,14 @@ func (c *Command) Synopsis() string { return "Clear terminal" }
 
 // Run executes clear: it writes the terminal-clear escape sequence to stdout.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Clear the terminal screen by writing the escape sequence that moves the cursor to the home " +
+			"position and erases the display.",
+		Examples: []command.Example{
+			{Command: "clear", Explain: "Clear the terminal screen."},
+		},
+		ExitStatus: "0  success.\n1  the clear sequence could not be written.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/console-tools/clear/clear_test.go
+++ b/internal/applets/console-tools/clear/clear_test.go
@@ -29,3 +29,17 @@ func TestRun(t *testing.T) {
 		t.Errorf("out = %q, want %q", out, want)
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/debianutils/add-shell/add-shell.go
+++ b/internal/applets/debianutils/add-shell/add-shell.go
@@ -46,7 +46,15 @@ func (c *Command) Synopsis() string { return "Add shell name to /etc/shells" }
 
 // Run executes add-shell.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "SHELLNAME...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "SHELLNAME...", stdio.Err).WithHelp(command.Help{
+		Description: "Add each SHELLNAME to /etc/shells, appending only the names that are\n" +
+			"not already listed. The file is created if it does not yet exist.",
+		Examples: []command.Example{
+			{Command: "add-shell /bin/zsh", Explain: "add /bin/zsh to /etc/shells if absent"},
+			{Command: "add-shell /usr/bin/fish /bin/dash", Explain: "add several shells at once"},
+		},
+		ExitStatus: "0  success.\n1  no shell name was given, or /etc/shells could not be written.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/debianutils/add-shell/add-shell_test.go
+++ b/internal/applets/debianutils/add-shell/add-shell_test.go
@@ -2,12 +2,15 @@ package addShell_test
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	addShell "github.com/nao1215/mimixbox/internal/applets/debianutils/add-shell"
+	"github.com/nao1215/mimixbox/internal/command"
 )
 
 func TestNew(t *testing.T) {
@@ -73,5 +76,20 @@ func TestAddShellsExistingIsNoOp(t *testing.T) {
 	want := []string{"/bin/sh", "/bin/bash"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Errorf("lines = %v, want %v (existing shell should be a no-op)", got, want)
+	}
+}
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := addShell.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("--help missing Examples: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out.String())
 	}
 }

--- a/internal/applets/debianutils/ischroot/help_test.go
+++ b/internal/applets/debianutils/ischroot/help_test.go
@@ -1,0 +1,26 @@
+package ischroot_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/debianutils/ischroot"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := ischroot.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/debianutils/ischroot/ischroot.go
+++ b/internal/applets/debianutils/ischroot/ischroot.go
@@ -53,7 +53,17 @@ func (c *Command) Synopsis() string { return "Detect if running in a chroot" }
 // *command.ExitError carrying status 1 (not a chroot) or 2 (undetectable)
 // otherwise.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Detect whether the current process is running in a chroot. The result is " +
+			"reported through the exit status. When the status cannot be determined, -f and " +
+			"-t choose the fallback answer.",
+		Examples: []command.Example{
+			{Command: "ischroot", Explain: "Exit 0 inside a chroot, 1 outside, 2 if undetermined."},
+			{Command: "ischroot -f", Explain: "Assume not in a chroot when detection fails."},
+			{Command: "ischroot -t", Explain: "Assume in a chroot when detection fails."},
+		},
+		ExitStatus: "0  running in a chroot.\n1  not in a chroot.\n2  could not be determined.",
+	})
 	defaultFalse := fs.BoolP("default-false", "f", false, "return 1 if detection fails (not root)")
 	defaultTrue := fs.BoolP("default-true", "t", false, "return 0 if detection fails (not root)")
 

--- a/internal/applets/editors/awk/awk.go
+++ b/internal/applets/editors/awk/awk.go
@@ -28,7 +28,18 @@ func (c *Command) Synopsis() string { return "Pattern scanning and processing la
 
 // Run executes awk.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[-F sep] [-v var=val]... 'program' [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[-F sep] [-v var=val]... 'program' [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Apply the awk program to each FILE, or to standard input when no file is\n" +
+			"given. This is a small subset of awk: it supports BEGIN/END blocks,\n" +
+			"/regexp/ and comparison patterns, the field variables $0, $1..$NF, NR and\n" +
+			"NF, and the print and printf statements.",
+		Examples: []command.Example{
+			{Command: "awk '{print $1}' file.txt", Explain: "print the first field of every line"},
+			{Command: "awk -F: '{print $1}' /etc/passwd", Explain: "split fields on ':'"},
+			{Command: "awk -v n=3 '{print $n}' file.txt", Explain: "preset variable n before running"},
+		},
+		ExitStatus: "0  success.\n1  no program text was given, the program failed to parse, or a file could not be read.",
+	})
 	sep := fs.StringP("field-separator", "F", "", "use sep as the input field separator")
 	assigns := fs.StringArrayP("assign", "v", nil, "assign var=value before execution")
 

--- a/internal/applets/editors/awk/awk_test.go
+++ b/internal/applets/editors/awk/awk_test.go
@@ -248,4 +248,10 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: awk") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("help missing Exit status: %q", out)
+	}
 }

--- a/internal/applets/editors/diff/diff.go
+++ b/internal/applets/editors/diff/diff.go
@@ -31,7 +31,16 @@ func (c *Command) Synopsis() string { return "Compare files line by line" }
 
 // Run executes diff.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 FILE2", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 FILE2", stdio.Err).WithHelp(command.Help{
+		Description: "Compare FILE1 and FILE2 line by line and report how to change the first into " +
+			"the second. The classic \"normal\" format is produced by default and unified output with -u.",
+		Examples: []command.Example{
+			{Command: "diff old.txt new.txt", Explain: "Show the differences in the normal diff format."},
+			{Command: "diff -u old.txt new.txt", Explain: "Show the differences in unified format."},
+			{Command: "diff -q a.txt b.txt", Explain: "Report only whether the files differ."},
+		},
+		ExitStatus: "0  inputs are identical.\n1  they differ.\n2  an error occurred.",
+	})
 	unified := fs.BoolP("unified", "u", false, "output NUM (default 3) lines of unified context")
 	brief := fs.BoolP("brief", "q", false, "report only when files differ")
 	ignoreCase := fs.BoolP("ignore-case", "i", false, "ignore case differences in file contents")

--- a/internal/applets/editors/diff/diff_test.go
+++ b/internal/applets/editors/diff/diff_test.go
@@ -218,4 +218,9 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: diff") {
 		t.Errorf("help = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 }

--- a/internal/applets/fileutils/chgrp/chgrp.go
+++ b/internal/applets/fileutils/chgrp/chgrp.go
@@ -33,7 +33,15 @@ type options struct {
 
 // Run executes chgrp.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... GROUP FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... GROUP FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Change the group ownership of each FILE to GROUP. GROUP may be a group name or a numeric group ID.",
+		Examples: []command.Example{
+			{Command: "chgrp staff report.txt", Explain: "Change the group of report.txt to staff."},
+			{Command: "chgrp -R wheel /srv/www", Explain: "Recursively change the group of /srv/www and its contents."},
+			{Command: "chgrp -v 1000 file", Explain: "Change the group to GID 1000, reporting the change."},
+		},
+		ExitStatus: "0  all files were changed successfully.\n1  one or more files could not be changed.",
+	})
 	recursive := fs.BoolP("recursive", "R", false, "operate on files and directories recursively")
 	verbose := fs.BoolP("verbose", "v", false, "output a diagnostic for every file processed")
 

--- a/internal/applets/fileutils/chgrp/chgrp_test.go
+++ b/internal/applets/fileutils/chgrp/chgrp_test.go
@@ -119,3 +119,17 @@ func TestChgrpMissingOperand(t *testing.T) {
 		t.Errorf("stderr = %q, want missing operand error", errOut)
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/fileutils/chown/chown.go
+++ b/internal/applets/fileutils/chown/chown.go
@@ -31,7 +31,16 @@ func (c *Command) Synopsis() string {
 
 // Run executes chown.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... OWNER[:GROUP] FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... OWNER[:GROUP] FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Change the owner and/or group of each FILE. The owner spec is OWNER, OWNER:GROUP, OWNER:, " +
+			"or :GROUP, where each part is a name or a numeric ID; an omitted part is left unchanged.",
+		Examples: []command.Example{
+			{Command: "chown root file.txt", Explain: "Change the owner of file.txt to root."},
+			{Command: "chown root:staff file.txt", Explain: "Change the owner to root and the group to staff."},
+			{Command: "chown -R www-data /srv/www", Explain: "Recursively change the owner of /srv/www and its contents."},
+		},
+		ExitStatus: "0  all files were changed successfully.\n1  one or more files could not be changed.",
+	})
 	recursive := fs.BoolP("recursive", "R", false, "operate on files and directories recursively")
 	verbose := fs.BoolP("verbose", "v", false, "output a diagnostic for every file processed")
 

--- a/internal/applets/fileutils/chown/chown_test.go
+++ b/internal/applets/fileutils/chown/chown_test.go
@@ -139,3 +139,17 @@ func TestRunMissingOperand(t *testing.T) {
 		t.Errorf("stderr = %q, want missing-operand message", errOut)
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/fileutils/link/help_test.go
+++ b/internal/applets/fileutils/link/help_test.go
@@ -1,0 +1,26 @@
+package link_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/link"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := link.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/fileutils/link/link.go
+++ b/internal/applets/fileutils/link/link.go
@@ -24,7 +24,14 @@ func (c *Command) Synopsis() string { return "Create a hard link to a file" }
 
 // Run executes link.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "FILE1 FILE2", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "FILE1 FILE2", stdio.Err).WithHelp(command.Help{
+		Description: "Create a hard link named FILE2 to the existing file FILE1 by calling the " +
+			"link system call directly, with none of the options of the ln command.",
+		Examples: []command.Example{
+			{Command: "link file.txt hardlink.txt", Explain: "Create a hard link hardlink.txt to file.txt."},
+		},
+		ExitStatus: "0  the link was created.\n1  the link could not be created or the operands were wrong.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/findutils/grep/grep.go
+++ b/internal/applets/findutils/grep/grep.go
@@ -45,7 +45,16 @@ type options struct {
 
 // Run executes grep.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... PATTERN [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... PATTERN [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Search each FILE (or standard input when no FILE is given) for lines matching PATTERN and print " +
+			"them. PATTERN is a Go (RE2) regular expression by default; -F treats it as a fixed string.",
+		Examples: []command.Example{
+			{Command: "grep -rn TODO .", Explain: "Recursively search the current directory and print matching lines with line numbers."},
+			{Command: "grep -i error log.txt", Explain: "Print lines containing \"error\", ignoring case."},
+			{Command: "grep -c -v ^# config.ini", Explain: "Count the lines that are not comments."},
+		},
+		ExitStatus: "0  a line matched.\n1  no lines matched.\n2  an error occurred.",
+	})
 	patterns := fs.StringArrayP("regexp", "e", nil, "use PATTERN for matching (may be repeated)")
 	ignoreCase := fs.BoolP("ignore-case", "i", false, "ignore case distinctions")
 	invert := fs.BoolP("invert-match", "v", false, "select non-matching lines")

--- a/internal/applets/findutils/grep/grep_test.go
+++ b/internal/applets/findutils/grep/grep_test.go
@@ -209,4 +209,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: grep") {
 		t.Errorf("help = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 }

--- a/internal/applets/findutils/grepalias/grepalias.go
+++ b/internal/applets/findutils/grepalias/grepalias.go
@@ -34,7 +34,24 @@ func (c *Command) Synopsis() string {
 	return "Search with extended regular expressions (grep -E)"
 }
 
-// Run delegates to grep with the alias's mode flag prepended.
+// Run delegates to grep with the alias's mode flag prepended. A leading --help
+// renders alias-named structured help so the usage and example lines match the
+// invoked command rather than grep's.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
+	mode := "extended (-E)"
+	if c.flag == "-F" {
+		mode = "fixed-string (-F)"
+	}
+	if command.HandleHelpVersionWith(stdio, c.Name(), "[OPTION]... PATTERN [FILE]...", command.Help{
+		Description: "Search each FILE (or standard input) for lines matching PATTERN. " + c.Name() +
+			" is grep in " + mode + " mode.",
+		Examples: []command.Example{
+			{Command: c.Name() + " 'foo|bar' file.txt", Explain: "Print lines of file.txt that match the pattern."},
+			{Command: "ls | " + c.Name() + " -i readme", Explain: "Filter the listing case-insensitively."},
+		},
+		ExitStatus: "0  a line matched.\n1  no lines matched.\n2  an error occurred.",
+	}, args) {
+		return nil
+	}
 	return grep.New().Run(ctx, stdio, append([]string{c.flag}, args...))
 }

--- a/internal/applets/findutils/grepalias/grepalias_test.go
+++ b/internal/applets/findutils/grepalias/grepalias_test.go
@@ -32,3 +32,20 @@ func TestFgrepIsFixedString(t *testing.T) {
 		t.Errorf("fgrep = %q, want only the literal a.b line", got)
 	}
 }
+
+// TestHelpSections asserts egrep/fgrep --help render alias-named structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	for _, c := range []*Command{NewEgrep(), NewFgrep()} {
+		out := &bytes.Buffer{}
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		if err := c.Run(context.Background(), io, []string{"--help"}); err != nil {
+			t.Fatalf("%s --help err = %v", c.Name(), err)
+		}
+		for _, want := range []string{"Usage: " + c.Name(), "Examples:", "Exit status:"} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("%s --help missing %q: %q", c.Name(), want, out.String())
+			}
+		}
+	}
+}

--- a/internal/applets/games/lifegame/help_test.go
+++ b/internal/applets/games/lifegame/help_test.go
@@ -1,0 +1,26 @@
+package lifegame_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/games/lifegame"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := lifegame.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/games/lifegame/lifegame.go
+++ b/internal/applets/games/lifegame/lifegame.go
@@ -134,7 +134,15 @@ func (b *Board) Randomize(r *rand.Rand) {
 
 // Run executes lifegame.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Animate Conway's Game of Life on the terminal, starting from a random " +
+			"pattern that fills the screen. Press Esc, Ctrl-C, or Ctrl-D to quit. When no " +
+			"terminal is available, the command exits without animating.",
+		Examples: []command.Example{
+			{Command: "lifegame", Explain: "Run the Game of Life animation in the terminal."},
+		},
+		ExitStatus: "0  the animation ran and was quit normally, or no terminal was available.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/jokeutils/banner/banner.go
+++ b/internal/applets/jokeutils/banner/banner.go
@@ -28,7 +28,16 @@ const glyphHeight = 5
 
 // Run executes banner.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "MESSAGE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "MESSAGE...", stdio.Err).WithHelp(command.Help{
+		Description: "Print MESSAGE as large ASCII-art letters built from '#' characters.\n" +
+			"Multiple operands are joined with spaces, lowercase letters are\n" +
+			"upper-cased, and unknown characters are rendered as blank glyphs.",
+		Examples: []command.Example{
+			{Command: "banner HI", Explain: "print HI as ASCII-art letters"},
+			{Command: "banner hello world", Explain: "join the words and print them large"},
+		},
+		ExitStatus: "0  success.\n1  no message operand was given.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/jokeutils/banner/banner_test.go
+++ b/internal/applets/jokeutils/banner/banner_test.go
@@ -95,3 +95,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out)
+	}
+}

--- a/internal/applets/jokeutils/cmatrix/cmatrix.go
+++ b/internal/applets/jokeutils/cmatrix/cmatrix.go
@@ -72,7 +72,14 @@ func RenderFrame(width, height int, heads []int, glyph func(col, row int) rune) 
 
 // Run executes cmatrix.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Show the falling-glyph \"digital rain\" animation in the terminal. The effect needs a real " +
+			"terminal; without one (for example under tests or CI) it exits gracefully. Press Ctrl-C to stop.",
+		Examples: []command.Example{
+			{Command: "cmatrix", Explain: "Run the digital rain animation until interrupted."},
+		},
+		ExitStatus: "0  the animation exited cleanly (or no terminal was available).",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/jokeutils/cmatrix/cmatrix_test.go
+++ b/internal/applets/jokeutils/cmatrix/cmatrix_test.go
@@ -92,3 +92,18 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q section:\n%s", want, out.String())
+		}
+	}
+}

--- a/internal/applets/jokeutils/cowsay/cowsay.go
+++ b/internal/applets/jokeutils/cowsay/cowsay.go
@@ -40,7 +40,15 @@ func (c *Command) Synopsis() string { return "Print message with cow's ASCII art
 
 // Run executes cowsay.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [MESSAGE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [MESSAGE]", stdio.Err).WithHelp(command.Help{
+		Description: "Print MESSAGE inside a speech bubble above a cow drawn in ASCII art. The message is taken " +
+			"from the operands, or from standard input when no operands are given.",
+		Examples: []command.Example{
+			{Command: "cowsay Hello, world", Explain: "Print \"Hello, world\" in the cow's speech bubble."},
+			{Command: "echo Moo | cowsay", Explain: "Read the message from standard input."},
+		},
+		ExitStatus: "0  success.\n1  the message could not be read or written.",
+	})
 	proceed, err := fs.Parse(stdio, args)
 	if !proceed {
 		return err

--- a/internal/applets/jokeutils/cowsay/cowsay_test.go
+++ b/internal/applets/jokeutils/cowsay/cowsay_test.go
@@ -74,3 +74,17 @@ func TestMeta(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/jokeutils/cowthink/cowthink.go
+++ b/internal/applets/jokeutils/cowthink/cowthink.go
@@ -41,7 +41,15 @@ func (c *Command) Synopsis() string { return "Print message in a cow's thought b
 
 // Run executes cowthink.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [MESSAGE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [MESSAGE]", stdio.Err).WithHelp(command.Help{
+		Description: "Print MESSAGE inside a thought bubble above a cow drawn in ASCII art. The message is taken " +
+			"from the operands, or from standard input when no operands are given.",
+		Examples: []command.Example{
+			{Command: "cowthink Hmm, maybe", Explain: "Print \"Hmm, maybe\" in the cow's thought bubble."},
+			{Command: "echo Moo | cowthink", Explain: "Read the message from standard input."},
+		},
+		ExitStatus: "0  success.\n1  the message could not be read or written.",
+	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err

--- a/internal/applets/jokeutils/cowthink/cowthink_test.go
+++ b/internal/applets/jokeutils/cowthink/cowthink_test.go
@@ -83,3 +83,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/jokeutils/fakemovie/fakemovie.go
+++ b/internal/applets/jokeutils/fakemovie/fakemovie.go
@@ -82,7 +82,16 @@ type options struct {
 
 // Run executes fakemovie.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... IMAGE_FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... IMAGE_FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Draw a fake video playback button onto each IMAGE_FILE so the result looks like a " +
+			"movie thumbnail, writing a new image alongside the original.",
+		Examples: []command.Example{
+			{Command: "fakemovie photo.png", Explain: "Write photo_fake.png with a play button drawn on it."},
+			{Command: "fakemovie -o out.png photo.png", Explain: "Write the result to out.png."},
+			{Command: "fakemovie -p photo.png", Explain: "Use a p-hub style button instead of the default."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. the image could not be read or written).",
+	})
 	output := fs.StringP("output", "o", "", "output file name (default: add the suffix \"_fake\" to the original name)")
 	phub := fs.BoolP("phub", "p", false, "put a p-hub style button (default: a twitter-like button)")
 	radius := fs.IntP("radius", "r", 0, "radius of the button (default: auto calculate)")

--- a/internal/applets/jokeutils/fakemovie/fakemovie_test.go
+++ b/internal/applets/jokeutils/fakemovie/fakemovie_test.go
@@ -195,4 +195,9 @@ func TestRunHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: fakemovie") {
 		t.Errorf("--help out = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 }

--- a/internal/applets/jokeutils/fortune/fortune.go
+++ b/internal/applets/jokeutils/fortune/fortune.go
@@ -43,7 +43,15 @@ var fortunes = []string{
 
 // Run executes fortune.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print a random adage drawn from a built-in collection. With -s, restrict the selection to " +
+			"short adages only.",
+		Examples: []command.Example{
+			{Command: "fortune", Explain: "Print a random adage from the collection."},
+			{Command: "fortune -s", Explain: "Print a random short adage."},
+		},
+		ExitStatus: "0  an adage was printed.\n1  no adage was available or it could not be written.",
+	})
 	short := fs.BoolP("short", "s", false, "only print short fortunes")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/jokeutils/fortune/fortune_test.go
+++ b/internal/applets/jokeutils/fortune/fortune_test.go
@@ -80,3 +80,13 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/internal/applets/netutils/httpstatus/help_test.go
+++ b/internal/applets/netutils/httpstatus/help_test.go
@@ -1,0 +1,26 @@
+package httpstatus_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/netutils/httpstatus"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := httpstatus.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/netutils/httpstatus/httpstatus.go
+++ b/internal/applets/netutils/httpstatus/httpstatus.go
@@ -32,7 +32,17 @@ type status struct {
 
 // Run executes http-status-code.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "(search CODE... | list)", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "(search CODE... | list)", stdio.Err).WithHelp(command.Help{
+		Description: "Explain HTTP status codes and their defining references. The list " +
+			"subcommand prints every known code, while search CODE... prints the meaning " +
+			"and reference for each requested code.",
+		Examples: []command.Example{
+			{Command: "http-status-code list", Explain: "List every known status code."},
+			{Command: "http-status-code search 404", Explain: "Explain the 404 status code."},
+			{Command: "http-status-code search 200 301 500", Explain: "Explain several codes at once."},
+		},
+		ExitStatus: "0  every requested code was explained.\n1  a code was invalid, unknown, or no subcommand was given.",
+	})
 	fs.SetInterspersed(false)
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/arch/arch.go
+++ b/internal/applets/shellutils/arch/arch.go
@@ -27,7 +27,13 @@ var machine = realMachine
 
 // Run executes arch.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "", stdio.Err).WithHelp(command.Help{
+		Description: "Print the machine hardware name, equivalent to \"uname -m\".",
+		Examples: []command.Example{
+			{Command: "arch", Explain: "print the hardware name, e.g. x86_64"},
+		},
+		ExitStatus: "0  success.\n1  the machine hardware name could not be determined.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/arch/arch_test.go
+++ b/internal/applets/shellutils/arch/arch_test.go
@@ -65,3 +65,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out)
+	}
+}

--- a/internal/applets/shellutils/base64/base64.go
+++ b/internal/applets/shellutils/base64/base64.go
@@ -28,7 +28,17 @@ func (c *Command) Synopsis() string {
 
 // Run executes base64.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Base64 encode or decode FILE, or standard input when no FILE (or \"-\") is\n" +
+			"given, and write the result to standard output. By default the data is\n" +
+			"encoded; use -d to decode instead.",
+		Examples: []command.Example{
+			{Command: "base64 file.bin", Explain: "encode file.bin to base64"},
+			{Command: "base64 -d file.b64", Explain: "decode base64 back to bytes"},
+			{Command: "echo hello | base64", Explain: "encode standard input"},
+		},
+		ExitStatus: "0  success.\n1  the input file could not be read, or the data was not valid base64 while decoding.",
+	})
 	decode := fs.BoolP("decode", "d", false, "decode data")
 	ignoreGarbage := fs.BoolP("ignore-garbage", "i", false, "when decoding, ignore non-alphabet characters")
 	wrap := fs.IntP("wrap", "w", 76, "wrap encoded lines after COLS character (default 76).\nUse 0 to disable line wrapping")

--- a/internal/applets/shellutils/base64/base64_test.go
+++ b/internal/applets/shellutils/base64/base64_test.go
@@ -90,6 +90,12 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: base64") {
 		t.Errorf("--help out = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out)
+	}
 
 	out, _, err = run(t, "", "--version")
 	if err != nil {

--- a/internal/applets/shellutils/basename/basename.go
+++ b/internal/applets/shellutils/basename/basename.go
@@ -24,7 +24,18 @@ func (c *Command) Synopsis() string { return "Print basename (PATH without \"/\"
 
 // Run executes basename.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "NAME [SUFFIX] | OPTION... NAME...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "NAME [SUFFIX] | OPTION... NAME...", stdio.Err).WithHelp(command.Help{
+		Description: "Print NAME with any leading directory components removed. If SUFFIX is\n" +
+			"given and matches the trailing part of the result, it is removed too.\n" +
+			"With -a or -s each operand is treated as a NAME so several can be\n" +
+			"processed at once.",
+		Examples: []command.Example{
+			{Command: "basename /usr/bin/sort", Explain: "print \"sort\""},
+			{Command: "basename include/stdio.h .h", Explain: "print \"stdio\""},
+			{Command: "basename -a /a/x /b/y", Explain: "print each basename on its own line"},
+		},
+		ExitStatus: "0  success.\n1  no operand was given, or too many operands were given.",
+	})
 	multiple := fs.BoolP("multiple", "a", false, "support multiple arguments and treat each as a NAME")
 	suffix := fs.StringP("suffix", "s", "", "remove a trailing SUFFIX; implies -a")
 	zero := fs.BoolP("zero", "z", false, "end each output line with NUL, not newline")

--- a/internal/applets/shellutils/basename/basename_test.go
+++ b/internal/applets/shellutils/basename/basename_test.go
@@ -82,3 +82,17 @@ func TestRunExtraOperand(t *testing.T) {
 		t.Errorf("stderr = %q", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out)
+	}
+}

--- a/internal/applets/shellutils/cal/cal.go
+++ b/internal/applets/shellutils/cal/cal.go
@@ -36,7 +36,17 @@ func (c *Command) Synopsis() string { return "Display a calendar" }
 
 // Run executes cal.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [[MONTH] YEAR]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [[MONTH] YEAR]", stdio.Err).WithHelp(command.Help{
+		Description: "Display a calendar. With no operand the current month is shown; a single\n" +
+			"YEAR operand (or -y) shows the whole year, and a MONTH YEAR pair shows\n" +
+			"that month. Use -m to start each week on Monday.",
+		Examples: []command.Example{
+			{Command: "cal", Explain: "show the current month"},
+			{Command: "cal 2024", Explain: "show the whole year 2024"},
+			{Command: "cal 11 2023", Explain: "show November 2023"},
+		},
+		ExitStatus: "0  success.\n1  an invalid month or year operand was given.",
+	})
 	monday := fs.BoolP("monday", "m", false, "Monday as the first day of the week")
 	yearMode := fs.BoolP("year", "y", false, "display a calendar for the whole current year")
 

--- a/internal/applets/shellutils/cal/cal_test.go
+++ b/internal/applets/shellutils/cal/cal_test.go
@@ -162,6 +162,12 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: cal") {
 		t.Errorf("--help out = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out)
+	}
 
 	out, _, err = run(t, "--version")
 	if err != nil {

--- a/internal/applets/shellutils/chmod/chmod.go
+++ b/internal/applets/shellutils/chmod/chmod.go
@@ -37,7 +37,16 @@ type options struct {
 
 // Run executes chmod.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... MODE FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... MODE FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Change the file mode bits of each FILE to MODE. MODE is either an octal number (e.g. 755) " +
+			"or a comma-separated list of symbolic clauses (e.g. u+x,go-w).",
+		Examples: []command.Example{
+			{Command: "chmod 644 file.txt", Explain: "Set read/write for the owner and read-only for others."},
+			{Command: "chmod u+x script.sh", Explain: "Add execute permission for the owner."},
+			{Command: "chmod -R go-w /srv/www", Explain: "Recursively remove write permission for group and others."},
+		},
+		ExitStatus: "0  all files were changed successfully.\n1  one or more files could not be changed.",
+	})
 	recursive := fs.BoolP("recursive", "R", false, "change files and directories recursively")
 	verbose := fs.BoolP("verbose", "v", false, "output a diagnostic for every file processed")
 	changes := fs.BoolP("changes", "c", false, "like verbose but report only when a change is made")

--- a/internal/applets/shellutils/chmod/chmod_test.go
+++ b/internal/applets/shellutils/chmod/chmod_test.go
@@ -247,3 +247,17 @@ func TestRunVerbose(t *testing.T) {
 		t.Errorf("verbose stdout = %q, want diagnostic", out)
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/shellutils/cmp/cmp.go
+++ b/internal/applets/shellutils/cmp/cmp.go
@@ -92,7 +92,16 @@ func compare(r1, r2 io.Reader) (result, error) {
 
 // Run executes cmp.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 [FILE2]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 [FILE2]", stdio.Err).WithHelp(command.Help{
+		Description: "Compare two files byte by byte and report the byte offset and line number of the first " +
+			"difference. When FILE2 is omitted (or either file is '-'), standard input is compared.",
+		Examples: []command.Example{
+			{Command: "cmp a.txt b.txt", Explain: "Report the first byte at which a.txt and b.txt differ."},
+			{Command: "cmp -s a.txt b.txt", Explain: "Compare silently, reporting the result only via the exit status."},
+			{Command: "cmp -l a.txt b.txt", Explain: "List the offset and octal values of every differing byte."},
+		},
+		ExitStatus: "0  inputs are identical.\n1  they differ.\n2  an error occurred.",
+	})
 	silent := fs.BoolP("silent", "s", false, "suppress all normal output")
 	_ = fs.Bool("quiet", false, "suppress all normal output")
 	verbose := fs.BoolP("verbose", "l", false, "output byte numbers and differing byte values")

--- a/internal/applets/shellutils/cmp/cmp_test.go
+++ b/internal/applets/shellutils/cmp/cmp_test.go
@@ -174,3 +174,17 @@ func systemCmp(t *testing.T, a, b string) (string, bool) {
 	_ = c.Run() // exit 1 on differ is expected; ignore.
 	return out.String(), true
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, _, code := run(t, "--help")
+	if code != 0 {
+		t.Fatalf("--help exit code = %d, want 0", code)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/shellutils/cut/cut.go
+++ b/internal/applets/shellutils/cut/cut.go
@@ -48,7 +48,17 @@ type options struct {
 
 // Run executes cut.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "OPTION... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "OPTION... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print selected parts of each line from each FILE to standard output. " +
+			"Exactly one of -b (bytes), -c (characters), or -f (fields) selects the unit; " +
+			"with no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "cut -d: -f1 /etc/passwd", Explain: "Print the first colon-separated field of each line."},
+			{Command: "cut -c1-5 file.txt", Explain: "Print the first five characters of each line."},
+			{Command: "cut -f2,4 -d, data.csv", Explain: "Print the second and fourth comma-separated fields."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. an input file could not be read).",
+	})
 	bytesList := fs.StringP("bytes", "b", "", "select only these bytes")
 	charsList := fs.StringP("characters", "c", "", "select only these characters")
 	fieldsList := fs.StringP("fields", "f", "", "select only these fields")

--- a/internal/applets/shellutils/cut/cut_test.go
+++ b/internal/applets/shellutils/cut/cut_test.go
@@ -119,6 +119,11 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: cut") {
 		t.Errorf("--help out = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 
 	out, _, err = runStdin(t, "", "--version")
 	if err != nil {

--- a/internal/applets/shellutils/date/date.go
+++ b/internal/applets/shellutils/date/date.go
@@ -31,7 +31,17 @@ func (c *Command) Synopsis() string { return "Print or set the system date and t
 
 // Run executes date.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [+FORMAT]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [+FORMAT]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the current date and time, optionally formatted with a +FORMAT operand " +
+			"using strftime-style conversion specifiers. Setting the system clock is not supported.",
+		Examples: []command.Example{
+			{Command: "date", Explain: "Print the current date and time in the default format."},
+			{Command: "date -u", Explain: "Print the current date and time in UTC."},
+			{Command: "date +%Y-%m-%d", Explain: "Print the current date as YYYY-MM-DD."},
+			{Command: "date -R", Explain: "Print the date and time in RFC 5322 format."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. an invalid date or format).",
+	})
 	utc := fs.BoolP("utc", "u", false, "print Coordinated Universal Time (UTC)")
 	dateStr := fs.StringP("date", "d", "", "display time described by STRING, not 'now'")
 	rfcEmail := fs.BoolP("rfc-email", "R", false, "output date and time in RFC 5322 format")

--- a/internal/applets/shellutils/date/date_test.go
+++ b/internal/applets/shellutils/date/date_test.go
@@ -142,6 +142,11 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: date") {
 		t.Errorf("--help out = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 
 	out, _, err = run(t, "--version")
 	if err != nil {

--- a/internal/applets/shellutils/dd/dd.go
+++ b/internal/applets/shellutils/dd/dd.go
@@ -89,6 +89,18 @@ type result struct {
 
 // Run executes dd.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	if command.HandleHelpVersionWith(stdio, c.Name(), "[OPERAND]...", command.Help{
+		Description: "Copy a file, converting and formatting according to the operands. Operands use " +
+			"the GNU dd OPERAND=VALUE syntax: if=FILE, of=FILE, bs=BYTES, count=N, skip=N, seek=N, " +
+			"and conv=CONVS. With no if=/of= it copies standard input to standard output.",
+		Examples: []command.Example{
+			{Command: "dd if=/dev/zero of=out bs=1M count=10", Explain: "Write 10 MiB of zeros to 'out'."},
+			{Command: "dd if=disk.img bs=512 skip=1", Explain: "Copy disk.img to stdout, skipping the first 512-byte block."},
+		},
+		ExitStatus: "0  the copy completed successfully.\n1  an operand was invalid or an I/O error occurred.",
+	}, args) {
+		return nil
+	}
 	opts, err := parseArgs(args)
 	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "dd: %v\n", err)

--- a/internal/applets/shellutils/dd/dd_test.go
+++ b/internal/applets/shellutils/dd/dd_test.go
@@ -167,3 +167,18 @@ func TestParseSize(t *testing.T) {
 		}
 	}
 }
+
+// TestHelpSections asserts `dd --help` renders structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := dd.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Usage: dd", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/df/df.go
+++ b/internal/applets/shellutils/df/df.go
@@ -138,7 +138,16 @@ func formatSize(bytes uint64, human bool) string {
 
 // Run executes df.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Report file system disk space usage for the file system that contains each FILE, " +
+			"or for the current directory's file system when no FILE is given.",
+		Examples: []command.Example{
+			{Command: "df", Explain: "Show disk space usage for the current file system."},
+			{Command: "df -h /", Explain: "Show usage for the root file system in human-readable form."},
+			{Command: "df -i .", Explain: "Show inode usage instead of block usage."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be stat'd).",
+	})
 	human := fs.BoolP("human-readable", "h", false, "print sizes in powers of 1024 (e.g., 1023M)")
 	_ = fs.BoolP("kilobytes", "k", false, "use 1024-byte (1K) blocks (default)")
 	inodes := fs.BoolP("inodes", "i", false, "list inode information instead of block usage")

--- a/internal/applets/shellutils/df/df_test.go
+++ b/internal/applets/shellutils/df/df_test.go
@@ -241,4 +241,9 @@ func TestRunHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: df") {
 		t.Errorf("help output missing usage, got %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 }

--- a/internal/applets/shellutils/dirname/dirname.go
+++ b/internal/applets/shellutils/dirname/dirname.go
@@ -24,7 +24,16 @@ func (c *Command) Synopsis() string { return "Print only directory path" }
 
 // Run executes dirname.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME...", stdio.Err).WithHelp(command.Help{
+		Description: "Print each NAME with its last non-slash component and any trailing slashes removed; " +
+			"if NAME contains no slashes, print \".\" (meaning the current directory).",
+		Examples: []command.Example{
+			{Command: "dirname /usr/bin/sort", Explain: "Print \"/usr/bin\"."},
+			{Command: "dirname stdio.h", Explain: "Print \".\"."},
+			{Command: "dirname /usr/lib /tmp/x", Explain: "Print the directory of each operand on its own line."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. no operand was given).",
+	})
 	zero := fs.BoolP("zero", "z", false, "end each output line with NUL, not newline")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/dirname/dirname_test.go
+++ b/internal/applets/shellutils/dirname/dirname_test.go
@@ -60,3 +60,16 @@ func TestRunMissingOperand(t *testing.T) {
 		t.Errorf("stderr = %q", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/shellutils/du/du.go
+++ b/internal/applets/shellutils/du/du.go
@@ -49,7 +49,16 @@ type entry struct {
 
 // Run executes du.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Estimate and summarize disk space usage for each FILE, recursing into directories. " +
+			"With no FILE, summarize the current directory.",
+		Examples: []command.Example{
+			{Command: "du", Explain: "Show usage of the current directory tree."},
+			{Command: "du -sh /var/log", Explain: "Show a single human-readable total for /var/log."},
+			{Command: "du -a dir", Explain: "Show usage for every file, not just directories."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be read).",
+	})
 	summarize := fs.BoolP("summarize", "s", false, "display only a total for each argument")
 	all := fs.BoolP("all", "a", false, "write counts for all files, not just directories")
 	human := fs.BoolP("human-readable", "h", false, "print sizes in human readable format (e.g., 1K 234M 2G)")

--- a/internal/applets/shellutils/du/du_test.go
+++ b/internal/applets/shellutils/du/du_test.go
@@ -223,6 +223,11 @@ func TestHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: du") {
 		t.Errorf("--help out = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 
 	out, _, err = runDu(t, "--version")
 	if err != nil {

--- a/internal/applets/shellutils/echo/echo.go
+++ b/internal/applets/shellutils/echo/echo.go
@@ -29,7 +29,16 @@ func (c *Command) Synopsis() string { return "Display a line of text" }
 
 // Run executes echo.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	if command.HandleHelpVersion(stdio, c.Name(), "[OPTION]... [STRING]...", args) {
+	if command.HandleHelpVersionWith(stdio, c.Name(), "[OPTION]... [STRING]...", command.Help{
+		Description: "Write each STRING to standard output, separated by spaces and followed by a " +
+			"newline. With -n no trailing newline is written; with -e backslash escapes (\\n, \\t, ...) " +
+			"are interpreted.",
+		Examples: []command.Example{
+			{Command: "echo hello world", Explain: "Print 'hello world' and a newline."},
+			{Command: "echo -n no-newline", Explain: "Print without the trailing newline."},
+		},
+		ExitStatus: "0  always, unless writing to standard output fails.",
+	}, args) {
 		return nil
 	}
 

--- a/internal/applets/shellutils/echo/echo_test.go
+++ b/internal/applets/shellutils/echo/echo_test.go
@@ -78,3 +78,18 @@ func TestVersionAsFirstArg(t *testing.T) {
 		t.Errorf("version out = %q", out)
 	}
 }
+
+// TestHelpSections asserts `echo --help` renders structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := echo.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Usage: echo", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/env/env.go
+++ b/internal/applets/shellutils/env/env.go
@@ -29,7 +29,16 @@ func (c *Command) Synopsis() string {
 
 // Run executes env.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]", stdio.Err).WithHelp(command.Help{
+		Description: "Set each NAME=VALUE in the environment and run COMMAND with the resulting environment. " +
+			"With no COMMAND, print the resulting environment instead.",
+		Examples: []command.Example{
+			{Command: "env", Explain: "Print the current environment, one variable per line."},
+			{Command: "env FOO=bar printenv FOO", Explain: "Run printenv with FOO set to bar."},
+			{Command: "env -i sh -c 'echo $PATH'", Explain: "Run a command with an empty environment."},
+		},
+		ExitStatus: "0    success.\n127  COMMAND could not be started (e.g. not found).\nN    otherwise, the exit status of COMMAND.",
+	})
 	// Options stop at the first operand so that flags meant for COMMAND (such as
 	// "sh -c") are passed through untouched instead of parsed by env.
 	fs.SetInterspersed(false)

--- a/internal/applets/shellutils/env/env_test.go
+++ b/internal/applets/shellutils/env/env_test.go
@@ -149,6 +149,11 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: env") {
 		t.Errorf("--help out = %q", out)
 	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
 
 	out, _, err = run(t, "", "--version")
 	if err != nil {

--- a/internal/applets/shellutils/expr/expr.go
+++ b/internal/applets/shellutils/expr/expr.go
@@ -38,6 +38,19 @@ func (e *syntaxError) Error() string { return e.msg }
 // whether the result is null/zero (status 1) or not (status 0). A malformed
 // expression prints "expr: <message>" to stderr and exits with status 2.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
+	if command.HandleHelpVersionWith(stdio, c.Name(), "EXPRESSION", command.Help{
+		Description: "Evaluate EXPRESSION and write the result to standard output. Supports arithmetic " +
+			"(+, -, *, /, %), comparisons (=, !=, <, <=, >, >=), the string operators : (match), " +
+			"length, substr, index, and grouping with parentheses.",
+		Examples: []command.Example{
+			{Command: "expr 6 + 7", Explain: "Print 13."},
+			{Command: `expr length "hello"`, Explain: "Print 5."},
+		},
+		ExitStatus: "0  the result is neither null nor zero.\n1  the result is null or zero.\n" +
+			"2  the expression is malformed.\n3  an internal or write error occurred.",
+	}, args) {
+		return nil
+	}
 	result, err := eval(args)
 	if err != nil {
 		var se *syntaxError

--- a/internal/applets/shellutils/expr/expr_test.go
+++ b/internal/applets/shellutils/expr/expr_test.go
@@ -135,3 +135,18 @@ func TestEval(t *testing.T) {
 		})
 	}
 }
+
+// TestHelpSections asserts `expr --help` renders structured help.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if code := command.Execute(context.Background(), expr.New(), io, []string{"--help"}); code != command.ExitSuccess {
+		t.Fatalf("--help exit = %d, want 0", code)
+	}
+	for _, want := range []string{"Usage: expr", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/false/false.go
+++ b/internal/applets/shellutils/false/false.go
@@ -22,7 +22,15 @@ func (c *Command) Synopsis() string { return "Do nothing. Return failure(1)" }
 // Run always fails with exit status 1. Like GNU false it ignores its operands,
 // except that a leading --help or --version is honored and exits successfully.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	if command.HandleHelpVersion(stdio, c.Name(), "[IGNORED]...", args) {
+	if command.HandleHelpVersionWith(stdio, c.Name(), "[IGNORED]...", command.Help{
+		Description: "Do nothing and exit with a failure status. All operands are ignored; false exists " +
+			"so that shell scripts have a command that always fails.",
+		Examples: []command.Example{
+			{Command: "false || echo failed", Explain: "Print failed, because false always fails."},
+			{Command: "if false; then echo yes; fi", Explain: "Run nothing, because the condition is false."},
+		},
+		ExitStatus: "1  always.",
+	}, args) {
 		return nil
 	}
 	return &command.ExitError{Code: command.ExitFailure}

--- a/internal/applets/shellutils/false/false_test.go
+++ b/internal/applets/shellutils/false/false_test.go
@@ -44,3 +44,18 @@ func TestRunVersionSucceeds(t *testing.T) {
 		t.Errorf("version out = %q", out.String())
 	}
 }
+
+// TestHelpSections asserts `false --help` renders structured help and exits 0.
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if code := command.Execute(context.Background(), boolfalse.New(), io, []string{"--help"}); code != command.ExitSuccess {
+		t.Fatalf("--help exit = %d, want 0", code)
+	}
+	for _, want := range []string{"Usage: false", "Examples:", "Exit status:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("--help missing %q: %q", want, out.String())
+		}
+	}
+}

--- a/internal/applets/shellutils/free/free.go
+++ b/internal/applets/shellutils/free/free.go
@@ -33,7 +33,16 @@ var meminfoSource = func() (io.Reader, error) {
 
 // Run executes free.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Display the total, used, and free physical and swap memory in the system, reading the figures " +
+			"from /proc/meminfo. By default the amounts are shown in kibibytes.",
+		Examples: []command.Example{
+			{Command: "free", Explain: "Show memory usage in kibibytes."},
+			{Command: "free -m", Explain: "Show memory usage in mebibytes."},
+			{Command: "free -h", Explain: "Show memory usage with human-readable binary suffixes."},
+		},
+		ExitStatus: "0  the report was printed successfully.\n1  memory information could not be read.",
+	})
 	bytesUnit := fs.BoolP("bytes", "b", false, "show output in bytes")
 	kibi := fs.BoolP("kibi", "k", false, "show output in kibibytes (default)")
 	mebi := fs.BoolP("mebi", "m", false, "show output in mebibytes")

--- a/internal/applets/shellutils/free/free_test.go
+++ b/internal/applets/shellutils/free/free_test.go
@@ -126,3 +126,13 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/internal/applets/shellutils/ghrdc/ghrdc.go
+++ b/internal/applets/shellutils/ghrdc/ghrdc.go
@@ -141,7 +141,16 @@ type GitHubReleaseData struct {
 
 // Run executes ghrdc.
 func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... USER/REPOSITORY", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... USER/REPOSITORY", stdio.Err).WithHelp(command.Help{
+		Description: "Query the GitHub releases API for USER/REPOSITORY and print the number of downloads per release, " +
+			"counted separately for binary assets and source-code archives. By default only the latest release is shown.",
+		Examples: []command.Example{
+			{Command: "ghrdc nao1215/mimixbox", Explain: "Show download counts for the latest release."},
+			{Command: "ghrdc -a nao1215/mimixbox", Explain: "Show download counts for every release."},
+			{Command: "ghrdc -t nao1215/mimixbox", Explain: "Show the total download counts across all releases."},
+		},
+		ExitStatus: "0  the report was printed successfully.\n1  the operand was invalid or release data could not be retrieved.",
+	})
 	all := fs.BoolP("all", "a", false, "Show total number of downloads per release")
 	total := fs.BoolP("total", "t", false, "Show total number of downloads for all releases")
 

--- a/internal/applets/shellutils/ghrdc/ghrdc_test.go
+++ b/internal/applets/shellutils/ghrdc/ghrdc_test.go
@@ -177,4 +177,7 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: ghrdc") {
 		t.Errorf("--help out = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
 }

--- a/internal/applets/shellutils/groups/groups.go
+++ b/internal/applets/shellutils/groups/groups.go
@@ -26,7 +26,16 @@ func (c *Command) Synopsis() string { return "Print the groups to which USERNAME
 
 // Run executes groups.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[USERNAME]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[USERNAME]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the names of the groups each USERNAME belongs to. With no operand, print the groups of " +
+			"the current user.",
+		Examples: []command.Example{
+			{Command: "groups", Explain: "Print the groups the current user belongs to."},
+			{Command: "groups root", Explain: "Print the groups the root user belongs to."},
+			{Command: "groups alice bob", Explain: "Print the groups for several users, one per line."},
+		},
+		ExitStatus: "0  all named users were found.\n1  a named user could not be found.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/groups/groups_test.go
+++ b/internal/applets/shellutils/groups/groups_test.go
@@ -80,3 +80,13 @@ func TestRunUnknownUser(t *testing.T) {
 		t.Errorf("exit code = %d, want non-zero", code)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/internal/applets/shellutils/hostid/hostid.go
+++ b/internal/applets/shellutils/hostid/hostid.go
@@ -33,7 +33,14 @@ func (c *Command) Synopsis() string {
 
 // Run executes hostid.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]", stdio.Err).WithHelp(command.Help{
+		Description: "Print the numeric identifier of the current host as a zero-padded 8-digit hexadecimal number, " +
+			"matching GNU coreutils' hostid.",
+		Examples: []command.Example{
+			{Command: "hostid", Explain: "Print the host identifier, for example 007f0101."},
+		},
+		ExitStatus: "0  the host identifier was printed successfully.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/shellutils/hostid/hostid_test.go
+++ b/internal/applets/shellutils/hostid/hostid_test.go
@@ -33,3 +33,13 @@ func TestRun(t *testing.T) {
 		t.Errorf("hostid output = %q, want one line of 8 hex digits", out)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/internal/applets/shellutils/hostname/help_test.go
+++ b/internal/applets/shellutils/hostname/help_test.go
@@ -1,0 +1,26 @@
+package hostname_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/hostname"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := hostname.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/hostname/hostname.go
+++ b/internal/applets/shellutils/hostname/hostname.go
@@ -28,7 +28,15 @@ var hostFn = os.Hostname
 
 // Run executes hostname.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the name of the current host. With -s, print only the short host " +
+			"name by trimming everything from the first dot onward.",
+		Examples: []command.Example{
+			{Command: "hostname", Explain: "Print the full host name."},
+			{Command: "hostname -s", Explain: "Print the short host name (up to the first dot)."},
+		},
+		ExitStatus: "0  the host name was printed.\n1  the host name could not be determined.",
+	})
 	short := fs.BoolP("short", "s", false, "display the short host name (up to the first dot)")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/shellutils/id/help_test.go
+++ b/internal/applets/shellutils/id/help_test.go
@@ -1,0 +1,26 @@
+package id_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/id"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := id.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/id/id.go
+++ b/internal/applets/shellutils/id/id.go
@@ -25,7 +25,18 @@ func (c *Command) Synopsis() string { return "Print User ID and Group ID" }
 
 // Run executes id.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [USER]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [USER]", stdio.Err).WithHelp(command.Help{
+		Description: "Print user and group information for the current user, or for USER when " +
+			"one is given. With no options, print the real and effective user ID, group ID, " +
+			"and the list of supplementary groups.",
+		Examples: []command.Example{
+			{Command: "id", Explain: "Print all ID information for the current user."},
+			{Command: "id -u", Explain: "Print only the effective user ID."},
+			{Command: "id -un", Explain: "Print only the effective user name."},
+			{Command: "id root", Explain: "Print ID information for the user root."},
+		},
+		ExitStatus: "0  the requested information was printed.\n1  an option was misused or the user could not be resolved.",
+	})
 	userOnly := fs.BoolP("user", "u", false, "print only the effective user ID")
 	groupOnly := fs.BoolP("group", "g", false, "print only the effective group ID")
 	allGroups := fs.BoolP("groups", "G", false, "print all group IDs")

--- a/internal/applets/shellutils/install/help_test.go
+++ b/internal/applets/shellutils/install/help_test.go
@@ -1,0 +1,26 @@
+package install_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/install"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := install.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/install/install.go
+++ b/internal/applets/shellutils/install/install.go
@@ -40,7 +40,17 @@ type options struct {
 
 // Run executes install.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [-T] SOURCE DEST", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [-T] SOURCE DEST", stdio.Err).WithHelp(command.Help{
+		Description: "Copy SOURCE to DEST, or several SOURCEs to an existing DIRECTORY, while " +
+			"setting permission modes. With -d, create the named directories instead of " +
+			"copying files.",
+		Examples: []command.Example{
+			{Command: "install -m 644 file /etc/file", Explain: "Copy file to /etc/file with mode 644."},
+			{Command: "install -d /opt/app/bin", Explain: "Create the directory /opt/app/bin."},
+			{Command: "install -t /usr/local/bin prog", Explain: "Copy prog into the /usr/local/bin directory."},
+		},
+		ExitStatus: "0  all files or directories were installed.\n1  an operand was invalid or an install failed.",
+	})
 	directory := fs.BoolP("directory", "d", false, "treat all arguments as directory names; create them")
 	createDir := fs.BoolP("create-leading", "D", false, "create all leading components of DEST, then copy SOURCE")
 	noTarget := fs.BoolP("no-target-directory", "T", false, "treat DEST as a normal file")

--- a/internal/applets/shellutils/kill/help_test.go
+++ b/internal/applets/shellutils/kill/help_test.go
@@ -1,0 +1,26 @@
+package kill_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/kill"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := kill.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/kill/kill.go
+++ b/internal/applets/shellutils/kill/kill.go
@@ -42,7 +42,18 @@ var signals = signal.List()
 //	kill -SIGNAL PID...    send SIGNAL to each PID (e.g. -9, -KILL, -SIGKILL)
 //	kill -l                list signal names
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[-s SIGNAL | -SIGNAL] PID... | -l", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[-s SIGNAL | -SIGNAL] PID... | -l", stdio.Err).WithHelp(command.Help{
+		Description: "Send a signal to each process identified by PID. The default signal is " +
+			"SIGTERM (15); a different signal may be given by name or number with -s or as " +
+			"-SIGNAL. With -l, list the known signal names.",
+		Examples: []command.Example{
+			{Command: "kill 1234", Explain: "Send SIGTERM to process 1234."},
+			{Command: "kill -9 1234", Explain: "Send SIGKILL to process 1234."},
+			{Command: "kill -s HUP 1234", Explain: "Send SIGHUP to process 1234."},
+			{Command: "kill -l", Explain: "List the available signal names."},
+		},
+		ExitStatus: "0  every signal was delivered.\n1  a PID was invalid or a signal could not be sent.",
+	})
 	sigName := fs.StringP("signal", "s", "", "send the given SIGNAL instead of SIGTERM")
 	list := fs.BoolP("list", "l", false, "list signal names")
 

--- a/internal/applets/shellutils/killall/help_test.go
+++ b/internal/applets/shellutils/killall/help_test.go
@@ -1,0 +1,26 @@
+package killall_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/killall"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := killall.New().Run(context.Background(), io, []string{"--help"}); err != nil {
+		t.Fatalf("--help returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Examples:") {
+		t.Errorf("help output missing Examples section:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Exit status:") {
+		t.Errorf("help output missing Exit status section:\n%s", out.String())
+	}
+}

--- a/internal/applets/shellutils/killall/killall.go
+++ b/internal/applets/shellutils/killall/killall.go
@@ -43,7 +43,17 @@ var killProcess = func(pid int, sig syscall.Signal) error {
 
 // Run executes killall.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... NAME...", stdio.Err).WithHelp(command.Help{
+		Description: "Send a signal to every process running any of the named programs. The " +
+			"default signal is SIGTERM; a different one may be given by name or number with " +
+			"-s.",
+		Examples: []command.Example{
+			{Command: "killall firefox", Explain: "Send SIGTERM to every firefox process."},
+			{Command: "killall -s KILL nginx", Explain: "Send SIGKILL to every nginx process."},
+			{Command: "killall -q sleep", Explain: "Kill matching processes without complaining if none are found."},
+		},
+		ExitStatus: "0  at least one process was signaled for every name.\n1  a name matched no running process.",
+	})
 	signalName := fs.StringP("signal", "s", "TERM", "send this signal instead of SIGTERM")
 	quiet := fs.BoolP("quiet", "q", false, "do not complain if no process was killed")
 

--- a/internal/applets/textutils/base32/base32.go
+++ b/internal/applets/textutils/base32/base32.go
@@ -28,7 +28,17 @@ func (c *Command) Synopsis() string {
 
 // Run executes base32.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]", stdio.Err).WithHelp(command.Help{
+		Description: "Base32 encode or decode FILE, or standard input when no FILE (or \"-\") is\n" +
+			"given, and write the result to standard output. By default the data is\n" +
+			"encoded; use -d to decode instead.",
+		Examples: []command.Example{
+			{Command: "base32 file.bin", Explain: "encode file.bin to base32"},
+			{Command: "base32 -d file.b32", Explain: "decode base32 back to bytes"},
+			{Command: "echo hello | base32", Explain: "encode standard input"},
+		},
+		ExitStatus: "0  success.\n1  the input file could not be read, or the data was not valid base32 while decoding.",
+	})
 	decode := fs.BoolP("decode", "d", false, "decode data")
 	ignoreGarbage := fs.BoolP("ignore-garbage", "i", false, "when decoding, ignore non-alphabet characters")
 	wrap := fs.IntP("wrap", "w", 76, "wrap encoded lines after COLS character (default 76).\nUse 0 to disable line wrapping")

--- a/internal/applets/textutils/base32/base32_test.go
+++ b/internal/applets/textutils/base32/base32_test.go
@@ -112,3 +112,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out)
+	}
+}

--- a/internal/applets/textutils/cat/cat.go
+++ b/internal/applets/textutils/cat/cat.go
@@ -35,7 +35,17 @@ type options struct {
 
 // Run executes cat.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Concatenate each FILE to standard output. With no FILE, or when FILE is\n" +
+			"\"-\", read standard input. Options can number lines, squeeze repeated\n" +
+			"blank lines, and make line ends or tabs visible.",
+		Examples: []command.Example{
+			{Command: "cat file.txt", Explain: "print file.txt to standard output"},
+			{Command: "cat -n a.txt b.txt", Explain: "concatenate two files, numbering every line"},
+			{Command: "cat", Explain: "copy standard input to standard output"},
+		},
+		ExitStatus: "0  success.\n1  one or more files could not be opened or read.",
+	})
 	number := fs.BoolP("number", "n", false, "number all output lines")
 	numberNonBlank := fs.BoolP("number-nonblank", "b", false, "number non-empty output lines, overrides -n")
 	squeeze := fs.BoolP("squeeze-blank", "s", false, "suppress repeated empty output lines")

--- a/internal/applets/textutils/cat/cat_test.go
+++ b/internal/applets/textutils/cat/cat_test.go
@@ -115,6 +115,12 @@ func TestRunHelpAndVersion(t *testing.T) {
 	if !strings.Contains(out, "Usage: cat") {
 		t.Errorf("--help out = %q", out)
 	}
+	if !strings.Contains(out, "Examples:") {
+		t.Errorf("--help missing Examples: %q", out)
+	}
+	if !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing Exit status: %q", out)
+	}
 
 	out, _, err = runStdin(t, "", "--version")
 	if err != nil {

--- a/internal/applets/textutils/cksum/cksum.go
+++ b/internal/applets/textutils/cksum/cksum.go
@@ -24,7 +24,16 @@ func (c *Command) Synopsis() string { return "Print CRC checksum and byte count 
 
 // Run executes cksum.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print a POSIX CRC checksum and the byte count for each FILE. With no FILE, or when FILE " +
+			"is '-', read standard input. The output is compatible with GNU coreutils' cksum.",
+		Examples: []command.Example{
+			{Command: "cksum file.txt", Explain: "Print the CRC checksum, byte count, and name of file.txt."},
+			{Command: "cksum a.txt b.txt", Explain: "Print a checksum line for each named file."},
+			{Command: "cat file | cksum", Explain: "Checksum data read from standard input."},
+		},
+		ExitStatus: "0  all files were read successfully.\n1  one or more files could not be read.",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/textutils/cksum/cksum_test.go
+++ b/internal/applets/textutils/cksum/cksum_test.go
@@ -79,3 +79,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/textutils/comm/comm.go
+++ b/internal/applets/textutils/comm/comm.go
@@ -25,7 +25,16 @@ func (c *Command) Synopsis() string { return "Compare two sorted files line by l
 
 // Run executes comm.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 FILE2", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 FILE2", stdio.Err).WithHelp(command.Help{
+		Description: "Compare two sorted files line by line and print three columns: lines unique to FILE1, lines " +
+			"unique to FILE2, and lines common to both. Use -1, -2, or -3 to suppress the corresponding column.",
+		Examples: []command.Example{
+			{Command: "comm a.txt b.txt", Explain: "Show lines unique to each file and lines common to both."},
+			{Command: "comm -12 a.txt b.txt", Explain: "Print only the lines common to both files."},
+			{Command: "comm -3 a.txt b.txt", Explain: "Print only the lines that are unique to one file."},
+		},
+		ExitStatus: "0  success.\n1  a file could not be read or written.",
+	})
 	no1 := fs.BoolP("suppress-col1", "1", false, "suppress column 1 (lines unique to FILE1)")
 	no2 := fs.BoolP("suppress-col2", "2", false, "suppress column 2 (lines unique to FILE2)")
 	no3 := fs.BoolP("suppress-col3", "3", false, "suppress column 3 (lines that appear in both files)")

--- a/internal/applets/textutils/comm/comm_test.go
+++ b/internal/applets/textutils/comm/comm_test.go
@@ -104,3 +104,17 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+// TestHelpSections verifies that --help renders both the Examples and the
+// Exit status sections supplied through WithHelp.
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help err = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help missing %q section:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/textutils/dos2unix/dos2unix.go
+++ b/internal/applets/textutils/dos2unix/dos2unix.go
@@ -29,7 +29,14 @@ func (c *Command) Synopsis() string { return "Change CRLF to LF" }
 // stderr and makes the command exit non-zero; the remaining files are still
 // converted.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE...", stdio.Err).WithHelp(command.Help{
+		Description: "Convert CRLF (DOS) line endings to LF (Unix), editing each named FILE in place.",
+		Examples: []command.Example{
+			{Command: "dos2unix file.txt", Explain: "Convert file.txt to Unix line endings in place."},
+			{Command: "dos2unix a.txt b.txt", Explain: "Convert several files in place."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. a file was missing or could not be written).",
+	})
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {

--- a/internal/applets/textutils/dos2unix/dos2unix_test.go
+++ b/internal/applets/textutils/dos2unix/dos2unix_test.go
@@ -180,3 +180,16 @@ func TestRunPreservesFileMode(t *testing.T) {
 		t.Errorf("content = %q", got)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/textutils/expand/expand.go
+++ b/internal/applets/textutils/expand/expand.go
@@ -32,7 +32,16 @@ type options struct {
 
 // Run executes expand.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Convert tabs in each FILE to spaces, writing to standard output. " +
+			"With no FILE, or when FILE is -, read standard input.",
+		Examples: []command.Example{
+			{Command: "expand file.txt", Explain: "Convert tabs to spaces using 8-column tab stops."},
+			{Command: "expand -t 4 file.txt", Explain: "Use 4-column tab stops instead of 8."},
+			{Command: "expand -i file.txt", Explain: "Convert only the leading tabs on each line."},
+		},
+		ExitStatus: "0  success.\n1  an error occurred (e.g. an input file could not be read).",
+	})
 	tabs := fs.IntP("tabs", "t", 8, "have tabs N characters apart, not 8")
 	initial := fs.BoolP("initial", "i", false, "do not convert tabs after non blanks")
 

--- a/internal/applets/textutils/expand/expand_test.go
+++ b/internal/applets/textutils/expand/expand_test.go
@@ -109,3 +109,16 @@ func TestRunMissingFileContinues(t *testing.T) {
 		t.Errorf("stderr = %q, want expand error prefix", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	for _, want := range []string{"Examples:", "Exit status:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/applets/textutils/fmt/fmt.go
+++ b/internal/applets/textutils/fmt/fmt.go
@@ -26,7 +26,16 @@ func (c *Command) Synopsis() string { return "Simple optimal text formatter" }
 
 // Run executes fmt.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Reflow the paragraphs of each FILE (or standard input when no FILE is given), packing words " +
+			"into lines no wider than the target width. Blank lines separate paragraphs and are preserved.",
+		Examples: []command.Example{
+			{Command: "fmt notes.txt", Explain: "Reflow notes.txt to the default width of 75 columns."},
+			{Command: "fmt -w 60 notes.txt", Explain: "Reflow notes.txt so each line fits within 60 columns."},
+			{Command: "fmt -", Explain: "Reflow text read from standard input."},
+		},
+		ExitStatus: "0  all input was reflowed successfully.\n1  a file could not be read.",
+	})
 	width := fs.IntP("width", "w", 75, "maximum line width")
 
 	proceed, err := fs.Parse(stdio, args)

--- a/internal/applets/textutils/fmt/fmt_test.go
+++ b/internal/applets/textutils/fmt/fmt_test.go
@@ -84,3 +84,13 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/internal/applets/textutils/fold/fold.go
+++ b/internal/applets/textutils/fold/fold.go
@@ -26,7 +26,16 @@ func (c *Command) Synopsis() string { return "Wrap each input line to fit in spe
 
 // Run executes fold.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Wrap each input line from FILE (or standard input when no FILE is given) to fit within WIDTH " +
+			"columns, writing the result to standard output. With -s, break lines at spaces where possible.",
+		Examples: []command.Example{
+			{Command: "fold notes.txt", Explain: "Wrap each line of notes.txt to 80 columns."},
+			{Command: "fold -w 40 notes.txt", Explain: "Wrap each line to 40 columns."},
+			{Command: "fold -s -w 40 notes.txt", Explain: "Wrap to 40 columns, breaking at spaces so words stay intact."},
+		},
+		ExitStatus: "0  all input was wrapped successfully.\n1  a file could not be read.",
+	})
 	width := fs.IntP("width", "w", 80, "use WIDTH columns instead of 80")
 	spaces := fs.BoolP("spaces", "s", false, "break at spaces")
 

--- a/internal/applets/textutils/fold/fold_test.go
+++ b/internal/applets/textutils/fold/fold_test.go
@@ -80,3 +80,13 @@ func TestNameSynopsis(t *testing.T) {
 		t.Error("Synopsis() is empty")
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/internal/applets/textutils/head/head.go
+++ b/internal/applets/textutils/head/head.go
@@ -25,7 +25,16 @@ func (c *Command) Synopsis() string { return "Print the first NUMBER(default=10)
 
 // Run executes head.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err)
+	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
+		Description: "Print the first part of each FILE (or standard input when no FILE is given) to standard output. " +
+			"By default the first 10 lines are printed; with multiple files, each is preceded by a header.",
+		Examples: []command.Example{
+			{Command: "head notes.txt", Explain: "Print the first 10 lines of notes.txt."},
+			{Command: "head -n 5 notes.txt", Explain: "Print the first 5 lines of notes.txt."},
+			{Command: "head -c 100 notes.txt", Explain: "Print the first 100 bytes of notes.txt."},
+		},
+		ExitStatus: "0  all input was printed successfully.\n1  a file could not be read.",
+	})
 	lines := fs.IntP("lines", "n", 10, "print the first NUM lines instead of the first 10")
 	bytesN := fs.IntP("bytes", "c", 0, "print the first NUM bytes of each file")
 	quiet := fs.BoolP("quiet", "q", false, "never print headers giving file names")

--- a/internal/applets/textutils/head/head_test.go
+++ b/internal/applets/textutils/head/head_test.go
@@ -94,3 +94,13 @@ func TestRunMissingFile(t *testing.T) {
 		t.Errorf("stderr = %q", errOut)
 	}
 }
+
+func TestHelpSections(t *testing.T) {
+	out, _, err := run(t, "", "--help")
+	if err != nil {
+		t.Fatalf("--help error = %v", err)
+	}
+	if !strings.Contains(out, "Examples:") || !strings.Contains(out, "Exit status:") {
+		t.Errorf("--help missing structured sections:\n%s", out)
+	}
+}

--- a/test/it/spec/egrep_spec.sh
+++ b/test/it/spec/egrep_spec.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=sh
 # Issue #477: dedicated shell-level contract spec for the "egrep" applet.
-# egrep is a thin alias for `grep -E`; this file is the dedicated
+# egrep is grep -E; it renders its own egrep-named structured --help. This file is the dedicated
 # spec required by #477. Shared matching behavior is covered by the grep family.
 #
 # Every MimixBox applet's --help is rendered by internal/command's
@@ -12,7 +12,7 @@ Describe 'egrep'
   It 'describes itself with --help'
     When run command egrep --help
     The status should be success
-    The output should include 'Usage: grep'
+    The output should include 'Usage: egrep'
     The stderr should equal ''
   End
 End

--- a/test/it/spec/fgrep_spec.sh
+++ b/test/it/spec/fgrep_spec.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=sh
 # Issue #477: dedicated shell-level contract spec for the "fgrep" applet.
-# fgrep is a thin alias for `grep -F`; this file is the dedicated
+# fgrep is grep -F; it renders its own fgrep-named structured --help. This file is the dedicated
 # spec required by #477. Shared matching behavior is covered by the grep family.
 #
 # Every MimixBox applet's --help is rendered by internal/command's
@@ -12,7 +12,7 @@ Describe 'fgrep'
   It 'describes itself with --help'
     When run command fgrep --help
     The status should be success
-    The output should include 'Usage: grep'
+    The output should include 'Usage: fgrep'
     The stderr should equal ''
   End
 End

--- a/test/it/spec/help_structured_sections_2_spec.sh
+++ b/test/it/spec/help_structured_sections_2_spec.sh
@@ -1,0 +1,103 @@
+Describe 'more applets expose structured --help sections'
+    # GitHub issues: "add structured help sections for X" (second alphabet half).
+    # Each applet must route --help through the structured renderer, exit 0, and
+    # document a purpose paragraph, an Examples section, and an Exit status section.
+
+    Parameters
+        add-shell
+        ar
+        arch
+        awk
+        banner
+        base32
+        base64
+        basename
+        bunzip2
+        cal
+        cat
+        chgrp
+        chmod
+        chown
+        cksum
+        clear
+        cmatrix
+        cmp
+        comm
+        compress
+        cowsay
+        cowthink
+        cpio
+        cut
+        date
+        dd
+        df
+        diff
+        dirname
+        dos2unix
+        du
+        egrep
+        env
+        expand
+        expr
+        fakemovie
+        fgrep
+        fmt
+        fold
+        fortune
+        free
+        ghrdc
+        grep
+        groups
+        gunzip
+        gzip
+        halt
+        head
+        hostid
+        hostname
+        http-status-code
+        id
+        install
+        ischroot
+        killall
+        lifegame
+        link
+    End
+
+    It "$1 --help exposes structured sections"
+        When run "$1" --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with "Usage: $1"
+        The output should include "  $1 "
+    End
+
+    # echo/false/kill are shell builtins; run them through env to reach the applet.
+    It 'echo --help exposes structured sections'
+        When run env echo --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with 'Usage: echo'
+        The output should include '  echo '
+    End
+
+    It 'false --help exposes structured sections'
+        When run env false --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with 'Usage: false'
+        The output should include '  false '
+    End
+
+    It 'kill --help exposes structured sections'
+        When run env kill --help
+        The status should be success
+        The output should include 'Examples:'
+        The output should include 'Exit status:'
+        The line 1 of output should start with 'Usage: kill'
+        The output should include '  kill '
+    End
+
+End


### PR DESCRIPTION
## Summary

60 more `[ux/help]` "add structured help sections for X" issues (the first half
of the alphabet, add-shell … link). Each applet now exposes a purpose paragraph,
an `Examples:` section, and an `Exit status:` section in `--help`.

- **53 applets** chain `.WithHelp(command.Help{...})` onto their `NewFlagSet`.
- **Custom-parsed** `dd`, `echo`, `expr`, `false`, and the `egrep`/`fgrep` grep
  aliases use `command.HandleHelpVersionWith` so their `--help` renders
  alias-named structured help without disturbing argument handling.

## Testing

- Per-package Go tests assert each `--help` contains `Examples:` and `Exit status:`.
- A parameterized ShellSpec spec asserts the full contract for all 60 commands
  (shell builtins `echo`/`false`/`kill` run through `env`).
- The pre-existing `egrep`/`fgrep` contract specs are updated to expect the
  applet's own `Usage:` line.
- `go build ./...`, full `go test ./...`, full `make test-e2e` (1751 examples, 0
  failures), and `golangci-lint` all pass.

Closes #498,Closes #499 Closes #500,Closes #501 Closes #502,Closes #503 Closes #504,Closes #505 Closes #506,Closes #507 Closes #508,Closes #509 Closes #510,Closes #511 Closes #512,Closes #513 Closes #514,Closes #515 Closes #516,Closes #517 Closes #518,Closes #519 Closes #520,Closes #521 Closes #522,Closes #523 Closes #524,Closes #525 Closes #526,Closes #527 Closes #528,Closes #529 Closes #530,Closes #531 Closes #532,Closes #533 Closes #534,Closes #535 Closes #536,Closes #537 Closes #538,Closes #539 Closes #540,Closes #541 Closes #542,Closes #543 Closes #544,Closes #545 Closes #546,Closes #547 Closes #548,Closes #549 Closes #550,Closes #551 Closes #552,Closes #553 Closes #554,Closes #555 Closes #556,Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved `--help` output across 70+ applets with expanded descriptions, concrete usage examples, and explicit exit status documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->