### PR TITLE
test(applets): raise coverage on low-coverage helper paths (batch 4)

### DIFF
--- a/internal/applets/archival/uncompress/uncompress_more_test.go
+++ b/internal/applets/archival/uncompress/uncompress_more_test.go
@@ -1,0 +1,117 @@
+package uncompress_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestKeepFlag covers the -k branch of processFile: the .Z input is decompressed
+// but left in place.
+func TestKeepFlag(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	zf := filepath.Join(dir, "keep.Z")
+	if err := os.WriteFile(zf, zbytes(t, "kept"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, errOut, err := run(t, nil, "-k", zf); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "keep"))
+	if err != nil {
+		t.Fatalf("expected decompressed file: %v", err)
+	}
+	if string(got) != "kept" {
+		t.Errorf("decompressed = %q, want kept", got)
+	}
+	if _, statErr := os.Stat(zf); statErr != nil {
+		t.Error("-k should keep the .Z input")
+	}
+}
+
+// TestExistingOutputBlocksWithoutForce covers the "already exists" guard.
+func TestExistingOutputBlocksWithoutForce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	zf := filepath.Join(dir, "doc.Z")
+	if err := os.WriteFile(zf, zbytes(t, "fresh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create the output so the decompress refuses to clobber it.
+	out := filepath.Join(dir, "doc")
+	if err := os.WriteFile(out, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, nil, zf)
+	if err == nil {
+		t.Fatal("expected an error when the output already exists")
+	}
+	if !strings.Contains(errOut, "already exists") {
+		t.Errorf("stderr = %q, want an 'already exists' message", errOut)
+	}
+	// The existing file must be untouched and the .Z kept.
+	got, _ := os.ReadFile(out) //nolint:gosec // test-written file
+	if string(got) != "old" {
+		t.Errorf("output should be untouched, got %q", got)
+	}
+}
+
+// TestForceOverwrites covers the -f branch: an existing output is overwritten.
+func TestForceOverwrites(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	zf := filepath.Join(dir, "doc.Z")
+	if err := os.WriteFile(zf, zbytes(t, "brand new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "doc")
+	if err := os.WriteFile(out, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, errOut, err := run(t, nil, "-f", zf); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(out) //nolint:gosec // test-written file
+	if string(got) != "brand new" {
+		t.Errorf("output = %q, want overwritten with 'brand new'", got)
+	}
+}
+
+// TestMissingInputFile covers the os.Open error branch of processFile.
+func TestMissingInputFile(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, nil, filepath.Join(t.TempDir(), "nope.Z"))
+	if err == nil {
+		t.Fatal("expected an error for a missing input file")
+	}
+	if !strings.Contains(errOut, "uncompress:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestMultipleFilesReportEachFailure verifies that one bad operand does not stop
+// the others and still sets a non-zero exit.
+func TestMultipleFilesReportEachFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.Z")
+	if err := os.WriteFile(good, zbytes(t, "ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(dir, "missing.Z")
+
+	_, errOut, err := run(t, nil, bad, good)
+	if err == nil {
+		t.Fatal("expected a non-zero exit because one operand failed")
+	}
+	if !strings.Contains(errOut, "uncompress:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+	// The good file was still decompressed.
+	got, rerr := os.ReadFile(filepath.Join(dir, "good"))
+	if rerr != nil || string(got) != "ok" {
+		t.Errorf("good file not decompressed: %v %q", rerr, got)
+	}
+}

--- a/internal/applets/archival/unzip/unzip_more_test.go
+++ b/internal/applets/archival/unzip/unzip_more_test.go
@@ -1,0 +1,118 @@
+package unzip_test
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExtractDirectoryEntry covers the IsDir branch of extractFile: a zip entry
+// whose name ends in "/" is recreated as a directory.
+func TestExtractDirectoryEntry(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "withdir.zip")
+
+	f, err := os.Create(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	// A directory header (trailing slash). Give it a real mode so MkdirAll
+	// produces a writable directory the nested file can then be created in.
+	dirHdr := &zip.FileHeader{Name: "emptydir/"}
+	dirHdr.SetMode(0o755 | os.ModeDir)
+	if _, err := zw.CreateHeader(dirHdr); err != nil {
+		t.Fatal(err)
+	}
+	w, err := zw.Create("emptydir/file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("inside")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	dest := filepath.Join(dir, "out")
+	if _, errOut, err := run(t, "-d", dest, archive); err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+
+	info, err := os.Stat(filepath.Join(dest, "emptydir"))
+	if err != nil {
+		t.Fatalf("directory entry not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("emptydir should be a directory")
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "emptydir", "file.txt"))
+	if err != nil || string(got) != "inside" {
+		t.Errorf("nested file not extracted: %v %q", err, got)
+	}
+}
+
+// TestVerboseReportsEachFile covers the verbose branch of extractFile, which
+// prints each extracted entry to stderr.
+func TestVerboseReportsEachFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "v.zip")
+	makeZip(t, archive, map[string]string{"note.txt": "hi"})
+
+	dest := filepath.Join(dir, "out")
+	_, errOut, err := run(t, "-v", "-d", dest, archive)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !strings.Contains(errOut, "extracting:") || !strings.Contains(errOut, "note.txt") {
+		t.Errorf("verbose stderr = %q, want an 'extracting: note.txt' line", errOut)
+	}
+}
+
+// TestZipSlipRejected covers the safeJoin guard that rejects entries whose names
+// try to escape the destination directory (a path-traversal "zip slip").
+func TestZipSlipRejected(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "evil.zip")
+
+	f, err := os.Create(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	// Use a raw header so the malicious "../" name is preserved verbatim.
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "../escape.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("pwned")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	dest := filepath.Join(dir, "out")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, "-d", dest, archive)
+	if err == nil {
+		t.Fatal("expected the path-traversal entry to be rejected")
+	}
+	if !strings.Contains(errOut, "outside the destination directory") {
+		t.Errorf("stderr = %q, want a zip-slip rejection", errOut)
+	}
+	// The file must not have been written outside dest.
+	if _, statErr := os.Stat(filepath.Join(dir, "escape.txt")); statErr == nil {
+		t.Error("zip-slip wrote a file outside the destination directory")
+	}
+}

--- a/internal/applets/archival/zip/zip_more_test.go
+++ b/internal/applets/archival/zip/zip_more_test.go
@@ -1,0 +1,86 @@
+package zip_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestZipVerbose covers addFile's verbose branch: each added entry is announced
+// on stderr, and the archive still round-trips correctly.
+func TestZipVerbose(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(a, []byte("alpha"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("beta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(dir, "out.zip")
+
+	_, errOut, err := run(t, "-v", archive, a, b)
+	if err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(errOut, "adding:") {
+		t.Errorf("stderr = %q, want 'adding:' lines with -v", errOut)
+	}
+	got := names(t, archive)
+	if got[filepath.ToSlash(a)] != "alpha" || got[filepath.ToSlash(b)] != "beta" {
+		t.Errorf("round-trip mismatch: %v", got)
+	}
+}
+
+// TestZipRecurseVerbose drives addDir together with the verbose path, archiving
+// a nested tree.
+func TestZipRecurseVerbose(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "tree", "deep")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "x.txt"), []byte("ex"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(dir, "out.zip")
+
+	_, errOut, err := run(t, "-r", "-v", archive, filepath.Join(dir, "tree"))
+	if err != nil {
+		t.Fatalf("err = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(errOut, "adding:") {
+		t.Errorf("stderr = %q, want 'adding:' lines", errOut)
+	}
+	got := names(t, archive)
+	if len(got) != 1 {
+		t.Errorf("entries = %v, want 1 recursed file", got)
+	}
+}
+
+// TestZipUnreadableFile covers addFile's os.Open error branch: a file that
+// exists at stat time but cannot be opened for reading makes zip fail.
+func TestZipUnreadableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permission checks")
+	}
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "secret")
+	if err := os.WriteFile(secret, []byte("nope"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o644) })
+	archive := filepath.Join(dir, "out.zip")
+
+	_, errOut, err := run(t, archive, secret)
+	if err == nil {
+		t.Fatal("expected error opening an unreadable file")
+	}
+	if !strings.Contains(errOut, "zip:") {
+		t.Errorf("stderr = %q, want zip: prefix", errOut)
+	}
+}

--- a/internal/applets/debianutils/valid-shell/valid-shell_more_test.go
+++ b/internal/applets/debianutils/valid-shell/valid-shell_more_test.go
@@ -1,0 +1,161 @@
+package validShell_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	validShell "github.com/nao1215/mimixbox/internal/applets/debianutils/valid-shell"
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func run(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: errBuf}
+	err := validShell.New().Run(context.Background(), io, args)
+	return out.String(), errBuf.String(), err
+}
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if validShell.New().Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestRunWithValidFileSucceeds drives Run end-to-end against a FILE operand that
+// lists an existing, executable shell. This covers the success exit path of Run
+// that the helper-only tests leave at 0%.
+func TestRunWithValidFileSucceeds(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	// /bin/sh exists and is executable on every system we run on. Comment and
+	// blank lines are also present to exercise those skip branches.
+	if err := os.WriteFile(path, []byte("# a comment\n\n/bin/sh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, errOut, err := run(t, path)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	if !strings.Contains(out, "OK: /bin/sh") {
+		t.Errorf("stdout = %q, want an OK line", out)
+	}
+	if strings.Contains(out, "# a comment") {
+		t.Errorf("comment lines must be ignored, got %q", out)
+	}
+}
+
+// TestRunWithInvalidShellExitsNonZero covers the !ok branch of Run, where a
+// listed shell does not exist.
+func TestRunWithInvalidShellExitsNonZero(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	if err := os.WriteFile(path, []byte("/no/such/shell\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := run(t, path)
+	if err == nil {
+		t.Fatal("expected a non-zero exit for a missing shell")
+	}
+	if !strings.Contains(out, "NG: /no/such/shell") {
+		t.Errorf("stdout = %q, want an NG line", out)
+	}
+}
+
+// TestRunWithMissingFileReportsError covers the open-error branch of Run.
+func TestRunWithMissingFileReportsError(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, filepath.Join(t.TempDir(), "no-shells-file"))
+	if err == nil {
+		t.Fatal("expected an error for a missing shells file")
+	}
+	if !strings.Contains(errOut, "valid-shell:") {
+		t.Errorf("stderr = %q, want a valid-shell error prefix", errOut)
+	}
+}
+
+// TestValidateShellsSkipsCommentsAndBlanks covers the comment/blank skip
+// branches of validateShells via the exported test hook.
+func TestValidateShellsSkipsCommentsAndBlanks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shells")
+	if err := os.WriteFile(path, []byte("# header\n\n   \n/bin/sh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	ok, err := validShell.ValidateShellsForTest(path, &out)
+	if err != nil {
+		t.Fatalf("validateShells error = %v", err)
+	}
+	if !ok {
+		t.Errorf("ok = false, want true; output = %q", out.String())
+	}
+	// Only the /bin/sh line produces output.
+	if lines := strings.Count(strings.TrimSpace(out.String()), "\n"); lines != 0 {
+		t.Errorf("expected a single output line, got:\n%s", out.String())
+	}
+}
+
+// TestValidateShellsDirectoryEntryIsNotExecutable covers isExecutable's IsDir
+// branch: a directory listed as a shell is reported NG.
+func TestValidateShellsDirectoryEntryIsNotExecutable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "adir")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "shells")
+	if err := os.WriteFile(path, []byte(subdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	ok, err := validShell.ValidateShellsForTest(path, &out)
+	if err != nil {
+		t.Fatalf("validateShells error = %v", err)
+	}
+	if ok {
+		t.Error("a directory must not count as an executable shell")
+	}
+	if !strings.Contains(out.String(), "NG: "+subdir) {
+		t.Errorf("output = %q, want an NG line for the directory", out.String())
+	}
+}
+
+// TestValidateShellsNonExecutableFileIsNG covers isExecutable's permission-bit
+// branch: an existing regular file without an execute bit is NG.
+func TestValidateShellsNonExecutableFileIsNG(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "plain")
+	if err := os.WriteFile(plain, []byte("not a shell"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "shells")
+	if err := os.WriteFile(path, []byte(plain+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	ok, err := validShell.ValidateShellsForTest(path, &out)
+	if err != nil {
+		t.Fatalf("validateShells error = %v", err)
+	}
+	if ok {
+		t.Error("a non-executable file must not count as a valid shell")
+	}
+	if !strings.Contains(out.String(), "NG: "+plain) {
+		t.Errorf("output = %q, want an NG line", out.String())
+	}
+}

--- a/internal/applets/debianutils/which/which_more_test.go
+++ b/internal/applets/debianutils/which/which_more_test.go
@@ -1,0 +1,70 @@
+package which_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/debianutils/which"
+)
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if which.New().Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestRunAllExplicitPath drives lookPathAll's path-separator branch: a name that
+// contains a separator is resolved directly (and made absolute) rather than
+// searched on $PATH.
+func TestRunAllExplicitPath(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "tool")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, errOut, err := run(t, "-a", bin)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	got := strings.TrimSpace(out)
+	if !filepath.IsAbs(got) {
+		t.Errorf("out = %q, want an absolute path", got)
+	}
+	if got != bin {
+		t.Errorf("out = %q, want %q", got, bin)
+	}
+}
+
+// TestRunAllExplicitPathNotExecutable: an explicit path that is not an
+// executable regular file yields nothing and a non-zero exit.
+func TestRunAllExplicitPathNotExecutable(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(plain, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, code := execute(t, "-a", plain)
+	if code == 0 {
+		t.Error("a non-executable explicit path should make which exit non-zero")
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+}
+
+// TestRunAllNotFound covers the -a branch where a bare name matches nothing on
+// $PATH.
+func TestRunAllNotFound(t *testing.T) {
+	out, _, code := execute(t, "-a", "this_command_does_not_exist_xyz")
+	if code == 0 {
+		t.Error("an unmatched -a name should make which exit non-zero")
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+}

--- a/internal/applets/editors/vi/editor_more_test.go
+++ b/internal/applets/editors/vi/editor_more_test.go
@@ -1,0 +1,229 @@
+package vi
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestWordMotionsAcrossLines exercises the line-wrapping branches of the word
+// motions, which the single-line cases in editor_test.go leave uncovered.
+func TestWordMotionsAcrossLines(t *testing.T) {
+	t.Parallel()
+
+	// w from the last word of a line wraps to the first word of the next line.
+	e := drive("ab cd\nef gh", "ww") // ab -> cd (col 3) -> wraps to ef on line 1
+	if e.cy != 1 || e.cx != 0 {
+		t.Errorf("ww across line -> (%d,%d), want (1,0)", e.cy, e.cx)
+	}
+
+	// w on the final word of the final line clamps at the last column.
+	e = drive("solo", "w")
+	if e.cy != 0 || e.cx != lastCol("solo") {
+		t.Errorf("w at end of buffer -> (%d,%d), want (0,%d)", e.cy, e.cx, lastCol("solo"))
+	}
+
+	// e wraps onto the next line and lands on that word's end.
+	e = drive("ab\ncde", "ee") // end of ab -> end of cde
+	if e.cy != 1 || e.cx != lastCol("cde") {
+		t.Errorf("ee across line -> (%d,%d), want (1,%d)", e.cy, e.cx, lastCol("cde"))
+	}
+
+	// b at column 0 wraps to the previous line.
+	e = drive("foo\nbar", "jb") // line 1 col 0, then b wraps to line 0
+	if e.cy != 0 {
+		t.Errorf("b from start of line -> cy=%d, want 0", e.cy)
+	}
+
+	// b at the very start of the buffer is a no-op.
+	e = drive("foo", "b")
+	if e.cy != 0 || e.cx != 0 {
+		t.Errorf("b at buffer start -> (%d,%d), want (0,0)", e.cy, e.cx)
+	}
+}
+
+// TestExCommandX covers the ":x" alias (write+quit) and the bare ":q" on a
+// clean buffer (quit without the dirty warning).
+func TestExCommandXAndCleanQuit(t *testing.T) {
+	t.Parallel()
+
+	e := drive("data", ":x\r")
+	if !e.save || !e.quit {
+		t.Errorf(":x save=%v quit=%v, want both true", e.save, e.quit)
+	}
+
+	e = drive("data", ":q\r") // clean buffer: q quits with no message
+	if !e.quit {
+		t.Error(":q on a clean buffer should quit")
+	}
+	if e.message != "" {
+		t.Errorf(":q on a clean buffer should not warn, message=%q", e.message)
+	}
+}
+
+// TestExCommandUnknownIsNoop verifies an unrecognized ex command neither saves
+// nor quits.
+func TestExCommandUnknownIsNoop(t *testing.T) {
+	t.Parallel()
+	e := drive("data", ":zzz\r")
+	if e.save || e.quit {
+		t.Errorf("unknown ex command changed state: save=%v quit=%v", e.save, e.quit)
+	}
+	if e.mode != modeNormal {
+		t.Errorf("Enter should leave command mode, mode=%s", modeName(e.mode))
+	}
+}
+
+// TestBackspaceAtBufferStartIsNoop covers the early-return branch of backspace
+// when the cursor is at row 0, column 0.
+func TestBackspaceAtBufferStartIsNoop(t *testing.T) {
+	t.Parallel()
+	e := drive("abc", "i\x7f") // insert at (0,0), backspace
+	if e.lines[0] != "abc" {
+		t.Errorf("backspace at start mutated buffer: %q", e.lines[0])
+	}
+}
+
+// TestDeleteLineLastLineMovesCursorUp covers the branch in deleteLine where the
+// cursor row exceeds the new line count after deleting the last line.
+func TestDeleteLineLastLineMovesCursorUp(t *testing.T) {
+	t.Parallel()
+	e := drive("l1\nl2\nl3", "Gdd") // go to last line, delete it
+	if e.content() != "l1\nl2\n" {
+		t.Errorf("Gdd -> %q, want %q", e.content(), "l1\nl2\n")
+	}
+	if e.cy != 1 {
+		t.Errorf("after deleting last line cy=%d, want 1", e.cy)
+	}
+}
+
+// TestSearchBackspaceEditsPattern drives the backspace branch of feedSearch.
+func TestSearchBackspaceEditsPattern(t *testing.T) {
+	t.Parallel()
+	// Type "/betX", backspace removes X, leaving "bet" which still matches "beta".
+	e := drive("alpha\nbeta", "/betX\x7f\r")
+	if e.cy != 1 {
+		t.Errorf("search after backspace -> cy=%d, want 1", e.cy)
+	}
+}
+
+// TestSearchEmptyPatternIsNoop covers the empty-pattern early return of
+// searchExecute (pressing Enter on an empty "/" prompt).
+func TestSearchEmptyPatternIsNoop(t *testing.T) {
+	t.Parallel()
+	e := drive("alpha\nbeta", "/\r")
+	if e.cy != 0 || e.cx != 0 {
+		t.Errorf("empty search moved cursor to (%d,%d), want (0,0)", e.cy, e.cx)
+	}
+}
+
+// TestSearchAgainWithoutPriorSearch covers searchAgain's guard when no search
+// has run yet (n / N before any /).
+func TestSearchAgainWithoutPriorSearch(t *testing.T) {
+	t.Parallel()
+	e := drive("alpha\nbeta", "n")
+	if e.cy != 0 || e.cx != 0 {
+		t.Errorf("n with no prior search moved cursor to (%d,%d)", e.cy, e.cx)
+	}
+}
+
+// TestNCommandRepeatsSearchForward exercises the n/N path that reuses
+// lastForward through searchAgain after a real search.
+func TestSearchNAndCapitalN(t *testing.T) {
+	t.Parallel()
+	e := drive("foo\nbar\nfoo\nbaz\nfoo", "/foo\r") // lands on line 2 (first match after cursor)
+	if e.cy != 2 {
+		t.Fatalf("/foo -> cy=%d, want 2", e.cy)
+	}
+	e.feedString("n") // next match -> line 4
+	if e.cy != 4 {
+		t.Errorf("n -> cy=%d, want 4", e.cy)
+	}
+	e.feedString("N") // previous match -> back to line 2
+	if e.cy != 2 {
+		t.Errorf("N -> cy=%d, want 2", e.cy)
+	}
+}
+
+// TestPasteWithEmptyRegisterIsNoop covers the empty-register guards of
+// pasteBelow and pasteAbove (p / P before any yank).
+func TestPasteWithEmptyRegisterIsNoop(t *testing.T) {
+	t.Parallel()
+	if e := drive("a\nb", "p"); e.content() != "a\nb\n" {
+		t.Errorf("p with empty register changed buffer: %q", e.content())
+	}
+	if e := drive("a\nb", "P"); e.content() != "a\nb\n" {
+		t.Errorf("P with empty register changed buffer: %q", e.content())
+	}
+}
+
+// TestUndoWithEmptyStackIsNoop covers undo's guard when nothing has been
+// recorded.
+func TestUndoWithEmptyStackIsNoop(t *testing.T) {
+	t.Parallel()
+	e := drive("abc", "u")
+	if e.content() != "abc\n" || e.dirty {
+		t.Errorf("u with empty undo stack changed state: content=%q dirty=%v", e.content(), e.dirty)
+	}
+}
+
+// TestYankPasteAbove exercises pasteAbove with a multi-line register.
+func TestYankMultiPasteAbove(t *testing.T) {
+	t.Parallel()
+	e := drive("l1\nl2\nl3", "2yyjP") // yank l1,l2; move down; paste above line 2
+	want := "l1\nl1\nl2\nl2\nl3\n"
+	if e.content() != want {
+		t.Errorf("2yy j P -> %q, want %q", e.content(), want)
+	}
+}
+
+// TestGotoLineWithCount covers the counted-G branch (jump to a specific line).
+func TestGotoLineWithCount(t *testing.T) {
+	t.Parallel()
+	e := drive("a\nb\nc\nd\ne", "3G")
+	if e.cy != 2 {
+		t.Errorf("3G -> cy=%d, want 2 (1-based line 3)", e.cy)
+	}
+	// A count past the end clamps to the last line.
+	e = drive("a\nb\nc", "9G")
+	if e.cy != 2 {
+		t.Errorf("9G -> cy=%d, want clamped to 2", e.cy)
+	}
+}
+
+// TestModeNameAllBranches covers modeName for every mode constant.
+func TestModeNameAllBranches(t *testing.T) {
+	t.Parallel()
+	cases := map[mode]string{
+		modeNormal:  "NORMAL",
+		modeInsert:  "INSERT",
+		modeCommand: "COMMAND",
+		modeSearch:  "SEARCH",
+	}
+	for m, want := range cases {
+		if got := modeName(m); got != want {
+			t.Errorf("modeName(%d) = %q, want %q", m, got, want)
+		}
+	}
+}
+
+// TestRedrawSearchStatus covers the search-prompt branches of redraw's status
+// line, both forward ("/") and backward ("?").
+func TestRedrawSearchStatus(t *testing.T) {
+	t.Parallel()
+
+	render := func(e *editor) string {
+		var b bytes.Buffer
+		redraw(&b, e)
+		return b.String()
+	}
+
+	// Forward search prompt shows "/pat".
+	if got := render(drive("alpha", "/al")); !bytes.Contains([]byte(got), []byte("/al")) {
+		t.Errorf("redraw should show forward search prompt /al: %q", got)
+	}
+
+	// Backward search prompt shows "?pat".
+	if got := render(drive("alpha", "?al")); !bytes.Contains([]byte(got), []byte("?al")) {
+		t.Errorf("redraw should show backward search prompt ?al: %q", got)
+	}
+}

--- a/internal/applets/editors/vi/vi_more_test.go
+++ b/internal/applets/editors/vi/vi_more_test.go
@@ -1,0 +1,37 @@
+package vi_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunReadErrorOnDirectory covers the non-IsNotExist read-error branch of
+// Run: passing a directory makes os.ReadFile fail with a non "not exist" error,
+// which must be reported and exit non-zero.
+func TestRunReadErrorOnDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, errOut, err := run(t, ":q\r", dir)
+	if err == nil {
+		t.Fatal("expected an error when the operand is a directory")
+	}
+	if !strings.Contains(errOut, "vi:") {
+		t.Errorf("stderr = %q, want a vi error prefix", errOut)
+	}
+}
+
+// TestRunSaveErrorUnwritablePath covers the write-error branch of Run: saving
+// into a path whose parent directory does not exist fails on os.WriteFile.
+func TestRunSaveErrorUnwritablePath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "missing-dir", "file.txt")
+	_, errOut, err := run(t, "iX\x1b:wq\r", bad)
+	if err == nil {
+		t.Fatal("expected a write error for a nonexistent parent directory")
+	}
+	if !strings.Contains(errOut, "vi:") {
+		t.Errorf("stderr = %q, want a vi error prefix", errOut)
+	}
+}

--- a/internal/applets/securityutils/unshadow/unshadow_more_test.go
+++ b/internal/applets/securityutils/unshadow/unshadow_more_test.go
@@ -1,0 +1,83 @@
+package unshadow
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// errWriter fails every Write, to exercise merge's write-error branch.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+// TestParseShadowSkipsBlankAndShortLines covers the empty-line and short-field
+// branches of parseShadow.
+func TestParseShadowSkipsBlankAndShortLines(t *testing.T) {
+	t.Parallel()
+	in := strings.NewReader(
+		"root:$6$HASH:19000:0:99999:7:::\n" + // normal
+			"\n" + // blank line, skipped
+			"noco lon line\n" + // no colon -> SplitN gives 1 field, skipped
+			"u:hash\n", // exactly two fields
+	)
+	hashes, err := parseShadow(in)
+	if err != nil {
+		t.Fatalf("parseShadow error = %v", err)
+	}
+	if hashes["root"] != "$6$HASH" {
+		t.Errorf("root hash = %q, want $6$HASH", hashes["root"])
+	}
+	if hashes["u"] != "hash" {
+		t.Errorf("u hash = %q, want hash", hashes["u"])
+	}
+	if _, ok := hashes["noco lon line"]; ok {
+		t.Error("a line without a colon must not produce an entry")
+	}
+	if len(hashes) != 2 {
+		t.Errorf("hashes has %d entries, want 2", len(hashes))
+	}
+}
+
+// TestMergeSkipsBlankAndShortLines covers the empty-line and short-field guards
+// in merge.
+func TestMergeSkipsBlankAndShortLines(t *testing.T) {
+	t.Parallel()
+	passwd := strings.NewReader(
+		"root:x:0:0:root:/root:/bin/bash\n" +
+			"\n" + // blank line, skipped
+			"justname\n" + // single field, skipped
+			"alice:x:1000:1000::/home/alice:/bin/sh\n",
+	)
+	hashes := map[string]string{"root": "$6$ROOT", "alice": "$6$ALICE"}
+
+	var out bytes.Buffer
+	c := &Command{}
+	if err := c.merge(command.IO{Out: &out}, passwd, hashes); err != nil {
+		t.Fatalf("merge error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "root:$6$ROOT:0:0:root:/root:/bin/bash") {
+		t.Errorf("root not merged: %q", got)
+	}
+	if !strings.Contains(got, "alice:$6$ALICE:1000:1000") {
+		t.Errorf("alice not merged: %q", got)
+	}
+	if strings.Contains(got, "justname") {
+		t.Errorf("single-field line should have been skipped: %q", got)
+	}
+}
+
+// TestMergeWriteError covers the Fprintln error branch of merge.
+func TestMergeWriteError(t *testing.T) {
+	t.Parallel()
+	passwd := strings.NewReader("root:x:0:0::/root:/bin/sh\n")
+	c := &Command{}
+	err := c.merge(command.IO{Out: errWriter{}}, passwd, map[string]string{})
+	if err == nil {
+		t.Fatal("expected a write error to propagate")
+	}
+}

--- a/internal/applets/securityutils/zippwcrack/zippwcrack_more_test.go
+++ b/internal/applets/securityutils/zippwcrack/zippwcrack_more_test.go
@@ -1,0 +1,163 @@
+package zippwcrack
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/flate"
+	"hash/crc32"
+	"testing"
+)
+
+// unencryptedZip builds a valid ZIP with a single Store-compressed member and no
+// encryption.
+func unencryptedZip(t *testing.T, name, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// TestFirstEncryptedSkipsUnencrypted: an archive with only unencrypted members
+// reports that no ZipCrypto entry was found (covering the skip branch).
+func TestFirstEncryptedNoEncryptedEntry(t *testing.T) {
+	t.Parallel()
+	data := unencryptedZip(t, "plain.txt", "no secrets here")
+	_, err := firstEncrypted(data)
+	if err == nil {
+		t.Fatal("expected an error when no encrypted entry exists")
+	}
+	if err.Error() != "no ZipCrypto-encrypted entry found" {
+		t.Errorf("err = %v, want 'no ZipCrypto-encrypted entry found'", err)
+	}
+}
+
+// TestFirstEncryptedFindsEncrypted confirms the encrypted fixture parses and
+// carries the recorded CRC and method.
+func TestFirstEncryptedFindsEncrypted(t *testing.T) {
+	t.Parallel()
+	e, err := firstEncrypted(fixture(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(e.encrypted) < 12 {
+		t.Errorf("encrypted payload too short: %d bytes", len(e.encrypted))
+	}
+	if e.crc32 == 0 {
+		t.Error("crc32 should be recorded from the archive")
+	}
+}
+
+// TestVerifyPasswordShortHeader: an entry whose payload is shorter than the
+// 12-byte ZipCrypto header can never verify.
+func TestVerifyPasswordShortHeader(t *testing.T) {
+	t.Parallel()
+	e := entry{encrypted: []byte("short"), method: zip.Store}
+	if verifyPassword(e, "whatever") {
+		t.Error("a sub-header payload must not verify")
+	}
+}
+
+// TestVerifyPasswordUnsupportedMethod: a member compressed with an unsupported
+// method is rejected even with the right key material.
+func TestVerifyPasswordUnsupportedMethod(t *testing.T) {
+	t.Parallel()
+	e := entry{encrypted: make([]byte, 16), method: 99}
+	if verifyPassword(e, "x") {
+		t.Error("an unsupported compression method must not verify")
+	}
+}
+
+// TestVerifyPasswordStoreRoundTrip exercises the zip.Store decrypt path
+// end-to-end: encrypt a stored payload with a known password, then confirm the
+// right password verifies and a wrong one does not.
+func TestVerifyPasswordStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+	const password = "s3cr3t"
+	raw := []byte("hello stored world")
+
+	enc := encryptStore(t, raw, password)
+	e := entry{
+		encrypted: enc,
+		crc32:     crc32.ChecksumIEEE(raw),
+		method:    zip.Store,
+	}
+
+	if !verifyPassword(e, password) {
+		t.Error("correct password should verify a Store entry")
+	}
+	if verifyPassword(e, "wrong") {
+		t.Error("wrong password should not verify")
+	}
+}
+
+// TestVerifyPasswordDeflateRoundTrip exercises the zip.Deflate decode path:
+// deflate-compress a body, encrypt it with a known password, and confirm the
+// CRC of the inflated plaintext is checked.
+func TestVerifyPasswordDeflateRoundTrip(t *testing.T) {
+	t.Parallel()
+	const password = "deflateKey"
+	raw := []byte(bytes.Repeat([]byte("compress me "), 8))
+
+	var comp bytes.Buffer
+	fw, err := flate.NewWriter(&comp, flate.DefaultCompression)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	enc := encryptStore(t, comp.Bytes(), password)
+	e := entry{
+		encrypted: enc,
+		crc32:     crc32.ChecksumIEEE(raw),
+		method:    zip.Deflate,
+	}
+
+	if !verifyPassword(e, password) {
+		t.Error("correct password should verify a Deflate entry")
+	}
+	if verifyPassword(e, "nope") {
+		t.Error("wrong password should not verify a Deflate entry")
+	}
+}
+
+// encryptStore produces a 12-byte-header ZipCrypto stream over raw using
+// password, mirroring the decrypt cipher in reverse so the fixture is internally
+// consistent.
+func encryptStore(t *testing.T, raw []byte, password string) []byte {
+	t.Helper()
+	zc := newZipCrypto(password)
+	// A deterministic 12-byte header; its plaintext content is irrelevant to the
+	// CRC check, which is computed over the body only.
+	header := []byte("ABCDEFGHIJKL")
+	plain := append(append([]byte{}, header...), raw...)
+
+	out := make([]byte, len(plain))
+	for i, p := range plain {
+		out[i] = zc.encryptByte(p)
+	}
+	return out
+}
+
+// encryptByte is the inverse of decryptByte: it XORs the same keystream byte and
+// advances the key schedule with the plaintext, exactly as decrypt does.
+func (z *zipCrypto) encryptByte(p byte) byte {
+	temp := uint16(z.key2|2) & 0xffff
+	c := p ^ byte((uint32(temp)*uint32(temp^1))>>8)
+	z.update(p)
+	return c
+}

--- a/internal/applets/shellutils/uname/uname_more_test.go
+++ b/internal/applets/shellutils/uname/uname_more_test.go
@@ -1,0 +1,79 @@
+package uname
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestEachIndividualFlag exercises every per-field flag, covering the -n, -r
+// and -v branches that the existing tests do not select individually.
+func TestEachIndividualFlag(t *testing.T) {
+	tests := []struct {
+		flag string
+		want string
+	}{
+		{"-n", "host\n"},
+		{"-r", "6.6.0\n"},
+		{"-v", "#1 SMP\n"},
+		{"-s", "Linux\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.flag, func(t *testing.T) {
+			withStub(t)
+			out, _, err := run(t, tt.flag)
+			if err != nil {
+				t.Fatalf("Run %s error = %v", tt.flag, err)
+			}
+			if out != tt.want {
+				t.Errorf("%s -> out = %q, want %q", tt.flag, out, tt.want)
+			}
+		})
+	}
+}
+
+// TestAllFieldsCombineInOrder verifies a multi-flag invocation prints the
+// fields in their fixed order, regardless of flag order on the command line.
+func TestAllFieldsCombineInOrder(t *testing.T) {
+	withStub(t)
+	out, _, err := run(t, "-v", "-n", "-r")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// Output order follows the field order in Run, not the argument order.
+	if out != "host 6.6.0 #1 SMP\n" {
+		t.Errorf("out = %q, want %q", out, "host 6.6.0 #1 SMP\n")
+	}
+}
+
+// TestSysInfoErrorIsReported covers the error branch of Run when the underlying
+// system call fails.
+func TestSysInfoErrorIsReported(t *testing.T) {
+	orig := sysInfo
+	sysInfo = func() (info, error) { return info{}, errors.New("boom") }
+	t.Cleanup(func() { sysInfo = orig })
+
+	_, _, err := run(t)
+	if err == nil {
+		t.Fatal("expected an error when sysInfo fails")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("err = %v, want it to mention the underlying failure", err)
+	}
+}
+
+// TestCharsToString covers the NUL-termination logic, including a string that
+// fills the whole buffer (no NUL) and one terminated early.
+func TestCharsToString(t *testing.T) {
+	t.Parallel()
+	if got := charsToString([]byte{'a', 'b', 'c', 0, 'd'}); got != "abc" {
+		t.Errorf("charsToString stopped at NUL = %q, want abc", got)
+	}
+	if got := charsToString([]byte{'x', 'y', 'z'}); got != "xyz" {
+		t.Errorf("charsToString without NUL = %q, want xyz", got)
+	}
+	if got := charsToString([]byte{}); got != "" {
+		t.Errorf("charsToString empty = %q, want empty", got)
+	}
+}

--- a/internal/applets/shellutils/uuidgen/uuidgen_more_test.go
+++ b/internal/applets/shellutils/uuidgen/uuidgen_more_test.go
@@ -1,0 +1,41 @@
+package uuidgen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/uuidgen"
+)
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if uuidgen.New().Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestVersionAndVariantBits asserts the generated UUID has the RFC 4122 version
+// (4) and variant (8/9/a/b) nibbles in the correct positions.
+func TestVersionAndVariantBits(t *testing.T) {
+	t.Parallel()
+	// Generate several to be sure the variant nibble is always one of 8/9/a/b.
+	for i := 0; i < 32; i++ {
+		out, errOut, err := run(t)
+		if err != nil {
+			t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+		}
+		id := strings.TrimSpace(out)
+		// Layout: xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
+		groups := strings.Split(id, "-")
+		if len(groups) != 5 {
+			t.Fatalf("uuid %q does not have 5 groups", id)
+		}
+		if version := groups[2][0]; version != '4' {
+			t.Errorf("version nibble = %q, want '4' (uuid=%q)", string(version), id)
+		}
+		if variant := groups[3][0]; !strings.ContainsRune("89ab", rune(variant)) {
+			t.Errorf("variant nibble = %q, want one of 8/9/a/b (uuid=%q)", string(variant), id)
+		}
+	}
+}

--- a/internal/applets/shellutils/wget/wget_internal_test.go
+++ b/internal/applets/shellutils/wget/wget_internal_test.go
@@ -1,0 +1,74 @@
+package wget
+
+import (
+	"errors"
+	"net/url"
+	"path/filepath"
+	"testing"
+)
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if c.Name() != "wget" {
+		t.Errorf("Name() = %q, want wget", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestDestination exercises the pure URL-to-filename derivation: -O overrides
+// everything, a path with no usable base name falls back to index.html, and -P
+// joins the derived name under a directory prefix.
+func TestDestination(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		opts   options
+		rawURL string
+		want   string
+	}{
+		{"basename", options{}, "https://example.com/a/b.tar.gz", "b.tar.gz"},
+		{"output overrides", options{output: "fixed.bin"}, "https://example.com/a/b.tar.gz", "fixed.bin"},
+		{"output stdout", options{output: "-"}, "https://example.com/file", "-"},
+		{"empty path falls back", options{}, "https://example.com", "index.html"},
+		{"root path falls back", options{}, "https://example.com/", "index.html"},
+		{"prefix joins", options{prefix: "downloads"}, "https://example.com/x.txt", filepath.Join("downloads", "x.txt")},
+		{"prefix with fallback", options{prefix: "out"}, "https://example.com/", filepath.Join("out", "index.html")},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := url.Parse(tt.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) = %v", tt.rawURL, err)
+			}
+			if got := destination(tt.opts, parsed); got != tt.want {
+				t.Errorf("destination(%+v, %q) = %q, want %q", tt.opts, tt.rawURL, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRetryableWrapping verifies the retryableErr marker: it reports as
+// retryable, and Unwrap exposes the underlying error for errors.Is/As.
+func TestRetryableWrapping(t *testing.T) {
+	t.Parallel()
+	base := errors.New("boom")
+	wrapped := retryable(base)
+
+	if !isRetryable(wrapped) {
+		t.Error("retryable(err) should be reported as retryable")
+	}
+	if wrapped.Error() != "boom" {
+		t.Errorf("Error() = %q, want %q", wrapped.Error(), "boom")
+	}
+	if !errors.Is(wrapped, base) {
+		t.Error("Unwrap should expose the wrapped error to errors.Is")
+	}
+	if isRetryable(base) {
+		t.Error("a plain error must not be reported as retryable")
+	}
+}

--- a/internal/applets/shellutils/who/who_internal_test.go
+++ b/internal/applets/shellutils/who/who_internal_test.go
@@ -1,0 +1,71 @@
+package who
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if New().Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestCString covers both branches: a NUL-terminated field is trimmed at the
+// NUL, and a field with no NUL is returned whole.
+func TestCString(t *testing.T) {
+	t.Parallel()
+	if got := cString([]byte("alice\x00\x00")); got != "alice" {
+		t.Errorf("cString(NUL-terminated) = %q, want %q", got, "alice")
+	}
+	full := []byte("noterminator")
+	if got := cString(full); got != "noterminator" {
+		t.Errorf("cString(no NUL) = %q, want %q", got, "noterminator")
+	}
+}
+
+// TestParseUtmpShortRecordIsEOF: a trailing partial record is treated as end of
+// data, not an error, and full records before it still parse.
+func TestParseUtmpShortRecordIsEOF(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	buf.Write(make([]byte, utmpRecordSize)) // one zero record
+	buf.Write([]byte{1, 2, 3})              // trailing short read
+
+	entries, err := parseUtmp(&buf)
+	if err != nil {
+		t.Fatalf("parseUtmp error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("entries = %d, want 1 (short trailing record dropped)", len(entries))
+	}
+}
+
+// errReader returns an error that is neither EOF nor a short read so parseUtmp's
+// error path is exercised.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failure") }
+
+func TestParseUtmpReadError(t *testing.T) {
+	t.Parallel()
+	if _, err := parseUtmp(errReader{}); err == nil {
+		t.Error("parseUtmp should propagate a non-EOF read error")
+	}
+}
+
+// TestFormatUserIdle covers formatUser's -u branch, which appends the host.
+func TestFormatUserIdle(t *testing.T) {
+	t.Parallel()
+	e := Entry{Type: userProcess, User: "bob", Line: "pts/0", Host: "1.2.3.4"}
+	got := formatUser(e, options{idle: true})
+	if !strings.Contains(got, "bob") || !strings.Contains(got, "pts/0") {
+		t.Errorf("formatUser = %q, want user and line", got)
+	}
+	if !strings.Contains(got, "1.2.3.4") {
+		t.Errorf("formatUser(-u) = %q, want host appended", got)
+	}
+}

--- a/internal/applets/shellutils/whoami/whoami_more_test.go
+++ b/internal/applets/shellutils/whoami/whoami_more_test.go
@@ -1,0 +1,22 @@
+package whoami_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/shellutils/whoami"
+)
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := whoami.New()
+	if c.Name() != "whoami" {
+		t.Errorf("Name() = %q, want whoami", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// The user.Current() failure path in Run is not exercised: it can only fail when
+// the current UID has no passwd entry, which is not reproducible deterministically
+// in a unit test without a real broken environment.

--- a/internal/applets/textutils/unexpand/unexpand_more_test.go
+++ b/internal/applets/textutils/unexpand/unexpand_more_test.go
@@ -1,0 +1,90 @@
+package unexpand_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/unexpand"
+)
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if unexpand.New().Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestLiteralTabRealignsBlanks drives the '\t' case of convertLine, where an
+// existing tab in the input advances the column so following spaces realign to
+// the next tab stop.
+func TestLiteralTabRealignsBlanks(t *testing.T) {
+	t.Parallel()
+	// A literal tab at column 0 advances to column 8; the following 8 spaces then
+	// span one more tab stop and collapse to a single tab.
+	in := "\t        x\n"
+	out, _, err := runStdin(t, in, "-a")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "\t\tx\n" {
+		t.Errorf("out = %q, want %q", out, "\t\tx\n")
+	}
+}
+
+// TestPartialTabStopStaysSpaces verifies that trailing blanks that do not reach
+// the next tab stop are emitted as spaces, not tabs (the "remaining columns"
+// loop of convertLine).
+func TestPartialTabStopStaysSpaces(t *testing.T) {
+	t.Parallel()
+	// 8 leading spaces become one tab; the remaining 3 spaces do not reach the
+	// next stop and stay as spaces.
+	out, _, err := runStdin(t, "           y\n")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "\t   y\n" {
+		t.Errorf("out = %q, want %q", out, "\t   y\n")
+	}
+}
+
+// TestFileOperandConverts exercises the file (non-stdin) path of run.
+func TestFileOperandConverts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "in.txt")
+	if err := os.WriteFile(f, []byte("        x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runStdin(t, "", f)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "\tx\n" {
+		t.Errorf("out = %q, want %q", out, "\tx\n")
+	}
+}
+
+// TestTwoFilesOneMissingKeepsFirstError exercises the keep() helper: the first
+// error is preserved while later files still process.
+func TestTwoFilesOneMissingKeepsFirstError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.txt")
+	if err := os.WriteFile(good, []byte("        z\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, errOut, err := runStdin(t, "", "/no/such/file", good)
+	if err == nil {
+		t.Fatal("expected a non-zero exit because one file is missing")
+	}
+	if !strings.Contains(errOut, "unexpand: /no/such/file:") {
+		t.Errorf("stderr = %q, want the missing-file message", errOut)
+	}
+	// The good file is still converted to stdout.
+	if out != "\tz\n" {
+		t.Errorf("out = %q, want the good file converted", out)
+	}
+}

--- a/internal/applets/textutils/unix2dos/unix2dos_more_test.go
+++ b/internal/applets/textutils/unix2dos/unix2dos_more_test.go
@@ -1,0 +1,106 @@
+package unix2dos_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/unix2dos"
+)
+
+// TestSynopsis covers the Synopsis accessor.
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	if unix2dos.New().Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestNoArgsIsNoop verifies that with no FILE operands the command does nothing
+// and exits successfully (the for-loop body never runs).
+func TestNoArgsIsNoop(t *testing.T) {
+	t.Parallel()
+	out, errOut, err := run(t)
+	if err != nil {
+		t.Fatalf("Run with no args error = %v", err)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("no-args run produced output: out=%q err=%q", out, errOut)
+	}
+}
+
+// TestWriteErrorInReadOnlyDirectory covers the write-error branch of Run.
+// ListToFile writes via a temp file in the file's parent directory and renames
+// it into place, so a read-only directory (not a read-only file) is what makes
+// the write fail. Skipped as root, which bypasses directory permission bits.
+func TestWriteErrorInReadOnlyDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission bits; cannot provoke a write error this way")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only permission semantics differ on Windows")
+	}
+	t.Parallel()
+	parent := t.TempDir()
+	roDir := filepath.Join(parent, "ro")
+	if err := os.Mkdir(roDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(roDir, "doc.txt")
+	if err := os.WriteFile(file, []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Make the directory read-only so the temp file cannot be created there.
+	if err := os.Chmod(roDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0o755) }) // allow TempDir cleanup
+
+	_, _, err := run(t, file)
+	if err == nil {
+		t.Fatal("expected a write error when the directory is not writable")
+	}
+}
+
+// TestRunPreservesTrailingDataWithoutNewline checks the readFileToStrList branch
+// where the final line has no trailing newline; it must still be converted and
+// kept.
+func TestRunPreservesTrailingDataWithoutNewline(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tail.txt")
+	if err := os.WriteFile(file, []byte("a\nb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, file); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The final "b" has no newline, so only the first LF becomes CRLF.
+	if string(got) != "a\r\nb" {
+		t.Errorf("file = %q, want %q", got, "a\r\nb")
+	}
+}
+
+// TestEnvVarExpansionInOperand covers os.ExpandEnv on the operand.
+func TestEnvVarExpansionInOperand(t *testing.T) {
+	// No t.Parallel(): t.Setenv forbids it.
+	dir := t.TempDir()
+	file := filepath.Join(dir, "env.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("U2D_TESTDIR", dir)
+
+	if _, _, err := run(t, "$U2D_TESTDIR/env.txt"); err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	got, _ := os.ReadFile(file) //nolint:gosec // test-written file
+	if string(got) != "x\r\n" {
+		t.Errorf("file = %q, want CRLF after env expansion", got)
+	}
+}

--- a/internal/applets/textutils/wc/wc_more_test.go
+++ b/internal/applets/textutils/wc/wc_more_test.go
@@ -1,0 +1,100 @@
+package wc_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/applets/textutils/wc"
+)
+
+func TestSynopsis(t *testing.T) {
+	t.Parallel()
+	c := wc.New()
+	if c.Name() != "wc" {
+		t.Errorf("Name() = %q, want wc", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis() is empty")
+	}
+}
+
+// TestRunMaxLineLength drives the -L column (the maxLine branch of
+// selectedValues and formatRow), checking the longest-line width is reported.
+func TestRunMaxLineLength(t *testing.T) {
+	t.Parallel()
+	// Longest line is "hello" -> width 5; trailing newline ignored.
+	out, _, err := run(t, "ab\nhello\nc\n", "-L")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "5\n" {
+		t.Errorf("out = %q, want %q", out, "5\n")
+	}
+}
+
+// TestRunAllColumns exercises every selected column together so the multi-column
+// width logic (fieldWidth with unknownSize from stdin) is covered.
+func TestRunAllColumns(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "alpha beta\n", "-l", "-w", "-m", "-c", "-L")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// lines=1 words=2 chars=11 bytes=11 maxline=10, padded to width 7.
+	fields := strings.Fields(out)
+	if len(fields) != 5 {
+		t.Fatalf("out = %q, want 5 columns", out)
+	}
+	want := []string{"1", "2", "11", "11", "10"}
+	for i, w := range want {
+		if fields[i] != w {
+			t.Errorf("column %d = %q, want %q (out=%q)", i, fields[i], w, out)
+		}
+	}
+}
+
+// TestRunMultipleMissingFiles makes two files fail so the keep() error-chaining
+// branch (an already-set firstErr is preserved) is exercised, and a total line
+// is not emitted because no row succeeded.
+func TestRunMultipleMissingFiles(t *testing.T) {
+	t.Parallel()
+	out, errOut, err := run(t, "", "/no/such/a", "/no/such/b")
+	if err == nil {
+		t.Fatal("expected error for missing files")
+	}
+	if !strings.Contains(errOut, "/no/such/a") || !strings.Contains(errOut, "/no/such/b") {
+		t.Errorf("stderr = %q, want both missing files reported", errOut)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty when all inputs failed", out)
+	}
+}
+
+// TestRunDirectory covers the path where a directory opens but cannot be read:
+// wc prints a zero row, reports the error, and exits non-zero.
+func TestRunDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(f, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, errOut, err := run(t, "", "-l", dir, f)
+	if err == nil {
+		t.Fatal("expected error for an unreadable directory input")
+	}
+	if !strings.Contains(errOut, "wc:") {
+		t.Errorf("stderr = %q, want wc: prefix", errOut)
+	}
+	// The good file's row and a total line should still be printed, widened to 7
+	// because the directory marks the size as unknown.
+	if !strings.Contains(out, "total") {
+		t.Errorf("out = %q, want a total line", out)
+	}
+	if !strings.Contains(out, f) {
+		t.Errorf("out = %q, want the readable file row", out)
+	}
+}


### PR DESCRIPTION
Final batch of the per-applet coverage backlog. Adds focused unit tests for low/zero-coverage helper and error paths across 16 applet packages (uname, uncompress, unexpand, unix2dos, unshadow, unzip, uuidgen, valid-shell, vi, wc, wget, which, who, whoami, zip, zippwcrack). Only test files are added. `go test`, `gofmt`, and `golangci-lint` pass.

Closes #877, #800, #895, #896, #847, #801, #878, #808, #818, #817, #897, #879, #809, #880, #881, #802, #848