### PR TITLE
test(applets): cover fortune/free helper paths; fix British spellings

### DIFF
--- a/internal/applets/fileutils/stat/stat_internal_test.go
+++ b/internal/applets/fileutils/stat/stat_internal_test.go
@@ -51,7 +51,7 @@ func TestUnwrap(t *testing.T) {
 	}
 }
 
-// TestUnescape covers the backslash escapes honoured inside a -c format.
+// TestUnescape covers the backslash escapes honored inside a -c format.
 func TestUnescape(t *testing.T) {
 	t.Parallel()
 	if got := unescape(`a\nb\tc\\d`); got != "a\nb\tc\\d" {

--- a/internal/applets/jokeutils/fortune/fortune_more_test.go
+++ b/internal/applets/jokeutils/fortune/fortune_more_test.go
@@ -1,0 +1,50 @@
+package fortune
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// errWriter fails every write, to exercise the output-error path.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+// TestRunNoFortunesAvailable covers the empty-pool branch by emptying the
+// built-in collection for the duration of the test.
+func TestRunNoFortunesAvailable(t *testing.T) {
+	orig := fortunes
+	fortunes = nil
+	t.Cleanup(func() { fortunes = orig })
+
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Fatal("expected an error when no fortunes are available")
+	}
+}
+
+// TestRunShortFiltersToEmpty covers candidates(short=true) yielding an empty
+// pool when no short fortunes exist.
+func TestRunShortFiltersToEmpty(t *testing.T) {
+	orig := fortunes
+	fortunes = []string{strings.Repeat("x", shortLimit+50)}
+	t.Cleanup(func() { fortunes = orig })
+
+	io := command.IO{In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"-s"}); err == nil {
+		t.Fatal("expected an error when no short fortunes are available")
+	}
+}
+
+// TestRunWriteError covers the Fprintln failure branch.
+func TestRunWriteError(t *testing.T) {
+	io := command.IO{In: strings.NewReader(""), Out: errWriter{}, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Fatal("expected an error when the adage cannot be written")
+	}
+}

--- a/internal/applets/netutils/ping/ping_more_test.go
+++ b/internal/applets/netutils/ping/ping_more_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// TestParseReplyWithOptions checks that parseReply honours the IHL field when
+// TestParseReplyWithOptions checks that parseReply honors the IHL field when
 // the IPv4 header carries options (ihl > 5), locating the ICMP message at the
 // correct offset.
 func TestParseReplyWithOptions(t *testing.T) {

--- a/internal/applets/shellutils/free/free_more_test.go
+++ b/internal/applets/shellutils/free/free_more_test.go
@@ -1,0 +1,54 @@
+package free
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestRunMeminfoSourceError covers the branch where /proc/meminfo cannot be
+// opened: Run must report a failure rather than print a report.
+func TestRunMeminfoSourceError(t *testing.T) {
+	orig := meminfoSource
+	meminfoSource = func() (io.Reader, error) { return nil, errors.New("boom") }
+	t.Cleanup(func() { meminfoSource = orig })
+
+	out, errOut, err := run(t)
+	if err == nil {
+		t.Fatal("expected an error when meminfo cannot be read")
+	}
+	if out != "" {
+		t.Errorf("no report should be printed on error, got %q", out)
+	}
+	_ = errOut
+}
+
+// errReader fails partway through, so bufio.Scanner surfaces the error via
+// sc.Err() and parseMeminfo returns it.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+
+// TestRunMeminfoReadError covers the parseMeminfo error branch.
+func TestRunMeminfoReadError(t *testing.T) {
+	orig := meminfoSource
+	meminfoSource = func() (io.Reader, error) { return errReader{}, nil }
+	t.Cleanup(func() { meminfoSource = orig })
+	if _, _, err := run(t); err == nil {
+		t.Fatal("expected an error when meminfo cannot be read")
+	}
+}
+
+// TestGibibytes covers chooseUnit's gibibyte branch and render at that scale.
+func TestGibibytes(t *testing.T) {
+	stubMeminfo(t, sampleMeminfo)
+	out, _, err := run(t, "-g")
+	if err != nil {
+		t.Fatalf("Run -g error = %v", err)
+	}
+	// 8000000 KiB / (1024*1024) rounds down to 7 GiB.
+	if !strings.Contains(out, "Mem:") || !strings.Contains(out, "7") {
+		t.Errorf("gibibyte output unexpected: %q", out)
+	}
+}

--- a/internal/applets/textutils/paste/paste_more_test.go
+++ b/internal/applets/textutils/paste/paste_more_test.go
@@ -6,7 +6,7 @@ import (
 
 // TestDelimiterEscapes covers each backslash escape understood by -d, plus the
 // "default" branch for an unknown escape and the multi-character separator
-// cycle. Behaviour matches GNU paste.
+// cycle. Behavior matches GNU paste.
 func TestDelimiterEscapes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -37,7 +37,7 @@ func TestDelimiterEscapes(t *testing.T) {
 			want:  "ab\n",
 		},
 		{
-			// An unrecognised escape (\q) falls through to the literal character.
+			// An unrecognized escape (\q) falls through to the literal character.
 			name:  "unknown escape is literal",
 			delim: `\q`,
 			stdin: "a\nb\n",


### PR DESCRIPTION
## Summary

- Adds tests for fortune's empty-pool and write-error branches and free's
  meminfo open/read-error and gibibyte paths (closing the last two per-applet
  coverage issues).
- Corrects British spellings introduced in earlier coverage test comments
  (honours/honoured/behaviour/unrecognised) to American spelling, matching the
  project convention and clearing the misspell reporter warnings.

## Testing

`go test`, `gofmt -l`, and `golangci-lint` pass.

Closes #841
Closes #861