### PR TITLE
feat(gnu): add GNU-compatible flags to ten text/file applets

### DIFF
--- a/internal/applets/shellutils/cmp/cmp.go
+++ b/internal/applets/shellutils/cmp/cmp.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
@@ -40,17 +42,43 @@ type result struct {
 	a, b byte
 }
 
+// compareOptions tunes the byte-by-byte comparison: how many bytes of each
+// stream to skip up front, and how many bytes to compare at most.
+type compareOptions struct {
+	// skip1 and skip2 are the number of leading bytes to discard from r1 and r2
+	// before comparison begins (--ignore-initial). The reported byteOffset and
+	// line are counted from the first compared byte, matching GNU cmp.
+	skip1, skip2 int64
+	// limit caps the number of byte pairs compared (--bytes). A value <= 0 means
+	// "no limit".
+	limit int64
+}
+
 // compare reads r1 and r2 byte by byte and reports the first difference, or
 // that one stream is a prefix of the other, or that they are equal. It is the
 // pure, unit-testable core of cmp: it touches no files, flags, or streams of
-// its own.
-func compare(r1, r2 io.Reader) (result, error) {
+// its own. opts controls leading-byte skipping and the comparison length cap.
+func compare(r1, r2 io.Reader, opts compareOptions) (result, error) {
 	br1 := bufio.NewReader(r1)
 	br2 := bufio.NewReader(r2)
+
+	// Discard the ignored prefixes. Hitting EOF inside a skip means that stream
+	// has no bytes left to compare, so it behaves like an empty (prefix) stream.
+	if err := discard(br1, opts.skip1); err != nil && !errors.Is(err, io.EOF) {
+		return result{}, err
+	}
+	if err := discard(br2, opts.skip2); err != nil && !errors.Is(err, io.EOF) {
+		return result{}, err
+	}
 
 	var offset int64
 	var line int64 = 1
 	for {
+		if opts.limit > 0 && offset >= opts.limit {
+			// Reached the --bytes cap with no difference: treat as equal.
+			return result{equal: true}, nil
+		}
+
 		b1, err1 := br1.ReadByte()
 		b2, err2 := br2.ReadByte()
 
@@ -90,6 +118,71 @@ func compare(r1, r2 io.Reader) (result, error) {
 	}
 }
 
+// discard reads and throws away n bytes from r, returning any read error
+// (including io.EOF if the stream ends before n bytes are consumed).
+func discard(r *bufio.Reader, n int64) error {
+	for ; n > 0; n-- {
+		if _, err := r.ReadByte(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseIgnoreInitial parses the --ignore-initial value, which is either a single
+// count "N" applied to both files, or "N:M" giving separate counts for FILE1 and
+// FILE2. It returns the two skip counts.
+func parseIgnoreInitial(s string) (int64, int64, error) {
+	if s == "" {
+		return 0, 0, nil
+	}
+	if i := strings.IndexByte(s, ':'); i >= 0 {
+		n, err := strconv.ParseInt(s[:i], 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+		m, err := strconv.ParseInt(s[i+1:], 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+		if n < 0 || m < 0 {
+			return 0, 0, fmt.Errorf("invalid --ignore-initial value %q", s)
+		}
+		return n, m, nil
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	if n < 0 {
+		return 0, 0, fmt.Errorf("invalid --ignore-initial value %q", s)
+	}
+	return n, n, nil
+}
+
+// sprintc renders a byte the way GNU cmp does for --print-bytes: the character
+// itself when printable, with caret notation for control bytes (^X), "^?" for
+// DEL, and an "M-" prefix for bytes with the high bit set. It mirrors GNU's
+// sprintc helper; the surrounding format string supplies the column spacing.
+func sprintc(b byte) string {
+	var sb strings.Builder
+	c := b
+	if c >= 0x80 {
+		sb.WriteString("M-")
+		c -= 0x80
+	}
+	switch {
+	case c < 0x20:
+		sb.WriteByte('^')
+		sb.WriteByte(c + 0x40)
+	case c == 0x7f:
+		sb.WriteString("^?")
+	default:
+		sb.WriteByte(c)
+	}
+	return sb.String()
+}
+
 // Run executes cmp.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
 	fs := command.NewFlagSet(c.Name(), "[OPTION]... FILE1 [FILE2]", stdio.Err).WithHelp(command.Help{
@@ -99,12 +192,18 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "cmp a.txt b.txt", Explain: "Report the first byte at which a.txt and b.txt differ."},
 			{Command: "cmp -s a.txt b.txt", Explain: "Compare silently, reporting the result only via the exit status."},
 			{Command: "cmp -l a.txt b.txt", Explain: "List the offset and octal values of every differing byte."},
+			{Command: "cmp -b a.txt b.txt", Explain: "Also show the differing byte values in the difference message."},
+			{Command: "cmp -n 100 a.txt b.txt", Explain: "Compare at most the first 100 bytes of each file."},
+			{Command: "cmp -i 4:8 a.txt b.txt", Explain: "Skip 4 bytes of a.txt and 8 of b.txt before comparing."},
 		},
 		ExitStatus: "0  inputs are identical.\n1  they differ.\n2  an error occurred.",
 	})
 	silent := fs.BoolP("silent", "s", false, "suppress all normal output")
 	_ = fs.Bool("quiet", false, "suppress all normal output")
 	verbose := fs.BoolP("verbose", "l", false, "output byte numbers and differing byte values")
+	printBytes := fs.BoolP("print-bytes", "b", false, "print differing bytes")
+	limit := fs.Int64P("bytes", "n", 0, "compare at most LIMIT bytes")
+	ignore := fs.StringP("ignore-initial", "i", "", "skip first N bytes of both inputs (or N:M for each)")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -112,6 +211,16 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 	quiet, _ := fs.GetBool("quiet")
 	silentMode := *silent || quiet
+
+	skip1, skip2, err := parseIgnoreInitial(*ignore)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "cmp: invalid --ignore-initial value '%s'\n", *ignore)
+		return &command.ExitError{Code: 2}
+	}
+	if *limit < 0 {
+		_, _ = fmt.Fprintf(stdio.Err, "cmp: invalid --bytes value '%d'\n", *limit)
+		return &command.ExitError{Code: 2}
+	}
 
 	operands := fs.Args()
 	if len(operands) < 1 {
@@ -147,7 +256,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 	defer func() { _ = r2.Close() }()
 
-	res, err := compare(r1, r2)
+	res, err := compare(r1, r2, compareOptions{skip1: skip1, skip2: skip2, limit: *limit})
 	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "cmp: %v\n", err)
 		return &command.ExitError{Code: 2}
@@ -170,9 +279,15 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 
 	// Files differ at a concrete byte.
 	if !silentMode {
-		if *verbose {
+		switch {
+		case *verbose:
 			_, _ = fmt.Fprintf(stdio.Out, "%d %o %o\n", res.byteOffset, res.a, res.b)
-		} else {
+		case *printBytes:
+			// GNU: "<f1> <f2> differ: byte N, line L is V1 C1 V2 C2", where V is
+			// the octal byte value and C the rendered character.
+			_, _ = fmt.Fprintf(stdio.Out, "%s %s differ: byte %d, line %d is %3o %s %3o %s\n",
+				name1, name2, res.byteOffset, res.line, res.a, sprintc(res.a), res.b, sprintc(res.b))
+		default:
 			_, _ = fmt.Fprintf(stdio.Out, "%s %s differ: byte %d, line %d\n",
 				name1, name2, res.byteOffset, res.line)
 		}

--- a/internal/applets/shellutils/cmp/cmp_test.go
+++ b/internal/applets/shellutils/cmp/cmp_test.go
@@ -264,6 +264,125 @@ func TestPrefixEOFOnSecond(t *testing.T) {
 	}
 }
 
+// TestBytesLimit covers -n/--bytes: a difference past the limit is not seen, so
+// the comparison succeeds (exit 0); within the limit it is reported (exit 1).
+func TestBytesLimit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "abcXdef")
+	b := writeFile(t, dir, "b", "abcYdef")
+
+	// Differ at byte 4; limiting to 3 bytes hides it.
+	out, errOut, code := run(t, "-n", "3", a, b)
+	if code != 0 {
+		t.Errorf("exit = %d, want 0 with -n 3", code)
+	}
+	if out != "" || errOut != "" {
+		t.Errorf("output = %q / %q, want empty", out, errOut)
+	}
+
+	// Long-form --bytes=4 reaches the difference.
+	out, _, code = run(t, "--bytes=4", a, b)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 with --bytes=4", code)
+	}
+	want := a + " " + b + " differ: byte 4, line 1\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestIgnoreInitialSingle covers -i N: the first N bytes of both files are
+// skipped before comparing.
+func TestIgnoreInitialSingle(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Bytes 1-3 differ but are skipped; the rest is identical.
+	a := writeFile(t, dir, "a", "XXXcommon")
+	b := writeFile(t, dir, "b", "YYYcommon")
+
+	out, errOut, code := run(t, "-i", "3", a, b)
+	if code != 0 {
+		t.Errorf("exit = %d, want 0 after skipping 3 bytes; stderr=%q", code, errOut)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+}
+
+// TestIgnoreInitialPair covers -i N:M: different skip counts for each file, with
+// reported offsets counted from the first compared byte.
+func TestIgnoreInitialPair(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Skip 1 of FILE1 and 3 of FILE2; remaining "abZ" vs "abQ" differ at byte 3.
+	a := writeFile(t, dir, "a", "_abZ")
+	b := writeFile(t, dir, "b", "___abQ")
+
+	out, _, code := run(t, "-i", "1:3", a, b)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	want := a + " " + b + " differ: byte 3, line 1\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestIgnoreInitialInvalid covers a malformed --ignore-initial value (exit 2).
+func TestIgnoreInitialInvalid(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "x")
+	b := writeFile(t, dir, "b", "x")
+	_, errOut, code := run(t, "-i", "abc", a, b)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "invalid --ignore-initial") {
+		t.Errorf("stderr = %q, want invalid --ignore-initial message", errOut)
+	}
+}
+
+// TestPrintBytes covers -b/--print-bytes: the differ message gains the octal
+// values and rendered characters of the two differing bytes, in GNU format.
+func TestPrintBytes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "first\nsecond\n")
+	b := writeFile(t, dir, "b", "first\nSECOND\n")
+
+	out, _, code := run(t, "-b", a, b)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	// 's' = 0163 octal, 'S' = 0123 octal; byte 7, line 2 (verified vs GNU cmp).
+	want := a + " " + b + " differ: byte 7, line 2 is 163 s 123 S\n"
+	if out != want {
+		t.Errorf("-b out = %q, want %q", out, want)
+	}
+}
+
+// TestPrintBytesControl covers sprintc's caret notation for control bytes in the
+// --print-bytes output.
+func TestPrintBytesControl(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a", "a\tb")
+	b := writeFile(t, dir, "b", "a\nb")
+
+	out, _, code := run(t, "-b", a, b)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	// '\t' = 11 octal, '\n' = 12 octal (GNU pads the octal field with spaces to
+	// width 3); rendered ^I and ^J. Verified against GNU cmp 3.10.
+	want := a + " " + b + " differ: byte 2, line 1 is  11 ^I  12 ^J\n"
+	if out != want {
+		t.Errorf("-b control out = %q, want %q", out, want)
+	}
+}
+
 // TestHelpSections verifies that --help renders both the Examples and the
 // Exit status sections supplied through WithHelp.
 func TestHelpSections(t *testing.T) {

--- a/internal/applets/shellutils/cmp/compare_internal_test.go
+++ b/internal/applets/shellutils/cmp/compare_internal_test.go
@@ -18,10 +18,10 @@ func TestCompareReadError(t *testing.T) {
 	t.Parallel()
 	boom := errors.New("boom")
 
-	if _, err := compare(failingReader{err: boom}, strings.NewReader("x")); !errors.Is(err, boom) {
+	if _, err := compare(failingReader{err: boom}, strings.NewReader("x"), compareOptions{}); !errors.Is(err, boom) {
 		t.Errorf("error from first reader = %v, want boom", err)
 	}
-	if _, err := compare(strings.NewReader("x"), failingReader{err: boom}); !errors.Is(err, boom) {
+	if _, err := compare(strings.NewReader("x"), failingReader{err: boom}, compareOptions{}); !errors.Is(err, boom) {
 		t.Errorf("error from second reader = %v, want boom", err)
 	}
 }
@@ -31,13 +31,13 @@ func TestCompareReadError(t *testing.T) {
 func TestCompareEqualAndDiff(t *testing.T) {
 	t.Parallel()
 
-	res, err := compare(strings.NewReader("ab\ncd\n"), strings.NewReader("ab\ncd\n"))
+	res, err := compare(strings.NewReader("ab\ncd\n"), strings.NewReader("ab\ncd\n"), compareOptions{})
 	if err != nil || !res.equal {
 		t.Errorf("equal streams: res=%+v err=%v", res, err)
 	}
 
 	// First difference at byte 5 (the 'c'/'C'), on line 2.
-	res, err = compare(strings.NewReader("ab\ncd"), strings.NewReader("ab\nCd"))
+	res, err = compare(strings.NewReader("ab\ncd"), strings.NewReader("ab\nCd"), compareOptions{})
 	if err != nil {
 		t.Fatalf("diff err = %v", err)
 	}
@@ -45,12 +45,61 @@ func TestCompareEqualAndDiff(t *testing.T) {
 		t.Errorf("diff res = %+v, want byte 4 line 2 c/C", res)
 	}
 
-	res, _ = compare(strings.NewReader("abc"), strings.NewReader("abcd"))
+	res, _ = compare(strings.NewReader("abc"), strings.NewReader("abcd"), compareOptions{})
 	if res.eofOn != 1 {
 		t.Errorf("first-prefix res = %+v, want eofOn=1", res)
 	}
-	res, _ = compare(strings.NewReader("abcd"), strings.NewReader("abc"))
+	res, _ = compare(strings.NewReader("abcd"), strings.NewReader("abc"), compareOptions{})
 	if res.eofOn != 2 {
 		t.Errorf("second-prefix res = %+v, want eofOn=2", res)
+	}
+}
+
+// TestCompareLimit verifies --bytes (limit) stops the comparison early: a
+// difference past the limit is not seen, so the streams compare equal.
+func TestCompareLimit(t *testing.T) {
+	t.Parallel()
+
+	// Differ at byte 3, but limit to 2 bytes -> equal.
+	res, err := compare(strings.NewReader("abX"), strings.NewReader("abY"), compareOptions{limit: 2})
+	if err != nil || !res.equal {
+		t.Errorf("limited compare: res=%+v err=%v, want equal", res, err)
+	}
+
+	// Limit equal to the difference offset still catches it (offset 3 with limit 3).
+	res, err = compare(strings.NewReader("abX"), strings.NewReader("abY"), compareOptions{limit: 3})
+	if err != nil {
+		t.Fatalf("limit err = %v", err)
+	}
+	if res.equal || res.byteOffset != 3 {
+		t.Errorf("limit-at-diff res = %+v, want byte 3 diff", res)
+	}
+}
+
+// TestCompareIgnoreInitial verifies --ignore-initial skips leading bytes of each
+// stream, and that offsets are counted from the first compared byte.
+func TestCompareIgnoreInitial(t *testing.T) {
+	t.Parallel()
+
+	// Skip 3 of each; the remaining "abc" vs "abc" are equal.
+	res, err := compare(strings.NewReader("XYZabc"), strings.NewReader("123abc"), compareOptions{skip1: 3, skip2: 3})
+	if err != nil || !res.equal {
+		t.Errorf("skip N: res=%+v err=%v, want equal", res, err)
+	}
+
+	// Asymmetric skip N:M. Skip 1 of file1 and 3 of file2; remaining "bcd" vs
+	// "bcd" equal. Verifies the two counts are independent.
+	res, err = compare(strings.NewReader("Abcd"), strings.NewReader("XYZbcd"), compareOptions{skip1: 1, skip2: 3})
+	if err != nil || !res.equal {
+		t.Errorf("skip N:M: res=%+v err=%v, want equal", res, err)
+	}
+
+	// After skipping, the first compared byte is offset 1.
+	res, err = compare(strings.NewReader("XXa"), strings.NewReader("XXb"), compareOptions{skip1: 2, skip2: 2})
+	if err != nil {
+		t.Fatalf("skip-diff err = %v", err)
+	}
+	if res.byteOffset != 1 || res.a != 'a' || res.b != 'b' {
+		t.Errorf("skip-diff res = %+v, want byte 1 a/b", res)
 	}
 }

--- a/internal/applets/shellutils/cut/cut.go
+++ b/internal/applets/shellutils/cut/cut.go
@@ -5,6 +5,7 @@ package cut
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -44,6 +45,8 @@ type options struct {
 	delimiter       string
 	outputDelimiter string
 	onlyDelimited   bool
+	complement      bool
+	lineDelim       byte
 }
 
 // Run executes cut.
@@ -65,6 +68,8 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	delimiter := fs.StringP("delimiter", "d", "\t", "use DELIM instead of TAB for field delimiter")
 	onlyDelimited := fs.BoolP("only-delimited", "s", false, "do not print lines not containing delimiters")
 	outputDelimiter := fs.String("output-delimiter", "", "use STRING as the output delimiter")
+	complement := fs.Bool("complement", false, "complement the set of selected bytes, characters or fields")
+	zeroTerminated := fs.BoolP("zero-terminated", "z", false, "line delimiter is NUL, not newline")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -72,7 +77,8 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 
 	opts, err := buildOptions(stdio, *bytesList, *charsList, *fieldsList,
-		*delimiter, *outputDelimiter, *onlyDelimited, fs.Changed("output-delimiter"))
+		*delimiter, *outputDelimiter, *onlyDelimited, fs.Changed("output-delimiter"),
+		*complement, *zeroTerminated)
 	if err != nil {
 		return err
 	}
@@ -84,7 +90,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 // range list, returning the resolved options. Errors are written to stderr and
 // reported as silent failures so the runner only sets the exit code.
 func buildOptions(stdio command.IO, bytesList, charsList, fieldsList,
-	delimiter, outputDelimiter string, onlyDelimited, outDelimSet bool) (options, error) {
+	delimiter, outputDelimiter string, onlyDelimited, outDelimSet, complement, zeroTerminated bool) (options, error) {
 	m, list, err := selectMode(stdio, bytesList, charsList, fieldsList)
 	if err != nil {
 		return options{}, err
@@ -107,12 +113,19 @@ func buildOptions(stdio command.IO, bytesList, charsList, fieldsList,
 		}
 	}
 
+	lineDelim := byte('\n')
+	if zeroTerminated {
+		lineDelim = 0
+	}
+
 	return options{
 		mode:            m,
 		ranges:          ranges,
 		delimiter:       delimiter,
 		outputDelimiter: outDelim,
 		onlyDelimited:   onlyDelimited,
+		complement:      complement,
+		lineDelim:       lineDelim,
 	}, nil
 }
 
@@ -170,10 +183,13 @@ func run(stdio command.IO, opts options, files []string) error {
 	return firstErr
 }
 
-// cutReader processes r line by line, writing the cut output to w.
+// cutReader processes r line by line, writing the cut output to w. Lines are
+// split on opts.lineDelim ('\n' by default, NUL with -z) and the same delimiter
+// terminates each emitted line.
 func cutReader(w io.Writer, r io.Reader, opts options) error {
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Split(splitOn(opts.lineDelim))
 	bw := bufio.NewWriter(w)
 	for sc.Scan() {
 		out, emit := cutLine(sc.Text(), opts)
@@ -183,7 +199,7 @@ func cutReader(w io.Writer, r io.Reader, opts options) error {
 		if _, err := bw.WriteString(out); err != nil {
 			return err
 		}
-		if err := bw.WriteByte('\n'); err != nil {
+		if err := bw.WriteByte(opts.lineDelim); err != nil {
 			return err
 		}
 	}
@@ -191,6 +207,24 @@ func cutReader(w io.Writer, r io.Reader, opts options) error {
 		return err
 	}
 	return bw.Flush()
+}
+
+// splitOn returns a bufio.SplitFunc that splits input on the byte delim,
+// stripping the delimiter from each returned token. A trailing chunk without a
+// final delimiter is still returned as the last token.
+func splitOn(delim byte) bufio.SplitFunc {
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := bytes.IndexByte(data, delim); i >= 0 {
+			return i + 1, data[:i], nil
+		}
+		if atEOF {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	}
 }
 
 // rng is a 1-based inclusive range from a cut list. A zero hi means the range
@@ -315,6 +349,16 @@ func selected(ranges []rng, pos int) bool {
 	return false
 }
 
+// keep reports whether the 1-based position pos should be emitted, honouring
+// --complement (which inverts the range selection).
+func keepPos(opts options, pos int) bool {
+	in := selected(opts.ranges, pos)
+	if opts.complement {
+		return !in
+	}
+	return in
+}
+
 // cutLine applies the selection to a single input line (without its trailing
 // newline). The second result reports whether the line should be emitted at
 // all (false only for -s lines that contain no delimiter).
@@ -329,49 +373,49 @@ func cutLine(line string, opts options) (string, bool) {
 	}
 }
 
-// cutBytes selects bytes from line, joining selected ranges with the output
-// delimiter.
+// cutBytes selects bytes from line. Contiguous kept positions are emitted as a
+// run; the output delimiter separates non-adjacent runs. --complement inverts
+// the kept set.
 func cutBytes(line string, opts options) string {
 	var b strings.Builder
-	for i, r := range opts.ranges {
-		if i > 0 {
-			b.WriteString(opts.outputDelimiter)
-		}
-		end := r.hi
-		if r.open() || end > len(line) {
-			end = len(line)
-		}
-		if r.lo > len(line) || r.lo > end {
+	prevKept := false
+	for i := 0; i < len(line); i++ {
+		if !keepPos(opts, i+1) {
+			prevKept = false
 			continue
 		}
-		b.WriteString(line[r.lo-1 : end])
+		if !prevKept && b.Len() > 0 {
+			b.WriteString(opts.outputDelimiter)
+		}
+		b.WriteByte(line[i])
+		prevKept = true
 	}
 	return b.String()
 }
 
-// cutRunes selects characters (runes) from line, joining selected ranges with
-// the output delimiter.
+// cutRunes selects characters (runes) from line, mirroring cutBytes but over
+// runes so multibyte characters stay intact.
 func cutRunes(line string, opts options) string {
 	runes := []rune(line)
 	var b strings.Builder
-	for i, r := range opts.ranges {
-		if i > 0 {
-			b.WriteString(opts.outputDelimiter)
-		}
-		end := r.hi
-		if r.open() || end > len(runes) {
-			end = len(runes)
-		}
-		if r.lo > len(runes) || r.lo > end {
+	prevKept := false
+	for i := range runes {
+		if !keepPos(opts, i+1) {
+			prevKept = false
 			continue
 		}
-		b.WriteString(string(runes[r.lo-1 : end]))
+		if !prevKept && b.Len() > 0 {
+			b.WriteString(opts.outputDelimiter)
+		}
+		b.WriteRune(runes[i])
+		prevKept = true
 	}
 	return b.String()
 }
 
 // cutFields selects fields from line split on the delimiter. Lines with no
 // delimiter are passed through unchanged unless -s suppresses them.
+// --complement inverts the selected fields.
 func cutFields(line string, opts options) (string, bool) {
 	if !strings.Contains(line, opts.delimiter) {
 		if opts.onlyDelimited {
@@ -382,7 +426,7 @@ func cutFields(line string, opts options) (string, bool) {
 	fields := strings.Split(line, opts.delimiter)
 	var selectedFields []string
 	for i := range fields {
-		if selected(opts.ranges, i+1) {
+		if keepPos(opts, i+1) {
 			selectedFields = append(selectedFields, fields[i])
 		}
 	}

--- a/internal/applets/shellutils/cut/cut.go
+++ b/internal/applets/shellutils/cut/cut.go
@@ -349,7 +349,7 @@ func selected(ranges []rng, pos int) bool {
 	return false
 }
 
-// keep reports whether the 1-based position pos should be emitted, honouring
+// keep reports whether the 1-based position pos should be emitted, honoring
 // --complement (which inverts the range selection).
 func keepPos(opts options, pos int) bool {
 	in := selected(opts.ranges, pos)

--- a/internal/applets/shellutils/cut/cut_test.go
+++ b/internal/applets/shellutils/cut/cut_test.go
@@ -73,6 +73,128 @@ func TestRunCut(t *testing.T) {
 	}
 }
 
+// TestRunComplement exercises --complement over fields, bytes and characters.
+func TestRunComplement(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{
+			"complement field keeps the rest",
+			"a,b,c\n",
+			[]string{"-f", "2", "-d", ",", "--complement"},
+			"a,c\n",
+		},
+		{
+			"complement field range",
+			"a,b,c,d\n",
+			[]string{"-f", "2-3", "-d", ",", "--complement"},
+			"a,d\n",
+		},
+		{
+			"complement open field range",
+			"a,b,c,d\n",
+			[]string{"-f", "3-", "-d", ",", "--complement"},
+			"a,b\n",
+		},
+		{
+			"complement chars keeps the others",
+			"abcde\n",
+			[]string{"-c", "2-3", "--complement"},
+			"ade\n",
+		},
+		{
+			"complement bytes keeps the others",
+			"abcde\n",
+			[]string{"-b", "1", "--complement"},
+			"bcde\n",
+		},
+		{
+			"complement chars single",
+			"abcde\n",
+			[]string{"-c", "3", "--complement"},
+			"abde\n",
+		},
+		{
+			"complement empty when all selected",
+			"abc\n",
+			[]string{"-c", "1-", "--complement"},
+			"\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunZeroTerminated checks NUL-delimited input and output for -z.
+func TestRunZeroTerminated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{
+			"zero terminated fields",
+			"a,b,c\x00d,e,f\x00",
+			[]string{"-f", "2", "-d", ",", "-z"},
+			"b\x00e\x00",
+		},
+		{
+			"zero terminated chars",
+			"abc\x00def\x00",
+			[]string{"-c", "1-2", "-z"},
+			"ab\x00de\x00",
+		},
+		{
+			"zero terminated long flag",
+			"abc\x00def\x00",
+			[]string{"-c", "1", "--zero-terminated"},
+			"a\x00d\x00",
+		},
+		{
+			"zero terminated complement",
+			"a,b,c\x00d,e,f\x00",
+			[]string{"-f", "2", "-d", ",", "-z", "--complement"},
+			"a,c\x00d,f\x00",
+		},
+		{
+			"zero terminated newline preserved in field",
+			"a\nx,b\x00",
+			[]string{"-f", "1", "-d", ",", "-z"},
+			"a\nx\x00",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunNoListSpecified(t *testing.T) {
 	t.Parallel()
 	out, errOut, err := runStdin(t, "a,b\n")

--- a/internal/applets/shellutils/tee/tee.go
+++ b/internal/applets/shellutils/tee/tee.go
@@ -5,12 +5,69 @@ package tee
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
+
+// isBrokenPipe reports whether err is (or wraps) an EPIPE write error, the
+// condition the *-nopipe output-error modes silently tolerate.
+func isBrokenPipe(err error) bool {
+	return errors.Is(err, syscall.EPIPE)
+}
+
+// outputErrorMode selects how tee reacts to write errors, mirroring GNU tee's
+// --output-error[=MODE].
+type outputErrorMode int
+
+const (
+	// outputErrorWarnNopipe diagnoses write errors but ignores broken-pipe
+	// errors; tee keeps going and exits nonzero at the end. This is the GNU
+	// default when --output-error is not given.
+	outputErrorWarnNopipe outputErrorMode = iota
+	// outputErrorWarn diagnoses every write error (including broken pipe) and
+	// keeps going, exiting nonzero at the end.
+	outputErrorWarn
+	// outputErrorExit exits on the first write error that is not a broken pipe.
+	outputErrorExit
+	// outputErrorExitNopipe exits on the first write error, treating a broken
+	// pipe as a normal (silent, successful) end of output.
+	outputErrorExitNopipe
+)
+
+// parseOutputErrorMode maps a --output-error MODE string onto an
+// outputErrorMode. The empty string selects GNU's "--output-error" default of
+// "warn".
+func parseOutputErrorMode(mode string) (outputErrorMode, error) {
+	switch mode {
+	case "", "warn":
+		return outputErrorWarn, nil
+	case "warn-nopipe":
+		return outputErrorWarnNopipe, nil
+	case "exit":
+		return outputErrorExit, nil
+	case "exit-nopipe":
+		return outputErrorExitNopipe, nil
+	default:
+		return 0, fmt.Errorf("invalid argument %q for --output-error", mode)
+	}
+}
+
+// ignoresPipe reports whether the mode treats a broken-pipe write error as a
+// normal, silent end of output rather than a diagnosable error.
+func (m outputErrorMode) ignoresPipe() bool {
+	return m == outputErrorWarnNopipe || m == outputErrorExitNopipe
+}
+
+// exitsOnError reports whether the mode stops at the first reportable write
+// error instead of continuing to the remaining writers.
+func (m outputErrorMode) exitsOnError() bool {
+	return m == outputErrorExit || m == outputErrorExitNopipe
+}
 
 // Command is the tee applet.
 type Command struct{}
@@ -41,20 +98,44 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	// -i/--ignore-interrupts is accepted for GNU compatibility; in this
 	// in-memory model there is no SIGINT to ignore, so it is a no-op.
 	_ = fs.BoolP("ignore-interrupts", "i", false, "ignore interrupt signals")
+	// --output-error[=MODE] takes an optional value. When given without "=MODE"
+	// GNU selects "warn"; when omitted entirely the default is "warn-nopipe".
+	fs.String("output-error", "",
+		"set behavior on write error: warn, warn-nopipe, exit, exit-nopipe (default warn when given without a MODE)")
+	fs.Lookup("output-error").NoOptDefVal = "warn"
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
 	}
 
-	return tee(stdio, fs.Args(), *appendMode)
+	modeStr, _ := fs.GetString("output-error")
+	mode, err := parseOutputErrorMode(modeStr)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "tee: %v\n", err)
+		_, _ = fmt.Fprintln(stdio.Err, "Try 'tee --help' for more information.")
+		return command.SilentFailure()
+	}
+
+	return tee(stdio, fs.Args(), *appendMode, mode)
 }
 
-// tee copies standard input to standard output and to each named file. A file
-// that cannot be opened or written is reported on stderr GNU-style and sets the
-// exit status to failure, but does not stop writing to standard output or the
-// remaining files.
-func tee(stdio command.IO, files []string, appendMode bool) error {
+// teeWriter pairs a destination with the label used to diagnose its errors and
+// tracks whether it has already failed so a broken writer is skipped for the
+// rest of the stream.
+type teeWriter struct {
+	w      io.Writer
+	label  string // empty for standard output
+	closer io.Closer
+	dead   bool
+}
+
+// tee copies standard input to standard output and to each named file. How a
+// write error is handled depends on mode: by default (warn-nopipe) errors are
+// reported on stderr, broken pipes are ignored, and tee keeps writing to the
+// remaining destinations, exiting nonzero at the end; the exit modes stop at the
+// first reportable error instead.
+func tee(stdio command.IO, files []string, appendMode bool, mode outputErrorMode) error {
 	flags := os.O_CREATE | os.O_WRONLY
 	if appendMode {
 		flags |= os.O_APPEND
@@ -62,7 +143,7 @@ func tee(stdio command.IO, files []string, appendMode bool) error {
 		flags |= os.O_TRUNC
 	}
 
-	writers := []io.Writer{stdio.Out}
+	dsts := []*teeWriter{{w: stdio.Out}}
 	var opened []*os.File
 	var failed bool
 	for _, name := range files {
@@ -70,27 +151,78 @@ func tee(stdio command.IO, files []string, appendMode bool) error {
 		if err != nil {
 			_, _ = fmt.Fprintf(stdio.Err, "tee: %s\n", command.FileError(name, err))
 			failed = true
+			if mode.exitsOnError() {
+				return command.SilentFailure()
+			}
 			continue
 		}
-		writers = append(writers, f)
+		dsts = append(dsts, &teeWriter{w: f, label: name, closer: f})
 		opened = append(opened, f)
 	}
 
-	mw := io.MultiWriter(writers...)
-	if _, err := io.Copy(mw, stdio.In); err != nil {
-		_, _ = fmt.Fprintf(stdio.Err, "tee: %s\n", err)
-		failed = true
-	}
+	copyFailed, stopped := copyStream(stdio, dsts, mode)
+	failed = failed || copyFailed
 
 	for _, f := range opened {
 		if cerr := f.Close(); cerr != nil {
-			_, _ = fmt.Fprintf(stdio.Err, "tee: %s\n", command.FileError(f.Name(), cerr))
-			failed = true
+			if reportWriteError(stdio, f.Name(), cerr, mode) {
+				failed = true
+			}
 		}
 	}
 
-	if failed {
+	if failed || stopped {
 		return command.SilentFailure()
 	}
 	return nil
+}
+
+// copyStream reads standard input in chunks and writes each chunk to every live
+// destination, applying the output-error policy. It returns whether any
+// reportable error occurred and whether an exit-mode caused an early stop.
+func copyStream(stdio command.IO, dsts []*teeWriter, mode outputErrorMode) (failed, stopped bool) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := stdio.In.Read(buf)
+		if n > 0 {
+			chunk := buf[:n]
+			for _, d := range dsts {
+				if d.dead {
+					continue
+				}
+				if _, werr := d.w.Write(chunk); werr != nil {
+					if reportWriteError(stdio, d.label, werr, mode) {
+						failed = true
+					}
+					d.dead = true
+					if mode.exitsOnError() {
+						return failed, true
+					}
+				}
+			}
+		}
+		if rerr != nil {
+			if !errors.Is(rerr, io.EOF) {
+				_, _ = fmt.Fprintf(stdio.Err, "tee: %v\n", rerr)
+				failed = true
+			}
+			return failed, stopped
+		}
+	}
+}
+
+// reportWriteError diagnoses a write error according to mode and reports whether
+// it counts toward a nonzero exit. A broken-pipe error is silently swallowed in
+// the *-nopipe modes; for the standard-output destination (empty label) the bare
+// error is printed, otherwise the GNU file-error form is used.
+func reportWriteError(stdio command.IO, label string, err error, mode outputErrorMode) bool {
+	if mode.ignoresPipe() && isBrokenPipe(err) {
+		return false
+	}
+	if label == "" {
+		_, _ = fmt.Fprintf(stdio.Err, "tee: %v\n", err)
+	} else {
+		_, _ = fmt.Fprintf(stdio.Err, "tee: %s\n", command.FileError(label, err))
+	}
+	return true
 }

--- a/internal/applets/shellutils/tee/tee_policy_test.go
+++ b/internal/applets/shellutils/tee/tee_policy_test.go
@@ -1,0 +1,139 @@
+package tee
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// syscallPipeErr returns an EPIPE error for the broken-pipe tolerance tests.
+func syscallPipeErr() error { return syscall.EPIPE }
+
+// failingWriter fails every Write with a non-pipe error, standing in for a
+// destination that cannot be written.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("disk full") }
+
+// TestParseOutputErrorMode covers every accepted MODE plus the invalid case.
+func TestParseOutputErrorMode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		want    outputErrorMode
+		wantErr bool
+	}{
+		{"", outputErrorWarn, false},
+		{"warn", outputErrorWarn, false},
+		{"warn-nopipe", outputErrorWarnNopipe, false},
+		{"exit", outputErrorExit, false},
+		{"exit-nopipe", outputErrorExitNopipe, false},
+		{"bogus", 0, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseOutputErrorMode(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseOutputErrorMode(%q) err = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseOutputErrorMode(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// teeTo runs tee directly against a custom destination list so a failing writer
+// can be injected. The writable file content and stderr are returned alongside
+// the error.
+func teeTo(t *testing.T, stdin string, dsts []*teeWriter, mode outputErrorMode) (string, error) {
+	t.Helper()
+	errBuf := &strings.Builder{}
+	stdio := command.IO{In: strings.NewReader(stdin), Out: io.Discard, Err: errBuf}
+	failed, stopped := copyStream(stdio, dsts, mode)
+	if failed || stopped {
+		return errBuf.String(), command.SilentFailure()
+	}
+	return errBuf.String(), nil
+}
+
+// TestWarnModeContinuesAndFails verifies that, with a failing writer present,
+// warn mode still writes the writable file and reports a nonzero exit.
+func TestWarnModeContinuesAndFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	dsts := []*teeWriter{
+		{w: failingWriter{}, label: "bad"},
+		{w: f, label: path},
+	}
+	stderr, runErr := teeTo(t, "payload\n", dsts, outputErrorWarn)
+	if runErr == nil {
+		t.Fatal("warn mode: expected nonzero exit when a writer fails")
+	}
+	if !strings.Contains(stderr, "tee: ") {
+		t.Errorf("warn mode: stderr = %q, want a tee diagnostic", stderr)
+	}
+	got, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(got) != "payload\n" {
+		t.Errorf("warn mode: writable file = %q, want %q (must keep writing)", string(got), "payload\n")
+	}
+}
+
+// TestExitModeStopsEarly verifies that exit mode stops at the first write error,
+// so a later writer in the list never receives the data.
+func TestExitModeStopsEarly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// The failing writer comes first; exit mode must stop before the file write.
+	dsts := []*teeWriter{
+		{w: failingWriter{}, label: "bad"},
+		{w: f, label: path},
+	}
+	if _, runErr := teeTo(t, "payload\n", dsts, outputErrorExit); runErr == nil {
+		t.Fatal("exit mode: expected nonzero exit when a writer fails")
+	}
+	got, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(got) != 0 {
+		t.Errorf("exit mode: writable file = %q, want empty (must stop on first error)", string(got))
+	}
+}
+
+// TestWarnNopipeIgnoresPipe confirms a broken-pipe write error is silently
+// tolerated by the *-nopipe modes but reported by warn.
+func TestWarnNopipeIgnoresPipe(t *testing.T) {
+	t.Parallel()
+	if reportWriteError(command.IO{Err: io.Discard}, "bad", syscallPipeErr(), outputErrorWarnNopipe) {
+		t.Error("warn-nopipe: broken pipe should not count toward failure")
+	}
+	if !reportWriteError(command.IO{Err: io.Discard}, "bad", syscallPipeErr(), outputErrorWarn) {
+		t.Error("warn: broken pipe should be reported")
+	}
+}

--- a/internal/applets/textutils/cat/cat.go
+++ b/internal/applets/textutils/cat/cat.go
@@ -26,11 +26,12 @@ func (c *Command) Name() string { return "cat" }
 func (c *Command) Synopsis() string { return "Concatenate files and print on the standard output" }
 
 type options struct {
-	number         bool
-	numberNonBlank bool
-	squeeze        bool
-	showEnds       bool
-	showTabs       bool
+	number          bool
+	numberNonBlank  bool
+	squeeze         bool
+	showEnds        bool
+	showTabs        bool
+	showNonprinting bool
 }
 
 // Run executes cat.
@@ -51,18 +52,22 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	squeeze := fs.BoolP("squeeze-blank", "s", false, "suppress repeated empty output lines")
 	showEnds := fs.BoolP("show-ends", "E", false, "display $ at end of each line")
 	showTabs := fs.BoolP("show-tabs", "T", false, "display TAB characters as ^I")
+	showNonprinting := fs.BoolP("show-nonprinting", "v", false, "use ^ and M- notation, except for LFD and TAB")
+	showAll := fs.BoolP("show-all", "A", false, "equivalent to -vET")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
 	}
 
+	// -A is equivalent to -vET (show-nonprinting + show-ends + show-tabs).
 	opts := options{
-		number:         *number,
-		numberNonBlank: *numberNonBlank,
-		squeeze:        *squeeze,
-		showEnds:       *showEnds,
-		showTabs:       *showTabs,
+		number:          *number,
+		numberNonBlank:  *numberNonBlank,
+		squeeze:         *squeeze,
+		showEnds:        *showEnds || *showAll,
+		showTabs:        *showTabs || *showAll,
+		showNonprinting: *showNonprinting || *showAll,
 	}
 
 	files := fs.Args()
@@ -94,9 +99,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 
 	src := io.Reader(io.MultiReader(readers...))
 
-	// Apply -s/-T/-E as a streaming filter before numbering, so the line counter
-	// still sees the squeezed lines (matching the previous behavior).
-	if opts.squeeze || opts.showTabs || opts.showEnds {
+	// Apply -s/-T/-E/-v as a streaming filter before numbering, so the line
+	// counter still sees the squeezed lines (matching the previous behavior).
+	if opts.squeeze || opts.showTabs || opts.showEnds || opts.showNonprinting {
 		raw := src // capture before reassigning src, or the goroutine would read the pipe itself
 		pr, pw := io.Pipe()
 		go func() { _ = pw.CloseWithError(renderStream(pw, raw, opts)) }()
@@ -130,6 +135,12 @@ func renderStream(w io.Writer, r io.Reader, opts options) error {
 				prevBlank = blank
 			}
 			if emit {
+				// -v renders non-printing bytes with caret/M- notation. It
+				// deliberately leaves TAB untouched (only -T converts TAB to
+				// ^I) and never touches the trailing newline.
+				if opts.showNonprinting {
+					body = showNonprinting(body)
+				}
 				if opts.showTabs {
 					body = strings.ReplaceAll(body, "\t", "^I")
 				}
@@ -148,6 +159,49 @@ func renderStream(w io.Writer, r io.Reader, opts options) error {
 			return err
 		}
 	}
+}
+
+// showNonprinting renders non-printing bytes the way GNU cat -v does:
+//
+//   - Control characters 0x00-0x1F (except TAB 0x09 and LF 0x0A, which GNU cat
+//     leaves alone for -v) become caret notation: ^@ ... ^_ (^X = 0x40+byte).
+//   - DEL (0x7F) becomes ^?.
+//   - Bytes 0x80-0xFF get the M- prefix, followed by the caret/printable form
+//     of the low 7 bits: 0x80-0x9F -> M-^@ ... M-^_, 0xA0-0xFE -> M-<char>,
+//     0xFF -> M-^?.
+//
+// TAB and LF are intentionally passed through untouched; only -T converts TAB.
+// Input is processed byte by byte (not rune by rune), matching GNU semantics.
+func showNonprinting(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\t' || c == '\n':
+			b.WriteByte(c)
+		case c < 0x20: // other C0 control chars
+			b.WriteByte('^')
+			b.WriteByte(c + 0x40)
+		case c < 0x7f: // printable ASCII
+			b.WriteByte(c)
+		case c == 0x7f: // DEL
+			b.WriteString("^?")
+		default: // c >= 0x80: meta (high-bit) byte
+			b.WriteString("M-")
+			m := c & 0x7f
+			switch {
+			case m < 0x20:
+				b.WriteByte('^')
+				b.WriteByte(m + 0x40)
+			case m == 0x7f:
+				b.WriteString("^?")
+			default:
+				b.WriteByte(m)
+			}
+		}
+	}
+	return b.String()
 }
 
 // writeStream writes src to w, numbering lines when -n/-b is set (streaming via

--- a/internal/applets/textutils/cat/cat_showall_test.go
+++ b/internal/applets/textutils/cat/cat_showall_test.go
@@ -1,0 +1,117 @@
+package cat_test
+
+import (
+	"testing"
+)
+
+// TestRunShowNonprinting covers GNU cat -v / --show-nonprinting: control
+// characters become caret notation (^X), DEL becomes ^?, and high bytes get
+// M- notation, while TAB and the trailing newline are left untouched.
+func TestRunShowNonprinting(t *testing.T) {
+	t.Parallel()
+	// 0x01 (control) -> ^A, a literal tab -> stays a tab (only -T converts it),
+	// 0x7f (DEL) -> ^?, 0x80 (high byte) -> M-^@, 0xe9 -> M-i.
+	stdin := "a\x01\tb\x7f\x80\xe9\n"
+	want := "a^A\tb^?M-^@M-i\n"
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"short -v", []string{"-v"}},
+		{"long --show-nonprinting", []string{"--show-nonprinting"}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != want {
+				t.Errorf("out = %q, want %q", out, want)
+			}
+		})
+	}
+}
+
+// TestRunShowNonprintingAliasIdentical asserts that -v and --show-nonprinting
+// produce byte-identical output on the same input.
+func TestRunShowNonprintingAliasIdentical(t *testing.T) {
+	t.Parallel()
+	stdin := "x\x00\x1f\x7f\x80\xff\ty\n\n"
+	short, _, err := runStdin(t, stdin, "-v")
+	if err != nil {
+		t.Fatalf("-v error = %v", err)
+	}
+	long, _, err := runStdin(t, stdin, "--show-nonprinting")
+	if err != nil {
+		t.Fatalf("--show-nonprinting error = %v", err)
+	}
+	if short != long {
+		t.Errorf("-v = %q, --show-nonprinting = %q; want identical", short, long)
+	}
+}
+
+// TestRunShowAll covers GNU cat -A / --show-all, which is equivalent to -vET:
+// non-printing characters via -v notation, TAB shown as ^I (-T), and a $ at
+// each line end (-E).
+func TestRunShowAll(t *testing.T) {
+	t.Parallel()
+	// Fixture: a tab, a blank line, and non-printable bytes 0x01, 0x7f, 0x80.
+	stdin := "a\tb\x01\n\n\x7f\x80\n"
+	// -v: 0x01->^A, 0x7f->^?, 0x80->M-^@; -T: tab->^I; -E: $ at each end.
+	want := "a^Ib^A$\n$\n^?M-^@$\n"
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"short -A", []string{"-A"}},
+		{"long --show-all", []string{"--show-all"}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := runStdin(t, stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != want {
+				t.Errorf("out = %q, want %q", out, want)
+			}
+		})
+	}
+}
+
+// TestRunShowAllEqualsVET verifies that -A is exactly equivalent to -vET.
+func TestRunShowAllEqualsVET(t *testing.T) {
+	t.Parallel()
+	stdin := "a\tb\x01\n\n\x7f\x80\xe9\n"
+	a, _, err := runStdin(t, stdin, "-A")
+	if err != nil {
+		t.Fatalf("-A error = %v", err)
+	}
+	vet, _, err := runStdin(t, stdin, "-v", "-E", "-T")
+	if err != nil {
+		t.Fatalf("-vET error = %v", err)
+	}
+	if a != vet {
+		t.Errorf("-A = %q, -vET = %q; want identical", a, vet)
+	}
+}
+
+// TestRunShowNonprintingLeavesTab confirms that -v alone never converts TAB
+// (only -T does) and leaves the trailing newline intact.
+func TestRunShowNonprintingLeavesTab(t *testing.T) {
+	t.Parallel()
+	out, _, err := runStdin(t, "a\tb\n", "-v")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "a\tb\n" {
+		t.Errorf("out = %q, want %q", out, "a\tb\n")
+	}
+}

--- a/internal/applets/textutils/comm/comm.go
+++ b/internal/applets/textutils/comm/comm.go
@@ -12,10 +12,18 @@ import (
 )
 
 // Command is the comm applet.
-type Command struct{}
+type Command struct {
+	// delimiter separates the columns. GNU comm uses a single tab by default;
+	// --output-delimiter=STR replaces it. The merge logic builds the per-column
+	// padding from repetitions of this string.
+	delimiter string
+	// terminator ends each output record: "\n" by default, or "\x00" with
+	// --zero-terminated/-z.
+	terminator string
+}
 
 // New returns a comm command.
-func New() *Command { return &Command{} }
+func New() *Command { return &Command{delimiter: "\t", terminator: "\n"} }
 
 // Name returns the command name.
 func (c *Command) Name() string { return "comm" }
@@ -32,16 +40,31 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "comm a.txt b.txt", Explain: "Show lines unique to each file and lines common to both."},
 			{Command: "comm -12 a.txt b.txt", Explain: "Print only the lines common to both files."},
 			{Command: "comm -3 a.txt b.txt", Explain: "Print only the lines that are unique to one file."},
+			{Command: "comm --output-delimiter=, a.txt b.txt", Explain: "Separate the columns with a comma."},
 		},
-		ExitStatus: "0  success.\n1  a file could not be read or written.",
+		ExitStatus: "0  success.\n1  a file could not be read, written, or was not in sorted order.",
 	})
 	no1 := fs.BoolP("suppress-col1", "1", false, "suppress column 1 (lines unique to FILE1)")
 	no2 := fs.BoolP("suppress-col2", "2", false, "suppress column 2 (lines unique to FILE2)")
 	no3 := fs.BoolP("suppress-col3", "3", false, "suppress column 3 (lines that appear in both files)")
+	outDelim := fs.String("output-delimiter", "", "separate columns with STR")
+	zero := fs.BoolP("zero-terminated", "z", false, "line delimiter is NUL, not newline")
+	checkOrder := fs.Bool("check-order", false, "check that the input is correctly sorted")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
+	}
+
+	if fs.Changed("output-delimiter") {
+		if *outDelim == "" {
+			_, _ = fmt.Fprintln(stdio.Err, "comm: empty --output-delimiter")
+			return command.SilentFailure()
+		}
+		c.delimiter = *outDelim
+	}
+	if *zero {
+		c.terminator = "\x00"
 	}
 
 	files := fs.Args()
@@ -50,48 +73,71 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.SilentFailure()
 	}
 
-	a, err := readLines(stdio, files[0])
+	a, err := readLines(stdio, files[0], *zero)
 	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "comm: %s\n", command.FileError(files[0], err))
 		return command.SilentFailure()
 	}
-	b, err := readLines(stdio, files[1])
+	b, err := readLines(stdio, files[1], *zero)
 	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "comm: %s\n", command.FileError(files[1], err))
 		return command.SilentFailure()
 	}
 
+	if *checkOrder {
+		if !sorted(a) {
+			_, _ = fmt.Fprintln(stdio.Err, "comm: file 1 is not in sorted order")
+			return command.SilentFailure()
+		}
+		if !sorted(b) {
+			_, _ = fmt.Fprintln(stdio.Err, "comm: file 2 is not in sorted order")
+			return command.SilentFailure()
+		}
+	}
+
 	return c.compare(stdio, a, b, !*no1, !*no2, !*no3)
+}
+
+// sorted reports whether lines are in non-decreasing order, matching the order
+// comm itself assumes for its merge.
+func sorted(lines []string) bool {
+	for i := 1; i < len(lines); i++ {
+		if lines[i] < lines[i-1] {
+			return false
+		}
+	}
+	return true
 }
 
 // compare walks the two sorted line slices in merge order and writes each line
 // in the column selected by show1/show2/show3.
 func (c *Command) compare(stdio command.IO, a, b []string, show1, show2, show3 bool) error {
-	// col2 indent skips the active leading columns; col3 skips both.
+	// col2 indent skips the active leading columns; col3 skips both. Each skipped
+	// column is represented by one delimiter.
 	pad2, pad3 := "", ""
 	if show1 {
-		pad2 = "\t"
-		pad3 = "\t"
+		pad2 = c.delimiter
+		pad3 = c.delimiter
 	}
 	if show2 {
-		pad3 += "\t"
+		pad3 += c.delimiter
 	}
 
 	i, j := 0, 0
 	for i < len(a) && j < len(b) {
 		switch {
 		case a[i] < b[j]:
-			if err := emit(stdio, show1, "", a[i]); err != nil {
+			if err := c.emit(stdio, show1, "", a[i]); err != nil {
 				return err
 			}
 			i++
 		case a[i] > b[j]:
-			if err := emit(stdio, show2, pad2, b[j]); err != nil {
+			if err := c.emit(stdio, show2, pad2, b[j]); err != nil {
 				return err
 			}
 			j++
 		default:
-			if err := emit(stdio, show3, pad3, a[i]); err != nil {
+			if err := c.emit(stdio, show3, pad3, a[i]); err != nil {
 				return err
 			}
 			i++
@@ -99,31 +145,33 @@ func (c *Command) compare(stdio command.IO, a, b []string, show1, show2, show3 b
 		}
 	}
 	for ; i < len(a); i++ {
-		if err := emit(stdio, show1, "", a[i]); err != nil {
+		if err := c.emit(stdio, show1, "", a[i]); err != nil {
 			return err
 		}
 	}
 	for ; j < len(b); j++ {
-		if err := emit(stdio, show2, pad2, b[j]); err != nil {
+		if err := c.emit(stdio, show2, pad2, b[j]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// emit writes line in its column (prefixed with pad) when show is true.
-func emit(stdio command.IO, show bool, pad, line string) error {
+// emit writes line in its column (prefixed with pad) when show is true, ending
+// the record with the configured terminator.
+func (c *Command) emit(stdio command.IO, show bool, pad, line string) error {
 	if !show {
 		return nil
 	}
-	if _, err := io.WriteString(stdio.Out, pad+line+"\n"); err != nil {
+	if _, err := io.WriteString(stdio.Out, pad+line+c.terminator); err != nil {
 		return command.Failure(err)
 	}
 	return nil
 }
 
-// readLines reads name fully and returns its lines without the line endings.
-func readLines(stdio command.IO, name string) ([]string, error) {
+// readLines reads name fully and returns its records without the terminators.
+// When zero is true, records are split on NUL instead of newline.
+func readLines(stdio command.IO, name string, zero bool) ([]string, error) {
 	r, err := command.Open(stdio, name)
 	if err != nil {
 		return nil, err
@@ -133,8 +181,28 @@ func readLines(stdio command.IO, name string) ([]string, error) {
 	var lines []string
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	if zero {
+		sc.Split(scanNUL)
+	}
 	for sc.Scan() {
 		lines = append(lines, sc.Text())
 	}
 	return lines, sc.Err()
+}
+
+// scanNUL is a bufio.SplitFunc that splits input on NUL bytes, mirroring
+// bufio.ScanLines but for NUL-terminated records.
+func scanNUL(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	for i := 0; i < len(data); i++ {
+		if data[i] == 0 {
+			return i + 1, data[:i], nil
+		}
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
 }

--- a/internal/applets/textutils/comm/comm_test.go
+++ b/internal/applets/textutils/comm/comm_test.go
@@ -71,6 +71,99 @@ func TestOnlyUniqueToFirst(t *testing.T) {
 	}
 }
 
+// TestOutputDelimiter verifies --output-delimiter=STR replaces the default tab
+// column separators with STR, including the per-column padding.
+func TestOutputDelimiter(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "apple\nbanana\ncherry\n")
+	b := writeFile(t, "banana\ncherry\ndate\n")
+	out, _, err := run(t, "--output-delimiter=,", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// col1 has no pad; col2 one delimiter; col3 two delimiters.
+	want := "apple\n,,banana\n,,cherry\n,date\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestEmptyOutputDelimiter verifies an explicitly empty --output-delimiter is
+// rejected (GNU treats it as an error).
+func TestEmptyOutputDelimiter(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "a\n")
+	b := writeFile(t, "b\n")
+	_, errOut, err := run(t, "--output-delimiter=", a, b)
+	if err == nil {
+		t.Fatal("expected error for empty --output-delimiter")
+	}
+	if !strings.Contains(errOut, "empty --output-delimiter") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestZeroTerminated verifies -z reads NUL-separated input records and writes
+// NUL-terminated output records.
+func TestZeroTerminated(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "apple\x00banana\x00")
+	b := writeFile(t, "banana\x00date\x00")
+	out, _, err := run(t, "-z", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	// Records terminated by NUL; columns still separated by tab padding.
+	want := "apple\x00\t\tbanana\x00\tdate\x00"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestCheckOrderUnsorted verifies --check-order reports an out-of-order input on
+// stderr and fails, naming the offending file.
+func TestCheckOrderUnsorted(t *testing.T) {
+	t.Parallel()
+	// FILE1 is unsorted (cherry before banana).
+	a := writeFile(t, "cherry\nbanana\n")
+	b := writeFile(t, "apple\nbanana\n")
+	_, errOut, err := run(t, "--check-order", a, b)
+	if err == nil {
+		t.Fatal("expected failure for unsorted input")
+	}
+	if !strings.Contains(errOut, "comm: file 1 is not in sorted order") {
+		t.Errorf("stderr = %q, want file-1-unsorted message", errOut)
+	}
+}
+
+// TestCheckOrderSecondUnsorted verifies the file-2 disorder branch.
+func TestCheckOrderSecondUnsorted(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "apple\nbanana\n")
+	b := writeFile(t, "date\nbanana\n")
+	_, errOut, err := run(t, "--check-order", a, b)
+	if err == nil {
+		t.Fatal("expected failure for unsorted second input")
+	}
+	if !strings.Contains(errOut, "comm: file 2 is not in sorted order") {
+		t.Errorf("stderr = %q, want file-2-unsorted message", errOut)
+	}
+}
+
+// TestCheckOrderSorted verifies --check-order succeeds on properly sorted input.
+func TestCheckOrderSorted(t *testing.T) {
+	t.Parallel()
+	a := writeFile(t, "apple\nbanana\n")
+	b := writeFile(t, "banana\ncherry\n")
+	out, _, err := run(t, "--check-order", a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "apple\n\t\tbanana\n\tcherry\n" {
+		t.Errorf("out = %q", out)
+	}
+}
+
 func TestWrongOperandCount(t *testing.T) {
 	t.Parallel()
 	_, errOut, err := run(t, "onlyone")

--- a/internal/applets/textutils/comm/emit_internal_test.go
+++ b/internal/applets/textutils/comm/emit_internal_test.go
@@ -25,11 +25,12 @@ func TestEmitWriteError(t *testing.T) {
 	t.Parallel()
 	boom := errors.New("broken pipe")
 	io := errIO(&failingWriter{err: boom})
+	c := New()
 
-	if err := emit(io, true, "", "line"); err == nil {
+	if err := c.emit(io, true, "", "line"); err == nil {
 		t.Error("emit must surface a write error when the column is shown")
 	}
-	if err := emit(io, false, "", "line"); err != nil {
+	if err := c.emit(io, false, "", "line"); err != nil {
 		t.Errorf("emit on a suppressed column must not error, got %v", err)
 	}
 }

--- a/internal/applets/textutils/head/head.go
+++ b/internal/applets/textutils/head/head.go
@@ -32,6 +32,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "head notes.txt", Explain: "Print the first 10 lines of notes.txt."},
 			{Command: "head -n 5 notes.txt", Explain: "Print the first 5 lines of notes.txt."},
 			{Command: "head -c 100 notes.txt", Explain: "Print the first 100 bytes of notes.txt."},
+			{Command: "head -z -n 1 notes.txt", Explain: "Treat NUL as the line delimiter and print the first record."},
 		},
 		ExitStatus: "0  all input was printed successfully.\n1  a file could not be read.",
 	})
@@ -39,6 +40,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	bytesN := fs.IntP("bytes", "c", 0, "print the first NUM bytes of each file")
 	quiet := fs.BoolP("quiet", "q", false, "never print headers giving file names")
 	verbose := fs.BoolP("verbose", "v", false, "always print headers giving file names")
+	zeroTerminated := fs.BoolP("zero-terminated", "z", false, "line delimiter is NUL, not newline")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -50,6 +52,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		files = []string{"-"}
 	}
 	showHeader := (len(files) > 1 || *verbose) && !*quiet
+	delim := byte('\n')
+	if *zeroTerminated {
+		delim = '\x00'
+	}
 
 	var firstErr error
 	for i, name := range files {
@@ -65,7 +71,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		if *bytesN > 0 {
 			err = textproc.HeadBytes(stdio.Out, r, *bytesN)
 		} else {
-			err = textproc.HeadLines(stdio.Out, r, *lines)
+			err = textproc.HeadRecords(stdio.Out, r, *lines, delim)
 		}
 		_ = r.Close()
 		if err != nil {

--- a/internal/applets/textutils/head/head_test.go
+++ b/internal/applets/textutils/head/head_test.go
@@ -49,6 +49,37 @@ func TestRunStdin(t *testing.T) {
 	}
 }
 
+// TestRunZeroTerminated checks that -z/--zero-terminated treats NUL as the
+// record delimiter, counts NUL-delimited records for -n, and preserves any
+// newlines embedded within a record.
+func TestRunZeroTerminated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"z first record", "a\nb\x00c\nd\x00", []string{"-z", "-n", "1"}, "a\nb\x00"},
+		{"z long flag", "a\nb\x00c\nd\x00", []string{"--zero-terminated", "-n", "1"}, "a\nb\x00"},
+		{"z two records", "a\nb\x00c\nd\x00", []string{"-z", "-n", "2"}, "a\nb\x00c\nd\x00"},
+		{"z bytes unaffected", "a\nb\x00c\nd\x00", []string{"-z", "-c", "3"}, "a\nb"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunMultipleFilesHaveHeaders(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/applets/textutils/nl/nl.go
+++ b/internal/applets/textutils/nl/nl.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
+	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
 	"github.com/nao1215/mimixbox/internal/textproc"
@@ -28,14 +30,18 @@ func (c *Command) Synopsis() string {
 // Run executes nl.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
 	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
-		Description: "Write each FILE (or standard input when no FILE is given, or FILE is '-') to standard output with line numbers prepended. By default only non-blank lines are numbered; -b a numbers all lines and -b n numbers none.",
+		Description: "Write each FILE (or standard input when no FILE is given, or FILE is '-') to standard output with line numbers prepended. Input is divided into header, body and footer sections by the delimiter lines \\:\\:\\:, \\:\\: and \\:; each section is numbered with its own STYLE (-h, -b, -f). By default only non-blank body lines are numbered. A STYLE is one of a (all lines), t (non-empty lines), n (no lines) or pBRE (lines matching the basic regular expression BRE).",
 		Examples: []command.Example{
 			{Command: "nl file.txt", Explain: "Number the non-blank lines of file.txt."},
 			{Command: "nl -b a -w 4 file.txt", Explain: "Number every line in a 4-column field."},
+			{Command: "nl -h a -f a file.txt", Explain: "Also number every header and footer line."},
 		},
 		ExitStatus: "0  success.\n1  a file could not be read.",
 	})
-	body := fs.StringP("body-numbering", "b", "t", "use STYLE for numbering body lines (a, t, or n)")
+	body := fs.StringP("body-numbering", "b", "t", "use STYLE for numbering body lines (a, t, n, or pBRE)")
+	header := fs.StringP("header-numbering", "h", "n", "use STYLE for numbering header lines (a, t, n, or pBRE)")
+	footer := fs.StringP("footer-numbering", "f", "n", "use STYLE for numbering footer lines (a, t, n, or pBRE)")
+	join := fs.IntP("join-blank-lines", "l", 1, "group of NUMBER empty lines counted as one")
 	separator := fs.StringP("number-separator", "s", "\t", "add STRING after possible line number")
 	width := fs.IntP("number-width", "w", 6, "use NUMBER columns for line numbers")
 	format := fs.StringP("number-format", "n", "rn", "insert line numbers according to FORMAT (ln, rn, rz)")
@@ -47,9 +53,23 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return err
 	}
 
-	style, ok := bodyStyle(*body)
+	bodyStyle, bodyRe, ok := sectionStyle(*body)
 	if !ok {
 		_, _ = fmt.Fprintf(stdio.Err, "nl: invalid body numbering style: %q\n", *body)
+		return command.SilentFailure()
+	}
+	headerStyle, headerRe, ok := sectionStyle(*header)
+	if !ok {
+		_, _ = fmt.Fprintf(stdio.Err, "nl: invalid header numbering style: %q\n", *header)
+		return command.SilentFailure()
+	}
+	footerStyle, footerRe, ok := sectionStyle(*footer)
+	if !ok {
+		_, _ = fmt.Fprintf(stdio.Err, "nl: invalid footer numbering style: %q\n", *footer)
+		return command.SilentFailure()
+	}
+	if *join < 1 {
+		_, _ = fmt.Fprintf(stdio.Err, "nl: invalid line number of blank lines: %d\n", *join)
 		return command.SilentFailure()
 	}
 	justify, ok := numberFormat(*format)
@@ -59,13 +79,20 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 
 	numberer := textproc.Numberer{
-		Style:     style,
-		Start:     *start,
-		Increment: *increment,
-		Width:     *width,
-		Separator: *separator,
-		Justify:   justify,
-		PadBlank:  true,
+		Style:          bodyStyle,
+		Pattern:        bodyRe,
+		Start:          *start,
+		Increment:      *increment,
+		Width:          *width,
+		Separator:      *separator,
+		Justify:        justify,
+		PadBlank:       true,
+		Sections:       true,
+		HeaderStyle:    headerStyle,
+		HeaderRegexp:   headerRe,
+		FooterStyle:    footerStyle,
+		FooterRegexp:   footerRe,
+		JoinBlankLines: *join,
 	}
 
 	files := fs.Args()
@@ -101,16 +128,26 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	return firstErr
 }
 
-func bodyStyle(s string) (textproc.NumberStyle, bool) {
+// sectionStyle parses an nl numbering STYLE: "a" (all lines), "t" (non-empty
+// lines), "n" (no lines) or "pBRE" (lines matching the basic regular expression
+// BRE). For pBRE it returns the compiled pattern.
+func sectionStyle(s string) (textproc.NumberStyle, *regexp.Regexp, bool) {
 	switch s {
 	case "a":
-		return textproc.NumberAll, true
+		return textproc.NumberAll, nil, true
 	case "t":
-		return textproc.NumberNonBlank, true
+		return textproc.NumberNonBlank, nil, true
 	case "n":
-		return textproc.NumberNone, true
+		return textproc.NumberNone, nil, true
 	default:
-		return 0, false
+		if strings.HasPrefix(s, "p") && len(s) > 1 {
+			re, err := regexp.Compile(s[1:])
+			if err != nil {
+				return 0, nil, false
+			}
+			return textproc.NumberRegexp, re, true
+		}
+		return 0, nil, false
 	}
 }
 

--- a/internal/applets/textutils/nl/nl_sections_test.go
+++ b/internal/applets/textutils/nl/nl_sections_test.go
@@ -1,0 +1,130 @@
+package nl_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// sectionInput is a header/body/footer fixture using nl's delimiter lines
+// (\:\:\: header, \:\: body, \: footer). Every section is non-empty so the
+// per-section STYLE choice is observable.
+const sectionInput = "H1\n\\:\\:\\:\nHDR\n\\:\\:\nB1\n\\:\nF1\n"
+
+func TestRunSectionStyles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			// Default: only non-empty body lines are numbered; header and footer
+			// styles default to "n" (no numbering). The first H1 is in the body
+			// section (no header delimiter precedes it).
+			name: "default header and footer unnumbered",
+			args: nil,
+			want: "     1\tH1\n\n       HDR\n\n     1\tB1\n\n       F1\n",
+		},
+		{
+			// -h a -f a numbers every header and footer line too. Each section
+			// delimiter resets the counter to the starting line number.
+			name: "all sections numbered",
+			args: []string{"-h", "a", "-b", "a", "-f", "a"},
+			want: "     1\tH1\n\n     1\tHDR\n\n     1\tB1\n\n     1\tF1\n",
+		},
+		{
+			// Mixed styles: header all, body non-empty, footer none.
+			name: "mixed per-section styles",
+			args: []string{"-h", "a", "-b", "t", "-f", "n"},
+			want: "     1\tH1\n\n     1\tHDR\n\n     1\tB1\n\n       F1\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, sectionInput, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunRegexpStyle(t *testing.T) {
+	t.Parallel()
+	// pBRE numbers only lines matching the pattern.
+	out, _, err := run(t, "foo\nbar\nfoobar\n", "-b", "pfoo")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "     1\tfoo\n       bar\n     2\tfoobar\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestRunJoinBlankLines(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			// -l 2 counts two consecutive blank lines as one numbered line:
+			// the number lands on the 2nd and 4th blank.
+			name: "join two blank lines",
+			args: []string{"-b", "a", "-l", "2"},
+			want: "     1\ta\n       \n     2\t\n       \n     3\t\n     4\tb\n",
+		},
+		{
+			// -l 3 numbers only every third blank line.
+			name: "join three blank lines",
+			args: []string{"-b", "a", "-l", "3"},
+			want: "     1\ta\n       \n       \n     2\t\n       \n     3\tb\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, "a\n\n\n\n\nb\n", tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunInvalidSectionStyles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"invalid header", []string{"-h", "z"}, "invalid header numbering style"},
+		{"invalid footer", []string{"-f", "z"}, "invalid footer numbering style"},
+		{"invalid join", []string{"-l", "0"}, "invalid line number of blank lines"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, errOut, err := run(t, "a\n", tt.args...)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(errOut, tt.wantMsg) {
+				t.Errorf("stderr = %q, want it to mention %q", errOut, tt.wantMsg)
+			}
+		})
+	}
+}

--- a/internal/applets/textutils/tail/tail.go
+++ b/internal/applets/textutils/tail/tail.go
@@ -34,6 +34,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 			{Command: "tail -n 50 file.log", Explain: "Print the last 50 lines."},
 			{Command: "tail -f app.log", Explain: "Follow the file and print new lines as they arrive."},
 			{Command: "tail -F app.log", Explain: "Follow by name and retry if the file is rotated."},
+			{Command: "tail -z -n 1 app.log", Explain: "Treat NUL as the line delimiter and print the last record."},
 		},
 		ExitStatus: "0  success.\n1  a file could not be opened (without --retry).",
 	})
@@ -41,6 +42,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 	bytesN := fs.IntP("bytes", "c", 0, "output the last NUM bytes of each file")
 	quiet := fs.BoolP("quiet", "q", false, "never print headers giving file names")
 	verbose := fs.BoolP("verbose", "v", false, "always print headers giving file names")
+	zeroTerminated := fs.BoolP("zero-terminated", "z", false, "line delimiter is NUL, not newline")
 	followMode := fs.StringP("follow", "f", "", "output appended data as the file grows; MODE is 'name' or 'descriptor'")
 	fs.Lookup("follow").NoOptDefVal = "descriptor"
 	followName := fs.BoolP("follow-name", "F", false, "same as --follow=name --retry")
@@ -68,6 +70,10 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		files = []string{"-"}
 	}
 	showHeader := (len(files) > 1 || *verbose) && !*quiet
+	delim := byte('\n')
+	if *zeroTerminated {
+		delim = '\x00'
+	}
 
 	var firstErr error
 	for i, name := range files {
@@ -83,7 +89,7 @@ func (c *Command) Run(ctx context.Context, stdio command.IO, args []string) erro
 		if *bytesN > 0 {
 			err = textproc.TailBytes(stdio.Out, r, *bytesN)
 		} else {
-			err = textproc.TailLines(stdio.Out, r, *lines)
+			err = textproc.TailRecords(stdio.Out, r, *lines, delim)
 		}
 		_ = r.Close()
 		if err != nil {

--- a/internal/applets/textutils/tail/tail_test.go
+++ b/internal/applets/textutils/tail/tail_test.go
@@ -49,6 +49,37 @@ func TestRunStdin(t *testing.T) {
 	}
 }
 
+// TestRunZeroTerminated checks that -z/--zero-terminated treats NUL as the
+// record delimiter, counts NUL-delimited records for -n, and preserves any
+// newlines embedded within a record.
+func TestRunZeroTerminated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"z last record", "a\nb\x00c\nd\x00", []string{"-z", "-n", "1"}, "c\nd\x00"},
+		{"z long flag", "a\nb\x00c\nd\x00", []string{"--zero-terminated", "-n", "1"}, "c\nd\x00"},
+		{"z two records", "a\nb\x00c\nd\x00", []string{"-z", "-n", "2"}, "a\nb\x00c\nd\x00"},
+		{"z bytes unaffected", "a\nb\x00c\nd\x00", []string{"-z", "-c", "3"}, "\nd\x00"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, tt.stdin, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunMultipleFilesHaveHeaders(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/applets/textutils/tr/tr.go
+++ b/internal/applets/textutils/tr/tr.go
@@ -25,9 +25,10 @@ func (c *Command) Name() string { return "tr" }
 func (c *Command) Synopsis() string { return "Translate or delete characters" }
 
 type options struct {
-	delete     bool
-	squeeze    bool
-	complement bool
+	delete       bool
+	squeeze      bool
+	complement   bool
+	truncateSet1 bool
 }
 
 // Run executes tr.
@@ -48,6 +49,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	complement := fs.BoolP("complement", "c", false, "use the complement of SET1")
 	// GNU tr also spells --complement as -C.
 	fs.BoolP("Complement", "C", false, "use the complement of SET1 (same as -c)")
+	truncate := fs.BoolP("truncate-set1", "t", false, "first truncate SET1 to length of SET2")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -56,9 +58,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 
 	complementC, _ := fs.GetBool("Complement")
 	opts := options{
-		delete:     *del,
-		squeeze:    *squeeze,
-		complement: *complement || complementC,
+		delete:       *del,
+		squeeze:      *squeeze,
+		complement:   *complement || complementC,
+		truncateSet1: *truncate,
 	}
 
 	operands := fs.Args()
@@ -78,6 +81,13 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			_, _ = fmt.Fprintf(stdio.Err, "tr: %v\n", err)
 			return command.SilentFailure()
 		}
+	}
+
+	// With --truncate-set1 (-t), SET1 is truncated to the length of SET2 before
+	// translating, so any SET1 characters beyond SET2's length are passed through
+	// unchanged. GNU applies this only when translating (SET2 present).
+	if opts.truncateSet1 && len(set2) > 0 && len(set1) > len(set2) {
+		set1 = set1[:len(set2)]
 	}
 
 	data, readErr := io.ReadAll(stdio.In)

--- a/internal/applets/textutils/tr/tr_test.go
+++ b/internal/applets/textutils/tr/tr_test.go
@@ -86,6 +86,40 @@ func TestRunMissingSet2(t *testing.T) {
 	}
 }
 
+// TestRunTruncateSet1 checks --truncate-set1/-t: SET1 is cut to the length of
+// SET2 before translating, so SET1 characters past SET2's length pass through
+// unchanged instead of mapping to SET2's last rune.
+func TestRunTruncateSet1(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		in   string
+		want string
+	}{
+		// SET1=abc SET2=xy: with -t, a->x, b->y, c is left unchanged.
+		{"long flag", []string{"--truncate-set1", "abc", "xy"}, "abc\n", "xyc\n"},
+		{"short flag", []string{"-t", "abc", "xy"}, "abc\n", "xyc\n"},
+		// Without -t the default GNU padding maps c to SET2's last rune (y).
+		{"no truncate pads", []string{"abc", "xy"}, "abc\n", "xyy\n"},
+		// Equal-length sets are unaffected by -t.
+		{"equal length", []string{"-t", "abc", "xyz"}, "abc\n", "xyz\n"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, errOut, err := run(t, tt.in, tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunHelp(t *testing.T) {
 	t.Parallel()
 	out, _, err := run(t, "", "--help")

--- a/internal/applets/textutils/wc/wc.go
+++ b/internal/applets/textutils/wc/wc.go
@@ -5,12 +5,42 @@ package wc
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
 	"github.com/nao1215/mimixbox/internal/textproc"
 )
+
+// totalMode selects when the "total" line is printed (--total=WHEN).
+type totalMode int
+
+const (
+	// totalAuto prints the total only when more than one input is counted.
+	totalAuto totalMode = iota
+	// totalAlways always prints the total line.
+	totalAlways
+	// totalOnly prints just the total line (no per-file rows).
+	totalOnly
+	// totalNever suppresses the total line.
+	totalNever
+)
+
+func parseTotalMode(s string) (totalMode, bool) {
+	switch s {
+	case "auto":
+		return totalAuto, true
+	case "always":
+		return totalAlways, true
+	case "only":
+		return totalOnly, true
+	case "never":
+		return totalNever, true
+	default:
+		return 0, false
+	}
+}
 
 // Command is the wc applet.
 type Command struct{}
@@ -53,11 +83,15 @@ func (s selection) orDefault() selection {
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
 	fs := command.NewFlagSet(c.Name(), "[OPTION]... [FILE]...", stdio.Err).WithHelp(command.Help{
 		Description: "Print newline, word, and byte counts for each FILE, and a total line when more than " +
-			"one FILE is given. With no FILE, or when FILE is -, read standard input.",
+			"one FILE is given. With no FILE, or when FILE is -, read standard input. " +
+			"--files0-from=F reads the NUL-separated input file names from F (- for standard input), and " +
+			"--total=WHEN controls the total line (auto, always, only, never).",
 		Examples: []command.Example{
 			{Command: "wc -l file.txt", Explain: "Count the lines in file.txt."},
 			{Command: "wc -w file.txt", Explain: "Count the words in file.txt."},
 			{Command: "wc file1 file2", Explain: "Count lines, words, and bytes with a total line."},
+			{Command: "wc --files0-from=list", Explain: "Count the files named in NUL-separated list."},
+			{Command: "wc --total=only file1 file2", Explain: "Print only the combined total."},
 		},
 		ExitStatus: "0  all counts were printed.\n1  a file could not be read.",
 	})
@@ -66,16 +100,41 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	chars := fs.BoolP("chars", "m", false, "print the character counts")
 	bytes := fs.BoolP("bytes", "c", false, "print the byte counts")
 	maxLine := fs.BoolP("max-line-length", "L", false, "print the maximum display width")
+	files0From := fs.String("files0-from", "", "read NUL-terminated input file names from F (- for standard input)")
+	totalWhen := fs.String("total", "auto", "when to print a total line (auto, always, only, never)")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
 	}
 
+	tmode, ok := parseTotalMode(*totalWhen)
+	if !ok {
+		_, _ = fmt.Fprintf(stdio.Err, "wc: invalid argument %q for '--total'\n", *totalWhen)
+		return command.SilentFailure()
+	}
+
 	sel := selection{*lines, *words, *chars, *bytes, *maxLine}.orDefault()
-	files := fs.Args()
-	if len(files) == 0 {
-		files = []string{"-"}
+
+	operands := fs.Args()
+	var files []string
+	if fs.Changed("files0-from") {
+		if len(operands) > 0 {
+			_, _ = fmt.Fprintf(stdio.Err, "wc: extra operand %q\n", operands[0])
+			_, _ = fmt.Fprintln(stdio.Err, "wc: file operands cannot be combined with --files0-from")
+			return command.SilentFailure()
+		}
+		names, err := readFiles0(stdio, *files0From)
+		if err != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "wc: %s\n", command.FileError(*files0From, err))
+			return command.SilentFailure()
+		}
+		files = names
+	} else {
+		files = operands
+		if len(files) == 0 {
+			files = []string{"-"}
+		}
 	}
 
 	var rows []fileRow
@@ -114,7 +173,22 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		total = total.Add(count)
 	}
 
-	if len(rows) > 1 {
+	// --total decides whether (and how) the summary line is printed. With "only"
+	// just the total is shown (no per-file rows and no "total" label); "auto"
+	// prints it when more than one input was given; "always" forces it; "never"
+	// suppresses it.
+	showTotal := false
+	switch tmode {
+	case totalAlways, totalOnly:
+		showTotal = true
+	case totalAuto:
+		showTotal = len(files) > 1
+	case totalNever:
+		showTotal = false
+	}
+	if tmode == totalOnly {
+		rows = []fileRow{{count: total}}
+	} else if showTotal {
 		rows = append(rows, fileRow{count: total, name: "total"})
 	}
 
@@ -186,6 +260,29 @@ func formatRow(c textproc.Count, name string, sel selection, width int) string {
 		line += " " + name
 	}
 	return line
+}
+
+// readFiles0 reads the NUL-separated list of input file names from F (or from
+// standard input when F is "-"). A trailing NUL is allowed, and empty names are
+// skipped, matching GNU wc --files0-from.
+func readFiles0(stdio command.IO, name string) ([]string, error) {
+	r, err := command.Open(stdio, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, part := range strings.Split(string(data), "\x00") {
+		if part != "" {
+			names = append(names, part)
+		}
+	}
+	return names, nil
 }
 
 func keep(existing error) error {

--- a/internal/applets/textutils/wc/wc_gnu_test.go
+++ b/internal/applets/textutils/wc/wc_gnu_test.go
@@ -1,0 +1,142 @@
+package wc_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// twoFiles writes two fixture files and returns their paths. a.txt has 3 lines
+// / 3 words / 6 bytes and b.txt has 1 line / 1 word / 2 bytes.
+func twoFiles(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(a, []byte("a\nb\nc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return a, b
+}
+
+func TestRunTotalModes(t *testing.T) {
+	t.Parallel()
+	a, b := twoFiles(t)
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "only prints just the total without a label",
+			args: []string{"--total=only", a, b},
+			want: "4 4 8\n",
+		},
+		{
+			name: "never suppresses the total",
+			args: []string{"--total=never", a, b},
+			want: "3 3 6 " + a + "\n1 1 2 " + b + "\n",
+		},
+		{
+			name: "always prints a total even for one file",
+			args: []string{"--total=always", a},
+			want: "3 3 6 " + a + "\n3 3 6 total\n",
+		},
+		{
+			name: "auto prints no total for one file",
+			args: []string{"--total=auto", a},
+			want: "3 3 6 " + a + "\n",
+		},
+		{
+			name: "auto prints a total for two files",
+			args: []string{"--total=auto", a, b},
+			want: "3 3 6 " + a + "\n1 1 2 " + b + "\n4 4 8 total\n",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, _, err := run(t, "", tt.args...)
+			if err != nil {
+				t.Fatalf("Run error = %v", err)
+			}
+			if out != tt.want {
+				t.Errorf("out = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunInvalidTotal(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "", "--total=bogus")
+	if err == nil {
+		t.Fatal("expected error for invalid --total")
+	}
+	if !strings.Contains(errOut, "invalid argument") {
+		t.Errorf("stderr = %q, want it to mention an invalid argument", errOut)
+	}
+}
+
+func TestRunFiles0From(t *testing.T) {
+	t.Parallel()
+	a, b := twoFiles(t)
+	dir := t.TempDir()
+	list := filepath.Join(dir, "list.nul")
+	// NUL-separated names with a trailing NUL, as GNU wc produces and accepts.
+	if err := os.WriteFile(list, []byte(a+"\x00"+b+"\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := run(t, "", "--files0-from="+list)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "3 3 6 " + a + "\n1 1 2 " + b + "\n4 4 8 total\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestRunFiles0FromStdin(t *testing.T) {
+	t.Parallel()
+	a, b := twoFiles(t)
+	// "-" reads the NUL-separated list from standard input.
+	out, _, err := run(t, a+"\x00"+b, "--files0-from=-")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	want := "3 3 6 " + a + "\n1 1 2 " + b + "\n4 4 8 total\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+func TestRunFiles0FromOnlyTotal(t *testing.T) {
+	t.Parallel()
+	a, b := twoFiles(t)
+	out, _, err := run(t, a+"\x00"+b+"\x00", "--files0-from=-", "--total=only")
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "4 4 8\n" {
+		t.Errorf("out = %q, want %q", out, "4 4 8\n")
+	}
+}
+
+func TestRunFiles0FromRejectsOperands(t *testing.T) {
+	t.Parallel()
+	a, _ := twoFiles(t)
+	_, errOut, err := run(t, "", "--files0-from=-", a)
+	if err == nil {
+		t.Fatal("expected error when operands are combined with --files0-from")
+	}
+	if !strings.Contains(errOut, "files0-from") {
+		t.Errorf("stderr = %q, want it to mention files0-from", errOut)
+	}
+}

--- a/internal/applets/textutils/wc/wc_more_test.go
+++ b/internal/applets/textutils/wc/wc_more_test.go
@@ -67,8 +67,10 @@ func TestRunMultipleMissingFiles(t *testing.T) {
 	if !strings.Contains(errOut, "/no/such/a") || !strings.Contains(errOut, "/no/such/b") {
 		t.Errorf("stderr = %q, want both missing files reported", errOut)
 	}
-	if out != "" {
-		t.Errorf("out = %q, want empty when all inputs failed", out)
+	// With two FILE operands the total line is printed even when every read
+	// fails, matching GNU wc (the counts are all zero).
+	if out != "0 0 0 total\n" {
+		t.Errorf("out = %q, want %q", out, "0 0 0 total\n")
 	}
 }
 

--- a/internal/textproc/textproc.go
+++ b/internal/textproc/textproc.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"unicode"
 )
@@ -110,6 +111,8 @@ const (
 	NumberAll
 	// NumberNonBlank numbers only non-empty lines (cat -b, nl -bt).
 	NumberNonBlank
+	// NumberRegexp numbers only lines matching Pattern (nl -b pBRE).
+	NumberRegexp
 )
 
 // NumberJustify selects how the line number is padded inside its field.
@@ -136,7 +139,34 @@ type Numberer struct {
 	Separator string
 	Justify   NumberJustify
 	PadBlank  bool
+	// Pattern is consulted when Style is NumberRegexp (nl -b pBRE).
+	Pattern *regexp.Regexp
+
+	// Sections enables nl's header/body/footer behavior. When false the input is
+	// numbered as a single body using Style. When true the input is divided into
+	// header/body/footer sections by the delimiter lines (\:\:\: header, \:\:
+	// body, \: footer); each section is numbered with HeaderStyle / Style /
+	// FooterStyle respectively, the delimiter lines are emitted as blank lines,
+	// and the line number resets to Start at the start of each logical page (the
+	// header, or a body that is not preceded by a header).
+	Sections     bool
+	HeaderStyle  NumberStyle
+	FooterStyle  NumberStyle
+	HeaderRegexp *regexp.Regexp
+	FooterRegexp *regexp.Regexp
+	// JoinBlankLines counts this many consecutive blank lines as a single line
+	// for numbering (nl -l). Zero or one disables the grouping.
+	JoinBlankLines int
 }
+
+// section identifies which logical part of the input a line belongs to.
+type section int
+
+const (
+	sectionBody section = iota
+	sectionHeader
+	sectionFooter
+)
 
 // WriteTo copies r to w, numbering lines according to the Numberer's settings.
 // It reads r one line at a time rather than slurping it all into memory, so it
@@ -145,6 +175,8 @@ type Numberer struct {
 func (n Numberer) WriteTo(w io.Writer, r io.Reader) error {
 	br := bufio.NewReader(r)
 	num := n.Start
+	cur := sectionBody
+	blankRun := 0 // consecutive blank lines seen so far in the current run
 	for {
 		chunk, err := br.ReadString('\n')
 		if chunk != "" {
@@ -152,7 +184,30 @@ func (n Numberer) WriteTo(w io.Writer, r io.Reader) error {
 			if strings.HasSuffix(chunk, "\n") {
 				body, nl = chunk[:len(chunk)-1], "\n"
 			}
-			numbered, werr := n.emitLine(w, body, nl, num)
+
+			// A section delimiter line switches sections, resets the line number
+			// to Start (every delimiter begins a fresh section, matching GNU nl
+			// without -p), and is itself emitted as a blank line (never numbered).
+			// Delimiters are only honored in Sections mode.
+			if n.Sections {
+				if sec, ok := delimiterSection(body); ok {
+					num = n.Start
+					cur = sec
+					blankRun = 0
+					if _, werr := io.WriteString(w, nl); werr != nil {
+						return werr
+					}
+					if err == io.EOF {
+						return nil
+					}
+					if err != nil {
+						return err
+					}
+					continue
+				}
+			}
+
+			numbered, werr := n.emitLine(w, body, nl, num, cur, &blankRun)
 			if werr != nil {
 				return werr
 			}
@@ -169,10 +224,39 @@ func (n Numberer) WriteTo(w io.Writer, r io.Reader) error {
 	}
 }
 
+// delimiterSection reports the section a delimiter line opens. GNU nl uses the
+// escape sequences "\:\:\:" (header), "\:\:" (body) and "\:" (footer), where the
+// backslash-colon pair appears literally in the input.
+func delimiterSection(body string) (section, bool) {
+	switch body {
+	case `\:\:\:`:
+		return sectionHeader, true
+	case `\:\:`:
+		return sectionBody, true
+	case `\:`:
+		return sectionFooter, true
+	default:
+		return sectionBody, false
+	}
+}
+
 // emitLine writes one numbered (or blank-padded) line and reports whether it
-// consumed a line number.
-func (n Numberer) emitLine(w io.Writer, body, nl string, num int) (bool, error) {
-	if n.numbered(body) {
+// consumed a line number. sec selects the section's numbering style, and
+// blankRun tracks the length of the current run of blank lines so that
+// JoinBlankLines can collapse N of them into a single numbered line.
+func (n Numberer) emitLine(w io.Writer, body, nl string, num int, sec section, blankRun *int) (bool, error) {
+	if body == "" {
+		*blankRun++
+	} else {
+		*blankRun = 0
+	}
+
+	if n.numbered(body, sec, *blankRun) {
+		if body == "" {
+			// A numbered blank line ends the current run so the next blank line
+			// starts a fresh group of JoinBlankLines.
+			*blankRun = 0
+		}
 		_, err := io.WriteString(w, n.format(num)+n.Separator+body+nl)
 		return true, err
 	}
@@ -184,12 +268,34 @@ func (n Numberer) emitLine(w io.Writer, body, nl string, num int) (bool, error) 
 	return false, err
 }
 
-func (n Numberer) numbered(body string) bool {
-	switch n.Style {
+// styleFor returns the numbering style and regexp pattern that govern the given
+// section.
+func (n Numberer) styleFor(sec section) (NumberStyle, *regexp.Regexp) {
+	switch sec {
+	case sectionHeader:
+		return n.HeaderStyle, n.HeaderRegexp
+	case sectionFooter:
+		return n.FooterStyle, n.FooterRegexp
+	default:
+		return n.Style, n.Pattern
+	}
+}
+
+// numbered reports whether the given line is numbered. blankRun is the count of
+// consecutive blank lines ending at this line (1 for the first blank); with
+// JoinBlankLines set to N a blank line is numbered only on every Nth blank.
+func (n Numberer) numbered(body string, sec section, blankRun int) bool {
+	style, pattern := n.styleFor(sec)
+	switch style {
 	case NumberAll:
+		if body == "" && n.JoinBlankLines > 1 {
+			return blankRun%n.JoinBlankLines == 0
+		}
 		return true
 	case NumberNonBlank:
 		return body != ""
+	case NumberRegexp:
+		return pattern != nil && pattern.MatchString(body)
 	default:
 		return false
 	}
@@ -208,12 +314,20 @@ func (n Numberer) format(num int) string {
 
 // HeadLines writes the first n lines of r to w, preserving line endings.
 func HeadLines(w io.Writer, r io.Reader, n int) error {
+	return HeadRecords(w, r, n, '\n')
+}
+
+// HeadRecords writes the first n records of r to w, preserving each record's
+// trailing delimiter. With delim '\n' this is the line-oriented head; with
+// delim '\0' (the -z/--zero-terminated mode) records are NUL-delimited and any
+// embedded newlines are kept verbatim.
+func HeadRecords(w io.Writer, r io.Reader, n int, delim byte) error {
 	if n <= 0 {
 		return nil
 	}
 	br := bufio.NewReader(r)
 	for i := 0; i < n; i++ {
-		s, err := br.ReadString('\n')
+		s, err := br.ReadString(delim)
 		if s != "" {
 			if _, werr := io.WriteString(w, s); werr != nil {
 				return werr
@@ -231,13 +345,21 @@ func HeadLines(w io.Writer, r io.Reader, n int) error {
 
 // TailLines writes the last n lines of r to w, preserving line endings.
 func TailLines(w io.Writer, r io.Reader, n int) error {
+	return TailRecords(w, r, n, '\n')
+}
+
+// TailRecords writes the last n records of r to w, preserving each record's
+// trailing delimiter. With delim '\n' this is the line-oriented tail; with
+// delim '\0' (the -z/--zero-terminated mode) records are NUL-delimited and any
+// embedded newlines are kept verbatim.
+func TailRecords(w io.Writer, r io.Reader, n int, delim byte) error {
 	if n <= 0 {
 		return nil
 	}
 	br := bufio.NewReader(r)
 	ring := make([]string, 0, n)
 	for {
-		s, err := br.ReadString('\n')
+		s, err := br.ReadString(delim)
 		if s != "" {
 			if len(ring) < n {
 				ring = append(ring, s)

--- a/internal/textproc/textproc_test.go
+++ b/internal/textproc/textproc_test.go
@@ -3,6 +3,7 @@ package textproc_test
 import (
 	"bytes"
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -389,5 +390,57 @@ func TestNumbererStreamsAcrossReads(t *testing.T) {
 	want := "     1\ta\n     2\tbb\n     3\tccc"
 	if buf.String() != want {
 		t.Errorf("streamed = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestNumbererSections(t *testing.T) {
+	t.Parallel()
+	// H1 is in the body section (no header delimiter precedes it); the
+	// delimiters \:\:\:, \:\: and \: switch to header, body and footer and reset
+	// the counter, and each is emitted as a blank line.
+	input := "H1\n\\:\\:\\:\nHDR\n\\:\\:\nB1\n\\:\nF1\n"
+	re := regexp.MustCompile("HDR")
+	n := textproc.Numberer{
+		Style:        textproc.NumberNonBlank,
+		Start:        1,
+		Increment:    1,
+		Width:        6,
+		Separator:    "\t",
+		PadBlank:     true,
+		Sections:     true,
+		HeaderStyle:  textproc.NumberRegexp,
+		HeaderRegexp: re,
+		FooterStyle:  textproc.NumberAll,
+	}
+	var buf bytes.Buffer
+	if err := n.WriteTo(&buf, strings.NewReader(input)); err != nil {
+		t.Fatalf("WriteTo error = %v", err)
+	}
+	want := "     1\tH1\n\n     1\tHDR\n\n     1\tB1\n\n     1\tF1\n"
+	if buf.String() != want {
+		t.Errorf("sections = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestNumbererJoinBlankLines(t *testing.T) {
+	t.Parallel()
+	n := textproc.Numberer{
+		Style:          textproc.NumberAll,
+		Start:          1,
+		Increment:      1,
+		Width:          6,
+		Separator:      "\t",
+		PadBlank:       true,
+		JoinBlankLines: 2,
+	}
+	var buf bytes.Buffer
+	if err := n.WriteTo(&buf, strings.NewReader("a\n\n\n\n\nb\n")); err != nil {
+		t.Fatalf("WriteTo error = %v", err)
+	}
+	// Two consecutive blank lines count as one: the number lands on the 2nd and
+	// 4th blank line.
+	want := "     1\ta\n       \n     2\t\n       \n     3\t\n     4\tb\n"
+	if buf.String() != want {
+		t.Errorf("join blank = %q, want %q", buf.String(), want)
 	}
 }

--- a/test/it/shellutils/cmp_gnu_test.sh
+++ b/test/it/shellutils/cmp_gnu_test.sh
@@ -1,0 +1,53 @@
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/cmp_gnu
+    mkdir -p ${TEST_DIR}
+    # Differ at byte 4 ('X' vs 'Y'); identical tail otherwise.
+    printf 'abcXdef' > ${TEST_DIR}/a.txt
+    printf 'abcYdef' > ${TEST_DIR}/b.txt
+    # First three bytes differ; the rest is common.
+    printf 'XXXcommon' > ${TEST_DIR}/skip_a.txt
+    printf 'YYYcommon' > ${TEST_DIR}/skip_b.txt
+    # Asymmetric skip case: skip 1 of file1, 3 of file2, remaining "abZ"/"abQ".
+    printf '_abZ' > ${TEST_DIR}/pair_a.txt
+    printf '___abQ' > ${TEST_DIR}/pair_b.txt
+    # Difference whose byte values matter for --print-bytes ('s' vs 'S').
+    printf 'first\nsecond\n' > ${TEST_DIR}/pb_a.txt
+    printf 'first\nSECOND\n' > ${TEST_DIR}/pb_b.txt
+}
+
+CleanUp() {
+    rm -rf ${MIMIXBOX_IT_ROOT}/cmp_gnu
+}
+
+# -n LIMIT stops before the difference at byte 4, so it reports equality.
+TestCmpBytesLimitEqual() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/cmp_gnu
+    cmp -n 3 ${TEST_DIR}/a.txt ${TEST_DIR}/b.txt
+    echo "rc=$?"
+}
+
+# --bytes=4 reaches the differing byte and reports it.
+TestCmpBytesLimitDiffer() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/cmp_gnu
+    cmp --bytes=4 ${TEST_DIR}/a.txt ${TEST_DIR}/b.txt
+}
+
+# -i N skips the first N bytes of both files before comparing.
+TestCmpIgnoreInitial() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/cmp_gnu
+    cmp -i 3 ${TEST_DIR}/skip_a.txt ${TEST_DIR}/skip_b.txt
+    echo "rc=$?"
+}
+
+# -i N:M skips N bytes of file1 and M of file2; offsets count from the first
+# compared byte.
+TestCmpIgnoreInitialPair() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/cmp_gnu
+    cmp -i 1:3 ${TEST_DIR}/pair_a.txt ${TEST_DIR}/pair_b.txt
+}
+
+# -b adds the octal value and rendered character of each differing byte.
+TestCmpPrintBytes() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/cmp_gnu
+    cmp -b ${TEST_DIR}/pb_a.txt ${TEST_DIR}/pb_b.txt
+}

--- a/test/it/shellutils/cut_test.sh
+++ b/test/it/shellutils/cut_test.sh
@@ -17,3 +17,23 @@ TestCutChars() {
 TestCutNoList() {
     printf 'a,b\n' | cut -d ,
 }
+
+TestCutComplementFields() {
+    printf 'a,b,c\n' | cut -f 2 -d , --complement
+}
+
+TestCutComplementBytes() {
+    printf 'abcde\n' | cut -b 2-3 --complement
+}
+
+# TestCutZeroTerminatedFields cuts the second field of each NUL-terminated
+# record and renders the NUL boundaries as '|' so the result is comparable as
+# plain text.
+TestCutZeroTerminatedFields() {
+    printf 'a,b,c\000d,e,f\000' | cut -f 2 -d , -z | tr '\000' '|'
+}
+
+# TestCutZeroTerminatedBytes keeps the first two bytes of each NUL record.
+TestCutZeroTerminatedBytes() {
+    printf 'abc\000def\000' | cut -b 1-2 -z | tr '\000' '|'
+}

--- a/test/it/shellutils/tee_output_error_test.sh
+++ b/test/it/shellutils/tee_output_error_test.sh
@@ -1,0 +1,42 @@
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/tee_output_error
+    mkdir -p ${TEST_DIR}
+}
+
+CleanUp() {
+    rm -rf ${MIMIXBOX_IT_ROOT}/tee_output_error
+}
+
+# A writable destination with an explicit MODE succeeds and copies the input.
+TestTeeOutputErrorWritable() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/tee_output_error
+    printf 'hello\n' | tee --output-error=warn ${TEST_DIR}/good.txt > /dev/null
+    cat ${TEST_DIR}/good.txt
+}
+
+# warn mode keeps writing to the good file even though the bad path fails, and
+# exits nonzero. We print the good file's content so the spec can assert it was
+# still written; the exit status reflects the failure.
+TestTeeOutputErrorWarnContinues() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/tee_output_error
+    printf 'payload\n' | tee --output-error=warn \
+        ${TEST_DIR}/missing-dir/bad.txt ${TEST_DIR}/good.txt > /dev/null 2>&1
+    local rc=$?
+    cat ${TEST_DIR}/good.txt 2>/dev/null
+    return ${rc}
+}
+
+# exit mode stops at the first failing destination, so the good file that comes
+# after the bad one is never created. We emit "absent" when it does not exist.
+TestTeeOutputErrorExitStops() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/tee_output_error
+    printf 'payload\n' | tee --output-error=exit \
+        ${TEST_DIR}/missing-dir/bad.txt ${TEST_DIR}/good.txt > /dev/null 2>&1
+    local rc=$?
+    if [ -f ${TEST_DIR}/good.txt ]; then
+        printf 'present\n'
+    else
+        printf 'absent\n'
+    fi
+    return ${rc}
+}

--- a/test/it/spec/cat_showall_spec.sh
+++ b/test/it/spec/cat_showall_spec.sh
@@ -1,0 +1,56 @@
+Describe 'cat -A and --show-all are aliases'
+    Include textutils/cat_showall_test.sh
+    BeforeEach 'SetupShowAll'
+    AfterEach 'CleanUpShowAll'
+
+    It 'produces byte-identical output for -A and --show-all'
+        When call TestCatShowAllAlias
+        The output should equal "identical"
+        The status should be success
+    End
+End
+
+Describe 'cat -v and --show-nonprinting are aliases'
+    Include textutils/cat_showall_test.sh
+    BeforeEach 'SetupShowAll'
+    AfterEach 'CleanUpShowAll'
+
+    It 'produces byte-identical output for -v and --show-nonprinting'
+        When call TestCatShowNonprintingAlias
+        The output should equal "identical"
+        The status should be success
+    End
+End
+
+Describe 'cat --show-all rendering'
+    Include textutils/cat_showall_test.sh
+    BeforeEach 'SetupShowAll'
+    AfterEach 'CleanUpShowAll'
+
+    result() { %text
+        #|a^Ib^A$
+        #|$
+        #|^?M-^@$
+    }
+
+    It 'shows tabs as ^I, non-printing bytes, and $ line ends'
+        When call TestCatShowAllRendered
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'cat --show-nonprinting rendering'
+    Include textutils/cat_showall_test.sh
+    BeforeEach 'SetupShowAll'
+    AfterEach 'CleanUpShowAll'
+
+    # TAB is left untouched by -v; only control/DEL/high bytes are rendered.
+    result() { printf 'a\tb^A\n\n^?M-^@'; }
+
+    It 'leaves TAB alone and renders ^X, ^?, and M- notation'
+        When call TestCatShowNonprintingRendered
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/cmp_gnu_spec.sh
+++ b/test/it/spec/cmp_gnu_spec.sh
@@ -1,0 +1,47 @@
+Describe 'cmp -n / --bytes'
+    Include shellutils/cmp_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'reports equality when the difference is past the byte limit'
+        When call TestCmpBytesLimitEqual
+        The output should equal 'rc=0'
+        The status should be success
+    End
+
+    It 'reports the difference within the byte limit'
+        When call TestCmpBytesLimitDiffer
+        The output should include 'differ: byte 4, line 1'
+        The status should be failure
+    End
+End
+
+Describe 'cmp -i / --ignore-initial'
+    Include shellutils/cmp_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'skips the first N bytes of both files'
+        When call TestCmpIgnoreInitial
+        The output should equal 'rc=0'
+        The status should be success
+    End
+
+    It 'skips N bytes of file1 and M of file2 with N:M'
+        When call TestCmpIgnoreInitialPair
+        The output should include 'differ: byte 3, line 1'
+        The status should be failure
+    End
+End
+
+Describe 'cmp -b / --print-bytes'
+    Include shellutils/cmp_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints the differing byte values in the message'
+        When call TestCmpPrintBytes
+        The output should include 'differ: byte 7, line 2 is 163 s 123 S'
+        The status should be failure
+    End
+End

--- a/test/it/spec/comm_gnu_spec.sh
+++ b/test/it/spec/comm_gnu_spec.sh
@@ -1,0 +1,39 @@
+Describe 'comm --output-delimiter'
+    Include textutils/comm_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'separates the columns with the given string'
+        When call TestCommOutputDelimiter
+        The line 1 of output should equal 'apple'
+        The line 2 of output should equal ',,banana'
+        The line 3 of output should equal ',,cherry'
+        The line 4 of output should equal ',date'
+        The status should be success
+    End
+End
+
+Describe 'comm -z (zero-terminated)'
+    Include textutils/comm_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'reads and writes NUL-terminated records'
+        When call TestCommZeroTerminated
+        The output should equal 'banana#'
+        The status should be success
+    End
+End
+
+Describe 'comm --check-order'
+    Include textutils/comm_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'reports an unsorted input on stderr and fails'
+        When call TestCommCheckOrder
+        The output should equal 'rc=1'
+        The error should include 'file 1 is not in sorted order'
+        The status should be success
+    End
+End

--- a/test/it/spec/cut_gnu_spec.sh
+++ b/test/it/spec/cut_gnu_spec.sh
@@ -1,0 +1,39 @@
+Describe 'cut --complement on fields'
+    Include shellutils/cut_test.sh
+
+    It 'keeps the fields not selected'
+        When call TestCutComplementFields
+        The output should equal 'a,c'
+        The status should be success
+    End
+End
+
+Describe 'cut --complement on bytes'
+    Include shellutils/cut_test.sh
+
+    It 'keeps the bytes not selected'
+        When call TestCutComplementBytes
+        The output should equal 'ade'
+        The status should be success
+    End
+End
+
+Describe 'cut -z zero-terminated fields'
+    Include shellutils/cut_test.sh
+
+    It 'splits and joins records on NUL'
+        When call TestCutZeroTerminatedFields
+        The output should equal 'b|e|'
+        The status should be success
+    End
+End
+
+Describe 'cut -z zero-terminated bytes'
+    Include shellutils/cut_test.sh
+
+    It 'cuts bytes from each NUL-delimited record'
+        When call TestCutZeroTerminatedBytes
+        The output should equal 'ab|de|'
+        The status should be success
+    End
+End

--- a/test/it/spec/head_zero_spec.sh
+++ b/test/it/spec/head_zero_spec.sh
@@ -1,0 +1,36 @@
+Describe 'head --zero-terminated'
+    # The fixture holds two NUL-delimited records, each containing an embedded
+    # newline: record 1 is "a\nb" and record 2 is "c\nd". With -z, head must
+    # split on NUL (not newline) and keep the embedded newlines verbatim, and
+    # emit NUL as the trailing record separator.
+    fixture() { printf 'a\nb\0c\nd\0'; }
+
+    Describe 'first NUL record with -z'
+        # head -z -n 1 -> "a\nb\0"; rendering NUL as '|' gives "a\nb|".
+        result() { %text
+            #|a
+            #|b|
+        }
+
+        It 'prints the first NUL-delimited record, preserving the embedded newline'
+            When call sh -c "printf 'a\nb\0c\nd\0' | head -z -n 1 | tr '\0' '|'"
+            The output should equal "$(result)"
+            The status should be success
+        End
+    End
+
+    Describe 'two NUL records with --zero-terminated'
+        # head --zero-terminated -n 2 -> "a\nb\0c\nd\0" -> "a\nb|c\nd|".
+        result() { %text
+            #|a
+            #|b|c
+            #|d|
+        }
+
+        It 'prints two NUL-delimited records with embedded newlines preserved'
+            When call sh -c "printf 'a\nb\0c\nd\0' | head --zero-terminated -n 2 | tr '\0' '|'"
+            The output should equal "$(result)"
+            The status should be success
+        End
+    End
+End

--- a/test/it/spec/nl_sections_spec.sh
+++ b/test/it/spec/nl_sections_spec.sh
@@ -1,0 +1,64 @@
+Describe 'nl numbers each header/body/footer section with its own style'
+    Include textutils/nl_test.sh
+    BeforeEach 'SetupNlSections'
+    AfterEach 'Cleanup'
+
+    result() {
+        printf '%s\n' \
+          "     1	H1" \
+          "" \
+          "     1	HDR" \
+          "" \
+          "     1	B1" \
+          "" \
+          "     1	F1"
+    }
+    It 'numbers every line in every section with -h a -b a -f a'
+        When call TestNlSectionsAll
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'nl honors a different style per section'
+    Include textutils/nl_test.sh
+    BeforeEach 'SetupNlSections'
+    AfterEach 'Cleanup'
+
+    result() {
+        printf '%s\n' \
+          "     1	H1" \
+          "" \
+          "     1	HDR" \
+          "" \
+          "     1	B1" \
+          "" \
+          "       F1"
+    }
+    It 'numbers header (a) and body (t) but not footer (n)'
+        When call TestNlSectionsMixed
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'nl counts a group of blank lines as one with -l'
+    Include textutils/nl_test.sh
+    BeforeEach 'SetupNlSections'
+    AfterEach 'Cleanup'
+
+    result() {
+        printf '%s\n' \
+          "     1	a" \
+          "       " \
+          "     2	" \
+          "       " \
+          "     3	" \
+          "     4	b"
+    }
+    It 'numbers every second blank line with -l 2'
+        When call TestNlJoinBlankLines
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/tail_zero_spec.sh
+++ b/test/it/spec/tail_zero_spec.sh
@@ -1,0 +1,34 @@
+Describe 'tail --zero-terminated'
+    # The fixture holds two NUL-delimited records, each containing an embedded
+    # newline: record 1 is "a\nb" and record 2 is "c\nd". With -z, tail must
+    # split on NUL (not newline) and keep the embedded newlines verbatim, and
+    # emit NUL as the trailing record separator.
+    Describe 'last NUL record with -z'
+        # tail -z -n 1 -> "c\nd\0"; rendering NUL as '|' gives "c\nd|".
+        result() { %text
+            #|c
+            #|d|
+        }
+
+        It 'prints the last NUL-delimited record, preserving the embedded newline'
+            When call sh -c "printf 'a\nb\0c\nd\0' | tail -z -n 1 | tr '\0' '|'"
+            The output should equal "$(result)"
+            The status should be success
+        End
+    End
+
+    Describe 'two NUL records with --zero-terminated'
+        # tail --zero-terminated -n 2 -> "a\nb\0c\nd\0" -> "a\nb|c\nd|".
+        result() { %text
+            #|a
+            #|b|c
+            #|d|
+        }
+
+        It 'prints two NUL-delimited records with embedded newlines preserved'
+            When call sh -c "printf 'a\nb\0c\nd\0' | tail --zero-terminated -n 2 | tr '\0' '|'"
+            The output should equal "$(result)"
+            The status should be success
+        End
+    End
+End

--- a/test/it/spec/tee_output_error_spec.sh
+++ b/test/it/spec/tee_output_error_spec.sh
@@ -1,0 +1,35 @@
+Describe 'tee --output-error writable path'
+    Include shellutils/tee_output_error_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'copies input and succeeds with an explicit MODE'
+        When call TestTeeOutputErrorWritable
+        The output should equal 'hello'
+        The status should be success
+    End
+End
+
+Describe 'tee --output-error=warn keeps writing on error'
+    Include shellutils/tee_output_error_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'still writes the good file but exits nonzero'
+        When call TestTeeOutputErrorWarnContinues
+        The output should equal 'payload'
+        The status should be failure
+    End
+End
+
+Describe 'tee --output-error=exit stops at first error'
+    Include shellutils/tee_output_error_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'does not create the later good file and exits nonzero'
+        When call TestTeeOutputErrorExitStops
+        The output should equal 'absent'
+        The status should be failure
+    End
+End

--- a/test/it/spec/tr_truncate_spec.sh
+++ b/test/it/spec/tr_truncate_spec.sh
@@ -1,0 +1,15 @@
+Describe 'tr --truncate-set1'
+    Include textutils/tr_truncate_test.sh
+
+    It 'truncates SET1 to SET2 length, leaving extra chars unchanged'
+        When call TestTrTruncateSet1
+        The output should equal 'xyc'
+        The status should be success
+    End
+
+    It 'accepts the -t short form'
+        When call TestTrTruncateSet1Short
+        The output should equal 'xyc'
+        The status should be success
+    End
+End

--- a/test/it/spec/wc_gnu_spec.sh
+++ b/test/it/spec/wc_gnu_spec.sh
@@ -1,0 +1,91 @@
+Describe 'wc --total=only prints just the combined total'
+    Include textutils/wc_test.sh
+    BeforeEach 'SetupWcGnu'
+    AfterEach 'CleanupWcGnu'
+    It 'says "4 4 8"'
+        When call TestWcTotalOnly
+        The output should equal "4 4 8"
+        The status should be success
+    End
+End
+
+Describe 'wc --total=never suppresses the total line'
+    Include textutils/wc_test.sh
+    BeforeEach 'SetupWcGnu'
+    AfterEach 'CleanupWcGnu'
+
+    result() {
+        printf '%s\n' \
+          "3 3 6 ${MIMIXBOX_IT_ROOT}/wc_a.txt" \
+          "1 1 2 ${MIMIXBOX_IT_ROOT}/wc_b.txt"
+    }
+    It 'prints only the per-file rows'
+        When call TestWcTotalNever
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'wc --total=always prints a total even for one file'
+    Include textutils/wc_test.sh
+    BeforeEach 'SetupWcGnu'
+    AfterEach 'CleanupWcGnu'
+
+    result() {
+        printf '%s\n' \
+          "3 3 6 ${MIMIXBOX_IT_ROOT}/wc_a.txt" \
+          "3 3 6 total"
+    }
+    It 'prints the file row and a total row'
+        When call TestWcTotalAlways
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'wc --files0-from reads a NUL-separated list of names'
+    Include textutils/wc_test.sh
+    BeforeEach 'SetupWcGnu'
+    AfterEach 'CleanupWcGnu'
+
+    result() {
+        printf '%s\n' \
+          "3 3 6 ${MIMIXBOX_IT_ROOT}/wc_a.txt" \
+          "1 1 2 ${MIMIXBOX_IT_ROOT}/wc_b.txt" \
+          "4 4 8 total"
+    }
+    It 'counts every file named in the list file'
+        When call TestWcFiles0From
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'wc --files0-from=- reads the name list from standard input'
+    Include textutils/wc_test.sh
+    BeforeEach 'SetupWcGnu'
+    AfterEach 'CleanupWcGnu'
+
+    result() {
+        printf '%s\n' \
+          "3 3 6 ${MIMIXBOX_IT_ROOT}/wc_a.txt" \
+          "1 1 2 ${MIMIXBOX_IT_ROOT}/wc_b.txt" \
+          "4 4 8 total"
+    }
+    It 'counts the files piped as a NUL-separated list'
+        When call TestWcFiles0FromStdin
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'wc --files0-from combines with --total=only'
+    Include textutils/wc_test.sh
+    BeforeEach 'SetupWcGnu'
+    AfterEach 'CleanupWcGnu'
+    It 'says "4 4 8"'
+        When call TestWcFiles0FromOnly
+        The output should equal "4 4 8"
+        The status should be success
+    End
+End

--- a/test/it/textutils/cat_showall_test.sh
+++ b/test/it/textutils/cat_showall_test.sh
@@ -1,0 +1,60 @@
+SetupShowAll() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}
+    export TEST_FILE_CAT_NP=${MIMIXBOX_IT_ROOT}/cat_nonprinting.bin
+    export LANG=C
+
+    mkdir -p ${TEST_DIR}
+
+    # Fixture containing a tab, a blank line, and non-printable bytes
+    # (0x01, 0x7f, 0x80). printf writes the raw bytes verbatim.
+    printf 'a\tb\x01\n\n\x7f\x80\n' > ${TEST_FILE_CAT_NP}
+}
+
+CleanUpShowAll() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}
+    rm -rf ${TEST_DIR}
+}
+
+# TestCatShowAllAlias compares `cat -A` with `cat --show-all` on the fixture and
+# prints "identical" only when the two outputs are byte-for-byte equal. The
+# outputs are written to files and compared with cmp so raw bytes are preserved.
+TestCatShowAllAlias() {
+    export TEST_FILE_CAT_NP=${MIMIXBOX_IT_ROOT}/cat_nonprinting.bin
+    short=${MIMIXBOX_IT_ROOT}/showall_short.out
+    long=${MIMIXBOX_IT_ROOT}/showall_long.out
+    cat -A ${TEST_FILE_CAT_NP} > ${short}
+    cat --show-all ${TEST_FILE_CAT_NP} > ${long}
+    if cmp -s ${short} ${long}; then
+        echo "identical"
+    else
+        echo "different"
+    fi
+}
+
+# TestCatShowNonprintingAlias compares `cat -v` with `cat --show-nonprinting`.
+TestCatShowNonprintingAlias() {
+    export TEST_FILE_CAT_NP=${MIMIXBOX_IT_ROOT}/cat_nonprinting.bin
+    short=${MIMIXBOX_IT_ROOT}/shownp_short.out
+    long=${MIMIXBOX_IT_ROOT}/shownp_long.out
+    cat -v ${TEST_FILE_CAT_NP} > ${short}
+    cat --show-nonprinting ${TEST_FILE_CAT_NP} > ${long}
+    if cmp -s ${short} ${long}; then
+        echo "identical"
+    else
+        echo "different"
+    fi
+}
+
+# TestCatShowAllRendered checks the actual -A rendering: tab -> ^I, non-printing
+# bytes via -v notation, and $ at each line end.
+TestCatShowAllRendered() {
+    export TEST_FILE_CAT_NP=${MIMIXBOX_IT_ROOT}/cat_nonprinting.bin
+    cat --show-all ${TEST_FILE_CAT_NP}
+}
+
+# TestCatShowNonprintingRendered checks the -v rendering: TAB is left untouched,
+# control chars become ^X, DEL becomes ^?, and high bytes get M- notation.
+TestCatShowNonprintingRendered() {
+    export TEST_FILE_CAT_NP=${MIMIXBOX_IT_ROOT}/cat_nonprinting.bin
+    cat --show-nonprinting ${TEST_FILE_CAT_NP}
+}

--- a/test/it/textutils/comm_gnu_test.sh
+++ b/test/it/textutils/comm_gnu_test.sh
@@ -1,0 +1,33 @@
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/comm_gnu
+    mkdir -p ${TEST_DIR}
+    printf 'apple\nbanana\ncherry\n' > ${TEST_DIR}/a.txt
+    printf 'banana\ncherry\ndate\n' > ${TEST_DIR}/b.txt
+    printf 'apple\x00banana\x00' > ${TEST_DIR}/za.txt
+    printf 'banana\x00date\x00' > ${TEST_DIR}/zb.txt
+    printf 'cherry\nbanana\n' > ${TEST_DIR}/unsorted.txt
+}
+
+CleanUp() {
+    rm -rf ${MIMIXBOX_IT_ROOT}/comm_gnu
+}
+
+# --output-delimiter replaces the tab column separators with the given string.
+TestCommOutputDelimiter() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/comm_gnu
+    comm --output-delimiter=, ${TEST_DIR}/a.txt ${TEST_DIR}/b.txt
+}
+
+# -z reads and writes NUL-terminated records; pipe through tr to make the NULs
+# visible as '#' so shellspec can match a plain string.
+TestCommZeroTerminated() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/comm_gnu
+    comm -z -1 -2 ${TEST_DIR}/za.txt ${TEST_DIR}/zb.txt | tr '\0' '#'
+}
+
+# --check-order fails (exit 1) and prints to stderr when an input is unsorted.
+TestCommCheckOrder() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/comm_gnu
+    comm --check-order ${TEST_DIR}/unsorted.txt ${TEST_DIR}/b.txt
+    echo "rc=$?"
+}

--- a/test/it/textutils/nl_test.sh
+++ b/test/it/textutils/nl_test.sh
@@ -63,3 +63,41 @@ EOS
 TestNlNoOperand() {
     nl no_exist_file
 }
+
+SetupNlSections() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}
+    export TEST_FILE_NL_SEC=${MIMIXBOX_IT_ROOT}/nl_sec.txt
+    export TEST_FILE_NL_BLANK=${MIMIXBOX_IT_ROOT}/nl_blank.txt
+    export LANG=C
+
+    mkdir -p ${TEST_DIR}
+
+    # Header/body/footer fixture using nl's delimiter lines.
+    {
+        printf 'H1\n'
+        printf '\\:\\:\\:\n'
+        printf 'HDR\n'
+        printf '\\:\\:\n'
+        printf 'B1\n'
+        printf '\\:\n'
+        printf 'F1\n'
+    } > ${TEST_FILE_NL_SEC}
+
+    # Blank-line fixture: a, four blank lines, b.
+    printf 'a\n\n\n\n\nb\n' > ${TEST_FILE_NL_BLANK}
+}
+
+TestNlSectionsAll() {
+    export TEST_FILE_NL_SEC=${MIMIXBOX_IT_ROOT}/nl_sec.txt
+    nl -h a -b a -f a ${TEST_FILE_NL_SEC}
+}
+
+TestNlSectionsMixed() {
+    export TEST_FILE_NL_SEC=${MIMIXBOX_IT_ROOT}/nl_sec.txt
+    nl -h a -b t -f n ${TEST_FILE_NL_SEC}
+}
+
+TestNlJoinBlankLines() {
+    export TEST_FILE_NL_BLANK=${MIMIXBOX_IT_ROOT}/nl_blank.txt
+    nl -b a -l 2 ${TEST_FILE_NL_BLANK}
+}

--- a/test/it/textutils/tr_truncate_test.sh
+++ b/test/it/textutils/tr_truncate_test.sh
@@ -1,0 +1,6 @@
+# --truncate-set1 cuts SET1 (abc) to the length of SET2 (xy), so a->x, b->y and
+# c is left unchanged, yielding "xyc".
+TestTrTruncateSet1() { printf 'abc\n' | tr --truncate-set1 abc xy; }
+
+# The -t short form behaves identically.
+TestTrTruncateSet1Short() { printf 'abc\n' | tr -t abc xy; }

--- a/test/it/textutils/wc_test.sh
+++ b/test/it/textutils/wc_test.sh
@@ -84,3 +84,54 @@ TestWcDirectoryAndFileSameTime() {
 TestWcNoExistFileNameFromPipeWithLinesOption() {
     echo "no_exist_file" | wc -l
 }
+
+SetupWcGnu() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}
+    export WC_A=${MIMIXBOX_IT_ROOT}/wc_a.txt
+    export WC_B=${MIMIXBOX_IT_ROOT}/wc_b.txt
+    export WC_LIST=${MIMIXBOX_IT_ROOT}/wc_list.nul
+    export LANG=C
+
+    mkdir -p ${TEST_DIR}
+
+    printf 'a\nb\nc\n' > ${WC_A}
+    printf 'x\n' > ${WC_B}
+    printf '%s\0%s\0' "${WC_A}" "${WC_B}" > ${WC_LIST}
+}
+
+CleanupWcGnu() {
+    rm -rf ${MIMIXBOX_IT_ROOT}
+}
+
+TestWcTotalOnly() {
+    export WC_A=${MIMIXBOX_IT_ROOT}/wc_a.txt
+    export WC_B=${MIMIXBOX_IT_ROOT}/wc_b.txt
+    wc --total=only ${WC_A} ${WC_B}
+}
+
+TestWcTotalNever() {
+    export WC_A=${MIMIXBOX_IT_ROOT}/wc_a.txt
+    export WC_B=${MIMIXBOX_IT_ROOT}/wc_b.txt
+    wc --total=never ${WC_A} ${WC_B}
+}
+
+TestWcTotalAlways() {
+    export WC_A=${MIMIXBOX_IT_ROOT}/wc_a.txt
+    wc --total=always ${WC_A}
+}
+
+TestWcFiles0From() {
+    export WC_LIST=${MIMIXBOX_IT_ROOT}/wc_list.nul
+    wc --files0-from=${WC_LIST}
+}
+
+TestWcFiles0FromStdin() {
+    export WC_A=${MIMIXBOX_IT_ROOT}/wc_a.txt
+    export WC_B=${MIMIXBOX_IT_ROOT}/wc_b.txt
+    printf '%s\0%s\0' "${WC_A}" "${WC_B}" | wc --files0-from=-
+}
+
+TestWcFiles0FromOnly() {
+    export WC_LIST=${MIMIXBOX_IT_ROOT}/wc_list.nul
+    wc --files0-from=${WC_LIST} --total=only
+}


### PR DESCRIPTION
## Summary

First wave of GNU-compatibility flag work. Each applet gains the documented GNU
options with unit tests and ShellSpec coverage; existing behavior is unchanged.

| applet | flags |
|---|---|
| cat | `--show-all`/`-A`, `--show-nonprinting`/`-v` (caret + M- rendering) |
| head / tail | `--zero-terminated`/`-z` (NUL records, embedded newlines preserved) |
| cut | `--complement`, `--zero-terminated`/`-z` |
| tee | `--output-error[=warn\|warn-nopipe\|exit\|exit-nopipe]` |
| tr | `--truncate-set1`/`-t` |
| comm | `--output-delimiter`, `--zero-terminated`/`-z`, `--check-order` |
| cmp | `--bytes`/`-n`, `--ignore-initial`/`-i`, `--print-bytes`/`-b` |
| nl | `--header-numbering`, `--footer-numbering`, `--join-blank-lines`, `pBRE` styles |
| wc | `--files0-from`, `--total=auto\|always\|only\|never` |

## Testing

`go build ./...`, full `go test ./...`, `golangci-lint`, and full `make test-e2e`
(1785 examples, 0 failures) all pass.

Closes #721
Closes #742
Closes #743
Closes #745
Closes #747
Closes #748
Closes #749
Closes #750
Closes #751
Closes #752