### PR TITLE
test(applets): raise coverage on low-coverage helper paths (batch 1)

### DIFF
--- a/internal/applets/archival/ar/ar_more_test.go
+++ b/internal/applets/archival/ar/ar_more_test.go
@@ -1,0 +1,119 @@
+package ar_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLongMemberNameTruncated drives writeMember's trunc() path: a member name
+// longer than the 16-byte ar name field forces the header to be rebuilt with a
+// truncated name. The archive must still list and round-trip.
+func TestLongMemberNameTruncated(t *testing.T) {
+	// Uses t.Chdir, so it cannot be parallel.
+	dir := t.TempDir()
+	longName := "this_is_a_very_long_member_name.txt" // > 16 bytes
+	src := filepath.Join(dir, longName)
+	write(t, src, "payload")
+	archive := filepath.Join(dir, "long.a")
+
+	if _, errOut, err := run(t, "r", archive, src); err != nil {
+		t.Fatalf("create err = %v (stderr=%q)", err, errOut)
+	}
+
+	out, _, err := run(t, "t", archive)
+	if err != nil {
+		t.Fatalf("list err = %v", err)
+	}
+	// The stored name is the (truncated, slash-trimmed) ar name field; it must be
+	// a 15-byte prefix of the original (16 minus the trailing '/').
+	listed := strings.TrimSpace(out)
+	if listed == "" || !strings.HasPrefix(longName, listed) {
+		t.Errorf("listed name %q is not a prefix of %q", listed, longName)
+	}
+	if len(listed) > 16 {
+		t.Errorf("listed name %q longer than 16 bytes", listed)
+	}
+}
+
+// TestCreateMissingSourceFile covers create()'s os.Stat error branch when a
+// named member does not exist.
+func TestCreateMissingSourceFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "x.a")
+	missing := filepath.Join(dir, "nope.o")
+
+	_, errOut, err := run(t, "r", archive, missing)
+	if err == nil {
+		t.Fatal("expected error for missing member")
+	}
+	if !strings.Contains(errOut, "ar:") {
+		t.Errorf("stderr = %q, want ar diagnostic", errOut)
+	}
+}
+
+// TestCreateUnwritableArchive covers create()'s os.Create error branch: writing
+// the archive into a path whose parent is not a directory fails.
+func TestCreateUnwritableArchive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	member := filepath.Join(dir, "m.o")
+	write(t, member, "data")
+	// A regular file used as a directory component makes os.Create fail.
+	notDir := filepath.Join(dir, "afile")
+	write(t, notDir, "x")
+	archive := filepath.Join(notDir, "out.a")
+
+	_, errOut, err := run(t, "r", archive, member)
+	if err == nil {
+		t.Fatal("expected error creating archive under a non-directory")
+	}
+	if !strings.Contains(errOut, "ar:") {
+		t.Errorf("stderr = %q, want ar diagnostic", errOut)
+	}
+}
+
+// TestExtractCorruptArchive covers extract()/readArchive error handling on an
+// archive whose member header is truncated/corrupt.
+func TestExtractCorruptArchive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "corrupt.a")
+	// Valid magic, then a too-short member header.
+	write(t, bad, "!<arch>\nshort-header")
+
+	_, errOut, err := run(t, "x", bad)
+	if err == nil {
+		t.Fatal("expected error for corrupt archive")
+	}
+	if !strings.Contains(errOut, "ar:") {
+		t.Errorf("stderr = %q, want ar diagnostic", errOut)
+	}
+}
+
+// TestExtractVerbose covers extract()'s verbose ("x - name") branch.
+func TestExtractVerbose(t *testing.T) {
+	// Uses t.Chdir, so it cannot be parallel.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "ev.txt")
+	write(t, src, "hello")
+	archive := filepath.Join(dir, "ev.a")
+	if _, _, err := run(t, "r", archive, src); err != nil {
+		t.Fatalf("create err = %v", err)
+	}
+
+	extractDir := filepath.Join(dir, "out")
+	if err := os.Mkdir(extractDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(extractDir)
+	out, _, err := run(t, "xv", archive)
+	if err != nil {
+		t.Fatalf("extract err = %v", err)
+	}
+	if !strings.Contains(out, "x - ev.txt") {
+		t.Errorf("verbose extract out = %q, want 'x - ev.txt'", out)
+	}
+}

--- a/internal/applets/archival/bunzip2/bunzip2_more_test.go
+++ b/internal/applets/archival/bunzip2/bunzip2_more_test.go
@@ -1,0 +1,111 @@
+package bunzip2_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTbz2SuffixMapping covers outputName's .tbz2 -> .tar mapping and a full
+// decompress-to-file run through that suffix.
+func TestTbz2SuffixMapping(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "archive.tbz2")
+	writeBz2(t, src)
+
+	if _, errOut, err := run(t, nil, src); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "archive.tar"))
+	if err != nil {
+		t.Fatalf("expected archive.tar: %v", err)
+	}
+	if string(got) != bz2Text {
+		t.Errorf("decompressed = %q", got)
+	}
+}
+
+// TestTbzSuffixMapping covers outputName's .tbz -> .tar mapping.
+func TestTbzSuffixMapping(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "data.tbz")
+	writeBz2(t, src)
+
+	if _, errOut, err := run(t, nil, src); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "data.tar")); err != nil {
+		t.Errorf("expected data.tar: %v", err)
+	}
+}
+
+// TestStdoutMissingFile covers processFile's os.Open error branch on the -c
+// path when the named file does not exist.
+func TestStdoutMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.bz2")
+
+	_, errOut, err := run(t, nil, "-c", missing)
+	if err == nil {
+		t.Fatal("expected error for missing file with -c")
+	}
+	if !strings.Contains(errOut, "bunzip2:") {
+		t.Errorf("stderr = %q, want bunzip2 diagnostic", errOut)
+	}
+}
+
+// TestReplaceMissingFile covers processFile's os.Open error branch on the
+// replace path (no -c) when the file does not exist.
+func TestReplaceMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "gone.bz2")
+
+	_, errOut, err := run(t, nil, missing)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(errOut, "bunzip2:") {
+		t.Errorf("stderr = %q, want bunzip2 diagnostic", errOut)
+	}
+}
+
+// TestCorruptData covers decompressStream's io.Copy error branch on bytes that
+// are not valid bzip2.
+func TestCorruptData(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, []byte("this is not bzip2 data at all"))
+	if err == nil {
+		t.Fatal("expected error decompressing non-bzip2 input")
+	}
+	if !strings.Contains(errOut, "bunzip2:") {
+		t.Errorf("stderr = %q, want bunzip2 diagnostic", errOut)
+	}
+}
+
+// TestMultipleFilesPartialFailure covers Run's per-file loop where one file
+// succeeds and another (unknown suffix) fails, so failed is set but the good
+// file is still decompressed.
+func TestMultipleFilesPartialFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	good := filepath.Join(dir, "ok.bz2")
+	bad := filepath.Join(dir, "noext")
+	writeBz2(t, good)
+	writeBz2(t, bad)
+
+	_, errOut, err := run(t, nil, good, bad)
+	if err == nil {
+		t.Fatal("expected error from the bad-suffix file")
+	}
+	if !strings.Contains(errOut, "unknown suffix") {
+		t.Errorf("stderr = %q, want unknown-suffix diagnostic", errOut)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "ok")); statErr != nil {
+		t.Errorf("good file should still be decompressed: %v", statErr)
+	}
+}

--- a/internal/applets/archival/compress/compress_test.go
+++ b/internal/applets/archival/compress/compress_test.go
@@ -169,6 +169,93 @@ func TestErrors(t *testing.T) {
 	})
 }
 
+// TestExistingOutputWithoutForce verifies compress refuses to clobber an
+// existing FILE.Z unless -f is given, and leaves the input in place.
+func TestExistingOutputWithoutForce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "e.txt")
+	if err := os.WriteFile(f, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create the .Z target so the existence check trips.
+	if err := os.WriteFile(f+".Z", []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := run(t, nil, f)
+	if err == nil {
+		t.Fatal("expected error when the .Z output already exists")
+	}
+	if !strings.Contains(errOut, "already exists; use -f to overwrite") {
+		t.Errorf("stderr = %q, want an already-exists message", errOut)
+	}
+	// The pre-existing .Z must be untouched and the input must remain.
+	if data, _ := os.ReadFile(f + ".Z"); string(data) != "old" {
+		t.Errorf(".Z output should be left untouched, got %q", string(data))
+	}
+	if _, statErr := os.Stat(f); statErr != nil {
+		t.Errorf("input should not be removed on failure: %v", statErr)
+	}
+}
+
+// TestForceOverwrite verifies -f replaces an existing .Z with valid compressed
+// data that round-trips back to the original content.
+func TestForceOverwrite(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "f.txt")
+	content := strings.Repeat("force ", 64)
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f+".Z", []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, errOut, err := run(t, nil, "-f", f); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	zdata, err := os.ReadFile(f + ".Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dec bytes.Buffer
+	if derr := lzw.Decompress(bytes.NewReader(zdata), &dec); derr != nil {
+		t.Fatalf("decompress err = %v", derr)
+	}
+	if dec.String() != content {
+		t.Error("force-overwritten .Z did not round-trip to the original content")
+	}
+}
+
+// TestCreateOutputError verifies a failure to create FILE.Z is reported. The
+// target FILE.Z path is shadowed by an existing directory, so os.Create fails.
+func TestCreateOutputError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "c.txt")
+	if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A directory at FILE.Z makes os.Create(FILE.Z) fail.
+	if err := os.Mkdir(f+".Z", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := run(t, nil, "-f", f)
+	if err == nil {
+		t.Fatal("expected error when the .Z output cannot be created")
+	}
+	if !strings.Contains(errOut, "compress:") {
+		t.Errorf("stderr = %q, want a compress error", errOut)
+	}
+	// The input must survive a creation failure.
+	if _, statErr := os.Stat(f); statErr != nil {
+		t.Errorf("input should not be removed on failure: %v", statErr)
+	}
+}
+
 func TestHelp(t *testing.T) {
 	t.Parallel()
 	out, _, err := run(t, nil, "--help")

--- a/internal/applets/archival/cpio/cpio_test.go
+++ b/internal/applets/archival/cpio/cpio_test.go
@@ -142,6 +142,94 @@ func TestBadArchive(t *testing.T) {
 	}
 }
 
+// TestCopyOutMissingFile covers copyOut's os.Stat error branch.
+func TestCopyOutMissingFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, []byte("no_such_file_here.txt\n"), "-o")
+	if err == nil {
+		t.Fatal("expected error when a named file is missing")
+	}
+	if !strings.Contains(errOut, "cpio:") {
+		t.Errorf("stderr = %q, want cpio: prefix", errOut)
+	}
+}
+
+// TestCopyOutSkipsBlankNames covers the blank-name continue branch of copyOut.
+func TestCopyOutSkipsBlankNames(t *testing.T) {
+	// Uses t.Chdir; cannot be parallel.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("only.txt", []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Blank lines and whitespace-only lines must be ignored.
+	out, _, err := run(t, []byte("\n  \nonly.txt\n\n"), "-o")
+	if err != nil {
+		t.Fatalf("copy-out err = %v", err)
+	}
+	listOut, _, err := run(t, []byte(out), "-i", "-t")
+	if err != nil {
+		t.Fatalf("list err = %v", err)
+	}
+	if got := strings.Count(strings.TrimSpace(listOut), "\n"); got != 0 {
+		t.Errorf("expected exactly one listed entry, got %q", listOut)
+	}
+	if !strings.Contains(listOut, "only.txt") {
+		t.Errorf("list = %q, want only.txt", listOut)
+	}
+}
+
+// TestDirectoryRoundTrip covers copyOut for a directory (no data) and
+// extractEntry's IsDir branch.
+func TestDirectoryRoundTrip(t *testing.T) {
+	// Uses t.Chdir; cannot be parallel.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.Mkdir("adir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	archive := archiveOf(t, "adir")
+
+	extractDir := filepath.Join(dir, "out")
+	if err := os.Mkdir(extractDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(extractDir)
+	if _, errOut, err := run(t, archive, "-i"); err != nil {
+		t.Fatalf("extract err = %v (stderr=%q)", err, errOut)
+	}
+	info, err := os.Stat(filepath.Join(extractDir, "adir"))
+	if err != nil {
+		t.Fatalf("stat extracted dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("extracted adir is not a directory")
+	}
+}
+
+// TestTruncatedArchive covers copyIn's short-read error path: a header that
+// promises a name longer than the remaining bytes.
+func TestTruncatedArchive(t *testing.T) {
+	// Uses t.Chdir; cannot be parallel.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("f.txt", []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive := archiveOf(t, "f.txt")
+	// Cut off the archive mid-entry (keep the header but drop the body).
+	truncated := archive[:115]
+
+	_, errOut, err := run(t, truncated, "-i", "-t")
+	if err == nil {
+		t.Fatal("expected error for a truncated archive")
+	}
+	if !strings.Contains(errOut, "cpio:") {
+		t.Errorf("stderr = %q, want cpio: prefix", errOut)
+	}
+}
+
 func TestHelp(t *testing.T) {
 	t.Parallel()
 	out, _, err := run(t, nil, "--help")

--- a/internal/applets/debianutils/add-shell/add-shell_more_test.go
+++ b/internal/applets/debianutils/add-shell/add-shell_more_test.go
@@ -1,0 +1,120 @@
+package addShell_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	addShell "github.com/nao1215/mimixbox/internal/applets/debianutils/add-shell"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := addShell.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// TestNameSynopsis covers the Name and Synopsis metadata accessors.
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := addShell.New()
+	if c.Name() != "add-shell" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+	if c.Synopsis() != "Add shell name to /etc/shells" {
+		t.Errorf("Synopsis() = %q", c.Synopsis())
+	}
+}
+
+// TestRunNoArgs covers the "no shell name given" branch of Run.
+func TestRunNoArgs(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t)
+	if err == nil {
+		t.Fatal("expected error when no shell name is given")
+	}
+	if !strings.Contains(errOut, "add-shell:") {
+		t.Errorf("stderr = %q, want add-shell usage", errOut)
+	}
+}
+
+// TestRunWriteFailure drives Run's addShells error branch. Run always targets
+// /etc/shells, which an unprivileged test cannot write; the operation must fail
+// and Run must report it and exit non-zero. If the test happens to run as root
+// (where the append could succeed) it is skipped so it stays deterministic.
+func TestRunWriteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; /etc/shells may be writable")
+	}
+	// A shell that is almost certainly not already listed, so addShells reaches
+	// the append (and the open fails on a read-only /etc/shells).
+	_, errOut, err := run(t, "/nonexistent/mimixbox-test-shell")
+	if err == nil {
+		t.Skip("environment allowed writing /etc/shells; nothing to assert")
+	}
+	if !strings.Contains(errOut, "add-shell:") {
+		t.Errorf("stderr = %q, want add-shell error prefix", errOut)
+	}
+}
+
+// TestAddShellsCreatesMissingFile covers readShells' os.IsNotExist branch (a
+// not-yet-created shells file is treated as empty) and the file-creation path
+// of addShells.
+func TestAddShellsCreatesMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells") // does not exist yet
+
+	if err := addShell.AddShellsForTest(path, []string{"/bin/sh", "/bin/zsh"}); err != nil {
+		t.Fatalf("addShells error = %v", err)
+	}
+	got := readLines(t, path)
+	if strings.Join(got, ",") != "/bin/sh,/bin/zsh" {
+		t.Errorf("lines = %v, want [/bin/sh /bin/zsh]", got)
+	}
+}
+
+// TestAddShellsSkipsBlankAndDuplicate covers readShells' blank-line skipping and
+// the in-batch duplicate suppression in addShells.
+func TestAddShellsSkipsBlankAndDuplicate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	if err := os.WriteFile(path, []byte("/bin/sh\n\n  \n/bin/bash\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// /bin/bash already present; /bin/dash given twice should be added once.
+	if err := addShell.AddShellsForTest(path, []string{"/bin/bash", "/bin/dash", "/bin/dash"}); err != nil {
+		t.Fatalf("addShells error = %v", err)
+	}
+	// The pre-existing blank lines are left untouched; /bin/dash is appended
+	// exactly once and /bin/bash (already listed) is not re-added.
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(content), "/bin/dash"); n != 1 {
+		t.Errorf("/bin/dash appears %d times, want 1: %q", n, content)
+	}
+	if n := strings.Count(string(content), "/bin/bash"); n != 1 {
+		t.Errorf("/bin/bash appears %d times, want 1 (no duplicate): %q", n, content)
+	}
+}
+
+// TestAddShellsReadError covers addShells returning readShells' error when the
+// shells path is a directory rather than a regular file.
+func TestAddShellsReadError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir() // a directory used where a file is expected
+	if err := addShell.AddShellsForTest(dir, []string{"/bin/sh"}); err == nil {
+		t.Error("expected error when shells path is a directory")
+	}
+}

--- a/internal/applets/editors/awk/awk_more_test.go
+++ b/internal/applets/editors/awk/awk_more_test.go
@@ -1,0 +1,222 @@
+package awk_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLexicalComparisons drives compare()'s string (non-numeric) branch for
+// each relational operator.
+func TestLexicalComparisons(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		stdin   string
+		program string
+		want    string
+	}{
+		{"string less than", "apple\nzebra\n", `$1 < "m"`, "apple\n"},
+		{"string greater than", "apple\nzebra\n", `$1 > "m"`, "zebra\n"},
+		{"string le", "abc\nabd\n", `$1 <= "abc"`, "abc\n"},
+		{"string ge", "abc\nabd\n", `$1 >= "abd"`, "abd\n"},
+		{"string ne", "cat\ndog\n", `$1 != "cat"`, "dog\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, tt.program)
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestNumericLeGe covers compare()'s numeric <=/>= arms.
+func TestNumericLeGe(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "1\n2\n3\n", "$1 <= 2")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "1\n2\n" {
+		t.Errorf("out = %q, want 1,2", out)
+	}
+	out, _, err = run(t, "1\n2\n3\n", "$1 >= 2")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "2\n3\n" {
+		t.Errorf("out = %q, want 2,3", out)
+	}
+}
+
+// TestBareValuePattern covers evalCondition's bare-value truthiness: a non-zero
+// field is true, a zero field is false.
+func TestBareValuePattern(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "0\n5\n0\n", "$1")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "5\n" {
+		t.Errorf("out = %q, want only the non-zero line", out)
+	}
+}
+
+// TestRegexFieldSeparator covers setLine's multi-character (regular expression)
+// field-separator branch.
+func TestRegexFieldSeparator(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a12b345c\n", "-F", "[0-9]+", "{print $2}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "b\n" {
+		t.Errorf("out = %q, want b", out)
+	}
+}
+
+// TestMultiCharLiteralSeparator covers setLine's multi-char separator that is
+// not a valid regexp, exercising the strings.Split fallback. "[" alone is an
+// invalid regexp, so the literal split path is taken.
+func TestMultiCharLiteralSeparator(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a[b\n", "-F", "[", "{print $2}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "b\n" {
+		t.Errorf("out = %q, want b", out)
+	}
+}
+
+// TestVarReferenceMiss covers evalPrimary's bare-token branch when a referenced
+// name is not a -v variable: it is returned verbatim.
+func TestVarReferenceMiss(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "x\n", "{print undefined_name}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "undefined_name\n" {
+		t.Errorf("out = %q, want the bare token", out)
+	}
+}
+
+// TestDollarNR covers evalPrimary's "$NR" branch ($ followed by NR).
+func TestDollarNR(t *testing.T) {
+	t.Parallel()
+	// On record 1, $NR == $1; on record 2, $NR == $2.
+	out, _, err := run(t, "a b c\nd e f\n", "{print $NR}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "a\ne\n" {
+		t.Errorf("out = %q, want a,e", out)
+	}
+}
+
+// TestDollarNonNumeric covers evalPrimary's "$<non-number>" branch, which
+// resolves to the empty field.
+func TestDollarNonNumeric(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a b\n", "{print $foo}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "\n" {
+		t.Errorf("out = %q, want empty line", out)
+	}
+}
+
+// TestFieldOutOfRange covers field()'s out-of-range branch returning "".
+func TestFieldOutOfRange(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a b\n", "{print $9}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "\n" {
+		t.Errorf("out = %q, want empty line", out)
+	}
+}
+
+// TestBeginOnly covers hasMainOrEnd's false branch: a program with only a BEGIN
+// block does not read input.
+func TestBeginOnly(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "ignored input\n", `BEGIN{print "hi"}`)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "hi\n" {
+		t.Errorf("out = %q, want hi", out)
+	}
+}
+
+// TestUnbalancedBraces covers parseProgram's unbalanced-braces error.
+func TestUnbalancedBraces(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "{print")
+	if err == nil {
+		t.Fatal("expected error for unbalanced braces")
+	}
+	if !strings.Contains(errOut, "awk:") {
+		t.Errorf("stderr = %q, want awk diagnostic", errOut)
+	}
+}
+
+// TestEmptyProgram covers parseProgram's empty-program error.
+func TestEmptyProgram(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "   ")
+	if err == nil {
+		t.Fatal("expected error for empty program")
+	}
+	if !strings.Contains(errOut, "awk:") {
+		t.Errorf("stderr = %q, want awk diagnostic", errOut)
+	}
+}
+
+// TestPrintfMultipleAndEscapes covers doPrintf with multiple values and the
+// unescape() handling of \t and \n.
+func TestPrintfMultipleAndEscapes(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "a b\n", `{printf "%s\t%s\n", $1, $2}`)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "a\tb\n" {
+		t.Errorf("out = %q, want a<tab>b", out)
+	}
+}
+
+// TestPrintNRandNF covers evalPrimary's NR/NF arms used inside print.
+func TestPrintNRandNF(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "x y z\n", "{print NR, NF}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "1 3\n" {
+		t.Errorf("out = %q, want '1 3'", out)
+	}
+}
+
+// TestInvalidRegexPattern covers match()'s regexp-compile-error branch, where a
+// malformed /regex/ matches nothing rather than failing the run.
+func TestInvalidRegexPattern(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "abc\n", "/[/{print}")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want no matches for invalid regex", out)
+	}
+}

--- a/internal/applets/editors/diff/diff_test.go
+++ b/internal/applets/editors/diff/diff_test.go
@@ -209,6 +209,117 @@ func TestMissingFile(t *testing.T) {
 	}
 }
 
+// TestMultiLineDeletionNormal covers rangeStr's start!=end branch (a
+// contiguous deletion of more than one line renders "2,3d1").
+func TestMultiLineDeletionNormal(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "one\ntwo\nthree\nfour\n", "one\nfour\n")
+	out, _, err := run(t, a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	want := "2,3d1\n< two\n< three\n"
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+// TestMultiLineInsertionNormal covers rangeStr in the insertion branch.
+func TestMultiLineInsertionNormal(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "one\nfour\n", "one\ntwo\nthree\nfour\n")
+	out, _, err := run(t, a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	want := "1a2,3\n> two\n> three\n"
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+// TestUnifiedMultiLineRange covers countRange's length!=1 branch: a multi-line
+// change renders "start,len" in the @@ header.
+func TestUnifiedMultiLineRange(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "a\nb\nc\n", "a\nX\nY\nZ\nc\n")
+	out, _, err := run(t, "-u", a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	// One a-line (b) deleted and three inserted; both sides span >1 line.
+	if !strings.Contains(out, "@@ -1,3 +1,5 @@") {
+		t.Errorf("unified header wrong: %q", out)
+	}
+}
+
+// TestUnifiedSeparateHunks covers the group-splitting branch of groupUnified:
+// two changes far apart produce two distinct @@ hunks rather than one.
+func TestUnifiedSeparateHunks(t *testing.T) {
+	t.Parallel()
+	aLines := make([]string, 0, 20)
+	bLines := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		aLines = append(aLines, "line")
+		bLines = append(bLines, "line")
+	}
+	// Change the first and last lines; the gap of 18 unchanged lines exceeds
+	// 2*context so the windows do not merge.
+	aLines[0], bLines[0] = "A", "A-changed"
+	aLines[19], bLines[19] = "Z", "Z-changed"
+	a, b := files(t, strings.Join(aLines, "\n")+"\n", strings.Join(bLines, "\n")+"\n")
+
+	out, _, err := run(t, "-u", a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	if got := strings.Count(out, "@@ -"); got != 2 {
+		t.Errorf("hunk count = %d, want 2 (out=%q)", got, out)
+	}
+}
+
+// TestUnifiedPureInsertEmptyA covers unifiedRange's aStart<0 reset: when the
+// original file is empty every op is an insert, so the a-side range starts at 0.
+func TestUnifiedPureInsertEmptyA(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "", "new1\nnew2\n")
+	out, _, err := run(t, "-u", a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	if !strings.Contains(out, "@@ -0,0 +1,2 @@") {
+		t.Errorf("pure-insert header wrong: %q", out)
+	}
+}
+
+// TestUnifiedSingleLineRange covers countRange's length==1 branch: a single
+// inserted line into an empty file renders the b-side range as bare "1".
+func TestUnifiedSingleLineRange(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "", "only\n")
+	out, _, err := run(t, "-u", a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	if !strings.Contains(out, "@@ -0,0 +1 @@") {
+		t.Errorf("single-line header wrong: %q", out)
+	}
+}
+
+// TestUnifiedPureDeleteEmptyB covers unifiedRange's bStart<0 reset: when the new
+// file is empty every op is a delete, so the b-side range starts at 0.
+func TestUnifiedPureDeleteEmptyB(t *testing.T) {
+	t.Parallel()
+	a, b := files(t, "old1\nold2\n", "")
+	out, _, err := run(t, "-u", a, b)
+	if exitCode(t, err) != 1 {
+		t.Fatalf("exit = %d, want 1", exitCode(t, err))
+	}
+	if !strings.Contains(out, "@@ -1,2 +0,0 @@") {
+		t.Errorf("pure-delete header wrong: %q", out)
+	}
+}
+
 func TestHelp(t *testing.T) {
 	t.Parallel()
 	out, _, err := run(t, "--help")

--- a/internal/applets/fileutils/chgrp/chgrp_more_test.go
+++ b/internal/applets/fileutils/chgrp/chgrp_more_test.go
@@ -1,0 +1,119 @@
+package chgrp_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/chgrp"
+)
+
+// TestSynopsis covers the Synopsis metadata accessor.
+func TestSynopsis(t *testing.T) {
+	c := chgrp.New()
+	if c.Synopsis() != "Change the group of each FILE to GROUP" {
+		t.Errorf("Synopsis() = %q", c.Synopsis())
+	}
+}
+
+// TestChgrpReportMissingFile drives the report() and changeGroup() error paths
+// by chgrp'ing a file that does not exist: os.Chown fails, report writes a
+// GNU-style diagnostic, and Run exits non-zero.
+func TestChgrpReportMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.txt")
+
+	_, errOut, err := run(t, "0", missing)
+	if err == nil {
+		t.Fatal("expected error (exit 1) for missing file")
+	}
+	if !strings.Contains(errOut, "changing group of '"+missing+"'") {
+		t.Errorf("stderr = %q, want changing-group diagnostic", errOut)
+	}
+}
+
+// TestChgrpRecursiveOwnGroup drives changeGroupRecursive over a small tree,
+// assigning every entry to one of the caller's own groups (no root needed).
+func TestChgrpRecursiveOwnGroup(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f1 := filepath.Join(dir, "a.txt")
+	f2 := filepath.Join(sub, "b.txt")
+	for _, f := range []string{f1, f2} {
+		if err := os.WriteFile(f, []byte("x\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	group := ownGroupName(t)
+	wantGid := gidOf(t, group)
+
+	out, errOut, err := run(t, "-Rv", group, dir)
+	if err != nil {
+		if strings.Contains(errOut, "not permitted") {
+			t.Skipf("chown is not permitted in this environment: %s", errOut)
+		}
+		t.Fatalf("Run -Rv error = %v, stderr = %q", err, errOut)
+	}
+	// -v reports each processed path, including the nested one.
+	if !strings.Contains(out, "changed group of '"+f2+"'") {
+		t.Errorf("verbose stdout = %q, want nested file reported", out)
+	}
+
+	for _, p := range []string{dir, sub, f1, f2} {
+		var st syscall.Stat_t
+		if err := syscall.Stat(p, &st); err != nil {
+			t.Fatal(err)
+		}
+		if int(st.Gid) != wantGid {
+			t.Errorf("%s gid = %d, want %d", p, st.Gid, wantGid)
+		}
+	}
+}
+
+// TestChgrpRecursiveMissingPath drives the filepath.Walk error branch (and the
+// report path inside it) by recursing into a path that does not exist.
+func TestChgrpRecursiveMissingPath(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "ghost")
+
+	_, errOut, err := run(t, "-R", "0", missing)
+	if err == nil {
+		t.Fatal("expected error for missing recursive path")
+	}
+	if !strings.Contains(errOut, "chgrp:") {
+		t.Errorf("stderr = %q, want chgrp diagnostic", errOut)
+	}
+}
+
+// TestChgrpNumericGidWithoutEntry covers lookupGid's numeric fallback: a gid
+// with no /etc/group entry still resolves. Use a high, almost-certainly-unused
+// gid so LookupGroup fails but the numeric branch succeeds.
+func TestChgrpNumericGidWithoutEntry(t *testing.T) {
+	if _, ok := chgrp.LookupGidForTest("4000000000"); !ok {
+		t.Error("LookupGid did not fall back to a numeric gid")
+	}
+	if _, ok := chgrp.LookupGidForTest("definitely_not_a_group"); ok {
+		t.Error("LookupGid resolved a non-existent group name")
+	}
+}
+
+func gidOf(t *testing.T, group string) int {
+	t.Helper()
+	gid, ok := chgrp.LookupGidForTest(group)
+	if !ok {
+		// Fall back to numeric parse if the helper somehow cannot resolve it.
+		n, err := strconv.Atoi(group)
+		if err != nil {
+			t.Fatalf("cannot resolve gid for %q", group)
+		}
+		return n
+	}
+	return gid
+}

--- a/internal/applets/fileutils/chgrp/export_test.go
+++ b/internal/applets/fileutils/chgrp/export_test.go
@@ -1,0 +1,7 @@
+package chgrp
+
+// LookupGidForTest exposes the unexported lookupGid helper to the external test
+// package so it can verify group-name and numeric-gid resolution directly.
+func LookupGidForTest(group string) (int, bool) {
+	return lookupGid(group)
+}

--- a/internal/applets/fileutils/chown/chown_test.go
+++ b/internal/applets/fileutils/chown/chown_test.go
@@ -140,6 +140,147 @@ func TestRunMissingOperand(t *testing.T) {
 	}
 }
 
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "chown" {
+		t.Errorf("Name() = %q, want chown", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestKeep verifies that the first error is preserved across multiple failing
+// operands and that a nil prior error is converted into a SilentFailure.
+func TestKeep(t *testing.T) {
+	t.Parallel()
+	first := keep(nil)
+	if first == nil {
+		t.Fatal("keep(nil) = nil, want a non-nil failure error")
+	}
+	if got := keep(first); got != first {
+		t.Errorf("keep(existing) = %v, want the existing error preserved", got)
+	}
+}
+
+// TestLookupGIDNumericAndUnknown exercises the numeric fallback and the
+// unknown-group error path that name resolution alone does not reach.
+func TestLookupGIDNumericAndUnknown(t *testing.T) {
+	t.Parallel()
+	gid, err := lookupGID("12345")
+	if err != nil {
+		t.Fatalf("lookupGID(numeric) err = %v", err)
+	}
+	if gid != 12345 {
+		t.Errorf("lookupGID(\"12345\") = %d, want 12345", gid)
+	}
+	if _, err := lookupGID("definitely-no-such-group-xyz"); err == nil {
+		t.Error("lookupGID on an unknown non-numeric group must error")
+	}
+}
+
+// TestLookupUIDNumericAndUnknown mirrors the GID test for the uid path.
+func TestLookupUIDNumericAndUnknown(t *testing.T) {
+	t.Parallel()
+	uid, err := lookupUID("54321")
+	if err != nil {
+		t.Fatalf("lookupUID(numeric) err = %v", err)
+	}
+	if uid != 54321 {
+		t.Errorf("lookupUID(\"54321\") = %d, want 54321", uid)
+	}
+	if _, err := lookupUID("definitely-no-such-user-xyz"); err == nil {
+		t.Error("lookupUID on an unknown non-numeric user must error")
+	}
+}
+
+// TestParseOwnerInvalidGroup exercises the "invalid group" branch, which the
+// existing table only reaches for users.
+func TestParseOwnerInvalidGroup(t *testing.T) {
+	t.Parallel()
+	if _, _, err := parseOwner("0:definitely-no-such-group-xyz"); err == nil {
+		t.Error("parseOwner with an unknown group must error")
+	}
+}
+
+// TestRunVerboseToSelf drives the verbose diagnostic path of chownOne by
+// chowning a file to the current user's own ids (a no-op needing no root).
+func TestRunVerboseToSelf(t *testing.T) {
+	t.Parallel()
+	uid, gid, _ := currentIDs(t)
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "v.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, errOut, err := run(t, "-v", strconv.Itoa(uid)+":"+strconv.Itoa(gid), file)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(out, "ownership of '"+file+"' retained") {
+		t.Errorf("verbose stdout = %q, want a retained-ownership diagnostic", out)
+	}
+}
+
+// TestRunRecursiveToSelf drives the recursive filepath.Walk path of apply over
+// a directory tree, again a no-op chown to the caller's own ids.
+func TestRunRecursiveToSelf(t *testing.T) {
+	t.Parallel()
+	uid, gid, _ := currentIDs(t)
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{filepath.Join(dir, "a.txt"), filepath.Join(sub, "b.txt")} {
+		if err := os.WriteFile(p, []byte("x\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, errOut, err := run(t, "-R", strconv.Itoa(uid)+":"+strconv.Itoa(gid), dir)
+	if err != nil {
+		t.Fatalf("recursive Run error = %v (stderr=%q)", err, errOut)
+	}
+	if errOut != "" {
+		t.Errorf("stderr = %q, want empty", errOut)
+	}
+}
+
+// TestRunRecursiveMissingPath drives the Walk error branch: the walk function's
+// err argument is non-nil for a path that does not exist.
+func TestRunRecursiveMissingPath(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "no-such-dir")
+	out, errOut, err := run(t, "-R", "0", missing)
+	if err == nil {
+		t.Fatal("recursive chown of a missing path must fail")
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	if !strings.Contains(errOut, "chown: ") {
+		t.Errorf("stderr = %q, want a chown error", errOut)
+	}
+}
+
+// TestRunMissingOperandAfterSpec covers the "missing operand after SPEC" branch
+// reached when an owner spec is given with no files.
+func TestRunMissingOperandAfterSpec(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "0")
+	if err == nil {
+		t.Fatal("expected error when no file operand follows the spec")
+	}
+	if !strings.Contains(errOut, "missing operand after '0'") {
+		t.Errorf("stderr = %q, want missing-operand-after message", errOut)
+	}
+}
+
 // TestHelpSections verifies that --help renders both the Examples and the
 // Exit status sections supplied through WithHelp.
 func TestHelpSections(t *testing.T) {

--- a/internal/applets/fileutils/cp/cp_test.go
+++ b/internal/applets/fileutils/cp/cp_test.go
@@ -21,6 +21,28 @@ func run(t *testing.T, args ...string) (string, string, error) {
 	return out.String(), errBuf.String(), err
 }
 
+// runStdin is like run but lets the caller supply stdin, which the interactive
+// (-i) overwrite prompt reads its answer from.
+func runStdin(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	err := cp.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+func TestSynopsisAndName(t *testing.T) {
+	t.Parallel()
+	c := cp.New()
+	if c.Name() != "cp" {
+		t.Errorf("Name() = %q, want cp", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
 func TestRunCopyFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -348,6 +370,246 @@ func TestRunArchiveImpliesRecursiveAndPreserve(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o755 {
 		t.Errorf("cp -a should preserve mode, got %o", info.Mode().Perm())
+	}
+}
+
+// TestRunVerboseFile covers the -v reporting branch of cpFile.
+func TestRunVerboseFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("v\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "-v", src, dst)
+	if err != nil {
+		t.Fatalf("cp -v error = %v", err)
+	}
+	want := "'" + src + "' -> '" + dst + "'"
+	if !strings.Contains(out, want) {
+		t.Errorf("stdout = %q, want to contain %q", out, want)
+	}
+}
+
+// TestRunVerboseDir covers the -v reporting branch inside cpDir.
+func TestRunVerboseDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "copy")
+	out, _, err := run(t, "-r", "-v", src, dst)
+	if err != nil {
+		t.Fatalf("cp -r -v error = %v", err)
+	}
+	if !strings.Contains(out, "f.txt'") {
+		t.Errorf("verbose stdout = %q, want to mention f.txt", out)
+	}
+}
+
+// TestRunInteractiveYesOverwrites covers question() returning true: an "y"
+// answer overwrites the existing destination.
+func TestRunInteractiveYesOverwrites(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runStdin(t, "y\n", "-i", src, dst)
+	if err != nil {
+		t.Fatalf("cp -i error = %v", err)
+	}
+	if !strings.Contains(out, "overwrite") {
+		t.Errorf("stdout = %q, want overwrite prompt", out)
+	}
+	got, _ := os.ReadFile(dst) //nolint:gosec // test-written file
+	if string(got) != "new\n" {
+		t.Errorf("dst content = %q, want new (yes should overwrite)", got)
+	}
+}
+
+// TestRunInteractiveNoKeeps covers question() returning false: a "n" answer
+// leaves the existing destination unchanged.
+func TestRunInteractiveNoKeeps(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runStdin(t, "n\n", "-i", src, dst); err != nil {
+		t.Fatalf("cp -i error = %v", err)
+	}
+	got, _ := os.ReadFile(dst) //nolint:gosec // test-written file
+	if string(got) != "old\n" {
+		t.Errorf("dst content = %q, want old (no should not overwrite)", got)
+	}
+}
+
+// TestRunMissingSource covers the os.Stat error branch in cp().
+func TestRunMissingSource(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	_, errOut, err := run(t, missing, dst)
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+	if !strings.Contains(errOut, "cp:") {
+		t.Errorf("stderr = %q, want cp: prefix", errOut)
+	}
+}
+
+// TestRunNoDereferenceOntoExistingLink covers copySymlink's branch that removes
+// an existing destination symlink before recreating it.
+func TestRunNoDereferenceOntoExistingLink(t *testing.T) {
+	t.Parallel()
+	dir, _, link := symlinkFixture(t)
+	dst := filepath.Join(dir, "copy")
+	// Pre-create a different symlink at the destination so copySymlink must
+	// remove it before writing the new one.
+	if err := os.Symlink("somewhere-else", dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, stderr, err := run(t, "-P", link, dst); err != nil {
+		t.Fatalf("cp -P error = %v (%s)", err, stderr)
+	}
+	target, err := os.Readlink(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "real.txt" {
+		t.Errorf("symlink target = %q, want real.txt (existing link should be replaced)", target)
+	}
+}
+
+// TestRunNoClobberSkipsExistingLink covers copySymlink's -n early return.
+func TestRunNoClobberSkipsExistingLink(t *testing.T) {
+	t.Parallel()
+	dir, _, link := symlinkFixture(t)
+	dst := filepath.Join(dir, "copy")
+	if err := os.Symlink("original-target", dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, stderr, err := run(t, "-P", "-n", link, dst); err != nil {
+		t.Fatalf("cp -P -n error = %v (%s)", err, stderr)
+	}
+	if target, _ := os.Readlink(dst); target != "original-target" {
+		t.Errorf("symlink target = %q, want original-target (-n must not replace it)", target)
+	}
+}
+
+// TestRunSymlinkSameFile covers the early same-path guard in cp() for the
+// copy-as-link path: "cp -P dir/link dir" resolves the target to dir/link.
+func TestRunSymlinkSameFile(t *testing.T) {
+	t.Parallel()
+	dir, _, link := symlinkFixture(t)
+	_, errOut, err := run(t, "-P", link, dir)
+	if err == nil {
+		t.Fatal("expected error when the resolved symlink target equals the source")
+	}
+	if !strings.Contains(errOut, "is same") {
+		t.Errorf("stderr = %q, want 'is same'", errOut)
+	}
+}
+
+// TestRunFollowCmdlineLink covers the derefCmdline (-H) resolution: a
+// command-line symlink is followed and its target copied.
+func TestRunFollowCmdlineLink(t *testing.T) {
+	t.Parallel()
+	dir, _, link := symlinkFixture(t)
+	dst := filepath.Join(dir, "copy")
+	if _, stderr, err := run(t, "-H", link, dst); err != nil {
+		t.Fatalf("cp -H error = %v (%s)", err, stderr)
+	}
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("cp -H should follow the command-line link, got a symlink at %q", dst)
+	}
+}
+
+// TestRunDirSymlinkToDirSkipped covers cpDir's branch that follows a symlink to
+// a directory within a tree but does not recurse into it.
+func TestRunDirSymlinkToDirSkipped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	realSub := filepath.Join(src, "realdir")
+	if err := os.MkdirAll(realSub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realSub, "inside.txt"), []byte("z"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink pointing at the sibling directory; default deref follows it but
+	// must not recurse into the target's contents.
+	if err := os.Symlink("realdir", filepath.Join(src, "dlink")); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst")
+	if _, stderr, err := run(t, "-r", src, dst); err != nil {
+		t.Fatalf("cp -r error = %v (%s)", err, stderr)
+	}
+	// dst did not exist, so the tree lands directly at dst. The real directory
+	// and its file are copied; the followed dir-symlink is not recursed into,
+	// so no dlink/inside.txt is created.
+	if _, err := os.Stat(filepath.Join(dst, "realdir", "inside.txt")); err != nil {
+		t.Errorf("real directory content not copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "dlink", "inside.txt")); err == nil {
+		t.Errorf("dir-symlink was recursed into; it should be skipped")
+	}
+}
+
+// TestRunDirNoClobberSkipsExistingInTree covers cpDir's -n branch that skips a
+// file already present in the destination tree.
+func TestRunDirNoClobberSkipsExistingInTree(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "f.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Destination already holds src/f.txt with different content.
+	dstTree := filepath.Join(dir, "dst", "src")
+	if err := os.MkdirAll(dstTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dstTree, "f.txt"), []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(dir, "dst")
+	if _, stderr, err := run(t, "-r", "-n", src, dst); err != nil {
+		t.Fatalf("cp -r -n error = %v (%s)", err, stderr)
+	}
+	got, _ := os.ReadFile(filepath.Join(dstTree, "f.txt")) //nolint:gosec // test-written file
+	if string(got) != "old\n" {
+		t.Errorf("existing file in tree was overwritten: %q, want old", got)
 	}
 }
 

--- a/internal/applets/jokeutils/cowsay/wrap_internal_test.go
+++ b/internal/applets/jokeutils/cowsay/wrap_internal_test.go
@@ -1,0 +1,44 @@
+package cowsay
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// TestWrapColumnBoundary covers wrap's column<=0 short-circuit (returns src
+// unchanged) and exact-multiple and remainder splitting.
+func TestWrapColumnBoundary(t *testing.T) {
+	t.Parallel()
+	if got := wrap("abcdef", 0); got != "abcdef" {
+		t.Errorf("wrap(_,0) = %q, want the unmodified source", got)
+	}
+	if got := wrap("abcdef", -3); got != "abcdef" {
+		t.Errorf("wrap(_,-3) = %q, want the unmodified source", got)
+	}
+	// Exact multiple: two full lines, no trailing empty segment.
+	if got := wrap("abcdef", 3); got != "abc\ndef" {
+		t.Errorf("wrap(\"abcdef\",3) = %q, want abc\\ndef", got)
+	}
+	// Remainder: last line is shorter.
+	if got := wrap("abcde", 2); got != "ab\ncd\ne" {
+		t.Errorf("wrap(\"abcde\",2) = %q, want ab\\ncd\\ne", got)
+	}
+}
+
+// errReader fails on the first read, modeling broken stdin.
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
+// TestReadMessageScannerError verifies readMessage surfaces a non-EOF scan
+// error rather than returning a truncated message.
+func TestReadMessageScannerError(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: errReader{err: errors.New("read fail")}, Out: &strings.Builder{}, Err: &strings.Builder{}}
+	if _, err := readMessage(io); err == nil {
+		t.Error("readMessage must surface a scanner read error")
+	}
+}

--- a/internal/applets/jokeutils/cowthink/wrap_internal_test.go
+++ b/internal/applets/jokeutils/cowthink/wrap_internal_test.go
@@ -1,0 +1,42 @@
+package cowthink
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// TestWrapColumnBoundary covers wrap's column<=0 short-circuit and the
+// exact-multiple / remainder splitting cases.
+func TestWrapColumnBoundary(t *testing.T) {
+	t.Parallel()
+	if got := wrap("abcdef", 0); got != "abcdef" {
+		t.Errorf("wrap(_,0) = %q, want the unmodified source", got)
+	}
+	if got := wrap("abcdef", -1); got != "abcdef" {
+		t.Errorf("wrap(_,-1) = %q, want the unmodified source", got)
+	}
+	if got := wrap("abcdef", 3); got != "abc\ndef" {
+		t.Errorf("wrap(\"abcdef\",3) = %q, want abc\\ndef", got)
+	}
+	if got := wrap("abcde", 2); got != "ab\ncd\ne" {
+		t.Errorf("wrap(\"abcde\",2) = %q, want ab\\ncd\\ne", got)
+	}
+}
+
+// errReader fails on the first read, modeling broken stdin.
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
+// TestReadMessageScannerError verifies readMessage surfaces a non-EOF scan
+// error rather than returning a truncated message.
+func TestReadMessageScannerError(t *testing.T) {
+	t.Parallel()
+	io := command.IO{In: errReader{err: errors.New("read fail")}, Out: &strings.Builder{}, Err: &strings.Builder{}}
+	if _, err := readMessage(io); err == nil {
+		t.Error("readMessage must surface a scanner read error")
+	}
+}

--- a/internal/applets/loginutils/chsh/chsh_test.go
+++ b/internal/applets/loginutils/chsh/chsh_test.go
@@ -65,6 +65,93 @@ func shellOf(t *testing.T, path, user string) string {
 	return ""
 }
 
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "chsh" {
+		t.Errorf("Name() = %q, want chsh", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestTargetUserDefaultsToCurrent verifies that with no operand the current
+// user is resolved.
+func TestTargetUserDefaultsToCurrent(t *testing.T) {
+	t.Parallel()
+	got, err := targetUser(nil)
+	if err != nil {
+		t.Fatalf("targetUser(nil) err = %v", err)
+	}
+	if got == "" {
+		t.Error("targetUser(nil) returned an empty user name")
+	}
+}
+
+// TestTargetUserErrors covers the operand-validation branches.
+func TestTargetUserErrors(t *testing.T) {
+	t.Parallel()
+	if _, err := targetUser([]string{"alice", "bob"}); err == nil {
+		t.Error("more than one operand must error")
+	}
+	if _, err := targetUser([]string{""}); err == nil {
+		t.Error("an empty operand must error")
+	}
+	got, err := targetUser([]string{"alice"})
+	if err != nil || got != "alice" {
+		t.Errorf("targetUser([alice]) = (%q,%v), want (alice,nil)", got, err)
+	}
+}
+
+// TestReadShellsMissingFile verifies the open-error path of readShells.
+func TestReadShellsMissingFile(t *testing.T) {
+	orig := shellsPath
+	shellsPath = filepath.Join(t.TempDir(), "no-such-shells")
+	t.Cleanup(func() { shellsPath = orig })
+	if _, err := readShells(); err == nil {
+		t.Error("readShells on a missing file must error")
+	}
+}
+
+// TestChangeShellReadError verifies changeShell surfaces a read error when the
+// passwd database is absent.
+func TestChangeShellReadError(t *testing.T) {
+	orig := passwdPath
+	passwdPath = filepath.Join(t.TempDir(), "no-such-passwd")
+	t.Cleanup(func() { passwdPath = orig })
+	if err := changeShell("alice", "/bin/sh"); err == nil {
+		t.Error("changeShell with a missing passwd file must error")
+	}
+}
+
+// TestReadLinesEmptyFile verifies an empty passwd file yields no lines and no
+// error, exercising the trimmed-empty short-circuit.
+func TestReadLinesEmptyFile(t *testing.T) {
+	t.Parallel()
+	p := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(p, []byte("\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lines, err := readLines(p)
+	if err != nil {
+		t.Fatalf("readLines err = %v", err)
+	}
+	if lines != nil {
+		t.Errorf("readLines(empty) = %v, want nil", lines)
+	}
+}
+
+// TestWriteLinesCreateTempError verifies writeLines fails when the temp file
+// cannot be created because the target directory does not exist.
+func TestWriteLinesCreateTempError(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "no-such-dir", "passwd")
+	if err := writeLines(missing, []string{"x"}); err == nil {
+		t.Error("writeLines into a non-existent directory must error")
+	}
+}
+
 func TestChangeOtherUserWithFlag(t *testing.T) {
 	pw := setup(t)
 	if _, err := run(t, "", "-s", "/bin/bash", "alice"); err != nil {

--- a/internal/applets/shellutils/cal/cal_more_test.go
+++ b/internal/applets/shellutils/cal/cal_more_test.go
@@ -1,0 +1,33 @@
+package cal_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/cal"
+)
+
+// TestCenter covers both branches of center(): a short string is padded on the
+// left only (extra odd space goes right, so the result is not right-padded),
+// and a string at least as wide as the field is returned unchanged.
+func TestCenter(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{"even padding", "ab", 6, "  ab"},
+		{"odd padding floors left", "abc", 6, " abc"},
+		{"equal width unchanged", "abcdef", 6, "abcdef"},
+		{"wider than field unchanged", "toolongtitle", 6, "toolongtitle"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := cal.Center(tt.s, tt.width); got != tt.want {
+				t.Errorf("Center(%q,%d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/applets/shellutils/cal/export_test.go
+++ b/internal/applets/shellutils/cal/export_test.go
@@ -6,3 +6,9 @@ import "time"
 func Month(year int, m time.Month, mondayFirst bool) string {
 	return month(year, m, mondayFirst)
 }
+
+// Center exposes the unexported center helper so the external test package can
+// cover its no-padding (len(s) >= width) branch directly.
+func Center(s string, width int) string {
+	return center(s, width)
+}

--- a/internal/applets/shellutils/chmod/chmod_more_test.go
+++ b/internal/applets/shellutils/chmod/chmod_more_test.go
@@ -1,0 +1,175 @@
+package chmod_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/chmod"
+)
+
+// TestUnwrap covers both branches of unwrap: a wrapped *os.PathError yields its
+// inner error, while a plain error passes through unchanged.
+func TestUnwrap(t *testing.T) {
+	inner := errors.New("boom")
+	pe := &os.PathError{Op: "chmod", Path: "/x", Err: inner}
+	if got := chmod.UnwrapForTest(pe); got != inner {
+		t.Errorf("unwrap(PathError) = %v, want %v", got, inner)
+	}
+	if got := chmod.UnwrapForTest(inner); got != inner {
+		t.Errorf("unwrap(plain) = %v, want %v", got, inner)
+	}
+}
+
+// TestApplyModeSetgidAndSticky exercises permBits/permMask/modeFromBits for the
+// setgid and sticky special bits, which the existing tests do not reach.
+func TestApplyModeSetgidAndSticky(t *testing.T) {
+	got, err := chmod.ApplyModeForTest(0o755, "g+s", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got&os.ModeSetgid == 0 {
+		t.Errorf("g+s did not set setgid: %v", got)
+	}
+
+	// Round-trip a mode that already carries setuid + setgid + sticky through
+	// applyMode so permBits sees all three special bits set on the input
+	// (covering its setuid/setgid/sticky arms).
+	cur := os.FileMode(0o755) | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+	got, err = chmod.ApplyModeForTest(cur, "u+r", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got&os.ModeSetuid == 0 || got&os.ModeSetgid == 0 || got&os.ModeSticky == 0 {
+		t.Errorf("setuid/setgid/sticky not preserved: %v", got)
+	}
+}
+
+// TestApplyModeAllSpecial covers permMask's "a+s" path (allWho sets both setuid
+// and setgid) and the standalone sticky "+t".
+func TestApplyModeAllSpecial(t *testing.T) {
+	got, err := chmod.ApplyModeForTest(0o755, "a+s", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got&os.ModeSetuid == 0 || got&os.ModeSetgid == 0 {
+		t.Errorf("a+s did not set both setuid and setgid: %v", got)
+	}
+
+	got, err = chmod.ApplyModeForTest(0o755, "+t", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got&os.ModeSticky == 0 {
+		t.Errorf("+t did not set sticky: %v", got)
+	}
+}
+
+// TestApplyModeInvalidOctal covers the out-of-range octal parse error.
+func TestApplyModeInvalidOctal(t *testing.T) {
+	// 77777777 is octal-shaped but overflows the 32-bit parse.
+	if _, err := chmod.ApplyModeForTest(0o644, "777777777777", false); err == nil {
+		t.Error("expected error for overflowing octal mode")
+	}
+}
+
+// TestRunInvalidModeSilent covers the silent (-f) branch of changeMode: the
+// invalid-mode error is suppressed on stderr but Run still exits non-zero.
+func TestRunInvalidModeSilent(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := run(t, "-f", "u?x", file)
+	if err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+	if strings.Contains(errOut, "invalid mode") {
+		t.Errorf("stderr = %q, want suppressed by -f", errOut)
+	}
+}
+
+// TestRunMissingFileSilent covers reportAccess's silent early return: -f
+// suppresses the "cannot access" diagnostic but the exit code is still non-zero.
+func TestRunMissingFileSilent(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.txt")
+
+	_, errOut, err := run(t, "-f", "644", missing)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if errOut != "" {
+		t.Errorf("stderr = %q, want empty under -f", errOut)
+	}
+}
+
+// TestRunChangesRetained covers changeMode's "retained" diagnostic: with -c and
+// a no-op mode the file is unchanged, so the retained message is emitted.
+func TestRunChangesRetained(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(file, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// -v with the same mode shows the "retained" line (changes==false branch).
+	out, _, err := run(t, "-v", "644", file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "retained as") {
+		t.Errorf("verbose stdout = %q, want retained diagnostic", out)
+	}
+
+	// -c on a no-op change should print nothing.
+	out, _, err = run(t, "-c", "644", file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "" {
+		t.Errorf("-c no-op stdout = %q, want empty", out)
+	}
+}
+
+// TestRunChangesReported covers the -c "changed" branch (changes && changed).
+func TestRunChangesReported(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(file, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := run(t, "-c", "644", file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "changed from") {
+		t.Errorf("-c stdout = %q, want changed diagnostic", out)
+	}
+}
+
+// TestRunRecursiveInaccessible drives changeModeRecursive's WalkDir error branch
+// by recursing into a path that does not exist.
+func TestRunRecursiveInaccessible(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "ghost")
+
+	_, errOut, err := run(t, "-R", "755", missing)
+	if err == nil {
+		t.Fatal("expected error for missing recursive path")
+	}
+	if !strings.Contains(errOut, "cannot access") {
+		t.Errorf("stderr = %q, want cannot-access diagnostic", errOut)
+	}
+}

--- a/internal/applets/shellutils/chmod/export_test.go
+++ b/internal/applets/shellutils/chmod/export_test.go
@@ -6,3 +6,9 @@ import "os"
 func ApplyModeForTest(cur os.FileMode, mode string, isDir bool) (os.FileMode, error) {
 	return applyMode(cur, mode, isDir)
 }
+
+// UnwrapForTest exposes the unexported unwrap helper so the external test
+// package can verify both the *os.PathError and pass-through branches.
+func UnwrapForTest(err error) error {
+	return unwrap(err)
+}

--- a/internal/applets/shellutils/chroot/run_internal_test.go
+++ b/internal/applets/shellutils/chroot/run_internal_test.go
@@ -1,0 +1,136 @@
+package chroot
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"reflect"
+	"testing"
+)
+
+// TestDecideExecCommand covers the three shapes: explicit command with args,
+// explicit command alone, and the $SHELL fallback (interactive) when no command
+// operand is given.
+func TestDecideExecCommand(t *testing.T) {
+	t.Run("explicit command with args", func(t *testing.T) {
+		name, argv := decideExecCommand([]string{"/bin/echo", "hi", "there"})
+		if name != "/bin/echo" {
+			t.Errorf("name = %q, want /bin/echo", name)
+		}
+		if !reflect.DeepEqual(argv, []string{"hi", "there"}) {
+			t.Errorf("argv = %v, want [hi there]", argv)
+		}
+	})
+
+	t.Run("explicit command alone", func(t *testing.T) {
+		name, argv := decideExecCommand([]string{"/bin/sh"})
+		if name != "/bin/sh" {
+			t.Errorf("name = %q, want /bin/sh", name)
+		}
+		if len(argv) != 0 {
+			t.Errorf("argv = %v, want empty", argv)
+		}
+	})
+
+	t.Run("shell fallback honors $SHELL", func(t *testing.T) {
+		t.Setenv("SHELL", "/usr/bin/fish")
+		name, argv := decideExecCommand(nil)
+		if name != "/usr/bin/fish" {
+			t.Errorf("name = %q, want /usr/bin/fish", name)
+		}
+		if !reflect.DeepEqual(argv, []string{"-i"}) {
+			t.Errorf("argv = %v, want [-i]", argv)
+		}
+	})
+
+	t.Run("shell fallback defaults to /bin/sh", func(t *testing.T) {
+		t.Setenv("SHELL", "")
+		name, argv := decideExecCommand(nil)
+		if name != "/bin/sh" {
+			t.Errorf("name = %q, want /bin/sh", name)
+		}
+		if !reflect.DeepEqual(argv, []string{"-i"}) {
+			t.Errorf("argv = %v, want [-i]", argv)
+		}
+	})
+}
+
+// TestReason maps the recognized failure kinds to their GNU-style messages and
+// falls back to the raw error text otherwise.
+func TestReason(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"not exist", &fs.PathError{Op: "chroot", Path: "/x", Err: fs.ErrNotExist}, "No such file or directory"},
+		{"permission", &fs.PathError{Op: "chroot", Path: "/x", Err: fs.ErrPermission}, "Operation not permitted"},
+		{"other", errors.New("some other failure"), "some other failure"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := reason(tc.err); got != tc.want {
+				t.Errorf("reason(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplySetgroupsError verifies apply surfaces a setgroups failure and stops
+// before dropping the gid/uid, so a failed supplementary-group set never leaves
+// the process with a partially-applied identity.
+func TestApplySetgroupsError(t *testing.T) {
+	origGroups, origGid, origUid := setgroups, setgid, setuid
+	t.Cleanup(func() { setgroups, setgid, setuid = origGroups, origGid, origUid })
+
+	gidCalled, uidCalled := false, false
+	setgroups = func([]int) error { return os.ErrPermission }
+	setgid = func(int) error { gidCalled = true; return nil }
+	setuid = func(int) error { uidCalled = true; return nil }
+
+	id := identity{uid: 1000, gid: 1000, groups: []int{10}}
+	err := id.apply()
+	if err == nil {
+		t.Fatal("apply must fail when setgroups fails")
+	}
+	if gidCalled || uidCalled {
+		t.Errorf("setgid/setuid must not run after a setgroups failure (gid=%v uid=%v)", gidCalled, uidCalled)
+	}
+}
+
+// TestApplySetgidError verifies a setgid failure aborts before setuid.
+func TestApplySetgidError(t *testing.T) {
+	origGroups, origGid, origUid := setgroups, setgid, setuid
+	t.Cleanup(func() { setgroups, setgid, setuid = origGroups, origGid, origUid })
+
+	uidCalled := false
+	setgroups = func([]int) error { return nil }
+	setgid = func(int) error { return os.ErrPermission }
+	setuid = func(int) error { uidCalled = true; return nil }
+
+	id := identity{uid: 1000, gid: 1000, groups: nil}
+	if err := id.apply(); err == nil {
+		t.Fatal("apply must fail when setgid fails")
+	}
+	if uidCalled {
+		t.Error("setuid must not run after a setgid failure")
+	}
+}
+
+// TestApplySetuidError verifies a setuid failure is surfaced.
+func TestApplySetuidError(t *testing.T) {
+	origGroups, origGid, origUid := setgroups, setgid, setuid
+	t.Cleanup(func() { setgroups, setgid, setuid = origGroups, origGid, origUid })
+
+	setgroups = func([]int) error { return nil }
+	setgid = func(int) error { return nil }
+	setuid = func(int) error { return os.ErrPermission }
+
+	id := identity{uid: 1000, gid: 1000, groups: nil}
+	if err := id.apply(); err == nil {
+		t.Fatal("apply must fail when setuid fails")
+	}
+}

--- a/internal/applets/shellutils/cmp/cmp_test.go
+++ b/internal/applets/shellutils/cmp/cmp_test.go
@@ -175,6 +175,95 @@ func systemCmp(t *testing.T, a, b string) (string, bool) {
 	return out.String(), true
 }
 
+func TestNameSynopsis(t *testing.T) {
+	t.Parallel()
+	c := cmp.New()
+	if c.Name() != "cmp" {
+		t.Errorf("Name() = %q, want cmp", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestVerboseListsDifferingByte covers the -l output path, which prints the
+// byte offset and the octal values of the two differing bytes.
+func TestVerboseListsDifferingByte(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// 'A' (0101 octal) vs 'B' (0102 octal) at the first byte.
+	a := writeFile(t, dir, "a", "A")
+	b := writeFile(t, dir, "b", "B")
+
+	out, _, code := run(t, "-l", a, b)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if out != "1 101 102\n" {
+		t.Errorf("-l out = %q, want %q", out, "1 101 102\n")
+	}
+}
+
+// TestMissingOperand covers the no-operand error (exit 2).
+func TestMissingOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, code := run(t)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "cmp: missing operand") {
+		t.Errorf("stderr = %q, want missing-operand message", errOut)
+	}
+}
+
+// TestExtraOperand covers the >2-operands error (exit 2).
+func TestExtraOperand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "x")
+	b := writeFile(t, dir, "b", "x")
+	c := writeFile(t, dir, "c", "x")
+	_, errOut, code := run(t, a, b, c)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "extra operand") {
+		t.Errorf("stderr = %q, want extra-operand message", errOut)
+	}
+}
+
+// TestBothStdin covers the rejection of two '-' operands (exit 2).
+func TestBothStdin(t *testing.T) {
+	t.Parallel()
+	_, errOut, code := run(t, "-", "-")
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "at most one operand may be '-'") {
+		t.Errorf("stderr = %q, want both-stdin message", errOut)
+	}
+}
+
+// TestPrefixEOFOnSecond exercises the eofOn==2 branch (second file is the
+// shorter prefix), which the existing prefix test does not reach.
+func TestPrefixEOFOnSecond(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	long := writeFile(t, dir, "long", "abcd")
+	short := writeFile(t, dir, "short", "abc")
+
+	out, errOut, code := run(t, long, short)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	if !strings.Contains(errOut, "cmp: EOF on "+short) {
+		t.Errorf("stderr = %q, want EOF on the second file %q", errOut, short)
+	}
+}
+
 // TestHelpSections verifies that --help renders both the Examples and the
 // Exit status sections supplied through WithHelp.
 func TestHelpSections(t *testing.T) {

--- a/internal/applets/shellutils/cmp/compare_internal_test.go
+++ b/internal/applets/shellutils/cmp/compare_internal_test.go
@@ -1,0 +1,56 @@
+package cmp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// failingReader always returns its configured error, modeling a stream that
+// fails partway through with something other than io.EOF.
+type failingReader struct{ err error }
+
+func (f failingReader) Read([]byte) (int, error) { return 0, f.err }
+
+// TestCompareReadError verifies compare surfaces a non-EOF read error from
+// either side rather than misreporting equality or a difference.
+func TestCompareReadError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("boom")
+
+	if _, err := compare(failingReader{err: boom}, strings.NewReader("x")); !errors.Is(err, boom) {
+		t.Errorf("error from first reader = %v, want boom", err)
+	}
+	if _, err := compare(strings.NewReader("x"), failingReader{err: boom}); !errors.Is(err, boom) {
+		t.Errorf("error from second reader = %v, want boom", err)
+	}
+}
+
+// TestCompareEqualAndDiff exercises the pure comparison directly: equal streams,
+// a concrete byte difference (with its line number), and prefix relationships.
+func TestCompareEqualAndDiff(t *testing.T) {
+	t.Parallel()
+
+	res, err := compare(strings.NewReader("ab\ncd\n"), strings.NewReader("ab\ncd\n"))
+	if err != nil || !res.equal {
+		t.Errorf("equal streams: res=%+v err=%v", res, err)
+	}
+
+	// First difference at byte 5 (the 'c'/'C'), on line 2.
+	res, err = compare(strings.NewReader("ab\ncd"), strings.NewReader("ab\nCd"))
+	if err != nil {
+		t.Fatalf("diff err = %v", err)
+	}
+	if res.equal || res.eofOn != 0 || res.byteOffset != 4 || res.line != 2 || res.a != 'c' || res.b != 'C' {
+		t.Errorf("diff res = %+v, want byte 4 line 2 c/C", res)
+	}
+
+	res, _ = compare(strings.NewReader("abc"), strings.NewReader("abcd"))
+	if res.eofOn != 1 {
+		t.Errorf("first-prefix res = %+v, want eofOn=1", res)
+	}
+	res, _ = compare(strings.NewReader("abcd"), strings.NewReader("abc"))
+	if res.eofOn != 2 {
+		t.Errorf("second-prefix res = %+v, want eofOn=2", res)
+	}
+}

--- a/internal/applets/shellutils/cut/cut_test.go
+++ b/internal/applets/shellutils/cut/cut_test.go
@@ -110,6 +110,102 @@ func TestRunInvalidList(t *testing.T) {
 	}
 }
 
+// TestRangeMergingAndBounds drives mergeRanges and the out-of-bounds clamping
+// in cutBytes/cutRunes via observable output.
+func TestRangeMergingAndBounds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"overlapping ranges merge", "abcdef\n", []string{"-c", "1-3,2-4"}, "abcd\n"},
+		{"adjacent ranges merge", "abcdef\n", []string{"-c", "1-2,3-4"}, "abcd\n"},
+		{"open range absorbs later", "abcdef\n", []string{"-c", "2-,4-5"}, "bcdef\n"},
+		{"open range earlier wins", "abcdef\n", []string{"-c", "1-,3"}, "abcdef\n"},
+		{"byte range past end clamps", "abc\n", []string{"-b", "2-10"}, "bc\n"},
+		{"byte lo past end yields empty", "abc\n", []string{"-b", "5-7"}, "\n"},
+		{"char range past end clamps", "abc\n", []string{"-c", "2-10"}, "bc\n"},
+		{"char lo past end yields empty", "abc\n", []string{"-c", "5-7"}, "\n"},
+		{"multibyte runes", "héllo\n", []string{"-c", "1-3"}, "hél\n"},
+		{"open from start", "abcdef\n", []string{"-c", "-3"}, "abc\n"},
+		{"duplicate single positions", "abcdef\n", []string{"-c", "2,2,2"}, "b\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunDecreasingRange covers the invalid-decreasing-range branch of parseRange.
+func TestRunDecreasingRange(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "abc\n", "-c", "5-2")
+	if err == nil {
+		t.Fatal("expected error for decreasing range")
+	}
+	if !strings.Contains(errOut, "decreasing range") {
+		t.Errorf("stderr = %q, want decreasing range", errOut)
+	}
+}
+
+// TestRunEmptyListItem covers the empty-item branch of parseRanges.
+func TestRunEmptyListItem(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "abc\n", "-c", "1,,3")
+	if err == nil {
+		t.Fatal("expected error for empty list item")
+	}
+	if !strings.Contains(errOut, "invalid byte, character or field list") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestRunNonNumericRange covers the parsePos non-numeric branch.
+func TestRunNonNumericRange(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "abc\n", "-c", "a-b")
+	if err == nil {
+		t.Fatal("expected error for non-numeric range")
+	}
+	if !strings.Contains(errOut, "invalid byte, character or field list") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestRunMissingFile exercises the open-error path in run() (keep()).
+func TestRunMissingFile(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := cut.New().Run(context.Background(), io, []string{"-c", "1", "/no/such/cut/file"})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(errBuf.String(), "cut:") {
+		t.Errorf("stderr = %q, want cut: prefix", errBuf.String())
+	}
+}
+
+// TestSynopsis ensures the one-line description is reported.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if s := cut.New().Synopsis(); s == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
 func TestRunHelpAndVersion(t *testing.T) {
 	t.Parallel()
 	out, _, err := runStdin(t, "", "--help")

--- a/internal/applets/shellutils/date/date_test.go
+++ b/internal/applets/shellutils/date/date_test.go
@@ -103,6 +103,82 @@ func TestRunFormats(t *testing.T) {
 	}
 }
 
+// TestHour12Midnight covers hour12's h==0 -> 12 branch (midnight in 12-hour
+// clock is 12 AM) and the %P lowercase am rendering.
+func TestHour12Midnight(t *testing.T) {
+	t.Parallel()
+	out, errOut, err := run(t, "-u", "-d", "2023-11-14T00:00:00Z", "+%I %p %P")
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if got := strings.TrimRight(out, "\n"); got != "12 AM am" {
+		t.Errorf("out = %q, want %q", got, "12 AM am")
+	}
+}
+
+// TestSundayISOWeekday covers specifier's %u Sunday=7 special case.
+func TestSundayISOWeekday(t *testing.T) {
+	t.Parallel()
+	// 2023-11-12 is a Sunday.
+	out, errOut, err := run(t, "-u", "-d", "2023-11-12", "+%u %w")
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if got := strings.TrimRight(out, "\n"); got != "7 0" {
+		t.Errorf("out = %q, want %q (ISO Sunday=7, w Sunday=0)", got, "7 0")
+	}
+}
+
+// TestISOFormats covers the hours/minutes/ns granularities of --iso-8601.
+func TestISOFormats(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		arg  string
+		want string
+	}{
+		{"hours", "2023-11-14T22+00:00"},
+		{"minutes", "2023-11-14T22:13+00:00"},
+		{"ns", "2023-11-14T22:13:20+00:00"}, // zero nanoseconds are trimmed by the ,999... layout
+		{"date", "2023-11-14"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.arg, func(t *testing.T) {
+			out, errOut, err := run(t, "-u", "--iso-8601="+tt.arg)
+			if err != nil {
+				t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+			}
+			if got := strings.TrimRight(out, "\n"); got != tt.want {
+				t.Errorf("--iso-8601=%s out = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInvalidISOArg covers isoFormat's default (error) branch.
+func TestInvalidISOArg(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "--iso-8601=bogus")
+	if err == nil {
+		t.Fatal("expected error for invalid --iso-8601 argument")
+	}
+	if !strings.Contains(errOut, "invalid argument") {
+		t.Errorf("stderr = %q, want invalid argument message", errOut)
+	}
+}
+
+// TestExtraOperand covers operandFormat's "extra operand" branch.
+func TestExtraOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "+%Y", "+%m")
+	if err == nil {
+		t.Fatal("expected error for a second operand")
+	}
+	if !strings.Contains(errOut, "extra operand") {
+		t.Errorf("stderr = %q, want extra operand message", errOut)
+	}
+}
+
 func TestRunInvalidDate(t *testing.T) {
 	t.Parallel()
 	_, errOut, err := run(t, "-d", "not-a-date")
@@ -191,7 +267,13 @@ func TestFormatTime(t *testing.T) {
 		{"%n", "\n"},
 		{"%t", "\t"},
 		{"trailing %", "trailing %"},
-		{"%Q", "%Q"}, // unknown specifier passes through
+		{"%Q", "%Q"},                        // unknown specifier passes through
+		{"%c", "Tue Nov  14 22:13:20 2023"}, // the layout pads the day field with a leading space
+		{"%D", "11/14/23"},
+		{"%r", "10:13:20 PM"},
+		{"%x", "11/14/23"},
+		{"%X", "22:13:20"},
+		{"%h", "Nov"},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/applets/shellutils/dd/dd_test.go
+++ b/internal/applets/shellutils/dd/dd_test.go
@@ -168,6 +168,221 @@ func TestParseSize(t *testing.T) {
 	}
 }
 
+// TestRun_Skip skips the first ibs-sized block of input.
+func TestRun_Skip(t *testing.T) {
+	out, _, err := run(t, "0123456789", "bs=2", "skip=1")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "23456789" {
+		t.Errorf("stdout = %q, want %q", out, "23456789")
+	}
+}
+
+// TestRun_Seek pads the output with NUL bytes before writing (stdout path).
+func TestRun_Seek(t *testing.T) {
+	out, _, err := run(t, "abc", "bs=1", "seek=2")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := "\x00\x00abc"
+	if out != want {
+		t.Errorf("stdout = %q, want %q", out, want)
+	}
+}
+
+// TestRun_SeekFile seeks within an output file.
+func TestRun_SeekFile(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.bin")
+	if _, _, err := run(t, "XYZ", "bs=1", "seek=3", "of="+outPath); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("\x00\x00\x00XYZ")
+	if !bytes.Equal(got, want) {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+// TestRun_ConvNotrunc keeps the tail of a pre-existing output file instead of
+// truncating it.
+func TestRun_ConvNotrunc(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(outPath, []byte("OLDDATA-TAIL"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "NEW", "bs=1", "conv=notrunc", "of="+outPath); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "NEW" overwrites the first three bytes; the tail survives.
+	if want := "NEWDATA-TAIL"; string(got) != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+// TestRun_ConvSync pads a short final block to ibs with NUL.
+func TestRun_ConvSync(t *testing.T) {
+	out, errOut, err := run(t, "abcde", "ibs=4", "obs=4", "conv=sync")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	// First full block "abcd" plus partial "e" padded to 4 bytes.
+	want := "abcde\x00\x00\x00"
+	if out != want {
+		t.Errorf("stdout = %q, want %q", out, want)
+	}
+	if !strings.Contains(errOut, "1+1 records in") {
+		t.Errorf("stderr = %q, want to contain %q", errOut, "1+1 records in")
+	}
+}
+
+// TestRun_StatusNoxferSuppressesByteLine drops the trailing "bytes copied" line.
+func TestRun_StatusNoxfer(t *testing.T) {
+	_, errOut, err := run(t, "data", "status=noxfer")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(errOut, "records out") {
+		t.Errorf("stderr = %q, want records summary", errOut)
+	}
+	if strings.Contains(errOut, "bytes copied") {
+		t.Errorf("stderr = %q, want no bytes-copied line for status=noxfer", errOut)
+	}
+}
+
+// TestRun_StatusProgress behaves like the default summary.
+func TestRun_StatusProgress(t *testing.T) {
+	_, errOut, err := run(t, "data", "status=progress")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(errOut, "bytes copied") {
+		t.Errorf("stderr = %q, want bytes-copied line for status=progress", errOut)
+	}
+}
+
+// TestRun_OpenInputError reports a missing input file.
+func TestRun_OpenInputError(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.bin")
+	_, errOut, err := run(t, "", "if="+missing)
+	if err == nil {
+		t.Fatal("Run() error = nil, want error for missing input")
+	}
+	if !strings.Contains(errOut, "dd:") {
+		t.Errorf("stderr = %q, want dd: prefix", errOut)
+	}
+}
+
+// TestRun_OpenOutputError reports an output path that cannot be created.
+func TestRun_OpenOutputError(t *testing.T) {
+	dir := t.TempDir()
+	// A path whose parent component is a file, not a directory.
+	notDir := filepath.Join(dir, "file")
+	if err := os.WriteFile(notDir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	badPath := filepath.Join(notDir, "child")
+	_, errOut, err := run(t, "data", "of="+badPath)
+	if err == nil {
+		t.Fatal("Run() error = nil, want error for bad output path")
+	}
+	if !strings.Contains(errOut, "dd:") {
+		t.Errorf("stderr = %q, want dd: prefix", errOut)
+	}
+}
+
+// TestRun_InvalidConv exercises the conv= error branch in parseArgs.
+func TestRun_InvalidConv(t *testing.T) {
+	_, errOut, err := run(t, "data", "conv=bogus")
+	if err == nil {
+		t.Fatal("Run() error = nil, want error for unknown conv")
+	}
+	if !strings.Contains(errOut, "unknown conversion") {
+		t.Errorf("stderr = %q, want unknown conversion", errOut)
+	}
+}
+
+// TestRun_ConvLcaseUcaseConflict rejects combining lcase and ucase.
+func TestRun_ConvLcaseUcaseConflict(t *testing.T) {
+	_, errOut, err := run(t, "data", "conv=lcase,ucase")
+	if err == nil {
+		t.Fatal("Run() error = nil, want error for lcase+ucase")
+	}
+	if !strings.Contains(errOut, "cannot combine") {
+		t.Errorf("stderr = %q, want cannot combine", errOut)
+	}
+}
+
+// TestRun_InvalidStatus exercises the status= error branch.
+func TestRun_InvalidStatus(t *testing.T) {
+	_, errOut, err := run(t, "data", "status=bogus")
+	if err == nil {
+		t.Fatal("Run() error = nil, want error for unknown status")
+	}
+	if !strings.Contains(errOut, "unknown status") {
+		t.Errorf("stderr = %q, want unknown status", errOut)
+	}
+}
+
+// TestRun_InvalidSizes drives parseSize error branches via every operand.
+func TestRun_InvalidSizes(t *testing.T) {
+	t.Parallel()
+	for _, op := range []string{"bs", "ibs", "obs", "count", "skip", "seek"} {
+		op := op
+		t.Run(op, func(t *testing.T) {
+			t.Parallel()
+			_, errOut, err := run(t, "data", op+"=notanumber")
+			if err == nil {
+				t.Fatalf("Run() error = nil, want error for %s=notanumber", op)
+			}
+			if !strings.Contains(errOut, "invalid "+op) {
+				t.Errorf("stderr = %q, want to contain %q", errOut, "invalid "+op)
+			}
+		})
+	}
+}
+
+// TestRun_IbsObsRespectedWhenNoBs ensures ibs=/obs= set independently when bs=
+// is absent.
+func TestRun_IbsObs(t *testing.T) {
+	out, errOut, err := run(t, "aabbccdd", "ibs=2", "obs=4")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "aabbccdd" {
+		t.Errorf("stdout = %q, want %q", out, "aabbccdd")
+	}
+	// 4 full input blocks of 2 bytes each. Output is written one input block
+	// at a time, so each 2-byte write is a partial obs(=4) block: 0+4 out.
+	if !strings.Contains(errOut, "4+0 records in") {
+		t.Errorf("stderr = %q, want 4+0 records in", errOut)
+	}
+	if !strings.Contains(errOut, "0+4 records out") {
+		t.Errorf("stderr = %q, want 0+4 records out", errOut)
+	}
+}
+
+// TestRun_BsOverridesIbsObs ensures bs= wins over a later ibs=/obs=.
+func TestRun_BsOverridesIbsObs(t *testing.T) {
+	out, _, err := run(t, "abcd", "bs=2", "ibs=99", "obs=99")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if out != "abcd" {
+		t.Errorf("stdout = %q, want %q", out, "abcd")
+	}
+}
+
 // TestHelpSections asserts `dd --help` renders structured help.
 func TestHelpSections(t *testing.T) {
 	t.Parallel()

--- a/internal/applets/shellutils/df/df_test.go
+++ b/internal/applets/shellutils/df/df_test.go
@@ -3,6 +3,7 @@ package df_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -199,6 +200,57 @@ func TestRunInodes(t *testing.T) {
 		if fields[i] != want[i] {
 			t.Errorf("inode row field %d = %q, want %q", i, fields[i], want[i])
 		}
+	}
+}
+
+// TestPercentZeroTotal covers the total==0 guard in percent via an empty
+// filesystem (no usable blocks), which must report 0% rather than divide by 0.
+func TestPercentZeroTotal(t *testing.T) {
+	s := df.StatfsResult{Bsize: 1024, Blocks: 0, Bfree: 0, Bavail: 0}
+	u := df.ComputeUsage(s)
+	if u.UsePct() != 0 {
+		t.Errorf("UsePct = %d, want 0 for empty filesystem", u.UsePct())
+	}
+}
+
+// TestRunStatfsError exercises the error path of Run (the keep() helper) by
+// injecting a statfs that fails, and confirms a non-zero exit while the header
+// is still printed.
+func TestRunStatfsError(t *testing.T) {
+	restore := df.SetStatfs(func(path string) (df.StatfsResult, error) {
+		return df.StatfsResult{}, errors.New("statfs boom")
+	})
+	defer restore()
+
+	out, errOut, err := run(t, "/data")
+	if err == nil {
+		t.Fatal("expected non-nil error when statfs fails")
+	}
+	if !strings.HasPrefix(out, "Filesystem") {
+		t.Errorf("header should still be printed, got %q", out)
+	}
+	if !strings.Contains(errOut, "df:") {
+		t.Errorf("stderr = %q, want df: prefix", errOut)
+	}
+}
+
+// TestRunStatfsErrorThenSuccess confirms keep() preserves the first error while
+// later operands are still processed.
+func TestRunStatfsErrorThenSuccess(t *testing.T) {
+	restore := df.SetStatfs(func(path string) (df.StatfsResult, error) {
+		if path == "/bad" {
+			return df.StatfsResult{}, errors.New("nope")
+		}
+		return df.StatfsResult{Bsize: 1024, Blocks: 10, Bavail: 5}, nil
+	})
+	defer restore()
+
+	out, _, err := run(t, "/bad", "/good")
+	if err == nil {
+		t.Fatal("expected non-nil error from the failing operand")
+	}
+	if !strings.Contains(out, "/good") {
+		t.Errorf("the good operand should still be printed, got %q", out)
 	}
 }
 

--- a/internal/applets/shellutils/du/du_test.go
+++ b/internal/applets/shellutils/du/du_test.go
@@ -203,6 +203,56 @@ func TestHumanReadableFormatter(t *testing.T) {
 	}
 }
 
+// TestSynopsisAndName covers the metadata accessors.
+func TestSynopsisAndName(t *testing.T) {
+	t.Parallel()
+	c := du.New()
+	if c.Name() != "du" {
+		t.Errorf("Name() = %q, want du", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestEmptyFileZeroBlocks covers the blocks(bytes<=0) branch: a zero-byte file
+// occupies zero 1K blocks.
+func TestEmptyFileZeroBlocks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(f, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runDu(t, f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	size, _ := splitLine(t, nonEmptyLines(out)[0])
+	if size != "0" {
+		t.Errorf("size = %q, want %q for empty file", size, "0")
+	}
+}
+
+// TestHumanReadableNoDecimalAboveTen covers the %.0f branch of humanReadable,
+// taken when the scaled value is >= 10 (here ~15K).
+func TestHumanReadableNoDecimalAboveTen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "big.bin")
+	if err := os.WriteFile(f, bytes.Repeat([]byte("z"), 15*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runDu(t, "-h", f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	size, _ := splitLine(t, nonEmptyLines(out)[0])
+	if size != "15K" {
+		t.Errorf("size = %q, want %q (no decimal place at/above 10)", size, "15K")
+	}
+}
+
 func TestMissingOperand(t *testing.T) {
 	t.Parallel()
 	_, errOut, err := runDu(t, "/no/such/path")

--- a/internal/applets/shellutils/echo/echo_test.go
+++ b/internal/applets/shellutils/echo/echo_test.go
@@ -53,6 +53,67 @@ func TestRun(t *testing.T) {
 	}
 }
 
+// TestEscapeExpansion drives every backslash escape branch of expandEscapes,
+// including octal/hex edge cases and malformed escapes.
+func TestEscapeExpansion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"alert", `\a`, "\a\n"},
+		{"backspace", `\b`, "\b\n"},
+		{"formfeed", `\f`, "\f\n"},
+		{"carriage return", `\r`, "\r\n"},
+		{"vertical tab", `\v`, "\v\n"},
+		{"literal backslash", `\\`, "\\\n"},
+		{"newline", `\n`, "\n\n"},
+		{"unknown escape kept literal", `\q`, "\\q\n"},
+		{"trailing backslash kept", `end\`, "end\\\n"},
+		{"hex two digits", `\x4a`, "J\n"},
+		{"hex one digit", `\x9z`, "\tz\n"},
+		{"hex no digits kept literal", `\xz`, "\\xz\n"},
+		{"octal full", `\0101`, "A\n"},
+		{"octal short", `\007`, "\a\n"},
+		{"octal zero only", `\0`, "\x00\n"},
+		{"text around escape", `a\tb\tc`, "a\tb\tc\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := run(t, "-e", tt.in)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestEFlagThenEDisablesEscapes verifies -E after -e turns interpretation off.
+func TestEFlagThenEDisablesEscapes(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "-e", "-E", `a\tb`)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if want := "a\\tb\n"; out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestSynopsis ensures the one-line description is reported.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if s := echo.New().Synopsis(); s == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
 // TestHelpAsFirstArg verifies that a leading --help prints usage rather than
 // echoing the literal text, matching GNU's standalone echo.
 func TestHelpAsFirstArg(t *testing.T) {

--- a/internal/applets/textutils/base32/base32_more_test.go
+++ b/internal/applets/textutils/base32/base32_more_test.go
@@ -1,0 +1,56 @@
+package base32_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEncodeNoWrap covers wrapLines' cols <= 0 branch (-w 0 disables wrapping):
+// a long encoding must come back as a single line plus a trailing newline.
+func TestEncodeNoWrap(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, strings.Repeat("a", 100), "-w", "0")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	body := strings.TrimRight(out, "\n")
+	if strings.Contains(body, "\n") {
+		t.Errorf("-w 0 should not wrap, got %d lines: %q", strings.Count(body, "\n")+1, out)
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("output should end with a newline: %q", out)
+	}
+}
+
+// TestEncodeFile covers operand() returning a named FILE (not "-") and encoding
+// data read from disk.
+func TestEncodeFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "in.bin")
+	if err := os.WriteFile(f, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "", f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if strings.TrimRight(out, "\n") != "NBSWY3DP" {
+		t.Errorf("encode of file = %q, want NBSWY3DP", out)
+	}
+}
+
+// TestDecodeWhitespaceStripped covers the default (non -i) decode path where
+// embedded ASCII whitespace is stripped before decoding.
+func TestDecodeWhitespaceStripped(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "NBSWY3DP\n", "-d")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "hello" {
+		t.Errorf("decode = %q, want hello", out)
+	}
+}

--- a/internal/applets/textutils/cat/cat_more_test.go
+++ b/internal/applets/textutils/cat/cat_more_test.go
@@ -1,0 +1,67 @@
+package cat_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/cat"
+)
+
+// TestSynopsis covers the Synopsis metadata accessor, which the Run-driven
+// tests never call.
+func TestSynopsis(t *testing.T) {
+	if got := cat.New().Synopsis(); got != "Concatenate files and print on the standard output" {
+		t.Errorf("Synopsis() = %q", got)
+	}
+}
+
+// TestRunMultipleMissingFiles drives keep()'s "existing != nil" branch: two
+// failed opens must still yield a single failure and report both names, while
+// the good file in between is still printed.
+func TestRunMultipleMissingFiles(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.txt")
+	if err := os.WriteFile(good, []byte("ok\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	miss1 := filepath.Join(dir, "miss1.txt")
+	miss2 := filepath.Join(dir, "miss2.txt")
+
+	out, errOut, err := runStdin(t, "", miss1, good, miss2)
+	if err == nil {
+		t.Fatal("expected error when files are missing")
+	}
+	if out != "ok\n" {
+		t.Errorf("out = %q, want the readable file's contents", out)
+	}
+	if !strings.Contains(errOut, "miss1.txt") || !strings.Contains(errOut, "miss2.txt") {
+		t.Errorf("stderr = %q, want both missing files reported", errOut)
+	}
+}
+
+// TestRunSqueezeShowEndsTabsCombined exercises renderStream with all of -s, -E
+// and -T together, including the squeeze that drops a repeated blank line.
+func TestRunSqueezeShowEndsTabsCombined(t *testing.T) {
+	out, _, err := runStdin(t, "a\tb\n\n\n\nc\n", "-s", "-E", "-T")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "a^Ib$\n$\nc$\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestRunNoTrailingNewline checks renderStream's handling of a final chunk that
+// lacks a trailing newline (the body/no-newline path).
+func TestRunNoTrailingNewline(t *testing.T) {
+	out, _, err := runStdin(t, "tail", "-E")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "tail$" {
+		t.Errorf("out = %q, want %q", out, "tail$")
+	}
+}

--- a/internal/applets/textutils/comm/emit_internal_test.go
+++ b/internal/applets/textutils/comm/emit_internal_test.go
@@ -1,0 +1,81 @@
+package comm
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// failingWriter fails every write, modeling a broken stdout (e.g. a closed
+// pipe), so the write-error branches of emit and compare are reachable.
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
+
+func errIO(w *failingWriter) command.IO {
+	return command.IO{In: strings.NewReader(""), Out: w, Err: &strings.Builder{}}
+}
+
+// TestEmitWriteError verifies emit converts a write failure into a command
+// failure, and that a suppressed column (show=false) writes nothing and never
+// errors even on a broken writer.
+func TestEmitWriteError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("broken pipe")
+	io := errIO(&failingWriter{err: boom})
+
+	if err := emit(io, true, "", "line"); err == nil {
+		t.Error("emit must surface a write error when the column is shown")
+	}
+	if err := emit(io, false, "", "line"); err != nil {
+		t.Errorf("emit on a suppressed column must not error, got %v", err)
+	}
+}
+
+// TestCompareWriteError verifies compare stops and reports the first write
+// failure rather than silently continuing through the merge.
+func TestCompareWriteError(t *testing.T) {
+	t.Parallel()
+	io := errIO(&failingWriter{err: errors.New("broken pipe")})
+	c := New()
+
+	// Unique-to-first, common, and unique-to-second lines each hit a different
+	// emit call site; any one failing must abort compare.
+	a := []string{"apple", "banana"}
+	b := []string{"banana", "date"}
+	if err := c.compare(io, a, b, true, true, true); err == nil {
+		t.Error("compare must surface a write error")
+	}
+}
+
+// TestCompareTailWriteError drives the trailing loops (after one slice is
+// exhausted) into a write failure. With only column 1 shown and b a strict
+// prefix of a, the leftover a entries are emitted in the first tail loop; with
+// only column 2 shown and a a strict prefix of b, the second tail loop runs.
+func TestCompareTailWriteError(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	io := errIO(&failingWriter{err: errors.New("broken pipe")})
+	if err := c.compare(io, []string{"a", "b", "c"}, []string{"a"}, true, false, false); err == nil {
+		t.Error("compare must surface a write error from the first tail loop")
+	}
+
+	io = errIO(&failingWriter{err: errors.New("broken pipe")})
+	if err := c.compare(io, []string{"a"}, []string{"a", "b", "c"}, false, true, false); err == nil {
+		t.Error("compare must surface a write error from the second tail loop")
+	}
+}
+
+// TestCompareSuppressAllNoOutput verifies that suppressing every column writes
+// nothing, so even a failing writer is never touched.
+func TestCompareSuppressAllNoOutput(t *testing.T) {
+	t.Parallel()
+	io := errIO(&failingWriter{err: errors.New("must not be called")})
+	c := New()
+	if err := c.compare(io, []string{"a"}, []string{"a", "b"}, false, false, false); err != nil {
+		t.Errorf("suppressing all columns must not write or error, got %v", err)
+	}
+}

--- a/internal/applets/textutils/dos2unix/dos2unix_test.go
+++ b/internal/applets/textutils/dos2unix/dos2unix_test.go
@@ -181,6 +181,91 @@ func TestRunPreservesFileMode(t *testing.T) {
 	}
 }
 
+// TestSynopsisAndName covers the metadata accessors.
+func TestSynopsisAndName(t *testing.T) {
+	t.Parallel()
+	c := dos2unix.New()
+	if c.Name() != "dos2unix" {
+		t.Errorf("Name() = %q, want dos2unix", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestRunLineWithoutTrailingCRLF covers the toLF branch that leaves a final line
+// without a trailing CRLF unchanged.
+func TestRunLineWithoutTrailingCRLF(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "noeol.txt")
+	// Last line "b" has no trailing newline at all.
+	if err := os.WriteFile(file, []byte("a\r\nb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, file); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got, _ := os.ReadFile(file) //nolint:gosec // test-written file
+	if want := "a\nb"; string(got) != want {
+		t.Errorf("content = %q, want %q", string(got), want)
+	}
+}
+
+// TestRunReadErrorReported covers the read-failure branch of convert: a regular
+// file that cannot be opened for reading.
+func TestRunReadErrorReported(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses file permission checks")
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "unreadable.txt")
+	if err := os.WriteFile(file, []byte("a\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(file, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(file, 0o600) }()
+
+	out, errOut, err := run(t, file)
+	if err == nil {
+		t.Fatal("expected error for unreadable file")
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want empty", out)
+	}
+	if !strings.Contains(errOut, "can't read file") {
+		t.Errorf("stderr = %q, want read-error message", errOut)
+	}
+}
+
+// TestRunWriteErrorReported covers the write-failure branch of convert: the file
+// is readable but its directory is read-only, so the atomic rewrite cannot
+// create its temporary file.
+func TestRunWriteErrorReported(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permission checks")
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "ro.txt")
+	if err := os.WriteFile(file, []byte("a\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(dir, 0o700) }()
+
+	_, errOut, err := run(t, file)
+	if err == nil {
+		t.Fatal("expected error when the directory is not writable")
+	}
+	if errOut == "" {
+		t.Error("stderr should report the write failure")
+	}
+}
+
 func TestHelpSections(t *testing.T) {
 	t.Parallel()
 	out, _, err := run(t, "--help")


### PR DESCRIPTION
## Summary

Adds focused, behavior-asserting unit tests for previously low/zero-coverage
helper and error paths across 27 applet packages (first batch of the per-applet
coverage backlog). Only `*_test.go` files are added — no production code changes.

Representative gains: add-shell 67→92%, chgrp 57→93%, chown 73→93%, ar 82→89%,
awk 83→94%, cmp 80→95%, dd parseArgs 47→94%, echo expandEscapes 64→100%, and
similar improvements across the rest. Tests drive real boundary/error conditions
(missing files via `t.TempDir()`, invalid input, conversion/formatting helpers),
not happy-path filler. Genuinely root-only or fault-injection-only branches are
left uncovered and noted in the commit history.

## Testing

`go test` on all touched packages, `gofmt -l`, and `golangci-lint` all pass.

Closes #804, #792, #810, #811, #882, #793, #849, #883, #819, #850, #820, #851, #844, #852, #884, #794, #838, #839, #821, #795, #853, #854, #855, #856, #812, #885, #857, #858