### PR TITLE
test(applets): raise coverage on low-coverage helper paths (batch 3)

### DIFF
--- a/internal/applets/archival/tar/tar_internal_test.go
+++ b/internal/applets/archival/tar/tar_internal_test.go
@@ -1,0 +1,163 @@
+package tar
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func testIO() (command.IO, *bytes.Buffer) {
+	errBuf := &bytes.Buffer{}
+	return command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: errBuf}, errBuf
+}
+
+// TestSafeJoin verifies path-traversal entries are rejected while normal names
+// resolve inside the destination.
+func TestSafeJoin(t *testing.T) {
+	t.Parallel()
+	dest := "/tmp/dest"
+	tests := []struct {
+		name    string
+		entry   string
+		wantErr bool
+	}{
+		{"plain", "file.txt", false},
+		{"nested", "sub/file.txt", false},
+		{"dot self", ".", false},
+		{"escape parent", "../evil", true},
+		{"deep escape", "a/../../evil", true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := safeJoin(dest, tt.entry)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("safeJoin(%q, %q) err = %v, wantErr %v", dest, tt.entry, err, tt.wantErr)
+			}
+			if !tt.wantErr && !strings.HasPrefix(got, filepath.Clean(dest)) {
+				t.Errorf("safeJoin = %q, want under %q", got, dest)
+			}
+		})
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	t.Parallel()
+	if !hasPrefix("abcdef", "abc") {
+		t.Error("hasPrefix(abcdef, abc) = false")
+	}
+	if hasPrefix("ab", "abc") {
+		t.Error("hasPrefix(ab, abc) = true")
+	}
+	if hasPrefix("xyz", "abc") {
+		t.Error("hasPrefix(xyz, abc) = true")
+	}
+}
+
+// TestExtractEntryDir covers the directory entry branch.
+func TestExtractEntryDir(t *testing.T) {
+	t.Parallel()
+	dest := t.TempDir()
+	io, _ := testIO()
+	hdr := &tar.Header{Name: "newdir/", Typeflag: tar.TypeDir, Mode: 0o755}
+	if err := extractEntry(io, nil, dest, hdr, false); err != nil {
+		t.Fatalf("extractEntry dir err = %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dest, "newdir"))
+	if err != nil || !info.IsDir() {
+		t.Fatalf("directory not created: %v", err)
+	}
+}
+
+// TestExtractEntryRegularVerbose covers the regular-file branch with verbose
+// output enabled (so the banner branch is taken too).
+func TestExtractEntryRegularVerbose(t *testing.T) {
+	t.Parallel()
+	dest := t.TempDir()
+	io, errBuf := testIO()
+	body := "hello body"
+	hdr := &tar.Header{Name: "sub/file.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body))}
+	tr := tar.NewReader(buildArchive(t, hdr, body))
+	if _, err := tr.Next(); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractEntry(io, tr, dest, hdr, true); err != nil {
+		t.Fatalf("extractEntry reg err = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "sub", "file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != body {
+		t.Errorf("extracted = %q, want %q", got, body)
+	}
+	if !strings.Contains(errBuf.String(), "sub/file.txt") {
+		t.Errorf("verbose stderr = %q, want entry name", errBuf.String())
+	}
+}
+
+// TestExtractEntrySymlink covers the symlink branch.
+func TestExtractEntrySymlink(t *testing.T) {
+	t.Parallel()
+	dest := t.TempDir()
+	io, _ := testIO()
+	hdr := &tar.Header{Name: "link", Typeflag: tar.TypeSymlink, Linkname: "target", Mode: 0o777}
+	if err := extractEntry(io, nil, dest, hdr, false); err != nil {
+		t.Fatalf("extractEntry symlink err = %v", err)
+	}
+	link, err := os.Readlink(filepath.Join(dest, "link"))
+	if err != nil {
+		t.Fatalf("readlink err = %v", err)
+	}
+	if link != "target" {
+		t.Errorf("symlink target = %q, want target", link)
+	}
+}
+
+// TestExtractEntryUnsupportedSkipped covers the default (skip) branch.
+func TestExtractEntryUnsupportedSkipped(t *testing.T) {
+	t.Parallel()
+	dest := t.TempDir()
+	io, _ := testIO()
+	hdr := &tar.Header{Name: "fifo", Typeflag: tar.TypeFifo, Mode: 0o644}
+	if err := extractEntry(io, nil, dest, hdr, false); err != nil {
+		t.Fatalf("extractEntry fifo err = %v, want nil (skipped)", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "fifo")); !os.IsNotExist(err) {
+		t.Errorf("fifo should have been skipped, stat err = %v", err)
+	}
+}
+
+// TestExtractEntryRejectsTraversal verifies a malicious entry name is refused.
+func TestExtractEntryRejectsTraversal(t *testing.T) {
+	t.Parallel()
+	dest := t.TempDir()
+	io, _ := testIO()
+	hdr := &tar.Header{Name: "../escape.txt", Typeflag: tar.TypeReg, Mode: 0o644}
+	if err := extractEntry(io, nil, dest, hdr, false); err == nil {
+		t.Fatal("expected extractEntry to reject a traversal entry")
+	}
+}
+
+// buildArchive returns a reader over a one-entry tar archive carrying body.
+func buildArchive(t *testing.T, hdr *tar.Header, body string) *bytes.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(body)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewReader(buf.Bytes())
+}

--- a/internal/applets/debianutils/remove-shell/export_test.go
+++ b/internal/applets/debianutils/remove-shell/export_test.go
@@ -5,3 +5,9 @@ package removeShell
 func RemoveShellsForTest(path string, shells []string) error {
 	return removeShells(path, shells)
 }
+
+// ReadShellsForTest exposes the unexported readShells helper to the external
+// test package.
+func ReadShellsForTest(path string) ([]string, error) {
+	return readShells(path)
+}

--- a/internal/applets/debianutils/remove-shell/remove-shell_more_test.go
+++ b/internal/applets/debianutils/remove-shell/remove-shell_more_test.go
@@ -1,0 +1,133 @@
+package removeShell_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	removeShell "github.com/nao1215/mimixbox/internal/applets/debianutils/remove-shell"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func runCmd(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := removeShell.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := removeShell.New()
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+	if c.Name() != "remove-shell" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+}
+
+// TestRunMissingOperand covers Run's empty-args branch (no SHELLNAME given).
+func TestRunMissingOperand(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runCmd(t)
+	if err == nil {
+		t.Fatal("expected error when no shell name is given")
+	}
+	if !strings.Contains(errOut, "shellname") {
+		t.Errorf("stderr = %q, want usage hint", errOut)
+	}
+}
+
+// TestReadShellsTrimsAndSkipsBlanks covers readShells trimming whitespace and
+// dropping empty lines.
+func TestReadShellsTrimsAndSkipsBlanks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	content := "  /bin/sh  \n\n\t\n/bin/bash\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := removeShell.ReadShellsForTest(path)
+	if err != nil {
+		t.Fatalf("readShells error = %v", err)
+	}
+	want := []string{"/bin/sh", "/bin/bash"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("lines = %v, want %v", got, want)
+	}
+}
+
+// TestReadShellsMissingFileIsEmpty covers readShells returning an empty list for
+// a nonexistent file (os.IsNotExist branch).
+func TestReadShellsMissingFileIsEmpty(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	got, err := removeShell.ReadShellsForTest(missing)
+	if err != nil {
+		t.Fatalf("readShells error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("lines = %v, want empty for missing file", got)
+	}
+}
+
+// TestRemoveShellsCreatesFileWhenMissing covers removeShells against a missing
+// path: readShells yields nothing and the file is created (empty) by the
+// rewrite.
+func TestRemoveShellsCreatesFileWhenMissing(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "fresh-shells")
+	if err := removeShell.RemoveShellsForTest(path, []string{"/bin/zsh"}); err != nil {
+		t.Fatalf("removeShells error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file should have been created: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("file content = %q, want empty", data)
+	}
+}
+
+// TestRemoveShellsRemovesMultiple covers dropping several names at once and
+// preserving the order of the remaining lines.
+func TestRemoveShellsRemovesMultiple(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	if err := os.WriteFile(path, []byte("/bin/sh\n/bin/bash\n/bin/zsh\n/bin/ksh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeShell.RemoveShellsForTest(path, []string{"/bin/bash", "/bin/ksh"}); err != nil {
+		t.Fatalf("removeShells error = %v", err)
+	}
+	got, err := removeShell.ReadShellsForTest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"/bin/sh", "/bin/zsh"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("lines = %v, want %v", got, want)
+	}
+}
+
+// TestReadShellsOpenError covers readShells's non-IsNotExist error path by
+// pointing at a directory, which cannot be scanned as a file.
+func TestReadShellsOpenError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Opening a directory succeeds, but scanning it yields a read error on
+	// Linux; either an open or scan error must surface as non-nil.
+	_, err := removeShell.ReadShellsForTest(dir)
+	if err == nil {
+		t.Skip("reading a directory did not error on this platform")
+	}
+}

--- a/internal/applets/editors/patch/patch_more_test.go
+++ b/internal/applets/editors/patch/patch_more_test.go
@@ -1,0 +1,167 @@
+package patch_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMalformedHeader covers parseUnified's "--- " without a following "+++ ".
+func TestMalformedHeader(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "--- only-one-header\nsome body\n")
+	if err == nil {
+		t.Fatal("expected error for malformed header")
+	}
+	if !strings.Contains(errOut, "malformed header") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestHunkBeforeHeader covers parseUnified's "hunk before file header" branch.
+func TestHunkBeforeHeader(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "@@ -1,1 +1,1 @@\n a\n")
+	if err == nil {
+		t.Fatal("expected error for hunk before header")
+	}
+	if !strings.Contains(errOut, "hunk before file header") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestBadHunkHeader covers parseHunkHeader rejecting a malformed @@ line.
+func TestBadHunkHeader(t *testing.T) {
+	t.Parallel()
+	// Too few fields after @@ to form a valid header.
+	diff := "--- f\n+++ f\n@@ -1,1\n a\n"
+	_, errOut, err := run(t, diff)
+	if err == nil {
+		t.Fatal("expected error for bad hunk header")
+	}
+	if !strings.Contains(errOut, "bad hunk header") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestBadRangeLength covers parseRange's non-numeric length.
+func TestBadRangeLength(t *testing.T) {
+	t.Parallel()
+	diff := "--- f\n+++ f\n@@ -1,x +1,1 @@\n a\n"
+	_, errOut, err := run(t, diff)
+	if err == nil {
+		t.Fatal("expected error for bad range length")
+	}
+	if !strings.Contains(errOut, "patch:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestHunkStartBeyondEnd covers applyHunks rejecting a hunk that starts past the
+// end of the file.
+func TestHunkStartBeyondEnd(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// File has a single line, but the hunk claims to start at line 5.
+	diff := "--- " + target + "\n+++ " + target + "\n@@ -5,1 +5,1 @@\n a\n"
+	_, errOut, err := run(t, diff)
+	if err == nil {
+		t.Fatal("expected error for hunk start beyond end")
+	}
+	if !strings.Contains(errOut, "beyond end of file") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestNoNewlineMarkerIgnored covers parseHunk's handling of the
+// "\ No newline at end of file" marker: it is skipped and the patch still
+// applies.
+func TestNoNewlineMarkerIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	diff := "--- " + target + "\n+++ " + target + "\n" +
+		"@@ -1,1 +1,1 @@\n" +
+		"-old\n" +
+		"\\ No newline at end of file\n" +
+		"+new\n" +
+		"\\ No newline at end of file\n"
+	if _, errOut, err := run(t, diff); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "new\n" {
+		t.Errorf("patched = %q, want new", got)
+	}
+}
+
+// TestTrailingTextEndsHunkBody covers parseHunk's default branch where a line
+// that is not part of the hunk body terminates it, and parsing continues. Here
+// a non-diff "garbage" line follows the hunk body.
+func TestTrailingTextEndsHunkBody(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(target, []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	diff := "--- " + target + "\n+++ " + target + "\n" +
+		"@@ -1,1 +1,1 @@\n" +
+		" one\n" +
+		"trailing prose that is not part of the hunk\n"
+	if _, errOut, err := run(t, diff); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "one\ntwo\n" {
+		t.Errorf("patched = %q", got)
+	}
+}
+
+// TestEmptyContextLineInHunk covers parseHunk's handling of a truly empty line
+// inside a hunk body (treated as a context line containing "").
+func TestEmptyContextLineInHunk(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "f.txt")
+	// Original content: "a", "", "b".
+	if err := os.WriteFile(target, []byte("a\n\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The middle empty line is represented as an empty body line in the diff.
+	diff := "--- " + target + "\n+++ " + target + "\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		" a\n" +
+		"\n" +
+		"-b\n" +
+		"+B\n"
+	if _, errOut, err := run(t, diff); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "a\n\nB\n" {
+		t.Errorf("patched = %q, want a\\n\\nB", got)
+	}
+}
+
+// TestApplyToMissingTarget covers applyFile's open-error path.
+func TestApplyToMissingTarget(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "no-such-target.txt")
+	diff := "--- " + missing + "\n+++ " + missing + "\n@@ -1,1 +1,1 @@\n a\n"
+	_, errOut, err := run(t, diff)
+	if err == nil {
+		t.Fatal("expected error for missing target file")
+	}
+	if !strings.Contains(errOut, "cannot open") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}

--- a/internal/applets/editors/sed/sed_more_test.go
+++ b/internal/applets/editors/sed/sed_more_test.go
@@ -1,0 +1,197 @@
+package sed_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestReplacementTranslations drives translateRepl across its escape handling:
+// the whole-match &, numbered group references, and the \n, \t, \\, \& and
+// literal-$ escapes.
+func TestReplacementTranslations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		script string
+		in     string
+		want   string
+	}{
+		{"whole match amp", `s/cat/[&]/`, "cat\n", "[cat]\n"},
+		{"group ref", `s/\(a\)\(b\)/\2\1/`, "ab\n", "ba\n"},
+		{"newline escape", `s/-/\n/`, "a-b\n", "a\nb\n"},
+		{"tab escape", `s/-/\t/`, "a-b\n", "a\tb\n"},
+		{"literal backslash", `s/x/\\/`, "x\n", "\\\n"},
+		{"literal ampersand", `s/x/\&/`, "x\n", "&\n"},
+		{"literal dollar in input", `s/a/Z/`, "a$\n", "Z$\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, errOut, err := run(t, tt.in, tt.script)
+			if err != nil {
+				t.Fatalf("err = %v (stderr=%q)", err, errOut)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestBREOperatorEscaping drives bre2ere: in basic regex mode the bare
+// characters ( ) + ? { } | are literals, while their backslash-escaped forms are
+// operators.
+func TestBREOperatorEscaping(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		script string
+		in     string
+		want   string
+	}{
+		// Bare '+' is a literal plus in BRE.
+		{"literal plus", `s/a+/X/`, "a+b\n", "Xb\n"},
+		// Escaped \+ is the one-or-more operator.
+		{"operator plus", `s/a\+/X/`, "aaab\n", "Xb\n"},
+		// Bare parentheses are literal in BRE.
+		{"literal parens", `s/(x)/Y/`, "(x)\n", "Y\n"},
+		// Escaped \( \) form a capture group whose match can be referenced in
+		// the replacement.
+		{"operator group", `s/\(ab\)c/[\1]/`, "abc\n", "[ab]\n"},
+		// Bare '?' is literal.
+		{"literal question", `s/a?/Q/`, "a?\n", "Q\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, errOut, err := run(t, tt.in, tt.script)
+			if err != nil {
+				t.Fatalf("err = %v (stderr=%q)", err, errOut)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtendedRegexFlag drives compileRE/parse in extended mode, where bare
+// operators keep their special meaning.
+func TestExtendedRegexFlag(t *testing.T) {
+	t.Parallel()
+	out, errOut, err := run(t, "aaab\n", "-E", "s/a+/X/")
+	if err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	if out != "Xb\n" {
+		t.Errorf("out = %q, want %q", out, "Xb\n")
+	}
+}
+
+// TestUnterminatedAddressRegex drives address()'s until-not-found path: a regex
+// address with no closing delimiter is reported.
+func TestUnterminatedAddressRegex(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "/abc")
+	if err == nil {
+		t.Fatal("expected error for an unterminated address regex")
+	}
+	if !strings.Contains(errOut, "unterminated address regex") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestInPlaceMultipleFilesOneMissing drives runInPlace's per-file failure path:
+// a missing file is reported but the readable file is still edited, and the run
+// fails overall.
+func TestInPlaceMultipleFilesOneMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.txt")
+	if err := os.WriteFile(good, []byte("foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "missing.txt")
+
+	_, errOut, err := run(t, "", "-i", "s/foo/bar/", missing, good)
+	if err == nil {
+		t.Fatal("expected an overall failure when one file is missing")
+	}
+	if !strings.Contains(errOut, "missing.txt") {
+		t.Errorf("stderr = %q, want a diagnostic for the missing file", errOut)
+	}
+	got, rerr := os.ReadFile(good)
+	if rerr != nil {
+		t.Fatalf("read good: %v", rerr)
+	}
+	if string(got) != "bar\n" {
+		t.Errorf("good file = %q, want %q", got, "bar\n")
+	}
+}
+
+// TestInPlacePreservesMode drives writeFilePreservingMode: the in-place rewrite
+// keeps the original permission bits of the file.
+func TestInPlacePreservesMode(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not meaningfully preserved on Windows")
+	}
+	dir := t.TempDir()
+	f := filepath.Join(dir, "perm.txt")
+	if err := os.WriteFile(f, []byte("hello\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	// Ensure the mode is exactly 0640 even under a restrictive umask.
+	if err := os.Chmod(f, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, errOut, err := run(t, "", "-i", "s/hello/world/", f); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	info, err := os.Stat(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o640 {
+		t.Errorf("mode after in-place edit = %o, want 640", perm)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != "world\n" {
+		t.Errorf("content = %q, want %q", got, "world\n")
+	}
+}
+
+// TestInPlaceRangeStateResetBetweenFiles drives cloneProgram: a two-address
+// range that is open at the end of the first file must not leak into the second.
+func TestInPlaceRangeStateResetBetweenFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.txt")
+	f2 := filepath.Join(dir, "b.txt")
+	// In f1, the range "/start/,/end/d" never sees its end, so it stays open.
+	if err := os.WriteFile(f1, []byte("keep\nstart\ndrop1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, errOut, err := run(t, "", "-i", "/start/,/end/d", f1, f2); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	g1, _ := os.ReadFile(f1)
+	if string(g1) != "keep\n" {
+		t.Errorf("f1 = %q, want %q", g1, "keep\n")
+	}
+	// f2 must be untouched: the range did not leak across files.
+	g2, _ := os.ReadFile(f2)
+	if string(g2) != "line1\nline2\n" {
+		t.Errorf("f2 = %q, want it unchanged", g2)
+	}
+}

--- a/internal/applets/fileutils/rm/rm_more_test.go
+++ b/internal/applets/fileutils/rm/rm_more_test.go
@@ -1,0 +1,171 @@
+package rm_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/rm"
+)
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := rm.New()
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+	if c.Name() != "rm" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+}
+
+// TestRemoveEmptyDirWithDirFlag covers the -d branch: an empty directory may be
+// removed without -r.
+func TestRemoveEmptyDirWithDirFlag(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "empty")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, nil, "-d", sub); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if exists(sub) {
+		t.Errorf("empty directory %q should have been removed with -d", sub)
+	}
+}
+
+// TestRemoveNonEmptyDirWithDirFlagErrors covers os.Remove failing on a
+// non-empty directory when -d (not -r) is used.
+func TestRemoveNonEmptyDirWithDirFlagErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "full")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(sub, "inner.txt"))
+
+	_, errOut, err := run(t, nil, "-d", sub)
+	if err == nil {
+		t.Fatal("expected error removing a non-empty directory with -d")
+	}
+	if !exists(sub) {
+		t.Errorf("directory %q should remain", sub)
+	}
+	if !strings.Contains(errOut, "rm:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestVerboseReportsRemoval covers report(): -v prints a removal notice on
+// stdout.
+func TestVerboseReportsRemoval(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "a.txt")
+	writeFile(t, f)
+
+	out, _, err := run(t, nil, "-v", f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "removed '"+f+"'") {
+		t.Errorf("verbose out = %q, want a removal notice", out)
+	}
+}
+
+// TestVerboseRecursiveReportsDir covers report() on the recursive-directory
+// path.
+func TestVerboseRecursiveReportsDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(sub, "inner.txt"))
+
+	out, _, err := run(t, nil, "-rv", sub)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "removed '"+sub+"'") {
+		t.Errorf("verbose out = %q", out)
+	}
+	if exists(sub) {
+		t.Errorf("directory %q should have been removed", sub)
+	}
+}
+
+// TestInteractiveEOFKeepsFile covers confirm()'s EOF branch: with -i and an
+// empty (EOF) answer, the file is kept.
+func TestInteractiveEOFKeepsFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "a.txt")
+	writeFile(t, f)
+
+	// Empty reader => ReadString hits EOF immediately with an empty answer.
+	_, errOut, err := run(t, strings.NewReader(""), "-i", f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !exists(f) {
+		t.Errorf("file %q should remain after EOF answer", f)
+	}
+	if !strings.Contains(errOut, "remove '"+f+"'?") {
+		t.Errorf("prompt = %q", errOut)
+	}
+}
+
+// TestInteractiveNoDirKeepsDir covers confirm() returning false on the directory
+// path (-r -i answered "no").
+func TestInteractiveNoDirKeepsDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, strings.NewReader("n\n"), "-r", "-i", sub); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !exists(sub) {
+		t.Errorf("directory %q should remain after answering no", sub)
+	}
+}
+
+// TestForceWithNoOperands covers Run's early return when -f is set and there are
+// no operands (no error, no output).
+func TestForceWithNoOperands(t *testing.T) {
+	t.Parallel()
+	out, errOut, err := run(t, nil, "-f")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("expected silent success, got out=%q err=%q", out, errOut)
+	}
+}
+
+// TestRecursiveAliasUppercaseR covers the -R alias for -r.
+func TestRecursiveAliasUppercaseR(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(sub, "inner.txt"))
+
+	if _, _, err := run(t, nil, "-R", sub); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if exists(sub) {
+		t.Errorf("directory %q should have been removed with -R", sub)
+	}
+}

--- a/internal/applets/fileutils/rmdir/rmdir_more_test.go
+++ b/internal/applets/fileutils/rmdir/rmdir_more_test.go
@@ -1,0 +1,121 @@
+package rmdir_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/fileutils/rmdir"
+)
+
+// TestSynopsis covers the one-line description helper.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if got := rmdir.New().Synopsis(); got != "Remove directory" {
+		t.Errorf("Synopsis() = %q", got)
+	}
+}
+
+// TestMultipleFailuresKeepsFirstError drives keep(): when two operands both
+// fail, a single failure error is still returned (the first one is kept).
+func TestMultipleFailuresKeepsFirstError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	nonEmptyA := filepath.Join(dir, "a")
+	nonEmptyB := filepath.Join(dir, "b")
+	for _, d := range []string{nonEmptyA, nonEmptyB} {
+		if err := os.MkdirAll(filepath.Join(d, "child"), 0o755); err != nil {
+			t.Fatalf("setup %s: %v", d, err)
+		}
+	}
+
+	_, errOut, err := run(t, nonEmptyA, nonEmptyB)
+	if err == nil {
+		t.Fatal("expected a failure when both directories are non-empty")
+	}
+	// Both failures are reported on stderr even though one error is returned.
+	for _, name := range []string{"'" + nonEmptyA + "'", "'" + nonEmptyB + "'"} {
+		if !strings.Contains(errOut, name) {
+			t.Errorf("stderr = %q, want a diagnostic for %s", errOut, name)
+		}
+	}
+}
+
+// TestParentsStopsAtFirstFailure verifies remove() aborts the ancestor walk when
+// a parent is not empty: 'rmdir -p a/b/c' fails at b when b also holds a sibling.
+func TestParentsStopsAtFirstFailure(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// a/b/c is empty, but b also contains a sibling so b cannot be removed.
+	abc := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(abc, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sibling := filepath.Join(root, "a", "b", "sibling")
+	if err := os.Mkdir(sibling, 0o755); err != nil {
+		t.Fatalf("mkdir sibling: %v", err)
+	}
+
+	_, _, err := run(t, "-p", abc)
+	if err == nil {
+		t.Fatal("expected failure: ancestor b is not empty")
+	}
+	// c was removed, but b survives because of the sibling.
+	if _, serr := os.Stat(abc); serr == nil {
+		t.Errorf("leaf %s should have been removed", abc)
+	}
+	if _, serr := os.Stat(filepath.Join(root, "a", "b")); serr != nil {
+		t.Errorf("non-empty ancestor b should survive: %v", serr)
+	}
+}
+
+// TestParentsRemovesAncestors verifies the success path of -p where every
+// ancestor of a relative operand becomes empty and is removed in turn. Running
+// from inside the temp root with a relative path "x/y/z" lets the ancestor walk
+// stop cleanly at "." instead of climbing into system directories.
+func TestParentsRemovesAncestors(t *testing.T) {
+	root := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	if err := os.MkdirAll(filepath.Join("x", "y", "z"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if _, _, err := run(t, "-p", filepath.Join("x", "y", "z")); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	for _, d := range []string{"x/y/z", "x/y", "x"} {
+		if _, serr := os.Stat(filepath.Join(root, filepath.FromSlash(d))); serr == nil {
+			t.Errorf("ancestor %s should have been removed", d)
+		}
+	}
+	// The temp root itself survives: the walk stops at "." before reaching it.
+	if _, serr := os.Stat(root); serr != nil {
+		t.Errorf("root should be untouched: %v", serr)
+	}
+}
+
+// TestVerboseReportsRemoval exercises the -v diagnostic on stdout.
+func TestVerboseReportsRemoval(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty")
+	if err := os.Mkdir(empty, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	out, _, err := run(t, "-v", empty)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.Contains(out, "removing directory") || !strings.Contains(out, empty) {
+		t.Errorf("verbose stdout = %q", out)
+	}
+}

--- a/internal/applets/fileutils/shred/shred_more_test.go
+++ b/internal/applets/fileutils/shred/shred_more_test.go
@@ -1,0 +1,75 @@
+package shred_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNonexistentFileReported drives shredFile's stat-error path: a missing file
+// is reported and yields a failure.
+func TestNonexistentFileReported(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "/no/such/file/here")
+	if err == nil {
+		t.Fatal("expected error for a nonexistent file")
+	}
+	if !strings.Contains(errOut, "shred: /no/such/file/here") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestEmptyFileOverwrite drives overwrite() with size 0: io.CopyN returns EOF
+// immediately, which must be treated as success.
+func TestEmptyFileOverwrite(t *testing.T) {
+	t.Parallel()
+	p := tmpFile(t, "")
+	if _, _, err := run(t, "-n", "2", p); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("empty file size = %d, want 0", info.Size())
+	}
+}
+
+// TestRemoveZeroPassCombined exercises -z together with -u: the file is
+// overwritten with zeros, then truncated and removed.
+func TestRemoveZeroPassCombined(t *testing.T) {
+	t.Parallel()
+	p := tmpFile(t, "topsecret")
+	if _, _, err := run(t, "-z", "-u", "-n", "1", p); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Error("file should have been removed after -z -u")
+	}
+}
+
+// TestMultipleFilesOneMissing verifies that a per-file error does not abort the
+// whole run: the good file is still shredded, and the run fails overall.
+func TestMultipleFilesOneMissing(t *testing.T) {
+	t.Parallel()
+	good := tmpFile(t, "keepme")
+	missing := filepath.Join(t.TempDir(), "gone")
+
+	_, errOut, err := run(t, missing, good)
+	if err == nil {
+		t.Fatal("expected an overall failure when one file is missing")
+	}
+	if !strings.Contains(errOut, "gone") {
+		t.Errorf("stderr = %q, want a diagnostic for the missing file", errOut)
+	}
+	// The good file was still processed: it survives (no -u) at its size.
+	info, serr := os.Stat(good)
+	if serr != nil {
+		t.Fatalf("good file stat: %v", serr)
+	}
+	if info.Size() != int64(len("keepme")) {
+		t.Errorf("good file size = %d, want %d", info.Size(), len("keepme"))
+	}
+}

--- a/internal/applets/fileutils/stat/stat_internal_test.go
+++ b/internal/applets/fileutils/stat/stat_internal_test.go
@@ -1,0 +1,60 @@
+package stat
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+)
+
+// TestFileType covers every mode-to-description branch of fileType, including
+// the device sub-cases that the on-disk fixtures in the external test cannot
+// portably exercise.
+func TestFileType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		mode fs.FileMode
+		want string
+	}{
+		{"regular", 0o644, "regular file"},
+		{"directory", fs.ModeDir | 0o755, "directory"},
+		{"symlink", fs.ModeSymlink | 0o777, "symbolic link"},
+		{"fifo", fs.ModeNamedPipe | 0o644, "fifo"},
+		{"socket", fs.ModeSocket | 0o644, "socket"},
+		{"char device", fs.ModeDevice | fs.ModeCharDevice | 0o644, "character special file"},
+		{"block device", fs.ModeDevice | 0o644, "block special file"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fileType(tt.mode); got != tt.want {
+				t.Errorf("fileType(%v) = %q, want %q", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnwrap verifies unwrap peels a *os.PathError but passes plain errors
+// through unchanged.
+func TestUnwrap(t *testing.T) {
+	t.Parallel()
+	inner := errors.New("boom")
+	pe := &os.PathError{Op: "stat", Path: "/x", Err: inner}
+	if got := unwrap(pe); got != inner {
+		t.Errorf("unwrap(PathError) = %v, want %v", got, inner)
+	}
+	plain := errors.New("plain")
+	if got := unwrap(plain); got != plain {
+		t.Errorf("unwrap(plain) = %v, want %v", got, plain)
+	}
+}
+
+// TestUnescape covers the backslash escapes honoured inside a -c format.
+func TestUnescape(t *testing.T) {
+	t.Parallel()
+	if got := unescape(`a\nb\tc\\d`); got != "a\nb\tc\\d" {
+		t.Errorf("unescape = %q", got)
+	}
+}

--- a/internal/applets/fileutils/touch/touch_internal_test.go
+++ b/internal/applets/fileutils/touch/touch_internal_test.go
@@ -1,0 +1,116 @@
+package touch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestTouchAccessOnlyPreservesModTime exercises the -a branch: only the access
+// time is advanced, the modification time keeps its old value.
+func TestTouchAccessOnlyPreservesModTime(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-3 * time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := touch(path, options{accessOnly: true}); err != nil {
+		t.Fatalf("touch -a err = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// -a must leave the modification time unchanged (within a second).
+	if delta := info.ModTime().Sub(old); delta < -time.Second || delta > time.Second {
+		t.Errorf("modtime moved by %v, want unchanged", delta)
+	}
+}
+
+// TestTouchModifyOnlyAdvancesModTime exercises the -m branch.
+func TestTouchModifyOnlyAdvancesModTime(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-3 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := touch(path, options{modifyOnly: true}); err != nil {
+		t.Fatalf("touch -m err = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().After(old) {
+		t.Errorf("modtime = %v, want advanced past %v", info.ModTime(), old)
+	}
+}
+
+// TestTouchNoCreateOnExistingStillUpdates verifies -c does not block updating an
+// already-existing file's timestamps.
+func TestTouchNoCreateOnExistingStillUpdates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-3 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := touch(path, options{noCreate: true}); err != nil {
+		t.Fatalf("touch -c err = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().After(old) {
+		t.Errorf("modtime = %v, want advanced", info.ModTime())
+	}
+}
+
+// TestTouchNoCreateOnMissingIsNoop verifies -c leaves a missing file absent and
+// returns no error.
+func TestTouchNoCreateOnMissingIsNoop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.txt")
+	if err := touch(path, options{noCreate: true}); err != nil {
+		t.Fatalf("touch -c missing err = %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should remain absent, stat err = %v", err)
+	}
+}
+
+// TestTouchCreateFailsInMissingDir exercises the os.Create error path.
+func TestTouchCreateFailsInMissingDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "no-such-subdir", "f.txt")
+	if err := touch(path, options{}); err == nil {
+		t.Fatal("expected an error creating a file in a missing directory")
+	}
+}
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if New().Synopsis() == "" {
+		t.Error("Synopsis() = empty")
+	}
+}

--- a/internal/applets/fileutils/truncate/truncate_internal_test.go
+++ b/internal/applets/fileutils/truncate/truncate_internal_test.go
@@ -1,0 +1,79 @@
+package truncate
+
+import "testing"
+
+// TestParseBytes covers the plain, suffixed, and invalid byte-count forms.
+func TestParseBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		spec    string
+		want    int64
+		wantErr bool
+	}{
+		{"plain", "100", 100, false},
+		{"zero", "0", 0, false},
+		{"K", "1K", 1024, false},
+		{"KB", "2KB", 2 * 1024, false},
+		{"M", "1M", 1024 * 1024, false},
+		{"MB", "3MB", 3 * 1024 * 1024, false},
+		{"G", "1G", 1024 * 1024 * 1024, false},
+		{"GB", "2GB", 2 * 1024 * 1024 * 1024, false},
+		{"non-numeric", "abc", 0, true},
+		{"negative", "-5", 0, true},
+		{"empty number with suffix", "K", 0, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseBytes(tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseBytes(%q) err = %v, wantErr %v", tt.spec, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseBytes(%q) = %d, want %d", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveSize covers absolute, relative (+/-) and the negative-clamp paths.
+func TestResolveSize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		spec    string
+		cur     int64
+		want    int64
+		wantErr bool
+	}{
+		{"absolute", "500", 100, 500, false},
+		{"absolute with suffix", "1K", 0, 1024, false},
+		{"grow", "+50", 100, 150, false},
+		{"grow suffix", "+1K", 0, 1024, false},
+		{"shrink", "-30", 100, 70, false},
+		{"shrink below zero clamps", "-200", 100, 0, false},
+		{"invalid", "+xyz", 0, 0, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveSize(tt.spec, tt.cur)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveSize(%q, %d) err = %v, wantErr %v", tt.spec, tt.cur, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("resolveSize(%q, %d) = %d, want %d", tt.spec, tt.cur, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if New().Synopsis() == "" {
+		t.Error("Synopsis() = empty")
+	}
+}

--- a/internal/applets/jokeutils/sl/sl_internal_test.go
+++ b/internal/applets/jokeutils/sl/sl_internal_test.go
@@ -1,0 +1,33 @@
+package sl
+
+import "testing"
+
+// TestLongestRow verifies longestRow returns the width of the widest train row.
+// It is the pure helper that drives how far the animation must scroll, so it can
+// be asserted without a terminal. drawString and animate require an initialized
+// termbox terminal (a real TTY) and so are not unit-testable here.
+func TestLongestRow(t *testing.T) {
+	got := longestRow()
+
+	// Compute the expected width directly from the package art so the test
+	// stays correct if the locomotive art changes.
+	want := 0
+	for _, row := range train {
+		if n := len([]rune(row)); n > want {
+			want = n
+		}
+	}
+
+	if got != want {
+		t.Errorf("longestRow() = %d, want %d", got, want)
+	}
+	if got <= 0 {
+		t.Errorf("longestRow() = %d, want a positive width", got)
+	}
+	// Every row must fit inside the reported longest width.
+	for i, row := range train {
+		if n := len([]rune(row)); n > got {
+			t.Errorf("row %d has width %d > longestRow() %d", i, n, got)
+		}
+	}
+}

--- a/internal/applets/netutils/ping/ping_more_test.go
+++ b/internal/applets/netutils/ping/ping_more_test.go
@@ -1,0 +1,75 @@
+package ping
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestParseReplyWithOptions checks that parseReply honours the IHL field when
+// the IPv4 header carries options (ihl > 5), locating the ICMP message at the
+// correct offset.
+func TestParseReplyWithOptions(t *testing.T) {
+	t.Parallel()
+	// ihl = 6 (24-byte header) => version/ihl byte 0x46.
+	const ihl = 6
+	packet := make([]byte, ihl*4+8)
+	packet[0] = 0x40 | ihl
+	icmp := packet[ihl*4:]
+	icmp[0] = icmpEchoReply
+	binary.BigEndian.PutUint16(icmp[4:], 0x0102)
+	binary.BigEndian.PutUint16(icmp[6:], 99)
+
+	id, seq, ok := parseReply(packet)
+	if !ok || id != 0x0102 || seq != 99 {
+		t.Errorf("parseReply = %#x, %d, %v; want 0x0102, 99, true", id, seq, ok)
+	}
+}
+
+// TestParseReplyTruncatedAfterIHL covers the second length guard: the packet is
+// at least 20 bytes but shorter than ihl*4+8.
+func TestParseReplyTruncatedAfterIHL(t *testing.T) {
+	t.Parallel()
+	// ihl = 15 (max) requires 60+8 bytes; supply far fewer.
+	packet := make([]byte, 24)
+	packet[0] = 0x4f // ihl = 15
+	if _, _, ok := parseReply(packet); ok {
+		t.Error("packet too short for its IHL should not parse")
+	}
+}
+
+// TestChecksumOddLength exercises the trailing-byte branch of checksum (odd
+// length) and verifies the one's-complement result.
+func TestChecksumOddLength(t *testing.T) {
+	t.Parallel()
+	// Single byte 0x01 -> sum 0x0100 -> ^0x0100 = 0xfeff.
+	if got := checksum([]byte{0x01}); got != 0xfeff {
+		t.Errorf("checksum(odd) = %#x, want 0xfeff", got)
+	}
+}
+
+// TestChecksumCarryFold exercises the high-bit carry fold loop with values that
+// overflow 16 bits when summed.
+func TestChecksumCarryFold(t *testing.T) {
+	t.Parallel()
+	// 0xffff + 0xffff = 0x1fffe; folded: 0xfffe + 1 = 0xffff; ^0xffff = 0.
+	if got := checksum([]byte{0xff, 0xff, 0xff, 0xff}); got != 0 {
+		t.Errorf("checksum(carry) = %#x, want 0", got)
+	}
+}
+
+// TestEchoRequestSeqWraps confirms a large sequence number is truncated to 16
+// bits, matching the on-wire field width.
+func TestEchoRequestSeqWraps(t *testing.T) {
+	t.Parallel()
+	pkt := echoRequest(0x10000, 0x10001)
+	if id := binary.BigEndian.Uint16(pkt[4:]); id != 0 {
+		t.Errorf("id field = %#x, want 0 (0x10000 truncated)", id)
+	}
+	if seq := binary.BigEndian.Uint16(pkt[6:]); seq != 1 {
+		t.Errorf("seq field = %d, want 1 (0x10001 truncated)", seq)
+	}
+	// The embedded checksum must still verify to zero.
+	if got := checksum(pkt); got != 0 {
+		t.Errorf("verification checksum = %#x, want 0", got)
+	}
+}

--- a/internal/applets/shellutils/od/od_more_test.go
+++ b/internal/applets/shellutils/od/od_more_test.go
@@ -1,0 +1,170 @@
+package od_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/od"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// TestRunFormatTypes drives the -t types whose unit renderers were previously
+// uncovered: signed (d1/d2), unsigned (u1/u2) and the named-character form (a).
+// Expected outputs were checked against GNU od.
+func TestRunFormatTypes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{
+			// 0xFF is -1 as int8; "A" is 65.
+			name:  "signed bytes d1",
+			stdin: "\xffA",
+			args:  []string{"-A", "n", "-t", "d1"},
+			want:  "   -1   65\n",
+		},
+		{
+			// little-endian 0xFFFF = -1 as int16.
+			name:  "signed words d2",
+			stdin: "\xff\xff",
+			args:  []string{"-A", "n", "-t", "d2"},
+			want:  "     -1\n",
+		},
+		{
+			name:  "unsigned bytes u1",
+			stdin: "\x00\xff",
+			args:  []string{"-A", "n", "-t", "u1"},
+			want:  "   0 255\n",
+		},
+		{
+			// little-endian 0xFF00 = 255.
+			name:  "unsigned words u2 shortcut -d",
+			stdin: "\xff\x00",
+			args:  []string{"-A", "n", "-d"},
+			want:  "   255\n",
+		},
+		{
+			// -t a names control characters and prints printable bytes as is.
+			name:  "named characters a",
+			stdin: "\x00 A\x7f\n",
+			args:  []string{"-A", "n", "-t", "a"},
+			want:  " nul  sp   A del  nl\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunCharNonPrintable exercises charUnit's octal fallback for a byte that
+// is neither a known C escape nor printable.
+func TestRunCharNonPrintable(t *testing.T) {
+	t.Parallel()
+	// 0xff has no C escape and is not printable -> rendered as octal "377".
+	out, _, err := runStdin(t, "\xff", "-A", "n", "-c")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != " 377\n" {
+		t.Errorf("out = %q, want octal fallback", out)
+	}
+}
+
+// TestRunMultipleFilesConcatenated checks that several operands are read and
+// dumped as one stream, and that the address counter spans both files.
+func TestRunMultipleFilesConcatenated(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.bin")
+	b := filepath.Join(dir, "b.bin")
+	if err := os.WriteFile(a, []byte("AB"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("CD"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runStdin(t, "", "-A", "n", "-t", "x1", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != " 41 42 43 44\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+// TestRunMultipleMissingFilesKeepsFirstError exercises keep(): two missing
+// operands still produce a single (non-nil) failure and both are reported.
+func TestRunMultipleMissingFilesKeepsFirstError(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := runStdin(t, "", "/no/such/a", "/no/such/b")
+	if err == nil {
+		t.Fatal("expected error for missing files")
+	}
+	if !strings.Contains(errOut, "/no/such/a") || !strings.Contains(errOut, "/no/such/b") {
+		t.Errorf("stderr = %q, want both missing files reported", errOut)
+	}
+}
+
+// TestRunMixedGoodAndMissingFile checks that a readable file still dumps even
+// when another operand is missing, and the exit code is still failure.
+func TestRunMixedGoodAndMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.bin")
+	if err := os.WriteFile(good, []byte("AB"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runStdin(t, "", "-A", "n", "-t", "x1", good, "/no/such/file")
+	if err == nil {
+		t.Fatal("expected failure because of the missing file")
+	}
+	if !strings.Contains(out, "41 42") {
+		t.Errorf("good file should still be dumped, out = %q", out)
+	}
+}
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := od.New()
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+	if c.Name() != "od" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+}
+
+// TestRunPadAndWideValue makes sure a single trailing partial unit is rendered
+// without panicking (little-endian zero-extends the missing high byte).
+func TestRunPadAndWideValue(t *testing.T) {
+	t.Parallel()
+	// Odd number of bytes with a 2-byte type: the last word is a partial unit.
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader("A"), Out: out, Err: &bytes.Buffer{}}
+	if err := od.New().Run(context.Background(), io, []string{"-A", "n", "-t", "x2"}); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// "A" is 0x41; the trailing partial word renders the single byte as "41",
+	// right-justified in the 2-byte field width of 4.
+	if out.String() != "   41\n" {
+		t.Errorf("out = %q", out.String())
+	}
+}

--- a/internal/applets/shellutils/printf/printf_more_test.go
+++ b/internal/applets/shellutils/printf/printf_more_test.go
@@ -1,0 +1,158 @@
+package printf_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/printf"
+)
+
+// TestFormatEscapes drives the backslash escapes interpreted directly in the
+// FORMAT string by formatEscape (including octal \0NNN and hex \xHH), plus the
+// "unknown escape" fall-through that emits a literal backslash. Outputs match
+// GNU printf.
+func TestFormatEscapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"bell", []string{`\a`}, "\a"},
+		{"backspace", []string{`\b`}, "\b"},
+		{"formfeed", []string{`\f`}, "\f"},
+		{"carriage return", []string{`\r`}, "\r"},
+		{"vertical tab", []string{`\v`}, "\v"},
+		{"literal backslash", []string{`\\`}, "\\"},
+		{"octal escape", []string{`\0101`}, "A"},      // 0101 octal = 65 = 'A'
+		{"bare null escape", []string{`\0`}, "\x00"},  // \0 with no digits = NUL
+		{"hex escape", []string{`\x41`}, "A"},         // 0x41 = 'A'
+		{"hex single digit", []string{`\x9z`}, "\tz"}, // \x9 = tab, then literal z
+		{"unknown escape literal", []string{`\q`}, `\q`},
+		{"trailing backslash literal", []string{`\`}, `\`},
+		{"bad hex emits literal", []string{`\xz`}, `\xz`},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestPercentBEscapes drives expandEscapes via the %b conversion, covering every
+// escape it understands plus the \c "stop output" escape and octal/hex forms.
+func TestPercentBEscapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"newline", []string{"%b", `a\nb`}, "a\nb"},
+		{"tab", []string{"%b", `a\tb`}, "a\tb"},
+		{"bell", []string{"%b", `\a`}, "\a"},
+		{"backspace", []string{"%b", `\b`}, "\b"},
+		{"formfeed", []string{"%b", `\f`}, "\f"},
+		{"carriage return", []string{"%b", `\r`}, "\r"},
+		{"vertical tab", []string{"%b", `\v`}, "\v"},
+		{"backslash", []string{"%b", `\\`}, "\\"},
+		{"octal", []string{"%b", `\0101`}, "A"},
+		{"hex", []string{"%b", `\x41`}, "A"},
+		{"bad hex keeps literal", []string{"%b", `\xz`}, `\xz`},
+		{"unknown escape literal", []string{"%b", `\q`}, `\q`},
+		{"c stops output", []string{"%b", `ab\ccd`}, "ab"},
+		{"trailing backslash literal", []string{"%b", `a\`}, `a\`},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnsignedConversions covers toUint's two parse paths: an unsigned literal
+// and the signed fallback for a negative argument (reinterpreted as unsigned).
+func TestUnsignedConversions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"hex of negative reinterpreted", []string{"%x", "-1"}, "ffffffffffffffff"},
+		{"upper hex", []string{"%X", "255"}, "FF"},
+		{"unsigned decimal", []string{"%u", "42"}, "42"},
+		{"unsigned of empty is zero", []string{"%u"}, "0"},
+		{"unsigned of garbage is zero", []string{"%u", "notnum"}, "0"},
+		{"hex literal input", []string{"%d", "0x1f"}, "31"},
+		{"decimal garbage is zero", []string{"%d", "nope"}, "0"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestConversionEdgeCases covers the trailing-'%'-with-no-verb path, an unknown
+// verb emitted literally, and an empty %c argument.
+func TestConversionEdgeCases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"trailing percent no verb", []string{"abc%"}, "abc%"},
+		{"unknown verb literal", []string{"%q", "x"}, "%q"},
+		{"empty c arg produces nothing", []string{"[%c]"}, "[]"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := printf.New()
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+	if c.Name() != "printf" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+}

--- a/internal/applets/shellutils/pwd/pwd_more_test.go
+++ b/internal/applets/shellutils/pwd/pwd_more_test.go
@@ -1,0 +1,110 @@
+package pwd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/pwd"
+)
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := pwd.New()
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+	if c.Name() != "pwd" {
+		t.Errorf("Name() = %q", c.Name())
+	}
+}
+
+// TestLogicalIgnoresStalePWD covers the namesCurrentDir mismatch branch: when
+// $PWD names a directory that is not the actual working directory, the logical
+// path is discarded and os.Getwd() is used instead.
+func TestLogicalIgnoresStalePWD(t *testing.T) {
+	dir := t.TempDir()
+	other := t.TempDir()
+	t.Chdir(dir)
+	// $PWD points somewhere else, so it must not be trusted.
+	t.Setenv("PWD", other)
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got := strings.TrimSuffix(out, "\n")
+	if sameDir(t, got, other) {
+		t.Errorf("output %q should not be the stale PWD %q", got, other)
+	}
+	if !sameDir(t, got, dir) {
+		t.Errorf("output = %q, want the real working directory %q", got, dir)
+	}
+}
+
+// TestLogicalIgnoresRelativePWD covers the !filepath.IsAbs(pwd) branch: a
+// relative $PWD is ignored entirely.
+func TestLogicalIgnoresRelativePWD(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("PWD", "relative/path")
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got := strings.TrimSuffix(out, "\n")
+	if !filepath.IsAbs(got) {
+		t.Errorf("output %q should be absolute despite a relative PWD", got)
+	}
+	if !sameDir(t, got, dir) {
+		t.Errorf("output = %q, want %q", got, dir)
+	}
+}
+
+// TestLogicalIgnoresNonexistentPWD covers the namesCurrentDir branch where
+// EvalSymlinks of $PWD fails because the path does not exist.
+func TestLogicalIgnoresNonexistentPWD(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("PWD", filepath.Join(dir, "does", "not", "exist"))
+
+	out, _, err := run(t)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got := strings.TrimSuffix(out, "\n")
+	if !sameDir(t, got, dir) {
+		t.Errorf("output = %q, want %q", got, dir)
+	}
+}
+
+// TestPhysicalThroughSymlink covers workingDir(physical=true) resolving a
+// symlinked working directory to its canonical target.
+func TestPhysicalThroughSymlink(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	link := filepath.Join(base, "link")
+	if err := os.Mkdir(real, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks not supported: %v", err)
+	}
+	t.Chdir(link)
+
+	out, _, err := run(t, "-P")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got := strings.TrimSuffix(out, "\n")
+	resolved, err := filepath.EvalSymlinks(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != resolved {
+		t.Errorf("-P output = %q, want resolved %q", got, resolved)
+	}
+}

--- a/internal/applets/shellutils/sddf/sddf_more_test.go
+++ b/internal/applets/shellutils/sddf/sddf_more_test.go
@@ -1,0 +1,208 @@
+package sddf_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/sddf"
+)
+
+// chdir changes into dir for the duration of the test, restoring the previous
+// working directory afterwards. sddf writes its *.sddf report relative to the
+// current directory, so report-writing tests run from a temp dir.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+}
+
+// TestSynopsis covers the one-line description helper.
+func TestSynopsis(t *testing.T) {
+	if got := sddf.New().Synopsis(); got != "Search & Delete Duplicated File" {
+		t.Errorf("Synopsis() = %q", got)
+	}
+}
+
+// TestScanWritesReport drives the default (no -d) path: the duplicate groups are
+// written to a *.sddf report. This exercises dumpToFile and decideOutputFileName.
+func TestScanWritesReport(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	uniq := filepath.Join(dir, "u.txt")
+	writeFile(t, a, []byte("dup-content"))
+	writeFile(t, b, []byte("dup-content"))
+	writeFile(t, uniq, []byte("only-me"))
+
+	work := t.TempDir()
+	chdir(t, work)
+
+	out, _, err := run(t, "", "-o", "report", dir)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+
+	report := filepath.Join(work, "report.sddf")
+	if !strings.Contains(out, "report.sddf") {
+		t.Errorf("output did not mention report file:\n%s", out)
+	}
+	data, rerr := os.ReadFile(report)
+	if rerr != nil {
+		t.Fatalf("report not written: %v", rerr)
+	}
+	text := string(data)
+	// The report records the two duplicates and not the unique file.
+	if !strings.Contains(text, a) || !strings.Contains(text, b) {
+		t.Errorf("report missing duplicate paths:\n%s", text)
+	}
+	if strings.Contains(text, uniq) {
+		t.Errorf("report unexpectedly contains the unique file:\n%s", text)
+	}
+	// A checksum header line is wrapped in [].
+	if !strings.Contains(text, "[") || !strings.Contains(text, "]") {
+		t.Errorf("report missing checksum header:\n%s", text)
+	}
+}
+
+// TestDefaultOutputNameGetsExtension verifies decideOutputFileName appends the
+// .sddf extension when the -o name lacks it (the default name "duplicated-file").
+func TestDefaultOutputNameGetsExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a"), []byte("x"))
+	writeFile(t, filepath.Join(dir, "b"), []byte("x"))
+
+	work := t.TempDir()
+	chdir(t, work)
+
+	if _, _, err := run(t, "", dir); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "duplicated-file.sddf")); err != nil {
+		t.Errorf("default report not written with .sddf extension: %v", err)
+	}
+}
+
+// TestExplicitSddfExtensionKept verifies decideOutputFileName keeps an -o name
+// that already ends in .sddf rather than doubling the extension.
+func TestExplicitSddfExtensionKept(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a"), []byte("y"))
+	writeFile(t, filepath.Join(dir, "b"), []byte("y"))
+
+	work := t.TempDir()
+	chdir(t, work)
+
+	if _, _, err := run(t, "", "-o", "mine.sddf", dir); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "mine.sddf")); err != nil {
+		t.Errorf("report not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "mine.sddf.sddf")); err == nil {
+		t.Error("extension was doubled to mine.sddf.sddf")
+	}
+}
+
+// TestRestoreReportAndDelete writes a report, then runs sddf on that report to
+// delete the duplicates it records. This exercises restoreAndDelete, restore and
+// isChecksumLine end-to-end.
+func TestRestoreReportAndDelete(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	c := filepath.Join(dir, "c.txt")
+	writeFile(t, a, []byte("same"))
+	writeFile(t, b, []byte("same"))
+	writeFile(t, c, []byte("same"))
+
+	work := t.TempDir()
+	chdir(t, work)
+
+	// 1. Scan to produce the report.
+	if _, _, err := run(t, "", "-o", "rep", dir); err != nil {
+		t.Fatalf("scan error = %v", err)
+	}
+	report := filepath.Join(work, "rep.sddf")
+
+	// 2. Delete from the report (no -d needed: a report always deletes).
+	if _, _, err := run(t, "", report); err != nil {
+		t.Fatalf("restore-delete error = %v", err)
+	}
+
+	remaining := 0
+	for _, p := range []string{a, b, c} {
+		if _, err := os.Stat(p); err == nil {
+			remaining++
+		}
+	}
+	if remaining != 1 {
+		t.Errorf("remaining files = %d, want 1 (newest kept)", remaining)
+	}
+}
+
+// TestRestoreReportDryRun verifies a report can be processed with --dry-run,
+// leaving the files in place.
+func TestRestoreReportDryRun(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	writeFile(t, a, []byte("twin"))
+	writeFile(t, b, []byte("twin"))
+
+	work := t.TempDir()
+	chdir(t, work)
+
+	if _, _, err := run(t, "", "-o", "rep", dir); err != nil {
+		t.Fatalf("scan error = %v", err)
+	}
+	report := filepath.Join(work, "rep.sddf")
+
+	out, _, err := run(t, "", "--dry-run", report)
+	if err != nil {
+		t.Fatalf("dry-run restore error = %v", err)
+	}
+	if !strings.Contains(out, "Delete(DryRun)") {
+		t.Errorf("dry-run output missing DryRun line:\n%s", out)
+	}
+	for _, p := range []string{a, b} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("dry-run removed %s: %v", p, err)
+		}
+	}
+}
+
+// TestNonSddfFileOperandRejected verifies a non-directory operand that does not
+// carry the .sddf extension is rejected by restoreAndDelete.
+func TestNonSddfFileOperandRejected(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "notes.txt")
+	writeFile(t, plain, []byte("hello"))
+
+	_, errOut, err := run(t, "", plain)
+	if err == nil {
+		t.Fatal("expected an error for a non-*.sddf file operand")
+	}
+	if !strings.Contains(errOut, "is not *.sddf") {
+		t.Errorf("stderr = %q, want a format complaint", errOut)
+	}
+}
+
+// TestNonexistentOperand verifies a missing operand path is reported and yields
+// a failure.
+func TestNonexistentOperand(t *testing.T) {
+	_, errOut, err := run(t, "", "/no/such/dir/exists")
+	if err == nil {
+		t.Fatal("expected error for nonexistent operand")
+	}
+	if !strings.Contains(errOut, "sddf:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}

--- a/internal/applets/shellutils/seq/seq_more_test.go
+++ b/internal/applets/shellutils/seq/seq_more_test.go
@@ -1,0 +1,116 @@
+package seq_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/seq"
+)
+
+// TestSynopsis covers the one-line description helper.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if got := seq.New().Synopsis(); got != "Print a column of numbers" {
+		t.Errorf("Synopsis() = %q", got)
+	}
+}
+
+// TestNegativeOperandsAfterTerminator drives escapeIfNegative: operands that
+// follow an explicit "--" terminator must still be recognized as negative
+// numbers rather than options.
+func TestNegativeOperandsAfterTerminator(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		// "--" then FIRST INCREMENT LAST, all negative: count up from -5 by 2.
+		{"negative range after terminator", []string{"--", "-5", "2", "-1"}, "-5\n-3\n-1\n"},
+		// "--" then a single negative LAST counts 1 down to -3.
+		{"single negative last", []string{"--", "-3"}, ""},
+		// "--" then a non-negative operand is passed through unchanged.
+		{"non negative after terminator", []string{"--", "3"}, "1\n2\n3\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestEqualWidthNoPaddingNeeded exercises padToEqualWidth where every value is
+// already the maximum width, so the early-continue branch is taken.
+func TestEqualWidthNoPaddingNeeded(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "-w", "10", "12")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// 10, 11, 12 are all two digits already; no zero-padding is added.
+	if out != "10\n11\n12\n" {
+		t.Errorf("out = %q, want %q", out, "10\n11\n12\n")
+	}
+}
+
+// TestEqualWidthNegativePadsAfterSign exercises padToEqualWidth's sign-aware
+// branch: zeros are inserted after the leading minus sign.
+func TestEqualWidthNegativePadsAfterSign(t *testing.T) {
+	t.Parallel()
+	// From -1 down to -100, step -1: the shorter values pad after the sign.
+	out, _, err := run(t, "-w", "-1", "-1", "-100")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	lines := []string{"-001", "-002", "-003"}
+	for _, want := range lines {
+		if !contains(out, want+"\n") {
+			t.Errorf("out missing zero-padded %q; got first lines:\n%.40s", want, out)
+		}
+	}
+}
+
+// TestFloatPrecisionFromOperands exercises precision/maxPrecision: the output
+// uses the greatest fractional-digit count among the operands.
+func TestFloatPrecisionFromOperands(t *testing.T) {
+	t.Parallel()
+	// Increment 0.25 has two fractional digits, so all output has two.
+	out, _, err := run(t, "1", "0.25", "1.5")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "1.00\n1.25\n1.50\n" {
+		t.Errorf("out = %q, want %q", out, "1.00\n1.25\n1.50\n")
+	}
+}
+
+// TestExponentOperandPrecision exercises precision's exponent-trimming branch:
+// the fractional digits are measured ignoring the exponent part.
+func TestExponentOperandPrecision(t *testing.T) {
+	t.Parallel()
+	// 1e1 == 10; it is treated as a float operand but has zero fractional digits.
+	out, _, err := run(t, "1", "1e1")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// Float formatting with zero precision yields plain integers.
+	if out != "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/applets/shellutils/serial/serial_more_test.go
+++ b/internal/applets/shellutils/serial/serial_more_test.go
@@ -1,0 +1,135 @@
+package serial_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/serial"
+)
+
+// TestSynopsis covers the one-line description helper.
+func TestSynopsis(t *testing.T) {
+	if got := serial.New().Synopsis(); got != "Rename the file to the name with a serial number" {
+		t.Errorf("Synopsis() = %q", got)
+	}
+}
+
+// TestNameWithDirectoryCreatesDir drives makeDirIfNeeded: when --name carries a
+// directory component that does not yet exist, the destination directory is
+// created and the renamed files are placed in it. With --suffix the serial
+// number follows the chosen base name.
+func TestNameWithDirectoryCreatesDir(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, "a.txt", "b.txt")
+	destDir := filepath.Join(dir, "out")
+	namePath := filepath.Join(destDir, "img")
+
+	if _, _, err := run(t, "--suffix", "--name", namePath, dir); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+
+	got := listDir(t, destDir)
+	want := []string{"img_0.txt", "img_1.txt"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("files in created dir = %v, want %v", got, want)
+	}
+}
+
+// TestExistingTargetWithoutForceFails drives dieIfExistSameNameFile: a rename
+// target that already exists is refused unless --force is given. The pre-created
+// collision file lives in a separate output directory (via --name) so it is not
+// itself picked up as a source.
+func TestExistingTargetWithoutForceFails(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, "a.txt")
+	outDir := t.TempDir()
+	// The target for a.txt with --suffix --name=outDir/img is img_0.txt.
+	if err := os.WriteFile(filepath.Join(outDir, "img_0.txt"), []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := run(t, "--suffix", "--name", filepath.Join(outDir, "img"), dir)
+	if err == nil {
+		t.Fatal("expected failure: target name already exists")
+	}
+}
+
+// TestForceOverwritesExistingCopyTarget drives the copyFiles overwrite branch:
+// with --keep and --force, an existing destination is removed before being
+// re-created as a hard link to the source.
+func TestForceOverwritesExistingCopyTarget(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, "a.txt")
+	outDir := t.TempDir()
+	target := filepath.Join(outDir, "img_0.txt")
+	// Pre-create the copy target with stale content.
+	if err := os.WriteFile(target, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := run(t, "--keep", "--force", "--suffix", "--name", filepath.Join(outDir, "img"), dir); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+
+	// The original a.txt is preserved (keep), and the target now mirrors it.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "a.txt" {
+		t.Errorf("overwritten copy content = %q, want %q", string(got), "a.txt")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "a.txt")); err != nil {
+		t.Errorf("original should be kept: %v", err)
+	}
+}
+
+// TestExtensionlessFilePrefixed drives baseNameWithoutExt's no-extension branch:
+// a file with no extension keeps its whole name as the base.
+func TestExtensionlessFilePrefixed(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, "README", "LICENSE")
+
+	if _, _, err := run(t, dir); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+
+	got := listDir(t, dir)
+	want := []string{"0_LICENSE", "1_README"}
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("renamed extensionless files = %v, want %v", got, want)
+	}
+}
+
+// TestInvalidNameDirectoryOnly verifies a --name that is only a directory (ends
+// with a slash) is rejected.
+func TestInvalidNameDirectoryOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, "a.txt")
+
+	_, errOut, err := run(t, "--name", "subdir/", dir)
+	if err == nil {
+		t.Fatal("expected failure for a directory-only --name")
+	}
+	if !strings.Contains(errOut, "invalid --name") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestExtraOperandRejected verifies a second positional operand is an error.
+func TestExtraOperandRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, "a.txt")
+
+	_, errOut, err := run(t, dir, dir)
+	if err == nil {
+		t.Fatal("expected failure for an extra operand")
+	}
+	if !strings.Contains(errOut, "extra operand") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}

--- a/internal/applets/shellutils/sort/sort_more_test.go
+++ b/internal/applets/shellutils/sort/sort_more_test.go
@@ -1,0 +1,121 @@
+package sortcmd_test
+
+import (
+	"strings"
+	"testing"
+
+	sortcmd "github.com/nao1215/mimixbox/internal/applets/shellutils/sort"
+)
+
+// TestSynopsis covers the one-line description helper.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if got := sortcmd.New().Synopsis(); got != "Sort lines of text files" {
+		t.Errorf("Synopsis() = %q", got)
+	}
+}
+
+// TestKeyDefVariants drives parseKey's acceptance of richer KEYDEFs: a
+// "start,end" range (the end is accepted but ignored), and a trailing column
+// offset / ordering flag such as "2.3" or "2n" that is stripped to the field.
+func TestKeyDefVariants(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"range keydef", "x 3\ny 1\nz 2\n", []string{"-k", "2,2"}, "y 1\nz 2\nx 3\n"},
+		{"column offset stripped", "x 3\ny 1\nz 2\n", []string{"-k", "2.1"}, "y 1\nz 2\nx 3\n"},
+		{"ordering flag stripped", "x 30\ny 1\nz 200\n", []string{"-n", "-k", "2n"}, "y 1\nx 30\nz 200\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestInvalidKeyDef drives parseKey's rejection paths: a non-numeric or
+// out-of-range start field is an error.
+func TestInvalidKeyDef(t *testing.T) {
+	t.Parallel()
+	for _, def := range []string{"abc", "0", ".5", ","} {
+		def := def
+		t.Run(def, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := run(t, "a\nb\n", "-k", def)
+			if err == nil {
+				t.Fatalf("expected error for -k %q", def)
+			}
+			if !strings.Contains(err.Error(), "invalid key definition") {
+				t.Errorf("err = %v", err)
+			}
+		})
+	}
+}
+
+// TestEmptyInput drives splitLines' empty branch and the empty-output path: no
+// input yields no output and no error.
+func TestEmptyInput(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+}
+
+// TestNumericNonNumericFields drives leadingNumber: lines whose key has no
+// number sort as zero, ahead of lines with positive numbers.
+func TestNumericNonNumericFields(t *testing.T) {
+	t.Parallel()
+	// "apple" has no leading number (0); "5x" parses as 5; "-3y" parses as -3.
+	out, _, err := run(t, "5x\napple\n-3y\n", "-n")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "-3y\napple\n5x\n" {
+		t.Errorf("out = %q, want %q", out, "-3y\napple\n5x\n")
+	}
+}
+
+// TestSeparatorMultiFieldKey drives field()'s separator join branch: with -t and
+// -k the key spans from the chosen field to the end of the line, rejoined with
+// the separator.
+func TestSeparatorMultiFieldKey(t *testing.T) {
+	t.Parallel()
+	// Sort on field 2 onward, separated by ':'. Keys: "b:z", "a:y", "c:x".
+	out, _, err := run(t, "1:b:z\n2:a:y\n3:c:x\n", "-t", ":", "-k", "2")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "2:a:y\n1:b:z\n3:c:x\n" {
+		t.Errorf("out = %q, want %q", out, "2:a:y\n1:b:z\n3:c:x\n")
+	}
+}
+
+// TestKeyFieldBeyondLine drives field()'s out-of-range branch: a key field past
+// the number of fields yields an empty key, so such lines sort first and stably.
+func TestKeyFieldBeyondLine(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "lonely\nx y\n", "-k", "2")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// "lonely" has no field 2 (empty key) and sorts before "x y" (key "y").
+	if out != "lonely\nx y\n" {
+		t.Errorf("out = %q, want %q", out, "lonely\nx y\n")
+	}
+}

--- a/internal/applets/shellutils/sync/sync_more_test.go
+++ b/internal/applets/shellutils/sync/sync_more_test.go
@@ -1,0 +1,23 @@
+package sync_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/sync"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// TestRunUnknownFlag drives Run's flag-parse failure branch (proceed == false /
+// err != nil), which the happy-path tests do not reach.
+func TestRunUnknownFlag(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	if err := sync.New().Run(context.Background(), io, []string{"--definitely-not-a-flag"}); err == nil {
+		t.Fatal("expected an error for an unknown flag")
+	}
+}

--- a/internal/applets/shellutils/test/test_internal_test.go
+++ b/internal/applets/shellutils/test/test_internal_test.go
@@ -1,0 +1,120 @@
+package testcmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHasPerm exercises the pure permission predicate across read, write and
+// execute bits for owner, group and other, including the empty-permission case.
+func TestHasPerm(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		mode os.FileMode
+		op   string
+		want bool
+	}{
+		{"owner read", 0o400, "-r", true},
+		{"group read", 0o040, "-r", true},
+		{"other read", 0o004, "-r", true},
+		{"no read", 0o222, "-r", false},
+		{"owner write", 0o200, "-w", true},
+		{"no write", 0o555, "-w", false},
+		{"owner exec", 0o100, "-x", true},
+		{"other exec", 0o001, "-x", true},
+		{"no exec", 0o666, "-x", false},
+		{"unknown op", 0o777, "-q", false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasPerm(tt.mode, tt.op); got != tt.want {
+				t.Errorf("hasPerm(%o, %q) = %v, want %v", tt.mode, tt.op, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEvalFileTestExisting drives the file-test branches that depend on the
+// real mode bits of files created on disk.
+func TestEvalFileTestExisting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	regular := filepath.Join(dir, "reg")
+	if err := os.WriteFile(regular, []byte("content"), 0o644); err != nil {
+		t.Fatalf("setup regular: %v", err)
+	}
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatalf("setup empty: %v", err)
+	}
+	readonly := filepath.Join(dir, "ro")
+	if err := os.WriteFile(readonly, []byte("x"), 0o444); err != nil {
+		t.Fatalf("setup readonly: %v", err)
+	}
+	exec := filepath.Join(dir, "exec")
+	if err := os.WriteFile(exec, []byte("x"), 0o755); err != nil {
+		t.Fatalf("setup exec: %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(regular, link); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+	missing := filepath.Join(dir, "missing")
+
+	tests := []struct {
+		name    string
+		op      string
+		path    string
+		want    bool
+		wantErr bool
+	}{
+		{"-e regular", "-e", regular, true, false},
+		{"-e missing", "-e", missing, false, false},
+		{"-f regular", "-f", regular, true, false},
+		{"-f dir", "-f", dir, false, false},
+		{"-d dir", "-d", dir, true, false},
+		{"-d regular", "-d", regular, false, false},
+		{"-s nonempty", "-s", regular, true, false},
+		{"-s empty", "-s", empty, false, false},
+		{"-b regular", "-b", regular, false, false},
+		{"-c regular", "-c", regular, false, false},
+		{"-p regular", "-p", regular, false, false},
+		{"-S regular", "-S", regular, false, false},
+		{"-L symlink", "-L", link, true, false},
+		{"-h regular", "-h", regular, false, false},
+		{"-L missing", "-L", missing, false, false},
+		{"-r readonly", "-r", readonly, true, false},
+		{"-w readonly", "-w", readonly, false, false},
+		{"-w regular", "-w", regular, true, false},
+		{"-x exec", "-x", exec, true, false},
+		{"-x regular", "-x", regular, false, false},
+		{"-r missing", "-r", missing, false, false},
+		{"unknown op", "-Q", regular, false, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := evalFileTest(tt.op, tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("evalFileTest(%q, ...) err = %v, wantErr %v", tt.op, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("evalFileTest(%q, ...) = %v, want %v", tt.op, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSynopsis covers the one-line description accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if New().Synopsis() == "" {
+		t.Error("Synopsis() = empty")
+	}
+}

--- a/internal/applets/textutils/paste/paste_more_test.go
+++ b/internal/applets/textutils/paste/paste_more_test.go
@@ -1,0 +1,126 @@
+package paste_test
+
+import (
+	"testing"
+)
+
+// TestDelimiterEscapes covers each backslash escape understood by -d, plus the
+// "default" branch for an unknown escape and the multi-character separator
+// cycle. Behaviour matches GNU paste.
+func TestDelimiterEscapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		delim string
+		stdin string
+		want  string
+	}{
+		{
+			// \t expands to a tab.
+			name:  "tab escape",
+			delim: `\t`,
+			stdin: "a\nb\n",
+			want:  "a\tb\n",
+		},
+		{
+			// \\ expands to a single backslash.
+			name:  "backslash escape",
+			delim: `\\`,
+			stdin: "a\nb\n",
+			want:  "a\\b\n",
+		},
+		{
+			// \0 means "no separator".
+			name:  "null escape joins with nothing",
+			delim: `\0`,
+			stdin: "a\nb\n",
+			want:  "ab\n",
+		},
+		{
+			// An unrecognised escape (\q) falls through to the literal character.
+			name:  "unknown escape is literal",
+			delim: `\q`,
+			stdin: "a\nb\n",
+			want:  "aqb\n",
+		},
+		{
+			// A trailing lone backslash is emitted literally.
+			name:  "trailing backslash literal",
+			delim: `\`,
+			stdin: "a\nb\n",
+			want:  "a\\b\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, "-s", "-d", tt.delim)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestSerialDelimiterCycle checks that a multi-character LIST is reused in a
+// cycle between successive lines of a serial paste.
+func TestSerialDelimiterCycle(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "1\n2\n3\n4\n", "-s", "-d", ",;")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// Separators cycle ",", ";", "," between the four values.
+	if out != "1,2;3,4\n" {
+		t.Errorf("out = %q, want 1,2;3,4", out)
+	}
+}
+
+// TestParallelDelimiterCycle checks the separator cycle across columns when
+// merging three files in parallel.
+func TestParallelDelimiterCycle(t *testing.T) {
+	t.Parallel()
+	f1 := writeFile(t, "a\n")
+	f2 := writeFile(t, "b\n")
+	f3 := writeFile(t, "c\n")
+	out, _, err := run(t, "", "-d", ",;", f1, f2, f3)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// Column separators cycle ",", ";".
+	if out != "a,b;c\n" {
+		t.Errorf("out = %q, want a,b;c", out)
+	}
+}
+
+// TestSerialMissingFileContinues confirms a missing operand is reported but the
+// remaining readable files are still pasted (firstErr path in serial).
+func TestSerialMissingFileContinues(t *testing.T) {
+	t.Parallel()
+	good := writeFile(t, "x\ny\n")
+	out, _, err := run(t, "", "-s", "/no/such/file", good)
+	if err == nil {
+		t.Fatal("expected failure for the missing file")
+	}
+	if out != "x\ty\n" {
+		t.Errorf("out = %q, want the good file still pasted", out)
+	}
+}
+
+// TestParallelMissingFileContinues confirms the parallel path also reports a
+// missing operand while merging the readable ones.
+func TestParallelMissingFileContinues(t *testing.T) {
+	t.Parallel()
+	good := writeFile(t, "x\n")
+	out, _, err := run(t, "", "/no/such/file", good)
+	if err == nil {
+		t.Fatal("expected failure for the missing file")
+	}
+	if out != "x\n" {
+		t.Errorf("out = %q, want the good file still pasted", out)
+	}
+}

--- a/internal/applets/textutils/split/split_more_test.go
+++ b/internal/applets/textutils/split/split_more_test.go
@@ -1,0 +1,105 @@
+package split_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestByBytesKiloSuffix drives parseSize's "K" suffix branch: -b 1K splits into
+// 1024-byte pieces.
+func TestByBytesKiloSuffix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "k-")
+	content := strings.Repeat("a", 1024) + strings.Repeat("b", 512)
+	if _, _, err := run(t, content, "-b", "1K", "-", prefix); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"aa", strings.Repeat("a", 1024))
+	checkFile(t, prefix+"ab", strings.Repeat("b", 512))
+}
+
+// TestByBytesMegaSuffix drives parseSize's "M" suffix branch.
+func TestByBytesMegaSuffix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "m-")
+	// One full MiB plus a small remainder, to produce two files.
+	content := strings.Repeat("x", 1024*1024) + "tail"
+	if _, _, err := run(t, content, "-b", "1M", "-", prefix); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	info, err := os.Stat(prefix + "aa")
+	if err != nil {
+		t.Fatalf("first piece missing: %v", err)
+	}
+	if info.Size() != 1024*1024 {
+		t.Errorf("first piece size = %d, want %d", info.Size(), 1024*1024)
+	}
+	checkFile(t, prefix+"ab", "tail")
+}
+
+// TestParseSizeRejectsZero verifies parseSize rejects a non-positive count even
+// with a suffix.
+func TestParseSizeRejectsZero(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "data", "-b", "0K")
+	if err == nil {
+		t.Fatal("expected error for -b 0K")
+	}
+	if !strings.Contains(errOut, "invalid number of bytes") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestByLinesExactMultiple drives byLines where the line count is an exact
+// multiple of the per-file size: the final file is closed mid-loop and no empty
+// trailing file is produced.
+func TestByLinesExactMultiple(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "exact-")
+	if _, _, err := run(t, "1\n2\n3\n4\n", "-l", "2", "-", prefix); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"aa", "1\n2\n")
+	checkFile(t, prefix+"ab", "3\n4\n")
+	// No third file should exist.
+	if _, err := os.Stat(prefix + "ac"); !os.IsNotExist(err) {
+		t.Errorf("unexpected extra file %sac", prefix)
+	}
+}
+
+// TestByLinesSingleFile drives byLines where all lines fit in one output file.
+func TestByLinesSingleFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "one-")
+	if _, _, err := run(t, "alpha\nbeta\n", "-l", "10", "-", prefix); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"aa", "alpha\nbeta\n")
+}
+
+// TestByLinesDefaultPrefix verifies the default prefix "x" is used when none is
+// given. Output files are created in the current directory, so the test runs
+// from a temp dir.
+func TestByLinesDefaultPrefix(t *testing.T) {
+	work := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	if _, _, err := run(t, "one\ntwo\n", "-l", "1"); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, filepath.Join(work, "xaa"), "one\n")
+	checkFile(t, filepath.Join(work, "xab"), "two\n")
+}

--- a/internal/applets/textutils/tac/tac_internal_test.go
+++ b/internal/applets/textutils/tac/tac_internal_test.go
@@ -1,0 +1,74 @@
+package tac
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWriteReversed exercises the record-splitting/reversal helper directly,
+// including the empty-input shortcut and a custom separator.
+func TestWriteReversed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		text string
+		sep  string
+		want string
+	}{
+		{"empty", "", "\n", ""},
+		{"trailing newline", "a\nb\nc\n", "\n", "c\nb\na\n"},
+		{"no trailing newline", "a\nb\nc", "\n", "cb\na\n"},
+		{"comma separator", "1,2,3,", ",", "3,2,1,"},
+		{"single record", "only", "\n", "only"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var b strings.Builder
+			if err := writeReversed(&b, tt.text, tt.sep); err != nil {
+				t.Fatalf("writeReversed err = %v", err)
+			}
+			if got := b.String(); got != tt.want {
+				t.Errorf("writeReversed(%q, %q) = %q, want %q", tt.text, tt.sep, got, tt.want)
+			}
+		})
+	}
+}
+
+// errWriter fails on the first write so writeReversed's error path is covered.
+type errWriter struct{ err error }
+
+func (e errWriter) Write([]byte) (int, error) { return 0, e.err }
+
+func TestWriteReversedWriteError(t *testing.T) {
+	t.Parallel()
+	werr := writeReversed(errWriter{err: boomError("boom")}, "a\nb\n", "\n")
+	if werr == nil {
+		t.Fatal("expected a write error")
+	}
+}
+
+type boomError string
+
+func (b boomError) Error() string { return string(b) }
+
+// TestFirstNonNil verifies an existing error is preserved and a new silent
+// failure is produced otherwise.
+func TestFirstNonNil(t *testing.T) {
+	t.Parallel()
+	existing := boomError("kept")
+	if got := firstNonNil(existing); got != error(existing) {
+		t.Errorf("firstNonNil(existing) = %v, want %v", got, existing)
+	}
+	if got := firstNonNil(nil); got == nil {
+		t.Error("firstNonNil(nil) = nil, want a failure")
+	}
+}
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if New().Synopsis() == "" {
+		t.Error("Synopsis() = empty")
+	}
+}

--- a/internal/applets/textutils/tail/tail_internal_test.go
+++ b/internal/applets/textutils/tail/tail_internal_test.go
@@ -1,0 +1,222 @@
+package tail
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func newIO(in string) (command.IO, *bytes.Buffer, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	return command.IO{In: strings.NewReader(in), Out: out, Err: errBuf}, out, errBuf
+}
+
+// TestNewFollowTargets covers the open/seek/retry branches without entering the
+// real-time follow loop.
+func TestNewFollowTargets(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(existing, []byte("hello\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "missing")
+
+	// Without retry the missing path is dropped, the existing one is opened
+	// positioned at EOF.
+	targets := newFollowTargets([]string{existing, missing}, false)
+	defer closeAll(targets)
+	if len(targets) != 1 {
+		t.Fatalf("targets = %d, want 1", len(targets))
+	}
+	if targets[0].offset != int64(len("hello\n")) {
+		t.Errorf("offset = %d, want %d", targets[0].offset, len("hello\n"))
+	}
+
+	// With retry the missing path is kept as a pending (file == nil) target.
+	retryTargets := newFollowTargets([]string{missing}, true)
+	defer closeAll(retryTargets)
+	if len(retryTargets) != 1 || retryTargets[0].file != nil {
+		t.Fatalf("retry targets = %+v, want one pending target", retryTargets)
+	}
+}
+
+// TestPollEmitsAppendedData appends to a followed file and polls once, checking
+// the new bytes are emitted and the offset advances.
+func TestPollEmitsAppendedData(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	targets := newFollowTargets([]string{path}, false)
+	defer closeAll(targets)
+
+	if err := os.WriteFile(path, []byte("a\nb\nc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	io, out, _ := newIO("")
+	last := ""
+	targets[0].poll(io, false, false, &last)
+	if out.String() != "b\nc\n" {
+		t.Errorf("poll output = %q, want %q", out.String(), "b\nc\n")
+	}
+	if targets[0].offset != int64(len("a\nb\nc\n")) {
+		t.Errorf("offset = %d, want %d", targets[0].offset, len("a\nb\nc\n"))
+	}
+}
+
+// TestPollDetectsTruncation verifies a shrunk file restarts from offset 0 and
+// reports the truncation on stderr.
+func TestPollDetectsTruncation(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("longcontent\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	targets := newFollowTargets([]string{path}, false)
+	defer closeAll(targets)
+
+	if err := os.WriteFile(path, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	io, out, errBuf := newIO("")
+	last := ""
+	targets[0].poll(io, false, false, &last)
+	if !strings.Contains(errBuf.String(), "file truncated") {
+		t.Errorf("stderr = %q, want truncation notice", errBuf.String())
+	}
+	if !strings.Contains(out.String(), "x\n") {
+		t.Errorf("output = %q, want restarted content", out.String())
+	}
+}
+
+// TestMaybeReopenOnReplacement covers the -F rotation path: the followed file is
+// renamed away and recreated, and maybeReopen switches to the new descriptor.
+func TestMaybeReopenOnReplacement(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	targets := newFollowTargets([]string{path}, true)
+	defer closeAll(targets)
+
+	if err := os.Rename(path, path+".old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	io, _, errBuf := newIO("")
+	targets[0].maybeReopen(io)
+	if targets[0].offset != 0 {
+		t.Errorf("offset after reopen = %d, want 0", targets[0].offset)
+	}
+	if !strings.Contains(errBuf.String(), "following new file") {
+		t.Errorf("stderr = %q, want reopen notice", errBuf.String())
+	}
+}
+
+// TestMaybeReopenWhenMissing covers the branch where the path disappears: the
+// held descriptor is released and the target becomes pending.
+func TestMaybeReopenWhenMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	targets := newFollowTargets([]string{path}, true)
+	defer closeAll(targets)
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	io, _, _ := newIO("")
+	targets[0].maybeReopen(io)
+	if targets[0].file != nil {
+		t.Error("file should be nil after the path disappears")
+	}
+
+	// A pending target whose path reappears should be picked up.
+	if err := os.WriteFile(path, []byte("back\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	io2, _, errBuf := newIO("")
+	targets[0].maybeReopen(io2)
+	if targets[0].file == nil {
+		t.Error("file should be reopened after the path reappears")
+	}
+	if !strings.Contains(errBuf.String(), "has appeared") {
+		t.Errorf("stderr = %q, want appearance notice", errBuf.String())
+	}
+}
+
+// TestFollowablePaths drops the stdin pseudo-file.
+func TestFollowablePaths(t *testing.T) {
+	t.Parallel()
+	got := followablePaths([]string{"-", "a.txt", "-", "b.txt"})
+	if len(got) != 2 || got[0] != "a.txt" || got[1] != "b.txt" {
+		t.Errorf("followablePaths = %v, want [a.txt b.txt]", got)
+	}
+}
+
+// TestWriteHeader covers both the first and subsequent header forms, including
+// the standard-input label.
+func TestWriteHeader(t *testing.T) {
+	t.Parallel()
+	var first bytes.Buffer
+	writeHeader(&first, "a.txt", true)
+	if first.String() != "==> a.txt <==\n" {
+		t.Errorf("first header = %q", first.String())
+	}
+	var later bytes.Buffer
+	writeHeader(&later, "-", false)
+	if later.String() != "\n==> standard input <==\n" {
+		t.Errorf("later header = %q", later.String())
+	}
+}
+
+// TestEmitWritesHeaderOnFileSwitch checks emit prints a banner when output
+// switches between files.
+func TestEmitWritesHeaderOnFileSwitch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("data\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	tgt := &followTarget{path: path, file: f, offset: 0}
+
+	io, out, _ := newIO("")
+	last := ""
+	tgt.emit(io, int64(len("data\n")), true, &last)
+	got := out.String()
+	if !strings.Contains(got, "==> "+path+" <==") || !strings.Contains(got, "data\n") {
+		t.Errorf("emit output = %q, want header and data", got)
+	}
+	if last != path {
+		t.Errorf("last = %q, want %q", last, path)
+	}
+}
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if New().Synopsis() == "" {
+		t.Error("Synopsis() = empty")
+	}
+}

--- a/internal/applets/textutils/tr/tr_internal_test.go
+++ b/internal/applets/textutils/tr/tr_internal_test.go
@@ -1,0 +1,119 @@
+package tr
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestExpandSetRangesAndEscapes drives expandSet through ranges, octal/C
+// escapes, character classes, and the error paths.
+func TestExpandSetRangesAndEscapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		spec    string
+		want    []rune
+		wantErr bool
+	}{
+		{"plain", "abc", []rune{'a', 'b', 'c'}, false},
+		{"range", "a-d", []rune{'a', 'b', 'c', 'd'}, false},
+		{"digit range", "0-3", []rune{'0', '1', '2', '3'}, false},
+		{"escape newline", `\n`, []rune{'\n'}, false},
+		{"escape tab", `\t`, []rune{'\t'}, false},
+		{"escape backslash", `\\`, []rune{'\\'}, false},
+		{"escape cr", `\r`, []rune{'\r'}, false},
+		{"escape bell", `\a`, []rune{'\a'}, false},
+		{"octal", `\101`, []rune{'A'}, false},
+		{"trailing backslash", `a\`, []rune{'a', '\\'}, false},
+		{"unknown escape literal", `\q`, []rune{'q'}, false},
+		{"class upper", "[:upper:]", rangeRunes('A', 'Z'), false},
+		{"class blank", "[:blank:]", []rune{'\t', ' '}, false},
+		{"reverse range err", "z-a", nil, true},
+		{"unknown class err", "[:bogus:]", nil, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := expandSet(tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("expandSet(%q) err = %v, wantErr %v", tt.spec, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("expandSet(%q) = %v, want %v", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExpandSetClassNotAtRangeStart ensures a "[" that is not a class opener is
+// treated as a literal character.
+func TestExpandSetLiteralBracket(t *testing.T) {
+	t.Parallel()
+	got, err := expandSet("[x]")
+	if err != nil {
+		t.Fatalf("expandSet err = %v", err)
+	}
+	want := []rune{'[', 'x', ']'}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expandSet = %v, want %v", got, want)
+	}
+}
+
+// TestClassRunes covers every supported POSIX class and the unknown case.
+func TestClassRunes(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"upper", "lower", "digit", "alpha", "alnum", "space", "blank"} {
+		r, ok := classRunes(name)
+		if !ok || len(r) == 0 {
+			t.Errorf("classRunes(%q) = (%v, %v), want non-empty ok", name, r, ok)
+		}
+	}
+	if _, ok := classRunes("bogus"); ok {
+		t.Error("classRunes(bogus) ok = true, want false")
+	}
+}
+
+// TestNextRune covers the escape decoding helper directly, including a
+// three-digit octal sequence stopping at a non-octal digit.
+func TestNextRune(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		src     string
+		i       int
+		wantR   rune
+		wantIdx int
+	}{
+		{"plain", "abc", 1, 'b', 2},
+		{"escape v", `\v`, 0, '\v', 2},
+		{"escape f", `\f`, 0, '\f', 2},
+		{"escape b", `\b`, 0, '\b', 2},
+		{"octal three", `\101`, 0, 'A', 4},
+		{"octal stops", `\18`, 0, '\001', 2},
+		{"trailing backslash", `\`, 0, '\\', 1},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r, idx, err := nextRune([]rune(tt.src), tt.i)
+			if err != nil {
+				t.Fatalf("nextRune err = %v", err)
+			}
+			if r != tt.wantR || idx != tt.wantIdx {
+				t.Errorf("nextRune(%q, %d) = (%q, %d), want (%q, %d)", tt.src, tt.i, r, idx, tt.wantR, tt.wantIdx)
+			}
+		})
+	}
+}
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if New().Synopsis() == "" {
+		t.Error("Synopsis() = empty")
+	}
+}


### PR DESCRIPTION
Third batch of the per-applet coverage backlog. Adds focused unit tests for low/zero-coverage helper and error paths across 26 applet packages (od, paste, patch, ping, printf, pwd, remove-shell, rm, rmdir, sddf, sed, seq, serial, shred, sl, sort, split, stat, sync, tac, tail, tar, test, touch, tr, truncate). Only test files are added. `go test`, `gofmt`, and `golangci-lint` pass.

Closes #868, #889, #814, #813, #846, #869, #870, #807, #828, #829, #871, #816, #815, #872, #873, #830, #843, #874, #890, #831, #875, #891, #893, #892, #799, #876, #832, #894, #833