### PR TITLE
feat(help): close final structured-help gaps and guard the contract

### DIFF
--- a/internal/applets/findutils/find/find.go
+++ b/internal/applets/findutils/find/find.go
@@ -249,6 +249,9 @@ func printUsage(w interface{ Write([]byte) (int, error) }) {
 		"  find . -name '*.go'          Find files whose name ends in .go.\n" +
 		"  find /tmp -type d -empty     Find empty directories under /tmp.\n" +
 		"  find . -type f -print0       Print file paths separated by NUL (for xargs -0).\n\n" +
+		"Exit status:\n" +
+		"  0  the search completed successfully.\n" +
+		"  1  a path could not be read or the expression was invalid.\n\n" +
 		"Notes:\n" +
 		"  - This is a subset of GNU find: the tests, depth limits, and actions listed above.\n" +
 		"  - -print0 pairs with 'xargs -0' to handle paths that contain spaces or newlines.\n"))

--- a/internal/applets/help_contract_test.go
+++ b/internal/applets/help_contract_test.go
@@ -1,0 +1,37 @@
+package applets
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// TestEveryAppletHelpHasExamplesAndExitStatus locks in the structured-help
+// rollout (GitHub issues #491, #493): every registered applet must answer
+// --help with a worked Examples section and an Exit status section, exiting 0.
+// This is the regression guard that keeps newly added applets from shipping a
+// bare option table.
+func TestEveryAppletHelpHasExamplesAndExitStatus(t *testing.T) {
+	t.Parallel()
+	for name, applet := range Applets {
+		name, applet := name, applet
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out := &bytes.Buffer{}
+			io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+			code := command.Execute(context.Background(), applet.Cmd, io, []string{"--help"})
+			if code != command.ExitSuccess {
+				t.Fatalf("%s --help exit = %d, want 0", name, code)
+			}
+			help := out.String()
+			for _, want := range []string{"Examples:", "Exit status:"} {
+				if !strings.Contains(help, want) {
+					t.Errorf("%s --help is missing the %q section\n%s", name, want, help)
+				}
+			}
+		})
+	}
+}

--- a/internal/applets/securityutils/selinux/selinux.go
+++ b/internal/applets/securityutils/selinux/selinux.go
@@ -399,7 +399,10 @@ func (c *Command) runPrivileged(stdio command.IO, args []string) error {
 	usage, desc := privilegedHelp(c.name)
 	fs := command.NewFlagSet(c.name, usage, stdio.Err).WithHelp(command.Help{
 		Description: desc,
-		ExitStatus:  "1  always in this build: the privileged operation is intentionally gated.",
+		Examples: []command.Example{
+			{Command: c.name + " " + exampleArgs(c.name), Explain: "Validate the request, then report the capability/policy requirement."},
+		},
+		ExitStatus: "1  always in this build: the privileged operation is intentionally gated.",
 		Notes: []string{
 			"Mutating SELinux operations require CAP_MAC_ADMIN and a loaded policy; this build refuses them deterministically instead of partially applying changes.",
 		},
@@ -433,4 +436,26 @@ func privilegedHelp(name string) (usage, desc string) {
 		return "", "Load a new SELinux policy into the running kernel. Requires CAP_MAC_ADMIN; intentionally gated in this build."
 	}
 	return "", "Privileged SELinux operation, intentionally gated in this build."
+}
+
+// exampleArgs returns representative operands for a privileged applet's worked
+// --help example.
+func exampleArgs(name string) string {
+	switch name {
+	case cmdSetenforce:
+		return "Permissive"
+	case cmdSetsebool:
+		return "httpd_can_network_connect on"
+	case cmdChcon:
+		return "-t httpd_sys_content_t /var/www/index.html"
+	case cmdRuncon:
+		return "system_u:system_r:httpd_t /usr/sbin/httpd"
+	case cmdRestorecon:
+		return "-R /var/www"
+	case cmdSetfiles:
+		return "file_contexts /var/www"
+	case cmdLoadPolicy:
+		return "" // load_policy takes no operands
+	}
+	return ""
 }

--- a/internal/applets/util-linux/script/script.go
+++ b/internal/applets/util-linux/script/script.go
@@ -158,6 +158,7 @@ func (c *Command) runReplay(_ context.Context, stdio command.IO, args []string) 
 		Examples: []command.Example{
 			{Command: "scriptreplay timing build.log", Explain: "Replay the recorded session."},
 		},
+		ExitStatus: "0  the session replayed successfully.\n1  the timing or typescript file could not be read.",
 	})
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {


### PR DESCRIPTION
## Summary

Completes the structured-help rollout (meta issues #491, #493). After this PR
**every** one of the 449 registered applets answers `--help` with both an
`Examples:` section and an `Exit status:` section.

- `securityutils/selinux`: worked examples for the privileged applets (chcon, runcon, restorecon, setfiles, setsebool, setenforce, load_policy).
- `findutils/find`: `Exit status:` section added to its custom help text.
- `util-linux/script`: `Exit status:` section added to `scriptreplay --help`.

A new table-driven regression guard, `TestEveryAppletHelpHasExamplesAndExitStatus`,
iterates the whole applet registry and asserts the contract, so newly added
applets cannot ship a bare option table.

## Testing

- `go test ./internal/applets/` (every applet's `--help` checked in-memory) — pass.
- `go build ./...`, `golangci-lint`, and full `make test-e2e` (1751 examples, 0 failures) all pass.

Closes #491
Closes #493