### PR TITLE
test: registry-wide contract, policy, E2E, parity, and install tests

### DIFF
--- a/cmd/mimixbox/install_smoke_test.go
+++ b/cmd/mimixbox/install_smoke_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInstallRemoveSmoke (GitHub issue #790) is an end-to-end smoke test of the
+// install / dispatch / remove lifecycle against a real mimixbox binary in a
+// temp directory:
+//
+//  1. --full-install populates an install dir with applet symlinks.
+//  2. A representative symlink (cat) resolves back to the mimixbox binary, and
+//     invoking it dispatches the real applet (cat --version banner).
+//  3. --remove deletes the symlinks while leaving the mimixbox binary in place.
+func TestInstallRemoveSmoke(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not available; skipping install smoke test")
+	}
+
+	// Build the mimixbox binary once into a temp dir from this package's source.
+	binDir := t.TempDir()
+	bin := filepath.Join(binDir, "mimixbox")
+	pkgDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	build := exec.Command(goBin, "build", "-o", bin, ".")
+	build.Dir = pkgDir
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	wantBin, err := filepath.EvalSymlinks(bin)
+	if err != nil {
+		t.Fatalf("eval mimixbox binary path: %v", err)
+	}
+
+	installDir := t.TempDir()
+
+	// Install every applet as a symlink in installDir.
+	if out, err := exec.Command(bin, "--full-install", installDir).CombinedOutput(); err != nil {
+		t.Fatalf("--full-install failed: %v\n%s", err, out)
+	}
+
+	// A representative symlink must exist and resolve to the mimixbox binary.
+	catLink := filepath.Join(installDir, "cat")
+	info, err := os.Lstat(catLink)
+	if err != nil {
+		t.Fatalf("expected symlink %s to exist: %v", catLink, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is not a symlink (mode %v)", catLink, info.Mode())
+	}
+	resolved, err := filepath.EvalSymlinks(catLink)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", catLink, err)
+	}
+	if resolved != wantBin {
+		t.Errorf("%s resolves to %q, want %q", catLink, resolved, wantBin)
+	}
+
+	// Invoking the symlink must dispatch the real cat applet.
+	out, err := exec.Command(catLink, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s --version failed: %v\n%s", catLink, err, out)
+	}
+	if !strings.Contains(string(out), "cat (mimixbox)") {
+		t.Errorf("%s --version output %q does not contain %q", catLink, out, "cat (mimixbox)")
+	}
+
+	// Remove the symlinks MimixBox created.
+	if out, err := exec.Command(bin, "--remove", installDir).CombinedOutput(); err != nil {
+		t.Fatalf("--remove failed: %v\n%s", err, out)
+	}
+
+	// The symlink must be gone...
+	if _, err := os.Lstat(catLink); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, lstat err = %v", catLink, err)
+	}
+	// ...while the mimixbox binary itself remains.
+	if _, err := os.Stat(bin); err != nil {
+		t.Errorf("mimixbox binary should still exist after --remove: %v", err)
+	}
+}

--- a/internal/applets/alias_parity_test.go
+++ b/internal/applets/alias_parity_test.go
@@ -1,0 +1,165 @@
+package applets
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// This file locks in the alias-parity contract (GitHub issue #789): the thin
+// wrapper applets must not drift from the commands they delegate to.
+//
+//   - egrep is grep -E and fgrep is grep -F (internal/applets/findutils/grepalias
+//     delegates to grep), so running the alias must match running grep with the
+//     forced mode flag over the same stdin - identical stdout and identical exit
+//     code, including on a shared error case.
+//   - netcat is an alias of nc (internal/applets/netutils/netcat delegates to
+//     nc); their --help must agree on the structured-help contract (same
+//     sections, both exit 0, clean stderr) while each wrapper intentionally
+//     renders its own command name, so the comparison is of the help body's
+//     shape and semantics rather than its literal name lines.
+//
+// Tests reach the applets through the same registry and command.Execute path
+// production uses, so they exercise the real dispatch rather than a private
+// constructor.
+
+// runApplet dispatches the registered applet under name with the given stdin and
+// arguments, returning its stdout, stderr, and exit code through the production
+// command.Execute path.
+func runApplet(t *testing.T, name, stdin string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	applet, ok := Applets[name]
+	if !ok {
+		t.Fatalf("applet %q is not registered", name)
+	}
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
+	code = command.Execute(context.Background(), applet.Cmd, io, args)
+	return out.String(), errBuf.String(), code
+}
+
+// TestEgrepMatchesGrepDashE asserts egrep PATTERN and grep -E PATTERN produce
+// identical stdout and exit code over the same stdin.
+func TestEgrepMatchesGrepDashE(t *testing.T) {
+	t.Parallel()
+	const in = "foo\nbar\nbaz\nqux\n"
+	pattern := "ba(r|z)"
+
+	aliasOut, _, aliasCode := runApplet(t, "egrep", in, pattern)
+	baseOut, _, baseCode := runApplet(t, "grep", in, "-E", pattern)
+
+	if aliasOut != baseOut {
+		t.Errorf("egrep stdout = %q, grep -E stdout = %q; want identical", aliasOut, baseOut)
+	}
+	if aliasCode != baseCode {
+		t.Errorf("egrep exit = %d, grep -E exit = %d; want identical", aliasCode, baseCode)
+	}
+}
+
+// TestFgrepMatchesGrepDashF asserts fgrep PATTERN and grep -F PATTERN produce
+// identical stdout and exit code over the same stdin. The pattern contains a
+// regex metacharacter so the fixed-string mode is observably different from
+// extended mode.
+func TestFgrepMatchesGrepDashF(t *testing.T) {
+	t.Parallel()
+	const in = "a.b\naxb\na.b.c\n"
+	pattern := "a.b"
+
+	aliasOut, _, aliasCode := runApplet(t, "fgrep", in, pattern)
+	baseOut, _, baseCode := runApplet(t, "grep", in, "-F", pattern)
+
+	if aliasOut != baseOut {
+		t.Errorf("fgrep stdout = %q, grep -F stdout = %q; want identical", aliasOut, baseOut)
+	}
+	if aliasCode != baseCode {
+		t.Errorf("fgrep exit = %d, grep -F exit = %d; want identical", aliasCode, baseCode)
+	}
+}
+
+// TestEgrepErrorExitParity asserts egrep and grep -E agree on a non-success exit
+// code for a shared error case: a pattern against a file that does not exist.
+func TestEgrepErrorExitParity(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist.txt")
+
+	_, _, aliasCode := runApplet(t, "egrep", "", "foo", missing)
+	_, _, baseCode := runApplet(t, "grep", "", "-E", "foo", missing)
+
+	if aliasCode == command.ExitSuccess {
+		t.Errorf("egrep on a missing file exited 0, want non-zero")
+	}
+	if aliasCode != baseCode {
+		t.Errorf("egrep exit = %d, grep -E exit = %d; want identical on the error case", aliasCode, baseCode)
+	}
+}
+
+// TestFgrepErrorExitParity is the fixed-string counterpart of
+// TestEgrepErrorExitParity.
+func TestFgrepErrorExitParity(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist.txt")
+
+	_, _, aliasCode := runApplet(t, "fgrep", "", "foo", missing)
+	_, _, baseCode := runApplet(t, "grep", "", "-F", "foo", missing)
+
+	if aliasCode == command.ExitSuccess {
+		t.Errorf("fgrep on a missing file exited 0, want non-zero")
+	}
+	if aliasCode != baseCode {
+		t.Errorf("fgrep exit = %d, grep -F exit = %d; want identical on the error case", aliasCode, baseCode)
+	}
+}
+
+// TestNetcatHelpParityWithNc asserts that netcat --help and nc --help honor the
+// same structured-help contract: both exit 0, write nothing to stderr, and carry
+// the same sections (Usage, Examples, Exit status). The one intentional
+// difference is the command name each wrapper prints, so this test compares the
+// help body's shape - not the literal name line - and confirms each wrapper
+// renders its own name in the Usage line (and does not leak the other's). No
+// sockets are opened: --help short-circuits before any network code runs.
+func TestNetcatHelpParityWithNc(t *testing.T) {
+	t.Parallel()
+	netcatOut, netcatErr, netcatCode := runApplet(t, "netcat", "", "--help")
+	ncOut, ncErr, ncCode := runApplet(t, "nc", "", "--help")
+
+	if netcatCode != command.ExitSuccess {
+		t.Errorf("netcat --help exit = %d, want 0", netcatCode)
+	}
+	if ncCode != command.ExitSuccess {
+		t.Errorf("nc --help exit = %d, want 0", ncCode)
+	}
+	if netcatErr != "" {
+		t.Errorf("netcat --help wrote to stderr: %q", netcatErr)
+	}
+	if ncErr != "" {
+		t.Errorf("nc --help wrote to stderr: %q", ncErr)
+	}
+
+	// Each wrapper renders its OWN name in the Usage line and never the other's.
+	if !strings.HasPrefix(netcatOut, "Usage: netcat") {
+		t.Errorf("netcat --help should start with %q:\n%s", "Usage: netcat", netcatOut)
+	}
+	if !strings.HasPrefix(ncOut, "Usage: nc") {
+		t.Errorf("nc --help should start with %q:\n%s", "Usage: nc", ncOut)
+	}
+	if strings.Contains(ncOut, "netcat") {
+		t.Errorf("nc --help leaks the alias name %q:\n%s", "netcat", ncOut)
+	}
+
+	// Structured-help parity: the same sections appear in both, so neither
+	// wrapper drifts to a bare option dump. This is the body/semantics comparison
+	// the contract calls for, independent of the per-command name and prose.
+	for _, section := range []string{"Usage:", "Options:", "Examples:", "Exit status:"} {
+		if !strings.Contains(netcatOut, section) {
+			t.Errorf("netcat --help missing %q section:\n%s", section, netcatOut)
+		}
+		if !strings.Contains(ncOut, section) {
+			t.Errorf("nc --help missing %q section:\n%s", section, ncOut)
+		}
+	}
+}

--- a/internal/applets/conformance_test.go
+++ b/internal/applets/conformance_test.go
@@ -1,0 +1,44 @@
+package applets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// TestEveryAppletSatisfiesHelpVersionContract is the registry-wide contract
+// (GitHub issue #785): every registered applet must answer --help and --version
+// the same way, so a user (or a tool) can rely on the conventions regardless of
+// which applet they invoke.
+//
+//   - --help exits 0 and prints a "Usage: <name>" line.
+//   - --version exits 0 and prints the "<name> (mimixbox) <version>" banner.
+//
+// This complements TestEveryAppletHelpHasExamplesAndExitStatus, which checks the
+// richer help sections; here we lock in the bare usage/version surface itself.
+func TestEveryAppletSatisfiesHelpVersionContract(t *testing.T) {
+	t.Parallel()
+	for name := range Applets {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			help, _, code := runApplet(t, name, "", "--help")
+			if code != command.ExitSuccess {
+				t.Fatalf("%s --help exit = %d, want %d", name, code, command.ExitSuccess)
+			}
+			if want := "Usage: " + name; !strings.Contains(help, want) {
+				t.Errorf("%s --help is missing usage text %q\n%s", name, want, help)
+			}
+
+			version, _, code := runApplet(t, name, "", "--version")
+			if code != command.ExitSuccess {
+				t.Fatalf("%s --version exit = %d, want %d", name, code, command.ExitSuccess)
+			}
+			if want := " (mimixbox) "; !strings.Contains(version, want) {
+				t.Errorf("%s --version is missing the %q banner\n%s", name, want, version)
+			}
+		})
+	}
+}

--- a/internal/applets/console-tools/stty/stty.go
+++ b/internal/applets/console-tools/stty/stty.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
+	"github.com/nao1215/mimixbox/internal/version"
 	"golang.org/x/sys/unix"
 )
 
@@ -68,6 +69,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		switch a {
 		case "--help", "-h":
 			fs.WriteUsage(stdio.Out)
+			return nil
+		case "--version":
+			version.Print(stdio.Out, c.Name())
 			return nil
 		case "-a", "--all":
 			all = true

--- a/internal/applets/console-tools/stty/stty_test.go
+++ b/internal/applets/console-tools/stty/stty_test.go
@@ -84,3 +84,15 @@ func TestApplySettings(t *testing.T) {
 		t.Errorf("an invalid setting should fail")
 	}
 }
+
+// TestVersion verifies stty honors --version (GitHub issue #785 contract).
+func TestVersion(t *testing.T) {
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	if err := New().Run(context.Background(), io, []string{"--version"}); err != nil {
+		t.Fatalf("--version err = %v", err)
+	}
+	if !strings.Contains(out.String(), "stty (mimixbox)") {
+		t.Errorf("--version = %q, want version banner", out.String())
+	}
+}

--- a/internal/applets/help_shape_policy_test.go
+++ b/internal/applets/help_shape_policy_test.go
@@ -1,0 +1,91 @@
+package applets
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// requiredHelpSections is the opted-in help-shape policy (GitHub issue #786):
+// every applet's --help must carry both a worked Examples block and an Exit
+// status block, not just a bare option table.
+var requiredHelpSections = []string{"Examples:", "Exit status:"}
+
+// missingHelpSections returns the policy sections that help does NOT contain.
+// An empty result means help satisfies the policy. Factoring the check here lets
+// the real applets and the negative fixture be judged by the exact same rule.
+func missingHelpSections(help string) []string {
+	var missing []string
+	for _, section := range requiredHelpSections {
+		if !strings.Contains(help, section) {
+			missing = append(missing, section)
+		}
+	}
+	return missing
+}
+
+// TestEveryAppletHelpSatisfiesShapePolicy asserts that every registered applet's
+// --help passes the help-shape policy.
+func TestEveryAppletHelpSatisfiesShapePolicy(t *testing.T) {
+	t.Parallel()
+	for name := range Applets {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			help, _, code := runApplet(t, name, "", "--help")
+			if code != command.ExitSuccess {
+				t.Fatalf("%s --help exit = %d, want %d", name, code, command.ExitSuccess)
+			}
+			if missing := missingHelpSections(help); len(missing) > 0 {
+				t.Errorf("%s --help violates help-shape policy: missing %v\n%s", name, missing, help)
+			}
+		})
+	}
+}
+
+// bareUsageCmd is a negative fixture: a command whose --help renders only a bare
+// "Usage:"/options block, with neither an Examples nor an Exit status section.
+// It exists to prove that missingHelpSections actually rejects an unadorned
+// usage block, so the policy test above cannot silently pass on everything.
+type bareUsageCmd struct{}
+
+func (bareUsageCmd) Name() string     { return "fixturecmd" }
+func (bareUsageCmd) Synopsis() string { return "negative fixture command" }
+
+func (bareUsageCmd) Run(_ context.Context, io command.IO, _ []string) error {
+	// Render the GNU-style usage block without attaching any WithHelp sections,
+	// so the output is exactly the bare "Usage:"/Options shape the policy must
+	// reject.
+	errBuf := &bytes.Buffer{}
+	fs := command.NewFlagSet("fixturecmd", "", errBuf)
+	fs.WriteUsage(io.Out)
+	return nil
+}
+
+// TestHelpShapePolicyRejectsBareUsageFixture verifies the policy detects a bare
+// usage block: the negative fixture's --help must be reported as missing BOTH
+// required sections.
+func TestHelpShapePolicyRejectsBareUsageFixture(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+	code := command.Execute(context.Background(), bareUsageCmd{}, io, []string{"--help"})
+	if code != command.ExitSuccess {
+		t.Fatalf("fixture --help exit = %d, want %d", code, command.ExitSuccess)
+	}
+
+	help := out.String()
+	if !strings.Contains(help, "Usage: fixturecmd") {
+		t.Fatalf("fixture --help should still print a usage line, got:\n%s", help)
+	}
+
+	missing := missingHelpSections(help)
+	if len(missing) != len(requiredHelpSections) {
+		t.Fatalf("policy should reject the bare usage fixture for all %d sections, but only flagged %v\n%s",
+			len(requiredHelpSections), missing, help)
+	}
+}

--- a/test/it/spec/alias_parity_spec.sh
+++ b/test/it/spec/alias_parity_spec.sh
@@ -1,0 +1,61 @@
+# shellcheck shell=sh
+# Issue #789: real-process alias-parity contract for the thin wrapper applets.
+#
+# These specs run the installed applets on PATH so the parity holds for the
+# shipped binaries, not just the in-memory dispatch covered by the Go unit
+# tests:
+#   - egrep is grep -E and fgrep is grep -F, so the alias and grep with the
+#     forced mode flag must produce the same match output over the same file.
+#   - netcat is an alias of nc; both must answer --help with exit 0 and an
+#     Examples section. Help short-circuits before any network code, so no
+#     sockets are opened.
+Describe 'alias parity'
+  setup() {
+    TEST_DIR=${MIMIXBOX_IT_ROOT}/alias_parity
+    mkdir -p "${TEST_DIR}"
+    # A regex metacharacter in the data makes -E (regex) and -F (fixed) modes
+    # observably distinct, so the egrep/fgrep parity below is meaningful.
+    printf 'apple\nbanana\na.b\naxb\n' > "${TEST_DIR}/fixture.txt"
+  }
+  cleanup() { rm -rf "${MIMIXBOX_IT_ROOT}/alias_parity"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  fixture() { printf '%s' "${MIMIXBOX_IT_ROOT}/alias_parity/fixture.txt"; }
+
+  Describe 'egrep == grep -E'
+    It 'matches the same lines as grep -E over the same file'
+      When run command egrep 'a(p|x)' "$(fixture)"
+      The status should be success
+      The output should equal "$(grep -E 'a(p|x)' "$(fixture)")"
+    End
+  End
+
+  Describe 'fgrep == grep -F'
+    It 'matches the same lines as grep -F over the same file'
+      # The fixed-string pattern "a.b" must match only the literal a.b line, not
+      # axb, exactly as grep -F does.
+      When run command fgrep 'a.b' "$(fixture)"
+      The status should be success
+      The output should equal "$(grep -F 'a.b' "$(fixture)")"
+    End
+  End
+
+  Describe 'netcat is an alias of nc'
+    It 'answers netcat --help with exit 0 and an Examples section'
+      When run command netcat --help
+      The status should be success
+      The output should include 'Usage: netcat'
+      The output should include 'Examples:'
+      The stderr should equal ''
+    End
+
+    It 'answers nc --help with exit 0 and an Examples section'
+      When run command nc --help
+      The status should be success
+      The output should include 'Usage: nc'
+      The output should include 'Examples:'
+      The stderr should equal ''
+    End
+  End
+End

--- a/test/it/spec/gated_plan_spec.sh
+++ b/test/it/spec/gated_plan_spec.sh
@@ -1,0 +1,44 @@
+# shellcheck shell=sh
+# Issue #788: deterministic planned-action E2E for privileged, capability-gated
+# applets.
+#
+# The "never ship a silent no-op" rule means each privileged applet first
+# validates its arguments and serializes the requested action (a plan), then
+# fails with a documented capability/gate error and a non-zero exit WITHOUT
+# performing the action. This spec picks one representative command per gated
+# family (netctl, selinux, modutils) and asserts both the normalized plan/
+# validation text and the gated error message, copied verbatim from each
+# applet's source so the assertions are deterministic. One case per family.
+Describe 'capability-gated applets validate, plan, then refuse'
+
+  Describe 'netctl: brctl addbr br0'
+    # internal/applets/netutils/netctl: a plan line on stdout, then a
+    # capability-gated backend error; exit 1 and no bridge created.
+    It 'prints the plan then fails with a capability-gated backend error'
+      When run brctl addbr br0
+      The status should be failure
+      The output should include 'brctl: planned action: brctl addbr br0'
+      The stderr should include 'planned action [brctl addbr br0] requires privileged kernel network configuration not available in this environment (capability-gated backend)'
+    End
+  End
+
+  Describe 'selinux: setenforce Permissive'
+    # internal/applets/securityutils/selinux: the mutating SELinux applets
+    # refuse deterministically (CAP_MAC_ADMIN gate) instead of changing state.
+    It 'refuses to mutate SELinux state and exits non-zero'
+      When run setenforce Permissive
+      The status should be failure
+      The stderr should include 'setenforce: refusing to mutate SELinux state: requires CAP_MAC_ADMIN and a loaded policy; this operation is intentionally not implemented in the hermetic build'
+    End
+  End
+
+  Describe 'modutils: modprobe foo'
+    # internal/applets/procps/modutils: the name validates, the plan is
+    # reported ("validated successfully"), then the CAP_SYS_MODULE gate fails.
+    It 'validates the module then fails on the CAP_SYS_MODULE gate'
+      When run modprobe foo
+      The status should be failure
+      The stderr should include 'modprobe: load of foo validated successfully, but inserting/removing kernel modules requires CAP_SYS_MODULE; this privileged step is intentionally not implemented in the hermetic build'
+    End
+  End
+End

--- a/test/it/spec/script_roundtrip_spec.sh
+++ b/test/it/spec/script_roundtrip_spec.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=sh
+# Issue #787: end-to-end round-trip for the "script" and "scriptreplay" applets.
+#
+# script -c COMMAND -T TIMINGFILE TYPESCRIPT records COMMAND's output, wrapping
+# it in "Script started"/"Script done" framing, and writes a "delay bytes"
+# timing file. scriptreplay TIMINGFILE TYPESCRIPT then re-emits the captured
+# payload. This spec records a deterministic two-line payload, asserts the
+# transcript framing + payload and the timing-file record shape, then replays
+# it and asserts the payload bytes survive the round trip.
+Describe 'script / scriptreplay round-trip'
+  setup() {
+    work="$(it_root)/script_roundtrip"
+    rm -rf "$work"
+    mkdir -p "$work"
+    transcript="$work/transcript"
+    timing="$work/timing"
+    script -c 'printf "hello\nworld\n"' -T "$timing" "$transcript" >/dev/null 2>&1
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'records the transcript framing'
+    When run cat "$transcript"
+    The status should be success
+    The output should include 'Script started'
+    The output should include 'Script done'
+  End
+
+  It 'records the command payload in the transcript'
+    When run cat "$transcript"
+    The status should be success
+    The output should include 'hello'
+    The output should include 'world'
+  End
+
+  It 'writes a timing file of "delay bytes" records'
+    # Every line is two whitespace-separated fields: a float delay and an
+    # integer byte count.
+    When run grep -Eq '^[0-9]+\.[0-9]+[[:space:]]+[0-9]+$' "$timing"
+    The status should be success
+  End
+
+  It 'replays the captured payload from the timing + transcript'
+    When run scriptreplay "$timing" "$transcript"
+    The status should be success
+    The output should include 'hello'
+    The output should include 'world'
+  End
+End

--- a/test/it/spec/script_roundtrip_spec.sh
+++ b/test/it/spec/script_roundtrip_spec.sh
@@ -35,9 +35,9 @@ Describe 'script / scriptreplay round-trip'
   End
 
   It 'writes a timing file of "delay bytes" records'
-    # Every line is two whitespace-separated fields: a float delay and an
-    # integer byte count.
-    When run grep -Eq '^[0-9]+\.[0-9]+[[:space:]]+[0-9]+$' "$timing"
+    # Every non-empty line must be two whitespace-separated fields: a float
+    # delay and an integer byte count (and there must be at least one record).
+    When run awk 'NF && $1 ~ /^[0-9]+\.[0-9]+$/ && $2 ~ /^[0-9]+$/ { ok++ } END { exit !(NR>0 && ok==NR) }' "$timing"
     The status should be success
   End
 


### PR DESCRIPTION
## Summary

Implements the `test/*` infrastructure backlog and fixes one real gap it surfaced.

- **conformance (#785)**: every applet's `--help` exits 0 with a `Usage:` line and `--version` exits 0 with the `(mimixbox)` banner.
- **help-shape policy (#786)**: table-driven `Examples:`/`Exit status:` policy with a **negative fixture** that proves a bare usage block is rejected.
- **script round-trip (#787)**: ShellSpec records a command and replays it, asserting transcript framing, timing-file shape, and replayed payload.
- **gated plans (#788)**: ShellSpec asserts the planned-action + documented gate error for one representative privileged applet per family (netctl, selinux, modutils).
- **alias parity (#789)**: unit + ShellSpec parity for `egrep`/`grep -E`, `fgrep`/`grep -F`, and `netcat`/`nc`.
- **install smoke (#790)**: builds the binary, `--full-install`s into a temp dir, dispatches `cat --version` through the symlink, then `--remove`s and verifies cleanup.

**Production fix:** `stty` hand-parses its operands and never honored `--version`; it now prints the version banner and exits 0, so the conformance contract holds registry-wide with no exemptions.

## Testing

`go test ./...`, `golangci-lint`, and full `make test-e2e` (1762 examples, 0 failures) all pass.

Closes #785
Closes #786
Closes #787
Closes #788
Closes #789
Closes #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` flag support to the `stty` command, allowing users to check the applet version.

* **Tests**
  * Expanded test coverage with installation lifecycle validation, alias parity verification, help/version contract compliance, and integration tests for script roundtrip and capability-gated applet behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->