### PR TITLE
feat(gnu): add GNU-compatible flags to ls, cp, ln, and mv

### DIFF
--- a/internal/applets/fileutils/cp/cp.go
+++ b/internal/applets/fileutils/cp/cp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
@@ -43,6 +44,22 @@ const (
 	derefCmdline
 )
 
+// backupMode selects how --backup names the backup of an overwritten
+// destination, mirroring GNU cp's CONTROL values.
+type backupMode int
+
+const (
+	// backupNone makes no backup (CONTROL none/off, or --backup absent).
+	backupNone backupMode = iota
+	// backupSimple appends the simple suffix (CONTROL simple/never), e.g. file~.
+	backupSimple
+	// backupNumbered makes numbered backups (CONTROL numbered/t), e.g. file.~1~.
+	backupNumbered
+	// backupExisting makes numbered backups if any already exist, else simple
+	// (CONTROL existing/nil).
+	backupExisting
+)
+
 type options struct {
 	recursive   bool
 	force       bool
@@ -50,7 +67,19 @@ type options struct {
 	interactive bool
 	preserve    bool
 	noClobber   bool
+	update      bool
 	deref       derefMode
+
+	// noTargetDir is -T: never treat the destination as a directory.
+	noTargetDir bool
+	// parents is --parents: recreate each source's full path prefix under the
+	// destination directory.
+	parents bool
+
+	// backup selects the backup naming scheme for an overwritten destination.
+	backup backupMode
+	// suffix is the simple-backup suffix (default "~").
+	suffix string
 }
 
 // Run executes cp.
@@ -64,6 +93,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			{Command: "cp -r src/ dst/", Explain: "Copy a directory tree."},
 			{Command: "cp -a src/ dst/", Explain: "Copy recursively, preserving mode and timestamps (= -rp)."},
 			{Command: "cp -i a.txt dir/", Explain: "Prompt before overwriting dir/a.txt."},
+			{Command: "cp -t dir/ a.txt b.txt", Explain: "Copy each source into dir/ (destination-first)."},
+			{Command: "cp --parents src/a/b.txt dst/", Explain: "Recreate the prefix as dst/src/a/b.txt."},
+			{Command: "cp -u a.txt dir/", Explain: "Copy only if a.txt is newer than dir/a.txt."},
+			{Command: "cp --backup a.txt dir/", Explain: "Back up an existing dir/a.txt before overwriting."},
 		},
 		ExitStatus: "0  all files were copied successfully.\n1  one or more files could not be copied.",
 		Notes: []string{
@@ -90,10 +123,25 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	_ = fs.MarkHidden("dereference-cmdline")
 	noDerefPreserve := fs.BoolP("no-deref-preserve-links", "d", false, "same as --no-dereference")
 	_ = fs.MarkHidden("no-deref-preserve-links")
+	update := fs.BoolP("update", "u", false, "copy only when the SOURCE file is newer than the destination file or when the destination file is missing")
+	targetDir := fs.StringP("target-directory", "t", "", "copy all SOURCE arguments into DIRECTORY")
+	noTargetDir := fs.BoolP("no-target-directory", "T", false, "treat DEST as a normal file")
+	parents := fs.Bool("parents", false, "use full source file name under DIRECTORY")
+	// --backup takes an optional CONTROL word; with no value (bare --backup) the
+	// default is "existing". pflag's NoOptDefVal makes "--backup" alone valid.
+	backup := fs.String("backup", "", "make a backup of each existing destination file (CONTROL: none, numbered, existing, simple)")
+	fs.Lookup("backup").NoOptDefVal = "existing"
+	suffix := fs.StringP("suffix", "S", "", "override the usual backup suffix")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
+	}
+
+	backupMode, err := resolveBackup(*backup)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "cp: %s\n", err)
+		return command.SilentFailure()
 	}
 
 	opts := options{
@@ -103,10 +151,33 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		interactive: *interactive,
 		preserve:    *preserve || *archive,
 		noClobber:   *noClobber,
+		update:      *update,
 		deref:       resolveDeref(*deref, *noDeref || *noDerefPreserve, *followCmdline, *archive),
+		noTargetDir: *noTargetDir,
+		parents:     *parents,
+		backup:      backupMode,
+		suffix:      resolveSuffix(*suffix),
+	}
+
+	if *noTargetDir && *targetDir != "" {
+		_, _ = fmt.Fprintf(stdio.Err, "cp: cannot combine --target-directory (-t) and --no-target-directory (-T)\n")
+		return command.SilentFailure()
 	}
 
 	operands := fs.Args()
+
+	// -t DIR: every operand is a SOURCE copied into DIR. Rearrange the operands
+	// into the internal "SOURCE... DEST" shape by appending DIR as the final
+	// destination, then proceed through the normal path.
+	if *targetDir != "" {
+		if len(operands) == 0 {
+			_, _ = fmt.Fprintf(stdio.Err, "cp: missing file operand\n")
+			return command.SilentFailure()
+		}
+		operands = append(operands, *targetDir)
+		return cp(stdio, operands, opts)
+	}
+
 	if len(operands) == 0 {
 		_, _ = fmt.Fprintf(stdio.Err, "cp: missing file operand\n")
 		return command.SilentFailure()
@@ -125,9 +196,25 @@ func cp(stdio command.IO, operands []string, opts options) error {
 	dest := os.ExpandEnv(operands[len(operands)-1])
 	sources := operands[:len(operands)-1]
 
+	// -T (--no-target-directory): the destination is always a normal file, never
+	// a directory, so it accepts exactly one source and must not already be a
+	// directory (GNU refuses to overwrite a directory with a non-directory).
+	if opts.noTargetDir {
+		if len(sources) > 1 {
+			_, _ = fmt.Fprintf(stdio.Err, "cp: extra operand '%s'\n", sources[1])
+			return command.SilentFailure()
+		}
+		if di, err := os.Stat(dest); err == nil && di.IsDir() {
+			_, _ = fmt.Fprintf(stdio.Err, "cp: cannot overwrite directory '%s' with non-directory\n", dest)
+			return command.SilentFailure()
+		}
+	}
+
 	// With more than one source, GNU cp requires the destination to be an
 	// existing directory; otherwise each source would overwrite the last.
-	if len(sources) > 1 {
+	// --parents always copies into the destination directory, so it has the same
+	// requirement even with a single source.
+	if len(sources) > 1 || opts.parents {
 		if di, err := os.Stat(dest); err != nil || !di.IsDir() {
 			_, _ = fmt.Fprintf(stdio.Err, "cp: target '%s' is not a directory\n", dest)
 			return command.SilentFailure()
@@ -168,13 +255,28 @@ func cp(stdio command.IO, operands []string, opts options) error {
 			return command.SilentFailure()
 		}
 
+		// --parents: recreate src's full directory prefix under the destination
+		// directory, so "cp --parents a/b/c.txt dst" creates dst/a/b/c.txt. The
+		// effective destination becomes dst/<dir(src)>, created up front.
+		effectiveDest := dest
+		if opts.parents {
+			prefix := filepath.Dir(src)
+			if prefix != "." && prefix != string(os.PathSeparator) {
+				effectiveDest = filepath.Join(dest, prefix)
+				if err := os.MkdirAll(effectiveDest, 0o755); err != nil {
+					_, _ = fmt.Fprintf(stdio.Err, "cp: %s\n", err)
+					return command.SilentFailure()
+				}
+			}
+		}
+
 		if info.IsDir() {
-			if err := cpDir(stdio, src, dest, opts); err != nil {
+			if err := cpDir(stdio, src, effectiveDest, opts); err != nil {
 				_, _ = fmt.Fprintf(stdio.Err, "cp: %s\n", err)
 				return command.SilentFailure()
 			}
 		} else {
-			if err := cpFile(stdio, src, dest, info, opts); err != nil {
+			if err := cpFile(stdio, src, effectiveDest, info, opts); err != nil {
 				_, _ = fmt.Fprintf(stdio.Err, "cp: %s\n", err)
 				return command.SilentFailure()
 			}
@@ -187,8 +289,12 @@ func cp(stdio command.IO, operands []string, opts options) error {
 // directory, the file keeps its base name inside it.
 func cpFile(stdio command.IO, src, dest string, info os.FileInfo, opts options) error {
 	target := dest
-	if di, err := os.Stat(dest); err == nil && di.IsDir() {
-		target = filepath.Join(dest, filepath.Base(src))
+	// -T forces the destination to be a normal file; otherwise an existing
+	// directory means the file keeps its base name inside it.
+	if !opts.noTargetDir {
+		if di, err := os.Stat(dest); err == nil && di.IsDir() {
+			target = filepath.Join(dest, filepath.Base(src))
+		}
 	}
 
 	// The early src-vs-dest check cannot see this: when dest is a directory the
@@ -205,12 +311,24 @@ func cpFile(stdio command.IO, src, dest string, info os.FileInfo, opts options) 
 		}
 	}
 
+	// -u: copy only when src is newer than an existing destination.
+	if opts.update {
+		if di, err := os.Stat(target); err == nil && !info.ModTime().After(di.ModTime()) {
+			return nil // destination is at least as new; skip
+		}
+	}
+
 	if opts.interactive {
 		if _, err := os.Stat(target); err == nil {
 			if !question(stdio, fmt.Sprintf("cp: overwrite '%s'? ", target)) {
 				return nil // skip this file
 			}
 		}
+	}
+
+	// --backup: before overwriting an existing destination, move it aside.
+	if err := makeBackup(target, opts); err != nil {
+		return err
 	}
 
 	if err := copyFileContents(src, target, info, opts); err != nil {
@@ -376,6 +494,89 @@ func resolveDeref(deref, noDeref, followCmdline, archive bool) derefMode {
 		return derefNever // -a implies -d
 	default:
 		return derefDefault
+	}
+}
+
+// resolveBackup maps a --backup CONTROL word to a backupMode. An empty string
+// means --backup was not given (no backup). GNU also honors VERSION_CONTROL but
+// the explicit flag value takes precedence here.
+func resolveBackup(control string) (backupMode, error) {
+	switch control {
+	case "":
+		return backupNone, nil
+	case "none", "off":
+		return backupNone, nil
+	case "numbered", "t":
+		return backupNumbered, nil
+	case "existing", "nil":
+		return backupExisting, nil
+	case "simple", "never":
+		return backupSimple, nil
+	default:
+		return backupNone, fmt.Errorf("invalid argument '%s' for '--backup'", control)
+	}
+}
+
+// resolveSuffix returns the simple-backup suffix: the explicit --suffix value,
+// then $SIMPLE_BACKUP_SUFFIX, then the default "~".
+func resolveSuffix(suffix string) string {
+	if suffix != "" {
+		return suffix
+	}
+	if env := os.Getenv("SIMPLE_BACKUP_SUFFIX"); env != "" {
+		return env
+	}
+	return "~"
+}
+
+// makeBackup moves an existing target aside before it is overwritten, following
+// the selected backup scheme. It is a no-op when --backup was not requested or
+// the target does not exist.
+func makeBackup(target string, opts options) error {
+	if opts.backup == backupNone {
+		return nil
+	}
+	if _, err := os.Lstat(target); err != nil {
+		return nil // nothing to back up
+	}
+
+	mode := opts.backup
+	if mode == backupExisting {
+		// Numbered if any numbered backup already exists, else simple.
+		if numberedBackupsExist(target) {
+			mode = backupNumbered
+		} else {
+			mode = backupSimple
+		}
+	}
+
+	var backupPath string
+	switch mode {
+	case backupNumbered:
+		backupPath = nextNumberedBackup(target)
+	default: // backupSimple
+		backupPath = target + opts.suffix
+	}
+	return os.Rename(target, backupPath)
+}
+
+// numberedBackupsExist reports whether any file named "<target>.~N~" exists.
+func numberedBackupsExist(target string) bool {
+	for n := 1; ; n++ {
+		p := fmt.Sprintf("%s.~%d~", target, n)
+		if _, err := os.Lstat(p); err != nil {
+			return n > 1
+		}
+	}
+}
+
+// nextNumberedBackup returns the first unused "<target>.~N~" name.
+func nextNumberedBackup(target string) string {
+	for n := 1; ; n++ {
+		p := target + ".~" + strconv.Itoa(n) + "~"
+		if _, err := os.Lstat(p); err != nil {
+			return p
+		}
 	}
 }
 

--- a/internal/applets/fileutils/cp/cp_test.go
+++ b/internal/applets/fileutils/cp/cp_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/cp"
 	"github.com/nao1215/mimixbox/internal/command"
@@ -713,6 +714,423 @@ func TestRunNoDereferencePreservesLinkInTree(t *testing.T) {
 	}
 	if fi.Mode()&os.ModeSymlink == 0 {
 		t.Errorf("cp -d should preserve the symlink within the copied tree")
+	}
+}
+
+// --- #727: --target-directory (-t) and --no-target-directory (-T) ----------
+
+// TestRunTargetDirectory proves "cp -t DST a b" copies both sources into DST,
+// equivalent to "cp a b DST".
+func TestRunTargetDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	dst := filepath.Join(dir, "out")
+	if err := os.WriteFile(a, []byte("A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "-t", dst, a, b); err != nil {
+		t.Fatalf("cp -t error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "a.txt")); string(got) != "A\n" {
+		t.Errorf("a.txt = %q, want A", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "b.txt")); string(got) != "B\n" {
+		t.Errorf("b.txt = %q, want B", got)
+	}
+}
+
+// TestRunTargetDirectoryLong covers the --target-directory=DIR spelling.
+func TestRunTargetDirectoryLong(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	dst := filepath.Join(dir, "out")
+	if err := os.WriteFile(a, []byte("A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--target-directory="+dst, a); err != nil {
+		t.Fatalf("cp --target-directory error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "a.txt")); string(got) != "A\n" {
+		t.Errorf("a.txt = %q, want A", got)
+	}
+}
+
+// TestRunNoTargetDirectoryRejectsDir proves -T refuses to overwrite an existing
+// directory with a non-directory source.
+func TestRunNoTargetDirectoryRejectsDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b") // a directory named like a destination
+	if err := os.WriteFile(a, []byte("A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(b, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, err := run(t, "-T", a, b)
+	if err == nil {
+		t.Fatal("expected error: cp -T must not copy onto a directory")
+	}
+	if !strings.Contains(stderr, "cannot overwrite directory") {
+		t.Errorf("stderr = %q, want 'cannot overwrite directory'", stderr)
+	}
+}
+
+// TestRunNoTargetDirectoryCopiesOntoName proves -T copies a onto b as a plain
+// file (b is not a directory), rather than into b/a.txt.
+func TestRunNoTargetDirectoryCopiesOntoName(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b") // does not exist yet
+	if err := os.WriteFile(a, []byte("A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "-T", a, b); err != nil {
+		t.Fatalf("cp -T error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(b); string(got) != "A\n" {
+		t.Errorf("b = %q, want A (should be a plain file copy)", got)
+	}
+	fi, err := os.Stat(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.IsDir() {
+		t.Errorf("-T destination should be a file, got a directory")
+	}
+}
+
+// --- #728: --parents -------------------------------------------------------
+
+// TestRunParentsRecreatesPrefix proves --parents recreates the source's full
+// path prefix under the destination directory.
+func TestRunParentsRecreatesPrefix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Work with relative paths so the recreated prefix is predictable.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join("src", "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("src", "a", "b.txt"), []byte("deep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir("dst", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, stderr, err := run(t, "--parents", filepath.Join("src", "a", "b.txt"), "dst"); err != nil {
+		t.Fatalf("cp --parents error = %v (%s)", err, stderr)
+	}
+	got, err := os.ReadFile(filepath.Join("dst", "src", "a", "b.txt"))
+	if err != nil {
+		t.Fatalf("read dst/src/a/b.txt: %v", err)
+	}
+	if string(got) != "deep\n" {
+		t.Errorf("content = %q, want deep", got)
+	}
+}
+
+// TestRunParentsRequiresDir proves --parents needs an existing destination dir.
+func TestRunParentsRequiresDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(src, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, err := run(t, "--parents", src, filepath.Join(dir, "nodir"))
+	if err == nil {
+		t.Fatal("expected error: --parents requires a directory destination")
+	}
+	if !strings.Contains(stderr, "is not a directory") {
+		t.Errorf("stderr = %q, want 'is not a directory'", stderr)
+	}
+}
+
+// --- #729: --update (-u) ---------------------------------------------------
+
+// TestRunUpdateSkipsWhenDestNewer proves -u does not copy when the destination
+// is newer than the source.
+func TestRunUpdateSkipsWhenDestNewer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old-but-newer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Make the source older than the destination.
+	old := time.Now().Add(-1 * time.Hour)
+	newer := time.Now()
+	if err := os.Chtimes(src, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dst, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "-u", src, dst); err != nil {
+		t.Fatalf("cp -u error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "old-but-newer\n" {
+		t.Errorf("dst = %q, want unchanged (src is older)", got)
+	}
+}
+
+// TestRunUpdateCopiesWhenSrcNewer proves -u copies when the source is newer.
+func TestRunUpdateCopiesWhenSrcNewer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-1 * time.Hour)
+	newer := time.Now()
+	if err := os.Chtimes(dst, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(src, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "-u", src, dst); err != nil {
+		t.Fatalf("cp -u error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "new\n" {
+		t.Errorf("dst = %q, want new (src is newer)", got)
+	}
+}
+
+// TestRunUpdateCopiesWhenDestMissing proves -u copies when the dest is absent.
+func TestRunUpdateCopiesWhenDestMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("fresh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "-u", src, dst); err != nil {
+		t.Fatalf("cp -u error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "fresh\n" {
+		t.Errorf("dst = %q, want fresh", got)
+	}
+}
+
+// --- #729: --backup and --suffix -------------------------------------------
+
+// TestRunBackupSimple proves --backup=simple makes a "file~" backup before the
+// overwrite.
+func TestRunBackupSimple(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup=simple", src, dst); err != nil {
+		t.Fatalf("cp --backup=simple error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "new\n" {
+		t.Errorf("dst = %q, want new", got)
+	}
+	if got, _ := os.ReadFile(dst + "~"); string(got) != "old\n" {
+		t.Errorf("backup dst~ = %q, want old", got)
+	}
+}
+
+// TestRunBackupNumbered proves --backup=numbered makes "file.~1~" then ".~2~".
+func TestRunBackupNumbered(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup=numbered", src, dst); err != nil {
+		t.Fatalf("cp --backup=numbered error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst + ".~1~"); string(got) != "v1\n" {
+		t.Errorf("dst.~1~ = %q, want v1", got)
+	}
+	// A second overwrite must produce .~2~ and not clobber .~1~.
+	if err := os.WriteFile(src, []byte("v3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup=numbered", src, dst); err != nil {
+		t.Fatalf("second cp --backup=numbered error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst + ".~1~"); string(got) != "v1\n" {
+		t.Errorf("dst.~1~ = %q, want v1 (must not be clobbered)", got)
+	}
+	if got, _ := os.ReadFile(dst + ".~2~"); string(got) != "v2\n" {
+		t.Errorf("dst.~2~ = %q, want v2", got)
+	}
+}
+
+// TestRunBackupExistingUsesNumberedWhenPresent proves --backup=existing makes a
+// numbered backup when numbered backups already exist, else a simple one.
+func TestRunBackupExistingUsesNumberedWhenPresent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("cur\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A pre-existing numbered backup steers "existing" toward numbered.
+	if err := os.WriteFile(dst+".~1~", []byte("old1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup=existing", src, dst); err != nil {
+		t.Fatalf("cp --backup=existing error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst + ".~2~"); string(got) != "cur\n" {
+		t.Errorf("dst.~2~ = %q, want cur (numbered backup expected)", got)
+	}
+}
+
+// TestRunBackupExistingUsesSimpleWhenNoneExist proves --backup=existing falls
+// back to a simple backup when no numbered backups exist.
+func TestRunBackupExistingUsesSimpleWhenNoneExist(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("cur\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup=existing", src, dst); err != nil {
+		t.Fatalf("cp --backup=existing error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst + "~"); string(got) != "cur\n" {
+		t.Errorf("dst~ = %q, want cur (simple backup expected)", got)
+	}
+}
+
+// TestRunBackupBareDefaultsToExisting proves bare --backup behaves as existing.
+func TestRunBackupBareDefaultsToExisting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("cur\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup", src, dst); err != nil {
+		t.Fatalf("cp --backup error = %v (%s)", err, stderr)
+	}
+	// No numbered backups exist, so bare --backup (= existing) makes a simple one.
+	if got, _ := os.ReadFile(dst + "~"); string(got) != "cur\n" {
+		t.Errorf("dst~ = %q, want cur", got)
+	}
+}
+
+// TestRunBackupCustomSuffix proves --suffix overrides the simple-backup suffix.
+func TestRunBackupCustomSuffix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup=simple", "--suffix=.bak", src, dst); err != nil {
+		t.Fatalf("cp --suffix error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dst + ".bak"); string(got) != "old\n" {
+		t.Errorf("dst.bak = %q, want old", got)
+	}
+}
+
+// TestRunBackupNoneMakesNoBackup proves --backup=none overwrites without a copy.
+func TestRunBackupNoneMakesNoBackup(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, stderr, err := run(t, "--backup=none", src, dst); err != nil {
+		t.Fatalf("cp --backup=none error = %v (%s)", err, stderr)
+	}
+	if _, err := os.Stat(dst + "~"); !os.IsNotExist(err) {
+		t.Errorf("--backup=none must not create dst~, stat err = %v", err)
+	}
+}
+
+// TestRunBackupInvalidControl proves an unknown CONTROL word is rejected.
+func TestRunBackupInvalidControl(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, err := run(t, "--backup=bogus", src, dst)
+	if err == nil {
+		t.Fatal("expected error for invalid --backup CONTROL")
+	}
+	if !strings.Contains(stderr, "invalid argument") {
+		t.Errorf("stderr = %q, want 'invalid argument'", stderr)
 	}
 }
 

--- a/internal/applets/fileutils/ln/ln.go
+++ b/internal/applets/fileutils/ln/ln.go
@@ -25,9 +25,12 @@ func (c *Command) Name() string { return "ln" }
 func (c *Command) Synopsis() string { return "Create hard or symbolic link" }
 
 type options struct {
-	symbolic bool
-	force    bool
-	verbose  bool
+	symbolic    bool
+	force       bool
+	verbose     bool
+	relative    bool
+	targetDir   string
+	noTargetDir bool
 }
 
 // Run executes ln.
@@ -43,6 +46,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	symbolic := fs.BoolP("symbolic", "s", false, "make symbolic links instead of hard links")
 	force := fs.BoolP("force", "f", false, "remove existing destination files")
 	verbose := fs.BoolP("verbose", "v", false, "print name of each linked file")
+	relative := fs.BoolP("relative", "r", false, "with -s, create links relative to link location")
+	targetDir := fs.StringP("target-directory", "t", "", "specify the DIRECTORY in which to create the links")
+	noTargetDir := fs.BoolP("no-target-directory", "T", false, "treat LINK_NAME as a normal file always")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -55,7 +61,14 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.SilentFailure()
 	}
 
-	opts := options{symbolic: *symbolic, force: *force, verbose: *verbose}
+	opts := options{
+		symbolic:    *symbolic,
+		force:       *force,
+		verbose:     *verbose,
+		relative:    *relative,
+		targetDir:   *targetDir,
+		noTargetDir: *noTargetDir,
+	}
 	return c.run(stdio, operands, opts)
 }
 
@@ -65,6 +78,18 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 //	ln TARGET LINK_NAME   -> link TARGET as LINK_NAME
 //	ln TARGET... DIRECTORY-> link each TARGET into DIRECTORY
 func (c *Command) run(stdio command.IO, operands []string, opts options) error {
+	// -t DIR: every operand is a target, linked into DIR (destination-first).
+	if opts.targetDir != "" {
+		var firstErr error
+		for _, target := range operands {
+			linkName := filepath.Join(opts.targetDir, filepath.Base(target))
+			if err := c.link(stdio, target, linkName, opts); err != nil {
+				firstErr = keep(firstErr)
+			}
+		}
+		return firstErr
+	}
+
 	// Single operand: create a link in the current directory whose name is
 	// the base name of the target.
 	if len(operands) == 1 {
@@ -73,6 +98,16 @@ func (c *Command) run(stdio command.IO, operands []string, opts options) error {
 	}
 
 	last := operands[len(operands)-1]
+
+	// -T: treat the destination as a normal file, never a directory. Only the
+	// two-operand "ln TARGET LINK_NAME" form is valid in this mode.
+	if opts.noTargetDir {
+		if len(operands) != 2 {
+			_, _ = fmt.Fprintf(stdio.Err, "%s: extra operand '%s'\n", c.Name(), operands[2])
+			return command.SilentFailure()
+		}
+		return c.link(stdio, operands[0], last, opts)
+	}
 
 	// When the final operand is an existing directory, link every target
 	// into it (GNU's "ln TARGET... DIRECTORY" form).
@@ -108,10 +143,22 @@ func (c *Command) link(stdio command.IO, target, linkName string, opts options) 
 	}
 
 	if opts.symbolic {
-		if err := os.Symlink(target, linkName); err != nil {
+		symTarget := target
+		// -r: store the target relative to the link's own directory so the
+		// symlink keeps resolving when the pair is moved together.
+		if opts.relative {
+			rel, err := relativeTarget(target, linkName)
+			if err != nil {
+				_, _ = fmt.Fprintf(stdio.Err, "%s: failed to create symbolic link '%s': %s\n", c.Name(), linkName, reason(err))
+				return command.SilentFailure()
+			}
+			symTarget = rel
+		}
+		if err := os.Symlink(symTarget, linkName); err != nil {
 			_, _ = fmt.Fprintf(stdio.Err, "%s: failed to create symbolic link '%s': %s\n", c.Name(), linkName, reason(err))
 			return command.SilentFailure()
 		}
+		target = symTarget
 	} else {
 		if err := os.Link(target, linkName); err != nil {
 			_, _ = fmt.Fprintf(stdio.Err, "%s: failed to create hard link '%s': %s\n", c.Name(), linkName, reason(err))
@@ -127,6 +174,21 @@ func (c *Command) link(stdio command.IO, target, linkName string, opts options) 
 		}
 	}
 	return nil
+}
+
+// relativeTarget returns target expressed relative to the directory that holds
+// linkName, mirroring GNU "ln -r". Both operands are resolved to absolute paths
+// first so filepath.Rel computes the link from the link's own location.
+func relativeTarget(target, linkName string) (string, error) {
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	absLink, err := filepath.Abs(linkName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Rel(filepath.Dir(absLink), absTarget)
 }
 
 // removeExisting deletes path when it exists, ignoring a not-exist condition so

--- a/internal/applets/fileutils/ln/ln_test.go
+++ b/internal/applets/fileutils/ln/ln_test.go
@@ -248,6 +248,122 @@ func TestHardLinkMissingTargetReportsReason(t *testing.T) {
 	}
 }
 
+// TestRelativeSymlink checks that -s -r stores the target relative to the
+// link's own directory rather than as the literal (absolute) operand.
+func TestRelativeSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// target lives in dir/a/target.txt, link in dir/b/link.txt, so the relative
+	// target from the link's directory is "../a/target.txt".
+	aDir := filepath.Join(dir, "a")
+	bDir := filepath.Join(dir, "b")
+	if err := os.MkdirAll(aDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(bDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(aDir, "target.txt")
+	link := filepath.Join(bDir, "link.txt")
+	writeTarget(t, target, "rel\n")
+
+	_, errOut, err := run(t, "-s", "-r", target, link)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	got, lerr := os.Readlink(link)
+	if lerr != nil {
+		t.Fatalf("symlink not created: %v", lerr)
+	}
+	want := filepath.Join("..", "a", "target.txt")
+	if got != want {
+		t.Errorf("symlink target = %q, want relative %q", got, want)
+	}
+	// The relative symlink must still resolve to the original content.
+	content, rerr := os.ReadFile(link)
+	if rerr != nil {
+		t.Fatalf("relative symlink does not resolve: %v", rerr)
+	}
+	if string(content) != "rel\n" {
+		t.Errorf("resolved content = %q, want %q", content, "rel\n")
+	}
+}
+
+// TestTargetDirectory checks that -t DIR links each operand into DIR using the
+// operand's base name (destination-first form).
+func TestTargetDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	writeTarget(t, a, "A\n")
+	writeTarget(t, b, "B\n")
+	destDir := filepath.Join(dir, "dest")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := run(t, "-s", "-t", destDir, a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if _, lerr := os.Lstat(filepath.Join(destDir, name)); lerr != nil {
+			t.Errorf("link %s missing in target dir: %v", name, lerr)
+		}
+	}
+}
+
+// TestNoTargetDirectoryUsesFileDest checks that -T treats the destination as a
+// normal file even when a directory of the same name would otherwise be used.
+func TestNoTargetDirectoryUsesFileDest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	writeTarget(t, target, "T\n")
+	// A directory named "link" exists; without -T, ln would place the link
+	// inside it. With -T the link itself must be created (and fail because the
+	// directory already occupies the path).
+	linkDir := filepath.Join(dir, "link")
+	if err := os.Mkdir(linkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := run(t, "-s", "-T", target, linkDir)
+	if err == nil {
+		t.Fatal("expected error: -T must not descend into an existing directory")
+	}
+	// The directory must remain a directory (no link created inside it).
+	info, serr := os.Lstat(linkDir)
+	if serr != nil || !info.IsDir() {
+		t.Errorf("link path is no longer the original directory: info=%v err=%v", info, serr)
+	}
+	if _, lerr := os.Lstat(filepath.Join(linkDir, "target.txt")); lerr == nil {
+		t.Error("-T must not create a link inside the directory")
+	}
+}
+
+// TestNoTargetDirectoryRejectsExtraOperand checks -T rejects more than two
+// operands.
+func TestNoTargetDirectoryRejectsExtraOperand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	writeTarget(t, a, "A\n")
+	destDir := filepath.Join(dir, "dest")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, "-s", "-T", a, b, destDir)
+	if err == nil {
+		t.Fatal("expected error for extra operand with -T")
+	}
+	if !strings.Contains(errOut, "extra operand") {
+		t.Errorf("stderr = %q, want extra-operand message", errOut)
+	}
+}
+
 func TestSingleOperandLinksInCwd(t *testing.T) {
 	dir := t.TempDir()
 	// The target lives in a subdirectory so the link, created in cwd with the

--- a/internal/applets/fileutils/ls/ls.go
+++ b/internal/applets/fileutils/ls/ls.go
@@ -1,6 +1,8 @@
 // Package ls implements the ls applet: list directory contents. It covers the
 // everyday desktop subset - plain, -1, -a, -A, -d, -l, -F, -h, -R - with stable
-// name sorting and deterministic error reporting.
+// name sorting and deterministic error reporting, plus the GNU presentation
+// flags --color, --file-type/--indicator-style, --sort/--time/--group-
+// directories-first, --hide/--ignore, and --inode/--block-size/--kibibytes.
 package ls
 
 import (
@@ -9,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -17,6 +20,7 @@ import (
 	"time"
 
 	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/term"
 )
 
 // Command is the ls applet.
@@ -31,14 +35,65 @@ func (c *Command) Name() string { return "ls" }
 // Synopsis returns the one-line description shown in the applet list.
 func (c *Command) Synopsis() string { return "List directory contents" }
 
+// indicatorStyle selects which trailing suffix is appended to entry names.
+type indicatorStyle int
+
+const (
+	indicatorNone     indicatorStyle = iota // no suffix
+	indicatorSlash                          // directories only, "/"
+	indicatorFileType                       // like classify but no "*" for executables
+	indicatorClassify                       // full set: / * @ | =
+)
+
+// sortKey selects the comparison used to order entries.
+type sortKey int
+
+const (
+	sortName      sortKey = iota // default: lexicographic name
+	sortNone                     // -U / --sort=none: directory order
+	sortSize                     // --sort=size
+	sortTime                     // --sort=time
+	sortVersion                  // --sort=version
+	sortExtension                // --sort=extension
+)
+
+// timeField selects which timestamp --sort=time (and -l) considers.
+type timeField int
+
+const (
+	timeMtime timeField = iota
+	timeAtime
+	timeCtime
+)
+
+// GNU-style default ANSI colors (LS_COLORS-like minimal set).
+const (
+	colorDir     = "\x1b[01;34m" // bold blue
+	colorExec    = "\x1b[01;32m" // bold green
+	colorSymlink = "\x1b[01;36m" // bold cyan
+	colorReset   = "\x1b[0m"
+)
+
 type options struct {
 	all       bool // -a: include . and ..
 	almostAll bool // -A: include dotfiles but not . and ..
 	long      bool // -l
 	dirSelf   bool // -d
-	classify  bool // -F
 	human     bool // -h
 	recursive bool // -R
+	inode     bool // -i: print inode number
+
+	indicator indicatorStyle // -F / --file-type / --indicator-style
+	color     bool           // resolved color decision (after auto)
+
+	sortBy    sortKey
+	timeBy    timeField
+	groupDirs bool // --group-directories-first
+
+	hide   string // --hide=PATTERN
+	ignore string // --ignore=PATTERN
+
+	blockSize int64 // bytes per block for -l sizes (0 == raw bytes)
 }
 
 // Run executes ls.
@@ -48,6 +103,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "ls -la", Explain: "Long format, including dotfiles."},
 			{Command: "ls -R dir", Explain: "List dir and its subdirectories recursively."},
+			{Command: "ls --color=always --sort=size", Explain: "Colorized output, largest first."},
 		},
 		ExitStatus: "0  success.\n2  a FILE could not be accessed.",
 	})
@@ -58,14 +114,74 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	classify := fs.BoolP("classify", "F", false, "append an indicator (one of */=@|) to entries")
 	human := fs.BoolP("human-readable", "h", false, "with -l, print sizes like 1K 234M")
 	recursive := fs.BoolP("recursive", "R", false, "list subdirectories recursively")
+	inode := fs.BoolP("inode", "i", false, "print the index number of each file")
 	_ = fs.BoolP("one-per-line", "1", false, "list one file per line (the default for non-terminals)")
-	_ = fs.String("color", "never", "colorize the output; only 'never' is supported")
+
+	// #722 color.
+	color := fs.String("color", "never", "colorize the output; WHEN is 'always', 'auto', or 'never'")
+	fs.Lookup("color").NoOptDefVal = "always" // bare --color == --color=always
+
+	// #723 indicator styles.
+	fileType := fs.Bool("file-type", false, "append indicators (/=@|) but not '*' for executables")
+	indicatorStyleFlag := fs.String("indicator-style", "", "append indicator STYLE: none, slash, file-type, classify")
+
+	// #724 sorting.
+	sortFlag := fs.String("sort", "name", "sort by WORD: none, size, time, version, extension")
+	timeFlag := fs.String("time", "mtime", "with --sort=time, use atime, mtime, or ctime")
+	groupDirs := fs.Bool("group-directories-first", false, "list directories before files")
+	noneSort := fs.BoolP("none-sort", "U", false, "do not sort; list entries in directory order")
+
+	// #725 hide/ignore.
+	hide := fs.String("hide", "", "do not list entries matching shell PATTERN (overridden by -a/-A)")
+	ignore := fs.String("ignore", "", "do not list entries matching shell PATTERN")
+
+	// #726 inode / block size.
+	blockSize := fs.String("block-size", "", "with -l, scale sizes by SIZE (e.g. K, M, 1024)")
+	kibibytes := fs.BoolP("kibibytes", "k", false, "with -l, use 1024-byte blocks for sizes")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
 		return err
 	}
-	opts := options{all: *all, almostAll: *almost, long: *long, dirSelf: *dirSelf, classify: *classify, human: *human, recursive: *recursive}
+
+	opts := options{
+		all:       *all,
+		almostAll: *almost,
+		long:      *long,
+		dirSelf:   *dirSelf,
+		human:     *human,
+		recursive: *recursive,
+		inode:     *inode,
+		groupDirs: *groupDirs,
+		hide:      *hide,
+		ignore:    *ignore,
+	}
+
+	opts.indicator = resolveIndicator(*classify, *fileType, *indicatorStyleFlag)
+
+	cm, err := parseColorMode(*color)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "ls: %s\n", err)
+		return &command.ExitError{Code: 2}
+	}
+	opts.color = resolveColor(cm, stdio.Out)
+
+	opts.sortBy, err = parseSort(*sortFlag, *noneSort)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "ls: %s\n", err)
+		return &command.ExitError{Code: 2}
+	}
+	opts.timeBy, err = parseTime(*timeFlag)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "ls: %s\n", err)
+		return &command.ExitError{Code: 2}
+	}
+
+	opts.blockSize, err = resolveBlockSize(*blockSize, *kibibytes)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "ls: %s\n", err)
+		return &command.ExitError{Code: 2}
+	}
 
 	operands := fs.Args()
 	if len(operands) == 0 {
@@ -90,6 +206,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 
 	if len(files) > 0 {
+		c.sortNames(files, "", opts)
 		c.listNames(stdio.Out, "", files, opts)
 		if len(dirs) > 0 {
 			_, _ = fmt.Fprintln(stdio.Out)
@@ -115,6 +232,164 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	return nil
 }
 
+// resolveIndicator collapses -F, --file-type, and --indicator-style into one
+// indicator style. An explicit --indicator-style wins; otherwise --file-type
+// implies file-type and -F implies classify.
+func resolveIndicator(classify, fileType bool, style string) indicatorStyle {
+	switch strings.ToLower(strings.TrimSpace(style)) {
+	case "none":
+		return indicatorNone
+	case "slash":
+		return indicatorSlash
+	case "file-type":
+		return indicatorFileType
+	case "classify":
+		return indicatorClassify
+	}
+	if fileType {
+		return indicatorFileType
+	}
+	if classify {
+		return indicatorClassify
+	}
+	return indicatorNone
+}
+
+// parseColorMode validates the --color WHEN argument.
+func parseColorMode(when string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(when)) {
+	case "", "always", "yes", "force":
+		if when == "" {
+			return "never", nil
+		}
+		return "always", nil
+	case "auto", "tty", "if-tty":
+		return "auto", nil
+	case "never", "no", "none":
+		return "never", nil
+	default:
+		return "", fmt.Errorf("invalid argument '%s' for '--color'", when)
+	}
+}
+
+// resolveColor turns a color mode into a concrete on/off decision. "auto"
+// colors only when out is a terminal.
+func resolveColor(mode string, out io.Writer) bool {
+	switch mode {
+	case "always":
+		return true
+	case "auto":
+		if f, ok := out.(*os.File); ok {
+			return term.IsTerminal(int(f.Fd()))
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// parseSort maps --sort/-U to a sort key.
+func parseSort(word string, none bool) (sortKey, error) {
+	if none {
+		return sortNone, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(word)) {
+	case "", "name":
+		return sortName, nil
+	case "none":
+		return sortNone, nil
+	case "size":
+		return sortSize, nil
+	case "time":
+		return sortTime, nil
+	case "version":
+		return sortVersion, nil
+	case "extension":
+		return sortExtension, nil
+	default:
+		return sortName, fmt.Errorf("invalid argument '%s' for '--sort'", word)
+	}
+}
+
+// parseTime maps --time to a timestamp field.
+func parseTime(word string) (timeField, error) {
+	switch strings.ToLower(strings.TrimSpace(word)) {
+	case "", "mtime", "modification", "mod":
+		return timeMtime, nil
+	case "atime", "access", "use":
+		return timeAtime, nil
+	case "ctime", "status":
+		return timeCtime, nil
+	default:
+		return timeMtime, fmt.Errorf("invalid argument '%s' for '--time'", word)
+	}
+}
+
+// resolveBlockSize converts -k / --block-size into a byte count per block. A
+// zero result means "report raw bytes" (the default).
+func resolveBlockSize(spec string, kibibytes bool) (int64, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		if kibibytes {
+			return 1024, nil
+		}
+		return 0, nil
+	}
+	n, err := parseSize(spec)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --block-size argument '%s'", spec)
+	}
+	return n, nil
+}
+
+// parseSize parses a size like "1024", "K", "1M", "512" into a byte count.
+// A bare suffix (e.g. "K") means one unit (1024 bytes).
+func parseSize(spec string) (int64, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+	// Split leading digits from a trailing unit suffix.
+	i := 0
+	for i < len(spec) && spec[i] >= '0' && spec[i] <= '9' {
+		i++
+	}
+	numPart := spec[:i]
+	unitPart := strings.ToUpper(spec[i:])
+
+	var base int64
+	switch unitPart {
+	case "":
+		base = 1
+	case "K", "KIB":
+		base = 1024
+	case "M", "MIB":
+		base = 1024 * 1024
+	case "G", "GIB":
+		base = 1024 * 1024 * 1024
+	case "KB":
+		base = 1000
+	case "MB":
+		base = 1000 * 1000
+	case "GB":
+		base = 1000 * 1000 * 1000
+	default:
+		return 0, fmt.Errorf("unknown unit %q", unitPart)
+	}
+
+	if numPart == "" {
+		return base, nil
+	}
+	n, err := strconv.ParseInt(numPart, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("non-positive size")
+	}
+	return n * base, nil
+}
+
 // listDir lists one directory's entries, recursing when -R is set.
 func (c *Command) listDir(out, errw io.Writer, dir string, opts options) error {
 	entries, err := os.ReadDir(dir)
@@ -128,13 +403,17 @@ func (c *Command) listDir(out, errw io.Writer, dir string, opts options) error {
 		names = append(names, ".", "..")
 	}
 	for _, e := range entries {
-		if !opts.all && !opts.almostAll && strings.HasPrefix(e.Name(), ".") {
+		name := e.Name()
+		if !opts.all && !opts.almostAll && strings.HasPrefix(name, ".") {
 			continue
 		}
-		names = append(names, e.Name())
+		if filtered(name, opts) {
+			continue
+		}
+		names = append(names, name)
 	}
-	sort.Strings(names)
 
+	c.sortNames(names, dir, opts)
 	c.listNames(out, dir, names, opts)
 
 	if opts.recursive {
@@ -159,11 +438,81 @@ func (c *Command) listDir(out, errw io.Writer, dir string, opts options) error {
 	return nil
 }
 
+// filtered reports whether name should be omitted by --ignore/--hide. --ignore
+// always applies; --hide is suppressed when -a/-A is given (GNU precedence).
+func filtered(name string, opts options) bool {
+	if opts.ignore != "" {
+		if ok, _ := path.Match(opts.ignore, name); ok {
+			return true
+		}
+	}
+	if opts.hide != "" && !opts.all && !opts.almostAll {
+		if ok, _ := path.Match(opts.hide, name); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// sortNames orders names in place according to the active sort key. "." and
+// ".." always sort first to match GNU's name ordering; --group-directories-
+// first hoists directories ahead of files within the chosen order.
+func (c *Command) sortNames(names []string, dir string, opts options) {
+	if opts.sortBy == sortNone && !opts.groupDirs {
+		return
+	}
+
+	less := func(i, j int) bool {
+		a, b := names[i], names[j]
+		if opts.groupDirs {
+			ad, bd := isDir(dir, a), isDir(dir, b)
+			if ad != bd {
+				return ad
+			}
+		}
+		switch opts.sortBy {
+		case sortNone:
+			return false // keep directory order within the group
+		case sortSize:
+			sa, sb := sizeOf(dir, a), sizeOf(dir, b)
+			if sa != sb {
+				return sa > sb // larger first, like GNU
+			}
+			return a < b
+		case sortTime:
+			ta, tb := timeOf(dir, a, opts.timeBy), timeOf(dir, b, opts.timeBy)
+			if !ta.Equal(tb) {
+				return ta.After(tb) // newest first
+			}
+			return a < b
+		case sortVersion:
+			if cmp := versionCompare(a, b); cmp != 0 {
+				return cmp < 0
+			}
+			return a < b
+		case sortExtension:
+			ea, eb := filepath.Ext(a), filepath.Ext(b)
+			if ea != eb {
+				return ea < eb
+			}
+			return a < b
+		default:
+			return a < b
+		}
+	}
+
+	sort.SliceStable(names, less)
+}
+
 // listNames prints the given names (which live in dir) in the selected format.
 func (c *Command) listNames(out io.Writer, dir string, names []string, opts options) {
 	if !opts.long {
 		for _, n := range names {
-			_, _ = fmt.Fprintln(out, n+c.indicator(dir, n, opts))
+			prefix := ""
+			if opts.inode {
+				prefix = fmt.Sprintf("%d ", inodeOf(dir, n))
+			}
+			_, _ = fmt.Fprintln(out, prefix+c.decorate(dir, n, opts))
 		}
 		return
 	}
@@ -172,21 +521,61 @@ func (c *Command) listNames(out io.Writer, dir string, names []string, opts opti
 	}
 }
 
-// indicator returns the -F suffix for a name, or "" when -F is off.
+// decorate returns the display name with color (if enabled) and indicator (if
+// requested) applied.
+func (c *Command) decorate(dir, name string, opts options) string {
+	return c.colorize(dir, name, opts) + c.indicator(dir, name, opts)
+}
+
+// colorize wraps name in ANSI escapes based on its type, when color is on.
+func (c *Command) colorize(dir, name string, opts options) string {
+	if !opts.color {
+		return name
+	}
+	info, err := os.Lstat(pathOf(dir, name))
+	if err != nil {
+		return name
+	}
+	var col string
+	switch {
+	case info.IsDir():
+		col = colorDir
+	case info.Mode()&os.ModeSymlink != 0:
+		col = colorSymlink
+	case info.Mode()&0o111 != 0 && info.Mode().IsRegular():
+		col = colorExec
+	default:
+		return name
+	}
+	return col + name + colorReset
+}
+
+// indicator returns the type suffix for a name per the active indicator style.
 func (c *Command) indicator(dir, name string, opts options) string {
-	if !opts.classify {
+	if opts.indicator == indicatorNone {
 		return ""
 	}
 	info, err := os.Lstat(pathOf(dir, name))
 	if err != nil {
 		return ""
 	}
-	switch {
-	case info.IsDir():
+	if info.IsDir() {
 		return "/"
+	}
+	if opts.indicator == indicatorSlash {
+		return ""
+	}
+	switch {
 	case info.Mode()&os.ModeSymlink != 0:
 		return "@"
+	case info.Mode()&os.ModeNamedPipe != 0:
+		return "|"
+	case info.Mode()&os.ModeSocket != 0:
+		return "="
 	case info.Mode()&0o111 != 0 && info.Mode().IsRegular():
+		if opts.indicator == indicatorFileType {
+			return "" // file-type omits the executable marker
+		}
 		return "*"
 	default:
 		return ""
@@ -207,16 +596,123 @@ func (c *Command) longLine(dir, name string, opts options) string {
 		owner = lookupUser(st.Uid)
 		group = lookupGroup(st.Gid)
 	}
-	size := sizeString(info.Size(), opts.human)
-	when := timeString(info.ModTime())
-	display := name + c.indicator(dir, name, opts)
+	size := sizeString(info.Size(), opts.human, opts.blockSize)
+	when := timeString(timeFromInfo(info, opts.timeBy))
+	display := c.colorize(dir, name, opts) + c.indicator(dir, name, opts)
 	if info.Mode()&os.ModeSymlink != 0 {
 		if target, err := os.Readlink(pathOf(dir, name)); err == nil {
-			display = name + " -> " + target
+			display = c.colorize(dir, name, opts) + " -> " + target
 		}
 	}
-	return fmt.Sprintf("%s %d %s %s %s %s %s", mode, nlink, owner, group, size, when, display)
+	prefix := ""
+	if opts.inode {
+		prefix = fmt.Sprintf("%d ", inodeOf(dir, name))
+	}
+	return fmt.Sprintf("%s%s %d %s %s %s %s %s", prefix, mode, nlink, owner, group, size, when, display)
 }
+
+// inodeOf returns the inode number for a name, or 0 when it cannot be stated.
+func inodeOf(dir, name string) uint64 {
+	info, err := os.Lstat(pathOf(dir, name))
+	if err != nil {
+		return 0
+	}
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		return st.Ino
+	}
+	return 0
+}
+
+// isDir reports whether name (in dir) is a directory.
+func isDir(dir, name string) bool {
+	info, err := os.Lstat(pathOf(dir, name))
+	return err == nil && info.IsDir()
+}
+
+// sizeOf returns the byte size of a name, or 0 when it cannot be stated.
+func sizeOf(dir, name string) int64 {
+	info, err := os.Lstat(pathOf(dir, name))
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+// timeOf returns the selected timestamp for a name.
+func timeOf(dir, name string, field timeField) time.Time {
+	info, err := os.Lstat(pathOf(dir, name))
+	if err != nil {
+		return time.Time{}
+	}
+	return timeFromInfo(info, field)
+}
+
+// timeFromInfo extracts the requested timestamp from a FileInfo.
+func timeFromInfo(info os.FileInfo, field timeField) time.Time {
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		switch field {
+		case timeAtime:
+			return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+		case timeCtime:
+			return time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
+		}
+	}
+	return info.ModTime()
+}
+
+// versionCompare compares two strings "naturally", so file2 sorts before
+// file10. It returns -1, 0, or 1.
+func versionCompare(a, b string) int {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		ai, bi := a[i], b[j]
+		if isDigit(ai) && isDigit(bi) {
+			// Compare runs of digits numerically.
+			si, ei := i, i
+			for ei < len(a) && isDigit(a[ei]) {
+				ei++
+			}
+			sj, ej := j, j
+			for ej < len(b) && isDigit(b[ej]) {
+				ej++
+			}
+			na := strings.TrimLeft(a[si:ei], "0")
+			nb := strings.TrimLeft(b[sj:ej], "0")
+			if len(na) != len(nb) {
+				if len(na) < len(nb) {
+					return -1
+				}
+				return 1
+			}
+			if na != nb {
+				if na < nb {
+					return -1
+				}
+				return 1
+			}
+			i, j = ei, ej
+			continue
+		}
+		if ai != bi {
+			if ai < bi {
+				return -1
+			}
+			return 1
+		}
+		i++
+		j++
+	}
+	switch {
+	case i < len(a):
+		return 1
+	case j < len(b):
+		return -1
+	default:
+		return 0
+	}
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
 
 func pathOf(dir, name string) string {
 	if dir == "" || name == "." || name == ".." {
@@ -259,7 +755,16 @@ func modeString(info os.FileInfo) string {
 	return b.String()
 }
 
-func sizeString(size int64, human bool) string {
+// sizeString renders a size for ls -l. When blockSize > 0 the size is scaled to
+// that many bytes per block (rounding up), matching GNU --block-size/-k.
+func sizeString(size int64, human bool, blockSize int64) string {
+	if blockSize > 0 {
+		blocks := size / blockSize
+		if size%blockSize != 0 {
+			blocks++
+		}
+		return strconv.FormatInt(blocks, 10)
+	}
 	if !human {
 		return strconv.FormatInt(size, 10)
 	}

--- a/internal/applets/fileutils/ls/ls_gnu_test.go
+++ b/internal/applets/fileutils/ls/ls_gnu_test.go
@@ -1,0 +1,361 @@
+package ls
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gnuFixture builds a directory with a subdir, an executable, a symlink, files
+// of distinct sizes/mtimes, and pattern-matching names (*.log, tmp*).
+func gnuFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "small.txt"), 10, 0o644)
+	mustWrite(t, filepath.Join(dir, "big.txt"), 5000, 0o644)
+	mustWrite(t, filepath.Join(dir, "run.sh"), 20, 0o755)
+	mustWrite(t, filepath.Join(dir, "a.log"), 1, 0o644)
+	mustWrite(t, filepath.Join(dir, "tmpfile"), 1, 0o644)
+	if err := os.MkdirAll(filepath.Join(dir, "adir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("small.txt", filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+	// Distinct mtimes for time sorting.
+	old := time.Now().Add(-48 * time.Hour)
+	recent := time.Now().Add(-1 * time.Hour)
+	_ = os.Chtimes(filepath.Join(dir, "small.txt"), old, old)
+	_ = os.Chtimes(filepath.Join(dir, "big.txt"), recent, recent)
+	return dir
+}
+
+func mustWrite(t *testing.T, path string, n int, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", n)), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ---- #722 color ----------------------------------------------------------
+
+func TestParseColorMode(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"always": "always", "auto": "auto", "never": "never",
+		"yes": "always", "no": "never", "tty": "auto", "": "never",
+	}
+	for in, want := range cases {
+		got, err := parseColorMode(in)
+		if err != nil || got != want {
+			t.Errorf("parseColorMode(%q) = %q, %v; want %q", in, got, err, want)
+		}
+	}
+	if _, err := parseColorMode("bogus"); err == nil {
+		t.Error("parseColorMode(bogus) should error")
+	}
+}
+
+func TestColorAlways(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "--color=always", gnuFixture(t))
+	if !strings.Contains(out, colorDir+"adir"+colorReset) {
+		t.Errorf("dir should be colored bold blue: %q", out)
+	}
+	if !strings.Contains(out, colorExec+"run.sh"+colorReset) {
+		t.Errorf("exec should be colored bold green: %q", out)
+	}
+	if !strings.Contains(out, colorSymlink+"link"+colorReset) {
+		t.Errorf("symlink should be colored bold cyan: %q", out)
+	}
+}
+
+func TestColorNeverAndAuto(t *testing.T) {
+	t.Parallel()
+	for _, when := range []string{"never", "auto"} {
+		out, _ := run(t, "--color="+when, gnuFixture(t))
+		if strings.Contains(out, "\x1b[") {
+			t.Errorf("--color=%s should emit no escapes (non-tty): %q", when, out)
+		}
+	}
+}
+
+// ---- #723 indicators -----------------------------------------------------
+
+func TestResolveIndicator(t *testing.T) {
+	t.Parallel()
+	if got := resolveIndicator(true, false, ""); got != indicatorClassify {
+		t.Errorf("-F => classify, got %v", got)
+	}
+	if got := resolveIndicator(false, true, ""); got != indicatorFileType {
+		t.Errorf("--file-type => file-type, got %v", got)
+	}
+	if got := resolveIndicator(false, false, "slash"); got != indicatorSlash {
+		t.Errorf("--indicator-style=slash, got %v", got)
+	}
+	if got := resolveIndicator(true, false, "none"); got != indicatorNone {
+		t.Errorf("explicit none should win over -F, got %v", got)
+	}
+}
+
+func TestClassifyIndicators(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "-F", gnuFixture(t))
+	for _, want := range []string{"adir/", "run.sh*", "link@"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("-F missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestFileTypeIndicators(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "--file-type", gnuFixture(t))
+	if !strings.Contains(out, "adir/") {
+		t.Errorf("--file-type should mark dirs: %q", out)
+	}
+	if strings.Contains(out, "run.sh*") {
+		t.Errorf("--file-type must NOT add * for executables: %q", out)
+	}
+	if !strings.Contains(out, "link@") {
+		t.Errorf("--file-type should mark symlinks: %q", out)
+	}
+}
+
+func TestIndicatorStyleSlash(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "--indicator-style=slash", gnuFixture(t))
+	if !strings.Contains(out, "adir/") {
+		t.Errorf("slash should mark dirs: %q", out)
+	}
+	if strings.Contains(out, "run.sh*") || strings.Contains(out, "link@") {
+		t.Errorf("slash should only mark dirs: %q", out)
+	}
+}
+
+// ---- #724 sorting --------------------------------------------------------
+
+func TestParseSort(t *testing.T) {
+	t.Parallel()
+	cases := map[string]sortKey{
+		"name": sortName, "none": sortNone, "size": sortSize,
+		"time": sortTime, "version": sortVersion, "extension": sortExtension,
+	}
+	for in, want := range cases {
+		got, err := parseSort(in, false)
+		if err != nil || got != want {
+			t.Errorf("parseSort(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+	if got, _ := parseSort("name", true); got != sortNone {
+		t.Errorf("-U should force sortNone, got %v", got)
+	}
+	if _, err := parseSort("bogus", false); err == nil {
+		t.Error("parseSort(bogus) should error")
+	}
+}
+
+func TestSortSize(t *testing.T) {
+	t.Parallel()
+	dir := gnuFixture(t)
+	names := []string{"small.txt", "big.txt", "a.log"}
+	c := New()
+	c.sortNames(names, dir, options{sortBy: sortSize})
+	if names[0] != "big.txt" {
+		t.Errorf("size sort should put big.txt first: %v", names)
+	}
+}
+
+func TestSortTime(t *testing.T) {
+	t.Parallel()
+	dir := gnuFixture(t)
+	names := []string{"small.txt", "big.txt"}
+	c := New()
+	c.sortNames(names, dir, options{sortBy: sortTime, timeBy: timeMtime})
+	// big.txt is more recent, so it sorts first.
+	if names[0] != "big.txt" {
+		t.Errorf("time sort newest-first wrong: %v", names)
+	}
+}
+
+func TestSortVersion(t *testing.T) {
+	t.Parallel()
+	names := []string{"file10", "file2", "file1"}
+	c := New()
+	c.sortNames(names, "", options{sortBy: sortVersion})
+	want := []string{"file1", "file2", "file10"}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("version sort = %v, want %v", names, want)
+		}
+	}
+}
+
+func TestSortExtension(t *testing.T) {
+	t.Parallel()
+	names := []string{"b.txt", "a.log", "c.txt"}
+	c := New()
+	c.sortNames(names, "", options{sortBy: sortExtension})
+	if names[0] != "a.log" {
+		t.Errorf(".log should sort before .txt: %v", names)
+	}
+}
+
+func TestGroupDirectoriesFirst(t *testing.T) {
+	t.Parallel()
+	dir := gnuFixture(t)
+	out, _ := run(t, "--group-directories-first", dir)
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if lines[0] != "adir" {
+		t.Errorf("group-dirs-first should list adir first: %v", lines)
+	}
+}
+
+func TestVersionCompare(t *testing.T) {
+	t.Parallel()
+	if versionCompare("file2", "file10") >= 0 {
+		t.Error("file2 < file10")
+	}
+	if versionCompare("a", "a") != 0 {
+		t.Error("equal strings")
+	}
+	if versionCompare("b", "a") <= 0 {
+		t.Error("b > a")
+	}
+}
+
+// ---- #725 hide / ignore --------------------------------------------------
+
+func TestIgnoreAlwaysFilters(t *testing.T) {
+	t.Parallel()
+	out, _ := run(t, "--ignore=*.log", gnuFixture(t))
+	if strings.Contains(out, "a.log") {
+		t.Errorf("--ignore should drop a.log: %q", out)
+	}
+	out2, _ := run(t, "-a", "--ignore=*.log", gnuFixture(t))
+	if strings.Contains(out2, "a.log") {
+		t.Errorf("--ignore should drop even with -a: %q", out2)
+	}
+}
+
+func TestHideOverriddenByAll(t *testing.T) {
+	t.Parallel()
+	// Without -a/-A, hide applies.
+	out, _ := run(t, "--hide=tmp*", gnuFixture(t))
+	if strings.Contains(out, "tmpfile") {
+		t.Errorf("--hide should drop tmpfile: %q", out)
+	}
+	// With -a, hide is ignored.
+	out2, _ := run(t, "-a", "--hide=tmp*", gnuFixture(t))
+	if !strings.Contains(out2, "tmpfile") {
+		t.Errorf("--hide must be overridden by -a: %q", out2)
+	}
+}
+
+func TestFiltered(t *testing.T) {
+	t.Parallel()
+	if !filtered("a.log", options{ignore: "*.log"}) {
+		t.Error("ignore *.log should filter a.log")
+	}
+	if filtered("a.log", options{ignore: "*.txt"}) {
+		t.Error("ignore *.txt should not filter a.log")
+	}
+	if !filtered("tmpx", options{hide: "tmp*"}) {
+		t.Error("hide tmp* should filter tmpx")
+	}
+	if filtered("tmpx", options{hide: "tmp*", all: true}) {
+		t.Error("hide must be disabled when all is set")
+	}
+}
+
+// ---- #726 inode / block-size --------------------------------------------
+
+func TestInode(t *testing.T) {
+	t.Parallel()
+	dir := gnuFixture(t)
+	out, _ := run(t, "-i", "--ignore=*", dir, filepath.Join(dir, "small.txt"))
+	// -i prints inode before the name; ensure the line starts with a number.
+	got := inodeOf(dir, "small.txt")
+	if got == 0 {
+		t.Skip("inode not available on this platform")
+	}
+	if !strings.Contains(out, "small.txt") {
+		t.Fatalf("output missing small.txt: %q", out)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.Contains(line, "small.txt") {
+			if line[0] < '0' || line[0] > '9' {
+				t.Errorf("-i line should start with inode number: %q", line)
+			}
+		}
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	t.Parallel()
+	cases := map[string]int64{
+		"1024": 1024, "K": 1024, "1K": 1024, "2K": 2048,
+		"1M": 1024 * 1024, "1KB": 1000,
+	}
+	for in, want := range cases {
+		got, err := parseSize(in)
+		if err != nil || got != want {
+			t.Errorf("parseSize(%q) = %d, %v; want %d", in, got, err, want)
+		}
+	}
+	if _, err := parseSize("bogus"); err == nil {
+		t.Error("parseSize(bogus) should error")
+	}
+}
+
+func TestResolveBlockSize(t *testing.T) {
+	t.Parallel()
+	if got, _ := resolveBlockSize("", false); got != 0 {
+		t.Errorf("default block size = %d, want 0", got)
+	}
+	if got, _ := resolveBlockSize("", true); got != 1024 {
+		t.Errorf("-k block size = %d, want 1024", got)
+	}
+	if got, _ := resolveBlockSize("512", false); got != 512 {
+		t.Errorf("--block-size=512 = %d", got)
+	}
+	if _, err := resolveBlockSize("bad", false); err == nil {
+		t.Error("--block-size=bad should error")
+	}
+}
+
+func TestSizeStringBlockSize(t *testing.T) {
+	t.Parallel()
+	// 5000 bytes in 1024-byte blocks rounds up to 5.
+	if got := sizeString(5000, false, 1024); got != "5" {
+		t.Errorf("sizeString(5000,1024) = %q, want 5", got)
+	}
+	if got := sizeString(1024, false, 1024); got != "1" {
+		t.Errorf("sizeString(1024,1024) = %q, want 1", got)
+	}
+	if got := sizeString(0, false, 1024); got != "0" {
+		t.Errorf("sizeString(0,1024) = %q, want 0", got)
+	}
+}
+
+func TestBlockSizeInLong(t *testing.T) {
+	t.Parallel()
+	dir := gnuFixture(t)
+	out, _ := run(t, "-l", "-k", "--ignore=*", dir, filepath.Join(dir, "big.txt"))
+	// big.txt is 5000 bytes => 5 blocks of 1024.
+	line := firstMatching(out, "big.txt")
+	if !strings.Contains(line, " 5 ") {
+		t.Errorf("-l -k should show 5 blocks for big.txt: %q", line)
+	}
+}
+
+func firstMatching(out, sub string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/applets/fileutils/ls/ls_test.go
+++ b/internal/applets/fileutils/ls/ls_test.go
@@ -136,11 +136,11 @@ func TestSizeString(t *testing.T) {
 	t.Parallel()
 	cases := map[int64]string{0: "0", 512: "512", 1024: "1.0K", 1048576: "1.0M"}
 	for in, want := range cases {
-		if got := sizeString(in, true); got != want {
+		if got := sizeString(in, true, 0); got != want {
 			t.Errorf("sizeString(%d) = %q, want %q", in, got, want)
 		}
 	}
-	if got := sizeString(2048, false); got != "2048" {
+	if got := sizeString(2048, false, 0); got != "2048" {
 		t.Errorf("sizeString plain = %q", got)
 	}
 }

--- a/internal/applets/fileutils/mv/mv.go
+++ b/internal/applets/fileutils/mv/mv.go
@@ -52,6 +52,9 @@ type options struct {
 	interactive bool
 	noClobber   bool
 	verbose     bool
+	update      bool
+	targetDir   string
+	noTargetDir bool
 }
 
 // Run executes mv.
@@ -69,6 +72,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	interactive := fs.BoolP("interactive", "i", false, "prompt before overwrite")
 	noClobber := fs.BoolP("no-clobber", "n", false, "do not overwrite an existing file")
 	verbose := fs.BoolP("verbose", "v", false, "explain what is being done")
+	update := fs.BoolP("update", "u", false, "move only when the SOURCE is newer than the destination, or when the destination is missing")
+	targetDir := fs.StringP("target-directory", "t", "", "move all SOURCE arguments into DIRECTORY")
+	noTargetDir := fs.BoolP("no-target-directory", "T", false, "treat DEST as a normal file always")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -81,15 +87,51 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		interactive: *interactive,
 		noClobber:   *noClobber,
 		verbose:     *verbose,
+		update:      *update,
+		targetDir:   *targetDir,
+		noTargetDir: *noTargetDir,
 	}
 
 	operands := fs.Args()
+
+	// -t DIR: every operand is a source moved into DIR. The destination is the
+	// target directory rather than the last operand.
+	if opts.targetDir != "" {
+		if len(operands) == 0 {
+			_, _ = fmt.Fprintln(stdio.Err, "mv: missing file operand")
+			return command.SilentFailure()
+		}
+		srcPaths := make([]string, 0, len(operands))
+		for _, arg := range operands {
+			abs, err := filepath.Abs(os.ExpandEnv(arg))
+			if err != nil {
+				return command.Failure(err)
+			}
+			srcPaths = append(srcPaths, abs)
+		}
+		destPath, err := filepath.Abs(os.ExpandEnv(opts.targetDir))
+		if err != nil {
+			return command.Failure(err)
+		}
+		if err := validArgs(opts); err != nil {
+			return command.Failure(err)
+		}
+		return c.move(stdio, srcPaths, destPath, opts)
+	}
+
 	if len(operands) == 0 {
 		_, _ = fmt.Fprintln(stdio.Err, "mv: missing file operand")
 		return command.SilentFailure()
 	}
 	if len(operands) == 1 {
 		_, _ = fmt.Fprintf(stdio.Err, "mv: missing destination file operand after '%s'\n", operands[0])
+		return command.SilentFailure()
+	}
+
+	// -T: the destination is always a normal file; reject the multi-source
+	// "mv SOURCE... DIRECTORY" form.
+	if opts.noTargetDir && len(operands) > 2 {
+		_, _ = fmt.Fprintf(stdio.Err, "mv: extra operand '%s'\n", operands[2])
 		return command.SilentFailure()
 	}
 
@@ -138,6 +180,12 @@ func (c *Command) move(stdio command.IO, srcPaths []string, dest string, opts op
 		if isSameFilePath(src, dest) {
 			_, _ = fmt.Fprintln(stdio.Err, "mv: source '"+src+"' and destination '"+dest+"' is same")
 			failed = true
+			continue
+		}
+
+		// -u: skip the move when the destination exists and is at least as new
+		// as the source. A missing destination always moves.
+		if opts.update && !shouldUpdate(src, decideDestAbsPath(src, dest, opts)) {
 			continue
 		}
 
@@ -288,6 +336,14 @@ func question(stdio command.IO, ask string) bool {
 func decideDestAbsPath(src string, dest string, opts options) string {
 	destPath := os.ExpandEnv(dest)
 	srcPath := os.ExpandEnv(src)
+	// -T: never descend into an existing destination directory; the
+	// destination path is used verbatim (with optional backup).
+	if opts.noTargetDir {
+		if mb.Exists(destPath) && opts.backup {
+			destPath = decideBackupFileName(destPath)
+		}
+		return destPath
+	}
 	if mb.IsDir(srcPath) && mb.IsDir(destPath) {
 		destPath = filepath.Join(dest, filepath.Base(srcPath))
 		if filepath.Base(srcPath) == filepath.Base(destPath) && opts.backup {
@@ -317,6 +373,23 @@ func decideBackupFileName(path string) string {
 
 func isSameFilePath(src string, dest string) bool {
 	return src == dest
+}
+
+// shouldUpdate reports whether -u should move src to destPath. It returns true
+// when the destination is missing or when the source's modification time is
+// strictly newer than the destination's; an equal-or-older source is skipped.
+func shouldUpdate(src, destPath string) bool {
+	destInfo, err := os.Stat(destPath)
+	if err != nil {
+		// Missing (or unstattable) destination: always move.
+		return true
+	}
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		// Let the later move attempt surface the source error.
+		return true
+	}
+	return srcInfo.ModTime().After(destInfo.ModTime())
 }
 
 // getSrcAbsPaths returns the absolute paths of every operand except the last

--- a/internal/applets/fileutils/mv/mv_test.go
+++ b/internal/applets/fileutils/mv/mv_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/mimixbox/internal/applets/fileutils/mv"
 	"github.com/nao1215/mimixbox/internal/command"
@@ -37,6 +38,161 @@ func TestNameAndSynopsis(t *testing.T) {
 	want := "Rename SOURCE to DESTINATION, or move SOURCE(s) to DIRECTORY"
 	if c.Synopsis() != want {
 		t.Errorf("Synopsis() = %q, want %q", c.Synopsis(), want)
+	}
+}
+
+// TestTargetDirectory checks that -t DIR moves every source into DIR
+// (destination-first form), keeping each source's base name.
+func TestTargetDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	writeFile(t, a, "A")
+	writeFile(t, b, "B")
+	destDir := filepath.Join(dir, "dest")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errOut, err := run(t, "", "-t", destDir, a, b)
+	if err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	for name, want := range map[string]string{"a.txt": "A", "b.txt": "B"} {
+		got, rerr := os.ReadFile(filepath.Join(destDir, name)) //nolint:gosec // test path
+		if rerr != nil {
+			t.Errorf("%s not moved into target dir: %v", name, rerr)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("%s content = %q, want %q", name, got, want)
+		}
+	}
+	// Sources must be gone.
+	for _, p := range []string{a, b} {
+		if _, serr := os.Stat(p); !os.IsNotExist(serr) {
+			t.Errorf("source %s still exists after move", p)
+		}
+	}
+}
+
+// TestNoTargetDirectory checks that -T treats the destination as a normal file
+// even when a directory of the same name already exists: the move must fail
+// rather than descend into the directory.
+func TestNoTargetDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	writeFile(t, src, "S")
+	destDir := filepath.Join(dir, "dest")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := run(t, "", "-T", src, destDir)
+	if err == nil {
+		t.Fatal("expected error: -T must not descend into an existing directory")
+	}
+	// destDir must remain a directory and not contain the source basename.
+	if info, serr := os.Stat(destDir); serr != nil || !info.IsDir() {
+		t.Errorf("dest no longer a directory: info=%v err=%v", info, serr)
+	}
+	if _, serr := os.Stat(filepath.Join(destDir, "src.txt")); serr == nil {
+		t.Error("-T must not move the source inside the directory")
+	}
+}
+
+// TestNoTargetDirectoryRejectsExtraOperand checks -T rejects the multi-source
+// form.
+func TestNoTargetDirectoryRejectsExtraOperand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	writeFile(t, a, "A")
+	writeFile(t, b, "B")
+	destDir := filepath.Join(dir, "dest")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, errOut, err := run(t, "", "-T", a, b, destDir)
+	if err == nil {
+		t.Fatal("expected error for extra operand with -T")
+	}
+	if !strings.Contains(errOut, "extra operand") {
+		t.Errorf("stderr = %q, want extra-operand message", errOut)
+	}
+}
+
+// TestUpdateSkipsNewerDestination checks that -u does not overwrite a
+// destination that is newer than the source, but does move when the
+// destination is older or missing.
+func TestUpdateSkipsNewerDestination(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dest := filepath.Join(dir, "dest.txt")
+	writeFile(t, src, "source")
+	writeFile(t, dest, "newer-dest")
+
+	// Make the destination strictly newer than the source.
+	old := time.Now().Add(-1 * time.Hour)
+	now := time.Now()
+	if err := os.Chtimes(src, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dest, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	// -u must skip: destination is newer, and the source must remain.
+	if _, errOut, err := run(t, "", "-u", src, dest); err != nil {
+		t.Fatalf("Run -u (skip) error = %v (stderr=%q)", err, errOut)
+	}
+	got, _ := os.ReadFile(dest) //nolint:gosec // test path
+	if string(got) != "newer-dest" {
+		t.Errorf("dest content = %q, want it preserved as %q", got, "newer-dest")
+	}
+	if _, serr := os.Stat(src); serr != nil {
+		t.Errorf("source must remain when -u skips: %v", serr)
+	}
+
+	// Now make the source newer; -u must move and overwrite the destination.
+	newer := time.Now().Add(1 * time.Hour)
+	if err := os.Chtimes(src, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	if _, errOut, err := run(t, "", "-u", src, dest); err != nil {
+		t.Fatalf("Run -u (move) error = %v (stderr=%q)", err, errOut)
+	}
+	got, _ = os.ReadFile(dest) //nolint:gosec // test path
+	if string(got) != "source" {
+		t.Errorf("dest content = %q, want overwrite to %q", got, "source")
+	}
+	if _, serr := os.Stat(src); !os.IsNotExist(serr) {
+		t.Error("source must be gone after -u moves")
+	}
+}
+
+// TestUpdateMovesWhenDestMissing checks -u always moves when the destination
+// does not yet exist.
+func TestUpdateMovesWhenDestMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dest := filepath.Join(dir, "dest.txt")
+	writeFile(t, src, "data")
+
+	if _, errOut, err := run(t, "", "-u", src, dest); err != nil {
+		t.Fatalf("Run error = %v (stderr=%q)", err, errOut)
+	}
+	got, rerr := os.ReadFile(dest) //nolint:gosec // test path
+	if rerr != nil {
+		t.Fatalf("dest not created: %v", rerr)
+	}
+	if string(got) != "data" {
+		t.Errorf("dest content = %q, want %q", got, "data")
 	}
 }
 

--- a/test/it/fileutils/ln_gnu_test.sh
+++ b/test/it/fileutils/ln_gnu_test.sh
@@ -1,0 +1,27 @@
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/ln_gnu
+    mkdir -p ${TEST_DIR}/a
+    mkdir -p ${TEST_DIR}/b
+    mkdir -p ${TEST_DIR}/dst
+    printf 'content\n' > ${TEST_DIR}/a/target.txt
+    printf 'A\n' > ${TEST_DIR}/a.txt
+    printf 'B\n' > ${TEST_DIR}/b.txt
+}
+
+CleanUp() {
+    rm -rf ${MIMIXBOX_IT_ROOT}/ln_gnu
+}
+
+# ln -s --relative stores the target relative to the link's own directory.
+TestLnRelative() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/ln_gnu
+    ln -s --relative ${TEST_DIR}/a/target.txt ${TEST_DIR}/b/link.txt
+    readlink ${TEST_DIR}/b/link.txt
+}
+
+# ln --target-directory dst a b links each operand into dst (destination-first).
+TestLnTargetDirectory() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/ln_gnu
+    ln --target-directory ${TEST_DIR}/dst ${TEST_DIR}/a.txt ${TEST_DIR}/b.txt
+    ls ${TEST_DIR}/dst
+}

--- a/test/it/fileutils/ls_gnu_test.sh
+++ b/test/it/fileutils/ls_gnu_test.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=sh
+# Helper for spec/ls_gnu_spec.sh: GNU ls presentation flags (#722-#726).
+
+GnuSetup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/ls_gnu
+    rm -rf "${TEST_DIR}"
+    mkdir -p "${TEST_DIR}/adir"
+    # small.txt: 10 bytes, big.txt: 5000 bytes (distinct sizes).
+    printf 'xxxxxxxxxx' > "${TEST_DIR}/small.txt"
+    dd if=/dev/zero of="${TEST_DIR}/big.txt" bs=1 count=5000 2>/dev/null
+    : > "${TEST_DIR}/a.log"
+    : > "${TEST_DIR}/tmpfile"
+    printf '#!/bin/sh\n' > "${TEST_DIR}/run.sh"
+    chmod 0755 "${TEST_DIR}/run.sh"
+    ln -s small.txt "${TEST_DIR}/link"
+}
+
+GnuCleanUp() { rm -rf "${MIMIXBOX_IT_ROOT}/ls_gnu"; }
+
+TestColorAlways() { ls --color=always "${TEST_DIR}"; }
+TestColorNever() { ls --color=never "${TEST_DIR}"; }
+TestClassify() { ls -F "${TEST_DIR}"; }
+TestFileType() { ls --file-type "${TEST_DIR}"; }
+TestIndicatorSlash() { ls --indicator-style=slash "${TEST_DIR}"; }
+TestSortSize() { ls --sort=size "${TEST_DIR}"; }
+TestGroupDirs() { ls --group-directories-first "${TEST_DIR}"; }
+TestIgnoreLog() { ls --ignore='*.log' "${TEST_DIR}"; }
+TestHideTmp() { ls --hide='tmp*' "${TEST_DIR}"; }
+TestHideTmpWithAll() { ls -a --hide='tmp*' "${TEST_DIR}"; }
+TestInode() { ls -i "${TEST_DIR}/small.txt"; }
+TestBlockSize() { ls -l -k "${TEST_DIR}/big.txt"; }

--- a/test/it/fileutils/mv_gnu_test.sh
+++ b/test/it/fileutils/mv_gnu_test.sh
@@ -1,0 +1,29 @@
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/mv_gnu
+    mkdir -p ${TEST_DIR}/dst
+    printf 'A\n' > ${TEST_DIR}/a.txt
+    printf 'B\n' > ${TEST_DIR}/b.txt
+}
+
+CleanUp() {
+    rm -rf ${MIMIXBOX_IT_ROOT}/mv_gnu
+}
+
+# mv --target-directory dst a b moves each source into dst (destination-first).
+TestMvTargetDirectory() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/mv_gnu
+    mv --target-directory ${TEST_DIR}/dst ${TEST_DIR}/a.txt ${TEST_DIR}/b.txt
+    ls ${TEST_DIR}/dst
+}
+
+# mv --update keeps a destination that is newer than the source.
+TestMvUpdateKeepsNewer() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/mv_gnu
+    # Create the source first, then the destination, so the destination's
+    # modification time is strictly newer than the source's.
+    printf 'source\n' > ${TEST_DIR}/src.txt
+    sleep 1
+    printf 'newer-dest\n' > ${TEST_DIR}/dest.txt
+    mv --update ${TEST_DIR}/src.txt ${TEST_DIR}/dest.txt
+    cat ${TEST_DIR}/dest.txt
+}

--- a/test/it/spec/cp_gnu_spec.sh
+++ b/test/it/spec/cp_gnu_spec.sh
@@ -1,0 +1,97 @@
+# GNU cp flag parity (Issues #727, #728, #729): --target-directory/-t and
+# --no-target-directory/-T, --parents, and --update/--backup/--suffix.
+
+# Each example works in its own subdirectory under the per-run temp root so the
+# cases stay isolated from one another and from the older cp_spec.sh fixtures.
+Describe 'cp GNU flags'
+    setup() {
+        WORK="${MIMIXBOX_IT_ROOT}/cp_gnu"
+        rm -rf "${WORK}"
+        mkdir -p "${WORK}"
+    }
+    cleanup() {
+        rm -rf "${MIMIXBOX_IT_ROOT}/cp_gnu"
+    }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    # #727: "cp --target-directory dst a b" must equal "cp a b dst".
+    It 'copies into the target directory (-t equals destination-last form)'
+        TestTargetDirEquivalence() {
+            cd "${WORK}" || exit 1
+            printf 'A\n' > a.txt
+            printf 'B\n' > b.txt
+            mkdir dst_t dst_plain
+
+            cp --target-directory dst_t a.txt b.txt
+            cp a.txt b.txt dst_plain
+
+            # Both forms must yield identical destination directory contents.
+            diff <(ls dst_t) <(ls dst_plain) && cat dst_t/a.txt dst_t/b.txt
+        }
+        When call TestTargetDirEquivalence
+        The output should equal "$(printf 'A\nB')"
+        The status should be success
+    End
+
+    # #727: -T must refuse to overwrite an existing directory.
+    It 'rejects a directory destination with --no-target-directory (-T)'
+        TestNoTargetDir() {
+            cd "${WORK}" || exit 1
+            printf 'A\n' > a.txt
+            mkdir b
+            cp -T a.txt b
+        }
+        When call TestNoTargetDir
+        The error should include "cannot overwrite directory"
+        The status should be failure
+    End
+
+    # #728: --parents recreates the full source prefix under the destination.
+    It 'recreates the source path prefix with --parents'
+        TestParents() {
+            cd "${WORK}" || exit 1
+            mkdir -p src/a dst
+            printf 'deep\n' > src/a/b.txt
+            cp --parents src/a/b.txt dst/
+            cat dst/src/a/b.txt
+        }
+        When call TestParents
+        The output should equal "deep"
+        The status should be success
+    End
+
+    # #729: --backup moves the existing destination aside before overwriting.
+    It 'makes a backup before overwriting with --backup'
+        TestBackup() {
+            cd "${WORK}" || exit 1
+            printf 'new\n' > src.txt
+            printf 'old\n' > dst.txt
+            cp --backup=simple src.txt dst.txt
+            # New content lands in dst.txt; the prior content is preserved in dst.txt~.
+            cat dst.txt dst.txt~
+        }
+        When call TestBackup
+        The output should equal "$(printf 'new\nold')"
+        The status should be success
+    End
+
+    # #729: -u skips the copy when the destination is newer than the source.
+    It 'skips the copy when the destination is newer (-u)'
+        TestUpdate() {
+            cd "${WORK}" || exit 1
+            # Write src first, then (after a pause) dst, so dst is genuinely
+            # newer on disk; -u must therefore leave dst untouched. A short sleep
+            # guarantees a distinct mtime without relying on GNU touch -d/-t,
+            # which mimixbox's touch does not implement.
+            printf 'srcdata\n' > src.txt
+            sleep 1.1
+            printf 'dstdata\n' > dst.txt
+            cp -u src.txt dst.txt
+            cat dst.txt
+        }
+        When call TestUpdate
+        The output should equal "dstdata"
+        The status should be success
+    End
+End

--- a/test/it/spec/ln_gnu_spec.sh
+++ b/test/it/spec/ln_gnu_spec.sh
@@ -1,0 +1,28 @@
+Describe 'ln -s --relative creates a relative symbolic link'
+    Include fileutils/ln_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'stores the target relative to the link location'
+        When call TestLnRelative
+        The output should equal '../a/target.txt'
+        The status should be success
+    End
+End
+
+Describe 'ln --target-directory links operands into a directory'
+    Include fileutils/ln_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|a.txt
+        #|b.txt
+    }
+
+    It 'creates a link per operand in the target directory'
+        When call TestLnTargetDirectory
+        The output should equal "$(result)"
+        The status should be success
+    End
+End

--- a/test/it/spec/ls_gnu_spec.sh
+++ b/test/it/spec/ls_gnu_spec.sh
@@ -1,0 +1,80 @@
+Describe 'ls GNU presentation flags'
+    Include fileutils/ls_gnu_test.sh
+    BeforeEach 'GnuSetup'
+    AfterEach 'GnuCleanUp'
+
+    # --- #722 color -------------------------------------------------------
+    It 'colors directories with --color=always'
+        When call TestColorAlways
+        The output should include 'adir'
+        The output should include "$(printf '\033[01;34m')"
+        The status should be success
+    End
+    It 'emits no escapes with --color=never'
+        When call TestColorNever
+        The output should not include "$(printf '\033')"
+        The status should be success
+    End
+
+    # --- #723 indicators --------------------------------------------------
+    It 'appends / * @ with -F'
+        When call TestClassify
+        The output should include 'adir/'
+        The output should include 'run.sh*'
+        The output should include 'link@'
+        The status should be success
+    End
+    It 'omits * for executables with --file-type'
+        When call TestFileType
+        The output should include 'adir/'
+        The output should not include 'run.sh*'
+        The status should be success
+    End
+    It 'marks only dirs with --indicator-style=slash'
+        When call TestIndicatorSlash
+        The output should include 'adir/'
+        The output should not include 'link@'
+        The status should be success
+    End
+
+    # --- #724 sorting -----------------------------------------------------
+    It 'lists largest first with --sort=size'
+        When call TestSortSize
+        The line 1 of output should equal 'big.txt'
+        The status should be success
+    End
+    It 'lists directories first with --group-directories-first'
+        When call TestGroupDirs
+        The line 1 of output should equal 'adir'
+        The status should be success
+    End
+
+    # --- #725 hide / ignore ----------------------------------------------
+    It 'drops matches with --ignore'
+        When call TestIgnoreLog
+        The output should not include 'a.log'
+        The status should be success
+    End
+    It 'drops matches with --hide'
+        When call TestHideTmp
+        The output should not include 'tmpfile'
+        The status should be success
+    End
+    It 'keeps hidden matches when -a is given'
+        When call TestHideTmpWithAll
+        The output should include 'tmpfile'
+        The status should be success
+    End
+
+    # --- #726 inode / block-size -----------------------------------------
+    It 'prints an inode number with -i'
+        When call TestInode
+        The output should match pattern '[0-9]* *small.txt'
+        The status should be success
+    End
+    It 'scales sizes to 1024-byte blocks with -k'
+        When call TestBlockSize
+        The output should include ' 5 '
+        The status should be success
+    End
+End

--- a/test/it/spec/mv_gnu_spec.sh
+++ b/test/it/spec/mv_gnu_spec.sh
@@ -1,0 +1,28 @@
+Describe 'mv --target-directory moves operands into a directory'
+    Include fileutils/mv_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    result() { %text
+        #|a.txt
+        #|b.txt
+    }
+
+    It 'moves each source into the target directory'
+        When call TestMvTargetDirectory
+        The output should equal "$(result)"
+        The status should be success
+    End
+End
+
+Describe 'mv --update preserves a newer destination'
+    Include fileutils/mv_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'does not overwrite a destination newer than the source'
+        When call TestMvUpdateKeepsNewer
+        The output should equal 'newer-dest'
+        The status should be success
+    End
+End


### PR DESCRIPTION
## Summary

Second wave of GNU-compatibility flags, with unit tests and ShellSpec coverage; existing behavior unchanged.

- **ls**: `--color=always|auto|never`, `--file-type`/`--indicator-style`, `--sort`/`--time`/`--group-directories-first`, `--hide`/`--ignore`, `--inode`/`--block-size`/`--kibibytes`.
- **cp**: `--target-directory`/`-t`, `--no-target-directory`/`-T`, `--parents`, `--update`/`-u`, `--backup`, `--suffix`/`-S`.
- **ln**: `--relative`/`-r`, `--target-directory`/`-t`, `--no-target-directory`/`-T`.
- **mv**: `--target-directory`/`-t`, `--no-target-directory`/`-T`, `--update`/`-u`.

## Testing

`go build ./...`, full `go test ./...`, `golangci-lint`, and full `make test-e2e` (1783 examples, 0 failures) all pass.

Closes #722
Closes #723
Closes #724
Closes #725
Closes #726
Closes #727
Closes #728
Closes #729
Closes #730
Closes #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `cp` with `--update` (conditional copying), `--no-target-directory` (file destination), `--parents` (path recreation), and `--backup`/`--suffix` options.
  * Extended `ln` with relative symlinks (`-r`), `--target-directory` for batch operations, and `--no-target-directory` support.
  * Upgraded `ls` with ANSI color output, advanced sorting (by size/time/version/extension), time-field selection, hide/ignore filtering, inode display, and block-size scaling.
  * Added `mv` options: `--update` for conditional moves, `--target-directory`, and `--no-target-directory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->