### PR TITLE
feat(gnu): add GNU-compatible flags to grep, rm, touch, readlink, stat, split, find

### DIFF
--- a/internal/applets/fileutils/readlink/readlink.go
+++ b/internal/applets/fileutils/readlink/readlink.go
@@ -37,7 +37,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		ExitStatus: "0  every operand was resolved.\n1  an operand was not a symlink or could not be resolved.",
 	})
 	canon := fs.BoolP("canonicalize", "f", false, "canonicalize by following every symlink")
+	canonExisting := fs.BoolP("canonicalize-existing", "e", false, "canonicalize, but all components must exist")
+	canonMissing := fs.BoolP("canonicalize-missing", "m", false, "canonicalize without requiring existence")
 	quiet := fs.BoolP("no-newline", "n", false, "do not output the trailing newline")
+	zero := fs.BoolP("zero", "z", false, "end each output line with NUL, not newline")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -49,9 +52,15 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.Failuref("missing operand")
 	}
 
+	mode := canonMode{
+		canonicalize: *canon,
+		existing:     *canonExisting,
+		missing:      *canonMissing,
+	}
+
 	var firstErr error
 	for _, name := range files {
-		target, err := resolve(name, *canon)
+		target, err := resolve(name, mode)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = command.SilentFailure()
@@ -59,7 +68,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			continue
 		}
 		end := "\n"
-		if *quiet {
+		switch {
+		case *zero:
+			end = "\x00"
+		case *quiet:
 			end = ""
 		}
 		if _, werr := io.WriteString(stdio.Out, target+end); werr != nil {
@@ -69,20 +81,84 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	return firstErr
 }
 
-// resolve returns the link target for name. With canon set it returns the
-// fully canonicalized absolute path; otherwise it reads the link directly,
-// which fails when name is not a symlink (matching GNU readlink).
-func resolve(name string, canon bool) (string, error) {
-	if canon {
-		abs, err := filepath.Abs(name)
+// canonMode selects how resolve canonicalizes a path: -f follows the chain and
+// requires the directory portion to exist, -e requires every component
+// (including the last) to exist, and -m canonicalizes without requiring that
+// any component exists.
+type canonMode struct {
+	canonicalize bool // -f
+	existing     bool // -e
+	missing      bool // -m
+}
+
+func (m canonMode) any() bool { return m.canonicalize || m.existing || m.missing }
+
+// resolve returns the link target for name. With a canonicalize mode it returns
+// a canonicalized absolute path; otherwise it reads the link directly, which
+// fails when name is not a symlink (matching GNU readlink).
+//
+//   - -f: follow every symlink; the directory portion must exist.
+//   - -e: like -f, but the final component must also exist.
+//   - -m: canonicalize lexically; no component is required to exist.
+func resolve(name string, mode canonMode) (string, error) {
+	if !mode.any() {
+		target, err := os.Readlink(name)
 		if err != nil {
+			return "", fmt.Errorf("readlink: %w", err)
+		}
+		return target, nil
+	}
+
+	abs, err := filepath.Abs(name)
+	if err != nil {
+		return "", err
+	}
+
+	if mode.missing {
+		// -m never touches the filesystem; resolve as far as it exists and
+		// canonicalize the remainder lexically.
+		return canonicalizeMissing(abs)
+	}
+
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		if mode.existing {
+			// -e requires every component, including the last, to exist.
 			return "", err
 		}
-		return filepath.EvalSymlinks(abs)
+		// -f tolerates a missing final component: resolve the parent and
+		// re-append the base name.
+		dir := filepath.Dir(abs)
+		base := filepath.Base(abs)
+		rdir, derr := filepath.EvalSymlinks(dir)
+		if derr != nil {
+			return "", derr
+		}
+		return filepath.Join(rdir, base), nil
 	}
-	target, err := os.Readlink(name)
-	if err != nil {
-		return "", fmt.Errorf("readlink: %w", err)
+	return resolved, nil
+}
+
+// canonicalizeMissing resolves the longest existing prefix of abs with
+// EvalSymlinks and re-appends the remaining (non-existent) components
+// lexically, so the whole path is canonicalized without requiring it to exist.
+func canonicalizeMissing(abs string) (string, error) {
+	abs = filepath.Clean(abs)
+	rest := ""
+	cur := abs
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			if rest == "" {
+				return resolved, nil
+			}
+			return filepath.Join(resolved, rest), nil
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root without finding an existing prefix.
+			return abs, nil
+		}
+		rest = filepath.Join(filepath.Base(cur), rest)
+		cur = parent
 	}
-	return target, nil
 }

--- a/internal/applets/fileutils/readlink/readlink_gnu_test.go
+++ b/internal/applets/fileutils/readlink/readlink_gnu_test.go
@@ -1,0 +1,89 @@
+package readlink_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCanonicalizeExistingFailsOnMissing verifies -e fails when the final
+// component does not exist.
+func TestCanonicalizeExistingFailsOnMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope")
+	_, _, err := run(t, "-e", missing)
+	if err == nil {
+		t.Fatal("expected -e to fail on a missing path")
+	}
+}
+
+// TestCanonicalizeExistingSucceedsOnExisting verifies -e succeeds and prints
+// the resolved path when every component exists.
+func TestCanonicalizeExistingSucceedsOnExisting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "t")
+	link := filepath.Join(dir, "l")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "-e", link)
+	if err != nil {
+		t.Fatalf("-e on existing err = %v", err)
+	}
+	resolved, _ := filepath.EvalSymlinks(target)
+	if strings.TrimRight(out, "\n") != resolved {
+		t.Errorf("out = %q, want %q", out, resolved)
+	}
+}
+
+// TestCanonicalizeMissingSucceeds verifies -m canonicalizes a path whose final
+// components do not exist, without failing.
+func TestCanonicalizeMissingSucceeds(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "a", "b", "c")
+	out, _, err := run(t, "-m", missing)
+	if err != nil {
+		t.Fatalf("-m err = %v", err)
+	}
+	got := strings.TrimRight(out, "\n")
+	// The existing prefix (dir) is resolved; the missing tail is appended.
+	resolvedDir, _ := filepath.EvalSymlinks(dir)
+	want := filepath.Join(resolvedDir, "a", "b", "c")
+	if got != want {
+		t.Errorf("out = %q, want %q", got, want)
+	}
+}
+
+// TestZeroNulTerminator verifies -z terminates output with NUL, not newline.
+func TestZeroNulTerminator(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "t")
+	link := filepath.Join(dir, "l")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "-z", link)
+	if err != nil {
+		t.Fatalf("-z err = %v", err)
+	}
+	if !strings.HasSuffix(out, "\x00") {
+		t.Errorf("output %q should end with NUL", out)
+	}
+	if strings.HasSuffix(out, "\n") {
+		t.Errorf("output %q should not end with newline under -z", out)
+	}
+	if out != target+"\x00" {
+		t.Errorf("out = %q, want %q", out, target+"\x00")
+	}
+}

--- a/internal/applets/fileutils/rm/rm.go
+++ b/internal/applets/fileutils/rm/rm.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
@@ -25,11 +27,13 @@ func (c *Command) Name() string { return "rm" }
 func (c *Command) Synopsis() string { return "Remove file(s) or directory(s)" }
 
 type options struct {
-	recursive   bool
-	force       bool
-	verbose     bool
-	dir         bool
-	interactive bool
+	recursive     bool
+	force         bool
+	verbose       bool
+	dir           bool
+	interactive   bool
+	preserveRoot  bool // refuse to recurse on "/" (GNU default ON)
+	oneFileSystem bool // skip subdirectories on a different filesystem
 }
 
 // Run executes rm.
@@ -54,6 +58,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	verbose := fs.BoolP("verbose", "v", false, "explain what is being done")
 	dir := fs.BoolP("dir", "d", false, "remove empty directories")
 	interactive := fs.BoolP("interactive", "i", false, "prompt before every removal")
+	// --preserve-root is the GNU default: refuse to recursively operate on "/".
+	preserveRoot := fs.Bool("preserve-root", true, "do not remove '/' recursively (default)")
+	noPreserveRoot := fs.Bool("no-preserve-root", false, "do not treat '/' specially")
+	oneFileSystem := fs.Bool("one-file-system", false, "when removing a hierarchy recursively, skip any directory that is on a file system different from that of the corresponding command line argument")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -61,11 +69,13 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 
 	opts := options{
-		recursive:   *recursive || *recursiveUpper,
-		force:       *force,
-		verbose:     *verbose,
-		dir:         *dir,
-		interactive: *interactive,
+		recursive:     *recursive || *recursiveUpper,
+		force:         *force,
+		verbose:       *verbose,
+		dir:           *dir,
+		interactive:   *interactive,
+		preserveRoot:  *preserveRoot && !*noPreserveRoot,
+		oneFileSystem: *oneFileSystem,
 	}
 
 	paths := fs.Args()
@@ -112,12 +122,28 @@ func remove(stdio command.IO, in *bufio.Reader, path string, opts options) error
 				return fmt.Errorf("can't remove %s: It's directory", path)
 			}
 		}
+		// --preserve-root: refuse to recursively operate on "/".
+		if opts.recursive && opts.preserveRoot && isRootPath(path) {
+			_, _ = fmt.Fprintf(stdio.Err, "rm: it is dangerous to operate recursively on '/'\n")
+			_, _ = fmt.Fprintf(stdio.Err, "rm: use --no-preserve-root to override this failsafe\n")
+			return command.SilentFailure()
+		}
 		if !confirm(stdio, in, path, opts) {
 			return nil
 		}
 		if opts.recursive {
-			if err := os.RemoveAll(path); err != nil {
-				return err
+			if opts.oneFileSystem {
+				dev, derr := deviceOf(path)
+				if derr != nil {
+					return derr
+				}
+				if err := removeTree(path, dev); err != nil {
+					return err
+				}
+			} else {
+				if err := os.RemoveAll(path); err != nil {
+					return err
+				}
 			}
 		} else {
 			if err := os.Remove(path); err != nil {
@@ -160,4 +186,82 @@ func report(stdio command.IO, path string, opts options) {
 	if opts.verbose {
 		_, _ = fmt.Fprintf(stdio.Out, "removed '%s'\n", path)
 	}
+}
+
+// isRootPath reports whether path resolves to the filesystem root "/". It
+// cleans the operand (so ".", trailing slashes and "/../" are handled) and,
+// when possible, also resolves it to an absolute path so that operands such as
+// "/." or symlinks pointing at "/" are caught by --preserve-root.
+func isRootPath(path string) bool {
+	if filepath.Clean(path) == "/" {
+		return true
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(abs) == "/"
+}
+
+// deviceOf returns the filesystem device id (st_dev) for path. It is used by
+// --one-file-system to detect when recursion would cross a mount point.
+func deviceOf(path string) (uint64, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return 0, err
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("cannot determine device of %s", path)
+	}
+	return uint64(st.Dev), nil
+}
+
+// removeTree recursively removes path, but with --one-file-system it skips any
+// subdirectory that lives on a different filesystem than dev (the device of the
+// top-level argument). Skipped directories are left in place, which means the
+// parent directory cannot be removed either; that mirrors GNU rm's behaviour.
+func removeTree(path string, dev uint64) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !info.IsDir() {
+		return os.Remove(path)
+	}
+
+	// A directory on a different device than the top argument is skipped.
+	if d, derr := deviceOf(path); derr == nil && d != dev {
+		return nil
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	skipped := false
+	for _, entry := range entries {
+		child := filepath.Join(path, entry.Name())
+		if entry.IsDir() {
+			if d, derr := deviceOf(child); derr == nil && d != dev {
+				// Different filesystem: leave it (and thus its parent) in place.
+				skipped = true
+				continue
+			}
+		}
+		if err := removeTree(child, dev); err != nil {
+			return err
+		}
+	}
+
+	if skipped {
+		// Cannot remove the directory while a foreign mount remains beneath it.
+		return nil
+	}
+	return os.Remove(path)
 }

--- a/internal/applets/fileutils/rm/rm_gnu_test.go
+++ b/internal/applets/fileutils/rm/rm_gnu_test.go
@@ -1,0 +1,90 @@
+package rm_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPreserveRootRefusesSlash verifies that the default --preserve-root guard
+// refuses to recursively operate on "/". The guard returns before any removal,
+// so this is safe: nothing is deleted.
+func TestPreserveRootRefusesSlash(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, nil, "-r", "/")
+	if err == nil {
+		t.Fatal("expected a nonzero exit when removing '/' with --preserve-root")
+	}
+	if !strings.Contains(errOut, "it is dangerous to operate recursively on '/'") {
+		t.Errorf("stderr missing danger message:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "use --no-preserve-root to override this failsafe") {
+		t.Errorf("stderr missing override hint:\n%s", errOut)
+	}
+}
+
+// TestNoPreserveRootOverridesGuard verifies --no-preserve-root disables the
+// guard. We assert the danger message is NOT printed; we point rm at a private
+// temp directory (never the real "/") so nothing dangerous happens.
+func TestNoPreserveRootOverridesGuard(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "victim")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(sub, "f.txt"))
+
+	_, errOut, err := run(t, nil, "-r", "--no-preserve-root", sub)
+	if err != nil {
+		t.Fatalf("rm -r --no-preserve-root err = %v, stderr=%s", err, errOut)
+	}
+	if strings.Contains(errOut, "dangerous to operate recursively") {
+		t.Errorf("guard should be disabled, stderr=%s", errOut)
+	}
+	if exists(sub) {
+		t.Errorf("%s should have been removed", sub)
+	}
+}
+
+// TestPreserveRootOnlyGuardsRoot ensures the failsafe does not interfere with
+// removing an ordinary directory: a non-"/" operand is removed normally.
+func TestPreserveRootOnlyGuardsRoot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "d")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(sub, "a"))
+
+	if _, _, err := run(t, nil, "-r", sub); err != nil {
+		t.Fatalf("rm -r on ordinary dir err = %v", err)
+	}
+	if exists(sub) {
+		t.Errorf("%s should have been removed", sub)
+	}
+}
+
+// TestOneFileSystemRemovesSameDevice verifies that with --one-file-system a
+// tree that lives entirely on one filesystem is removed normally (the common,
+// non-boundary case; we cannot mount a second filesystem in a unit test).
+func TestOneFileSystemRemovesSameDevice(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	root := filepath.Join(dir, "tree")
+	nested := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(nested, "leaf.txt"))
+	writeFile(t, filepath.Join(root, "top.txt"))
+
+	if _, errOut, err := run(t, nil, "-r", "--one-file-system", root); err != nil {
+		t.Fatalf("rm -r --one-file-system err = %v, stderr=%s", err, errOut)
+	}
+	if exists(root) {
+		t.Errorf("%s should have been removed entirely on a single filesystem", root)
+	}
+}

--- a/internal/applets/fileutils/stat/stat.go
+++ b/internal/applets/fileutils/stat/stat.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/user"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -34,10 +36,14 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "stat file.txt", Explain: "Show the full status of file.txt."},
 			{Command: "stat -c %s file.txt", Explain: "Print only the size of file.txt in bytes."},
+			{Command: "stat --printf '%n %s\\n' file.txt", Explain: "Print name and size, interpreting backslash escapes with no trailing newline."},
+			{Command: "stat --terse file.txt", Explain: "Print the status as a single space-separated line of raw fields."},
 		},
 		ExitStatus: "0  success.\n1  an error occurred (e.g. a file could not be stat'd).",
 	})
-	format := fs.StringP("format", "c", "", "use the specified FORMAT instead of the default")
+	format := fs.StringP("format", "c", "", "use the specified FORMAT instead of the default; output a trailing newline")
+	printf := fs.String("printf", "", "like --format, but interpret backslash escapes and print no trailing newline")
+	terse := fs.Bool("terse", false, "print the information in terse form")
 	deref := fs.BoolP("dereference", "L", false, "follow links")
 
 	proceed, err := fs.Parse(stdio, args)
@@ -50,6 +56,11 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.Failuref("missing operand")
 	}
 
+	// --printf takes precedence and is reported by GNU when both are given;
+	// here --printf overrides --format. The format/printf strings differ only in
+	// whether backslash escapes are honored and whether a newline is appended.
+	usePrintf := fs.Changed("printf")
+
 	var firstErr error
 	for _, name := range files {
 		info, err := lstatOrStat(name, *deref)
@@ -61,9 +72,14 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			continue
 		}
 		var line string
-		if *format != "" {
-			line = applyFormat(*format, name, info) + "\n"
-		} else {
+		switch {
+		case usePrintf:
+			line = applyFormat(unescape(*printf), name, info)
+		case *terse:
+			line = terseLine(name, info) + "\n"
+		case *format != "":
+			line = applyFormat(unescape(*format), name, info) + "\n"
+		default:
 			line = defaultLayout(name, info)
 		}
 		if _, werr := stdio.Out.Write([]byte(line)); werr != nil {
@@ -89,10 +105,10 @@ func unwrap(err error) error {
 	return err
 }
 
-// applyFormat renders the GNU -c format string. It supports the common
-// specifiers; an unknown specifier is emitted verbatim.
+// applyFormat renders the GNU -c/--printf format string. It supports the common
+// specifiers; an unknown specifier is emitted verbatim. Backslash-escape
+// expansion is the caller's responsibility (via unescape).
 func applyFormat(format, name string, info os.FileInfo) string {
-	format = unescape(format)
 	sys, _ := info.Sys().(*syscall.Stat_t)
 
 	var b strings.Builder
@@ -127,9 +143,27 @@ func applyFormat(format, name string, info os.FileInfo) string {
 			if sys != nil {
 				fmt.Fprintf(&b, "%d", sys.Uid)
 			}
+		case 'U':
+			b.WriteString(userName(sys))
 		case 'g':
 			if sys != nil {
 				fmt.Fprintf(&b, "%d", sys.Gid)
+			}
+		case 'G':
+			b.WriteString(groupName(sys))
+		case 'X':
+			fmt.Fprintf(&b, "%d", atime(sys, info))
+		case 'Y':
+			fmt.Fprintf(&b, "%d", info.ModTime().Unix())
+		case 'Z':
+			fmt.Fprintf(&b, "%d", ctime(sys, info))
+		case 'b':
+			if sys != nil {
+				fmt.Fprintf(&b, "%d", sys.Blocks)
+			}
+		case 'B':
+			if sys != nil {
+				fmt.Fprintf(&b, "%d", sys.Blksize)
 			}
 		case '%':
 			b.WriteByte('%')
@@ -141,10 +175,85 @@ func applyFormat(format, name string, info os.FileInfo) string {
 	return b.String()
 }
 
-// unescape expands the backslash escapes GNU stat honours inside a format.
+// terseLine renders the single space-separated field line GNU stat prints for
+// --terse: name size blocks rawmode uid gid devnumber inode nlink major minor
+// atime mtime ctime blocksize.
+func terseLine(name string, info os.FileInfo) string {
+	sys, _ := info.Sys().(*syscall.Stat_t)
+	var (
+		blocks, uid, gid, dev, ino, nlink, major, minor uint64
+		rawmode                                         uint64
+		blksize                                         int64
+		at, mt, ct                                      int64
+	)
+	mt = info.ModTime().Unix()
+	rawmode = uint64(info.Mode())
+	if sys != nil {
+		blocks = uint64(sys.Blocks)
+		uid = uint64(sys.Uid)
+		gid = uint64(sys.Gid)
+		dev = uint64(sys.Dev)
+		ino = sys.Ino
+		nlink = uint64(sys.Nlink)
+		major = uint64(sys.Rdev >> 8 & 0xff)
+		minor = uint64(sys.Rdev & 0xff)
+		blksize = int64(sys.Blksize)
+		at = atime(sys, info)
+		ct = ctime(sys, info)
+	} else {
+		at, ct = mt, mt
+	}
+	return fmt.Sprintf("%s %d %d %x %d %d %d %d %d %d %d %d %d %d %d",
+		name, info.Size(), blocks, rawmode, uid, gid, dev, ino, nlink,
+		major, minor, at, mt, ct, blksize)
+}
+
+// unescape expands the backslash escapes GNU stat honors inside a format.
 func unescape(s string) string {
 	r := strings.NewReplacer(`\n`, "\n", `\t`, "\t", `\\`, "\\")
 	return r.Replace(s)
+}
+
+// userName resolves the owning user's name for %U, falling back to the numeric
+// uid when the lookup fails.
+func userName(sys *syscall.Stat_t) string {
+	if sys == nil {
+		return ""
+	}
+	if u, err := user.LookupId(strconv.FormatUint(uint64(sys.Uid), 10)); err == nil {
+		return u.Username
+	}
+	return strconv.FormatUint(uint64(sys.Uid), 10)
+}
+
+// groupName resolves the owning group's name for %G, falling back to the numeric
+// gid when the lookup fails.
+func groupName(sys *syscall.Stat_t) string {
+	if sys == nil {
+		return ""
+	}
+	if g, err := user.LookupGroupId(strconv.FormatUint(uint64(sys.Gid), 10)); err == nil {
+		return g.Name
+	}
+	return strconv.FormatUint(uint64(sys.Gid), 10)
+}
+
+// atime returns the access time in Unix epoch seconds, falling back to the
+// modification time when the raw stat is unavailable.
+func atime(sys *syscall.Stat_t, info os.FileInfo) int64 {
+	if sys == nil {
+		return info.ModTime().Unix()
+	}
+	return sys.Atim.Sec
+}
+
+// ctime returns the status-change time in Unix epoch seconds, falling back to
+// the modification time when the raw stat is unavailable.
+func ctime(sys *syscall.Stat_t, info os.FileInfo) int64 {
+	if sys == nil {
+		return info.ModTime().Unix()
+	}
+	return sys.Ctim.Sec
 }
 
 // defaultLayout renders the multi-line human-readable status block.

--- a/internal/applets/fileutils/stat/stat_test.go
+++ b/internal/applets/fileutils/stat/stat_test.go
@@ -95,11 +95,12 @@ func TestDefaultLayout(t *testing.T) {
 func TestUnknownSpecifierPassThrough(t *testing.T) {
 	t.Parallel()
 	p := tmpFile(t, "x")
-	out, _, err := run(t, "-c", "%Z", p)
+	// %q is not a directive stat implements, so it is emitted verbatim.
+	out, _, err := run(t, "-c", "%q", p)
 	if err != nil {
 		t.Fatalf("Run error = %v", err)
 	}
-	if out != "%Z\n" {
+	if out != "%q\n" {
 		t.Errorf("out = %q", out)
 	}
 }
@@ -197,6 +198,90 @@ func TestNameSynopsis(t *testing.T) {
 	}
 	if c.Synopsis() == "" {
 		t.Error("Synopsis() is empty")
+	}
+}
+
+func TestPrintfNoTrailingNewlineAndEscapes(t *testing.T) {
+	t.Parallel()
+	p := tmpFile(t, "hello")
+	// --printf interprets backslash escapes and adds no trailing newline.
+	out, _, err := run(t, "--printf", `%n=%s\n`, p)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != p+"=5\n" {
+		t.Errorf("out = %q, want %q", out, p+"=5\n")
+	}
+}
+
+func TestPrintfNoNewlineWhenNoEscape(t *testing.T) {
+	t.Parallel()
+	p := tmpFile(t, "ab")
+	// Without an explicit \n, --printf emits nothing extra.
+	out, _, err := run(t, "--printf", "%s", p)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "2" {
+		t.Errorf("out = %q, want %q", out, "2")
+	}
+}
+
+func TestPrintfDirectives(t *testing.T) {
+	t.Parallel()
+	p := tmpFile(t, "abc")
+	// %a octal perms, %i inode, %Y mtime epoch. All numeric/non-empty.
+	out, _, err := run(t, "--printf", "%a|%i|%Y|%b|%B", p)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	fields := strings.Split(out, "|")
+	if len(fields) != 5 {
+		t.Fatalf("got %d fields: %q", len(fields), out)
+	}
+	if fields[0] != "644" {
+		t.Errorf("%%a = %q, want 644", fields[0])
+	}
+	for i, f := range fields {
+		if f == "" {
+			t.Errorf("field %d empty in %q", i, out)
+		}
+	}
+}
+
+func TestFormatAddsTrailingNewline(t *testing.T) {
+	t.Parallel()
+	p := tmpFile(t, "xy")
+	// -c/--format honors backslash escapes too, plus a trailing newline.
+	out, _, err := run(t, "--format", `%s`, p)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if out != "2\n" {
+		t.Errorf("out = %q, want %q", out, "2\n")
+	}
+}
+
+func TestTerseLine(t *testing.T) {
+	t.Parallel()
+	p := tmpFile(t, "hello")
+	out, _, err := run(t, "--terse", p)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("terse output should end with newline: %q", out)
+	}
+	fields := strings.Fields(strings.TrimRight(out, "\n"))
+	// name size blocks rawmode uid gid dev inode nlink major minor atime mtime ctime blksize = 15 fields.
+	if len(fields) != 15 {
+		t.Fatalf("terse line has %d fields, want 15: %q", len(fields), out)
+	}
+	if fields[0] != p {
+		t.Errorf("terse name = %q, want %q", fields[0], p)
+	}
+	if fields[1] != "5" {
+		t.Errorf("terse size = %q, want 5", fields[1])
 	}
 }
 

--- a/internal/applets/fileutils/touch/touch.go
+++ b/internal/applets/fileutils/touch/touch.go
@@ -8,9 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/sys/unix"
 )
 
 // Command is the touch applet.
@@ -28,9 +32,16 @@ func (c *Command) Synopsis() string {
 }
 
 type options struct {
-	noCreate   bool // -c, --no-create
-	accessOnly bool // -a
-	modifyOnly bool // -m
+	noCreate      bool // -c, --no-create
+	accessOnly    bool // -a
+	modifyOnly    bool // -m
+	noDereference bool // -h, --no-dereference: affect the symlink itself
+
+	// When useTimes is set, atime/mtime hold an explicit timestamp pair derived
+	// from --reference or --date instead of "now".
+	useTimes bool
+	atime    time.Time
+	mtime    time.Time
 }
 
 // Run executes touch.
@@ -48,6 +59,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	noCreate := fs.BoolP("no-create", "c", false, "do not create any files")
 	accessOnly := fs.BoolP("access", "a", false, "change only the access time")
 	modifyOnly := fs.BoolP("modify", "m", false, "change only the modification time")
+	noDereference := fs.BoolP("no-dereference", "h", false, "affect each symbolic link instead of any referenced file")
+	reference := fs.StringP("reference", "r", "", "use this file's times instead of the current time")
+	date := fs.StringP("date", "d", "", "parse STRING and use it instead of the current time")
+	timeWord := fs.String("time", "", "change the specified time: WORD is access, atime, use, modify or mtime")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -60,10 +75,49 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.SilentFailure()
 	}
 
+	accessSel := *accessOnly
+	modifySel := *modifyOnly
+	// --time=WORD is an alternate way to spell -a / -m.
+	switch *timeWord {
+	case "":
+	case "access", "atime", "use":
+		accessSel = true
+	case "modify", "mtime":
+		modifySel = true
+	default:
+		_, _ = fmt.Fprintf(stdio.Err, "touch: invalid argument %q for '--time'\n", *timeWord)
+		return command.SilentFailure()
+	}
+
 	opts := options{
-		noCreate:   *noCreate,
-		accessOnly: *accessOnly,
-		modifyOnly: *modifyOnly,
+		noCreate:      *noCreate,
+		accessOnly:    accessSel,
+		modifyOnly:    modifySel,
+		noDereference: *noDereference,
+	}
+
+	// --reference and --date provide an explicit timestamp. When both are given
+	// GNU touch lets --date win for whichever component it sets; here --date,
+	// when present, overrides the reference time entirely (the common case).
+	if *reference != "" {
+		ref, err := referenceTimes(*reference)
+		if err != nil {
+			_, _ = fmt.Fprintln(stdio.Err, "touch: "+err.Error())
+			return command.SilentFailure()
+		}
+		opts.useTimes = true
+		opts.atime = ref.atime
+		opts.mtime = ref.mtime
+	}
+	if *date != "" {
+		t, err := parseDate(*date)
+		if err != nil {
+			_, _ = fmt.Fprintln(stdio.Err, "touch: "+err.Error())
+			return command.SilentFailure()
+		}
+		opts.useTimes = true
+		opts.atime = t
+		opts.mtime = t
 	}
 
 	var firstErr error
@@ -78,13 +132,15 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	return firstErr
 }
 
-// touch updates the access and modification times of file to the current time.
-// When the file does not exist it is created, unless -c/--no-create was given.
-// The -a and -m options restrict which of the two timestamps is changed.
+// touch updates the access and modification times of file. When the file does
+// not exist it is created, unless -c/--no-create was given. The -a and -m
+// options restrict which of the two timestamps is changed; --reference/--date
+// supply an explicit timestamp instead of "now"; -h/--no-dereference acts on a
+// symbolic link itself rather than its target.
 func touch(file string, opts options) error {
 	path := os.ExpandEnv(file)
 
-	info, statErr := os.Stat(path)
+	info, statErr := os.Lstat(path)
 	if errors.Is(statErr, os.ErrNotExist) {
 		if opts.noCreate {
 			return nil
@@ -93,24 +149,100 @@ func touch(file string, opts options) error {
 		if err != nil {
 			return err
 		}
-		return f.Close()
-	}
-	if statErr != nil {
+		if err := f.Close(); err != nil {
+			return err
+		}
+		info, statErr = os.Lstat(path)
+		if statErr != nil {
+			return statErr
+		}
+	} else if statErr != nil {
 		return statErr
 	}
 
-	now := time.Now().Local()
-	atime, mtime := now, now
-	// -a leaves the modification time untouched; -m leaves the access time
-	// untouched. Without either flag both default to now.
+	base := time.Now().Local()
+	if opts.useTimes {
+		// Both default to the explicit timestamp; -a / -m below narrow it.
+		base = opts.atime
+	}
+	atime, mtime := base, base
+	if opts.useTimes {
+		atime, mtime = opts.atime, opts.mtime
+	}
+
+	// The current access time is not available portably, so when only one of
+	// -a / -m is given we keep the other timestamp at the file's existing value.
 	if opts.accessOnly && !opts.modifyOnly {
 		mtime = info.ModTime()
 	}
 	if opts.modifyOnly && !opts.accessOnly {
-		// The current access time is not available portably; fall back to the
-		// existing modification time so -m leaves the file's other timestamp
-		// at a sensible value rather than advancing it to now.
 		atime = info.ModTime()
 	}
+
+	if opts.noDereference {
+		return lutimes(path, atime, mtime)
+	}
 	return os.Chtimes(path, atime, mtime)
+}
+
+// lutimes sets the access and modification times of path without following a
+// symbolic link, so a symlink's own timestamps are changed rather than its
+// target's.
+func lutimes(path string, atime, mtime time.Time) error {
+	tv := []unix.Timeval{
+		unix.NsecToTimeval(atime.UnixNano()),
+		unix.NsecToTimeval(mtime.UnixNano()),
+	}
+	return unix.Lutimes(path, tv)
+}
+
+// refTimes carries the access and modification times read from a --reference
+// file.
+type refTimes struct {
+	atime time.Time
+	mtime time.Time
+}
+
+// referenceTimes returns the access and modification times of the --reference
+// file. The link itself is not dereferenced is left to the caller; here we
+// follow GNU touch and read the referenced file's times.
+func referenceTimes(ref string) (refTimes, error) {
+	info, err := os.Stat(os.ExpandEnv(ref))
+	if err != nil {
+		return refTimes{}, fmt.Errorf("failed to get attributes of %q: %w", ref, err)
+	}
+	mtime := info.ModTime()
+	atime := mtime
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		atime = time.Unix(st.Atim.Sec, st.Atim.Nsec)
+	}
+	return refTimes{atime: atime, mtime: mtime}, nil
+}
+
+// parseDate parses a --date STRING. It accepts an @UNIX seconds form and a few
+// common absolute formats (RFC3339 and "2006-01-02 15:04:05" with or without a
+// time-of-day component).
+func parseDate(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "@") {
+		secs, err := strconv.ParseInt(strings.TrimPrefix(s, "@"), 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid date format %q", s)
+		}
+		return time.Unix(secs, 0), nil
+	}
+	formats := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04",
+		"2006-01-02",
+	}
+	for _, f := range formats {
+		if t, err := time.ParseInLocation(f, s, time.Local); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid date format %q", s)
 }

--- a/internal/applets/fileutils/touch/touch_gnu_test.go
+++ b/internal/applets/fileutils/touch/touch_gnu_test.go
@@ -1,0 +1,175 @@
+package touch
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func atimeOf(t *testing.T, path string) time.Time {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("syscall.Stat_t unavailable")
+	}
+	return time.Unix(st.Atim.Sec, st.Atim.Nsec)
+}
+
+// TestReferenceCopiesMtime verifies --reference copies the reference file's
+// modification time onto the target.
+func TestReferenceCopiesMtime(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ref := filepath.Join(dir, "ref")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(ref, []byte("r"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("d"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2001, 2, 3, 4, 5, 6, 0, time.Local)
+	if err := os.Chtimes(ref, want, want); err != nil {
+		t.Fatal(err)
+	}
+
+	rt, err := referenceTimes(ref)
+	if err != nil {
+		t.Fatalf("referenceTimes err = %v", err)
+	}
+	if err := touch(dst, options{useTimes: true, atime: rt.atime, mtime: rt.mtime}); err != nil {
+		t.Fatalf("touch --reference err = %v", err)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(want) {
+		t.Errorf("mtime = %v, want %v", info.ModTime(), want)
+	}
+}
+
+// TestDateSetsKnownTime verifies --date sets both timestamps to a parsed value.
+func TestDateSetsKnownTime(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "f")
+	if err := os.WriteFile(dst, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	when, err := parseDate("2020-06-15 12:34:56")
+	if err != nil {
+		t.Fatalf("parseDate err = %v", err)
+	}
+	if err := touch(dst, options{useTimes: true, atime: when, mtime: when}); err != nil {
+		t.Fatalf("touch --date err = %v", err)
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(when) {
+		t.Errorf("mtime = %v, want %v", info.ModTime(), when)
+	}
+}
+
+// TestParseDateUnix verifies the @UNIX form.
+func TestParseDateUnix(t *testing.T) {
+	t.Parallel()
+	got, err := parseDate("@1000000000")
+	if err != nil {
+		t.Fatalf("parseDate @ err = %v", err)
+	}
+	if !got.Equal(time.Unix(1000000000, 0)) {
+		t.Errorf("got %v, want %v", got, time.Unix(1000000000, 0))
+	}
+}
+
+// TestParseDateInvalid verifies a bad string is rejected.
+func TestParseDateInvalid(t *testing.T) {
+	t.Parallel()
+	if _, err := parseDate("not a date"); err == nil {
+		t.Fatal("expected an error for an unparseable date")
+	}
+}
+
+// TestTimeAtimeSetsAccessOnly verifies --time=atime (modelled here as
+// accessOnly) advances the access time while leaving the modification time at
+// its old value.
+func TestTimeAtimeSetsAccessOnly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "f")
+	if err := os.WriteFile(dst, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-5 * time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(dst, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	newer := time.Now().Add(2 * time.Hour).Truncate(time.Second)
+	if err := touch(dst, options{accessOnly: true, useTimes: true, atime: newer, mtime: newer}); err != nil {
+		t.Fatalf("touch --time=atime err = %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mtime must be preserved at old.
+	if d := info.ModTime().Sub(old); d < -time.Second || d > time.Second {
+		t.Errorf("mtime moved by %v, want unchanged", d)
+	}
+	// atime must have advanced to newer.
+	if d := atimeOf(t, dst).Sub(newer); d < -time.Second || d > time.Second {
+		t.Errorf("atime = %v, want ~%v", atimeOf(t, dst), newer)
+	}
+}
+
+// TestNoDereferenceTouchesLinkNotTarget verifies -h changes the symlink's own
+// timestamps and leaves the target's modification time untouched.
+func TestNoDereferenceTouchesLinkNotTarget(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte("t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-6 * time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(target, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	when := time.Now().Add(3 * time.Hour).Truncate(time.Second)
+	if err := touch(link, options{noDereference: true, useTimes: true, atime: when, mtime: when}); err != nil {
+		t.Fatalf("touch -h err = %v", err)
+	}
+
+	// Target's mtime must be unchanged (still old).
+	ti, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := ti.ModTime().Sub(old); d < -time.Second || d > time.Second {
+		t.Errorf("target mtime moved by %v, want unchanged with -h", d)
+	}
+	// The link's own mtime should be the new value.
+	li, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := li.ModTime().Sub(when); d < -time.Second || d > time.Second {
+		t.Errorf("link mtime = %v, want ~%v", li.ModTime(), when)
+	}
+}

--- a/internal/applets/findutils/find/find.go
+++ b/internal/applets/findutils/find/find.go
@@ -241,6 +241,9 @@ func printUsage(w interface{ Write([]byte) (int, error) }) {
 	_, _ = w.Write([]byte("Usage: find [PATH]... [EXPRESSION]\n\n" +
 		"Search each PATH (default: the current directory) recursively and act on the\n" +
 		"entries that match EXPRESSION. With no expression, every entry is printed.\n\n" +
+		"Options:\n" +
+		"  --help     display this help and exit\n" +
+		"  --version  output version information and exit\n\n" +
 		"Tests: -name, -iname, -path, -type [f|d|l|p|s], -empty\n" +
 		"Depth: -maxdepth N, -mindepth N\n" +
 		"Actions: -print (default), -print0\n\n" +

--- a/internal/applets/findutils/find/find_test.go
+++ b/internal/applets/findutils/find/find_test.go
@@ -261,6 +261,16 @@ func TestHelp(t *testing.T) {
 	if !strings.Contains(out, "Usage: find") {
 		t.Errorf("help = %q", out)
 	}
+	// GNU-style help must carry an Options: block listing --help and --version,
+	// while still documenting the supported subset tokens.
+	for _, want := range []string{
+		"Options:", "--help", "--version",
+		"-name", "-type", "-print0", "-maxdepth", "-mindepth",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help missing %q:\n%s", want, out)
+		}
+	}
 }
 
 // TestVersion verifies that --version prints the version line, not usage text

--- a/internal/applets/findutils/grep/grep.go
+++ b/internal/applets/findutils/grep/grep.go
@@ -8,12 +8,16 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
+	"golang.org/x/term"
 )
 
 // Command is the grep applet.
@@ -28,6 +32,12 @@ func (c *Command) Name() string { return "grep" }
 // Synopsis returns the one-line description shown in the applet list.
 func (c *Command) Synopsis() string { return "Print lines that match patterns" }
 
+// colorMatch is the GNU default highlight for matched text (bold red).
+const (
+	colorStart = "\x1b[01;31m"
+	colorReset = "\x1b[0m"
+)
+
 // options holds the parsed switches.
 type options struct {
 	ignoreCase bool
@@ -36,11 +46,28 @@ type options struct {
 	count      bool
 	recursive  bool
 	filesMatch bool
+	filesNoMat bool
 	fixed      bool
 	word       bool
 	quiet      bool
 	withName   bool
 	noName     bool
+	byteOffset bool
+
+	after  int // -A: trailing context lines
+	before int // -B: leading context lines
+
+	color bool // emit color escapes around matches
+
+	include    string // --include glob (only in recursive mode)
+	exclude    string // --exclude glob
+	excludeDir string // --exclude-dir glob
+}
+
+// isTerminal reports whether w is a terminal; tests can replace it.
+var isTerminal = func(w io.Writer) bool {
+	f, ok := w.(interface{ Fd() uintptr })
+	return ok && term.IsTerminal(int(f.Fd()))
 }
 
 // Run executes grep.
@@ -63,12 +90,25 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	recursive := fs.BoolP("recursive", "r", false, "search directories recursively")
 	fs.BoolP("recursive-R", "R", false, "search directories recursively")
 	filesMatch := fs.BoolP("files-with-matches", "l", false, "print only names of FILEs with matches")
+	filesNoMat := fs.BoolP("files-without-match", "L", false, "print only names of FILEs with no match")
 	fixed := fs.BoolP("fixed-strings", "F", false, "PATTERN is a set of newline-separated strings")
 	_ = fs.BoolP("extended-regexp", "E", false, "PATTERN is an extended regular expression (default)")
 	word := fs.BoolP("word-regexp", "w", false, "match only whole words")
 	quiet := fs.BoolP("quiet", "q", false, "suppress all normal output")
 	withName := fs.BoolP("with-filename", "H", false, "print the file name for each match")
 	noName := fs.BoolP("no-filename", "h", false, "suppress the file name prefix on output")
+	byteOffset := fs.BoolP("byte-offset", "b", false, "print the byte offset with output lines")
+
+	after := fs.IntP("after-context", "A", 0, "print NUM lines of trailing context")
+	before := fs.IntP("before-context", "B", 0, "print NUM lines of leading context")
+	contextN := fs.IntP("context", "C", 0, "print NUM lines of output context")
+
+	colorWhen := fs.String("color", "", "use markers to highlight matches; WHEN is always, never, or auto")
+	colourWhen := fs.String("colour", "", "alias for --color")
+
+	include := fs.String("include", "", "search only files that match GLOB (recursive)")
+	exclude := fs.String("exclude", "", "skip files that match GLOB")
+	excludeDir := fs.String("exclude-dir", "", "skip directories that match GLOB (recursive)")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -80,11 +120,34 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		recurse = true
 	}
 
+	// -C NUM sets both before and after unless they were given explicitly.
+	a, b := *after, *before
+	if *contextN > 0 {
+		if !fs.Changed("after-context") {
+			a = *contextN
+		}
+		if !fs.Changed("before-context") {
+			b = *contextN
+		}
+	}
+
+	when := *colorWhen
+	if fs.Changed("colour") {
+		when = *colourWhen
+	}
+	color, cerr := resolveColor(fs, when, stdio.Out)
+	if cerr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "grep: %v\n", cerr)
+		return &command.ExitError{Code: 2}
+	}
+
 	opts := options{
 		ignoreCase: *ignoreCase, invert: *invert, lineNum: *lineNum,
 		count: *count, recursive: recurse, filesMatch: *filesMatch,
-		fixed: *fixed, word: *word, quiet: *quiet,
-		withName: *withName, noName: *noName,
+		filesNoMat: *filesNoMat, fixed: *fixed, word: *word, quiet: *quiet,
+		withName: *withName, noName: *noName, byteOffset: *byteOffset,
+		after: a, before: b, color: color,
+		include: *include, exclude: *exclude, excludeDir: *excludeDir,
 	}
 
 	operands := fs.Args()
@@ -111,6 +174,25 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 
 	g := &grepper{opts: opts, re: re, stdio: stdio, multi: len(files) > 1 || opts.recursive}
 	return g.run(files)
+}
+
+// resolveColor maps the --color WHEN value to a boolean. An empty WHEN means the
+// flag was used with no value (GNU treats "--color" as "always"); when the flag
+// is absent entirely, color is off.
+func resolveColor(fs *command.FlagSet, when string, out io.Writer) (bool, error) {
+	if !fs.Changed("color") && !fs.Changed("colour") {
+		return false, nil
+	}
+	switch when {
+	case "", "always":
+		return true, nil
+	case "never":
+		return false, nil
+	case "auto":
+		return isTerminal(out), nil
+	default:
+		return false, fmt.Errorf("invalid argument %q for '--color'", when)
+	}
 }
 
 // compile builds a single regular expression that matches any of the patterns.
@@ -140,6 +222,10 @@ type grepper struct {
 	multi   bool
 	matched bool
 	failed  bool
+
+	// printedAny tracks whether any output line has been written so far, so
+	// that the "--" group separator is only emitted between groups.
+	printedAny bool
 }
 
 // run searches every file (recursing into directories when -r is set) and
@@ -162,20 +248,47 @@ func (g *grepper) run(files []string) error {
 	return nil
 }
 
-// walk recursively searches every regular file under root.
+// walk recursively searches every regular file under root, honoring the
+// --include, --exclude and --exclude-dir glob filters.
 func (g *grepper) walk(root string) {
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
-			_, _ = fmt.Fprintf(g.stdio.Err, "grep: %s\n", command.FileError(path, err))
+			_, _ = fmt.Fprintf(g.stdio.Err, "grep: %s\n", command.FileError(p, err))
 			g.failed = true
 			return nil
 		}
+		base := filepath.Base(p)
 		if d.IsDir() {
+			if g.opts.excludeDir != "" && p != root && globMatch(g.opts.excludeDir, base) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
-		g.searchFile(path)
+		if !g.includeFile(base) {
+			return nil
+		}
+		g.searchFile(p)
 		return nil
 	})
+}
+
+// includeFile reports whether a regular file with the given base name should be
+// searched given the --include / --exclude filters.
+func (g *grepper) includeFile(base string) bool {
+	if g.opts.include != "" && !globMatch(g.opts.include, base) {
+		return false
+	}
+	if g.opts.exclude != "" && globMatch(g.opts.exclude, base) {
+		return false
+	}
+	return true
+}
+
+// globMatch reports whether name matches the shell pattern. A malformed pattern
+// never matches.
+func globMatch(pattern, name string) bool {
+	ok, err := path.Match(pattern, name)
+	return err == nil && ok
 }
 
 // searchFile opens name (or stdin for "-") and scans it line by line.
@@ -195,26 +308,69 @@ func (g *grepper) searchFile(name string) {
 
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	contextNeeded := g.opts.after > 0 || g.opts.before > 0
+	if g.opts.count || g.opts.filesMatch || g.opts.filesNoMat || g.opts.quiet {
+		contextNeeded = false
+	}
+
 	var count int
 	lineNo := 0
+	offset := 0
+	// ring holds recent non-matching lines for -B context.
+	var ring []ctxLine
+	pending := 0     // remaining -A trailing-context lines to print
+	lastPrinted := 0 // line number of the most recently printed line (0 = none)
+
 	for scanner.Scan() {
 		lineNo++
 		line := scanner.Text()
-		if g.re.MatchString(line) == g.opts.invert {
+		byteOff := offset
+		offset += len(line) + 1 // +1 for the stripped newline
+
+		isMatch := g.re.MatchString(line) != g.opts.invert
+		if !isMatch {
+			if contextNeeded {
+				// Emit trailing context for a recent match.
+				if pending > 0 {
+					g.printContextLine(display, lineNo, byteOff, line, &lastPrinted)
+					pending--
+				} else if g.opts.before > 0 {
+					ring = appendRing(ring, ctxLine{no: lineNo, off: byteOff, text: line}, g.opts.before)
+				}
+			}
 			continue
 		}
+
 		g.matched = true
 		count++
 		if g.opts.quiet {
 			return
 		}
-		if g.opts.count || g.opts.filesMatch {
+		if g.opts.count || g.opts.filesMatch || g.opts.filesNoMat {
 			continue
 		}
-		g.printLine(display, lineNo, line)
+
+		if contextNeeded {
+			// Print buffered leading context, with a "--" group separator
+			// when this group is detached from the previous output.
+			g.emitGroupSeparator(ring, lineNo, lastPrinted)
+			for _, cl := range ring {
+				g.printContextLine(display, cl.no, cl.off, cl.text, &lastPrinted)
+			}
+			ring = ring[:0]
+			g.printMatchLine(display, lineNo, byteOff, line, &lastPrinted)
+			pending = g.opts.after
+			continue
+		}
+
+		g.printMatchLine(display, lineNo, byteOff, line, &lastPrinted)
 	}
 
 	if g.opts.filesMatch && count > 0 {
+		_, _ = fmt.Fprintln(g.stdio.Out, display)
+	}
+	if g.opts.filesNoMat && count == 0 {
 		_, _ = fmt.Fprintln(g.stdio.Out, display)
 	}
 	if g.opts.count {
@@ -226,19 +382,99 @@ func (g *grepper) searchFile(name string) {
 	}
 }
 
-// printLine writes one matching line with the optional file-name and
-// line-number prefixes.
-func (g *grepper) printLine(name string, lineNo int, line string) {
-	var b strings.Builder
+// ctxLine is a buffered context line awaiting possible printing.
+type ctxLine struct {
+	no   int
+	off  int
+	text string
+}
+
+// appendRing appends cl to ring, keeping at most max trailing entries.
+func appendRing(ring []ctxLine, cl ctxLine, max int) []ctxLine {
+	ring = append(ring, cl)
+	if len(ring) > max {
+		ring = ring[len(ring)-max:]
+	}
+	return ring
+}
+
+// emitGroupSeparator prints the GNU "--" separator before a new context group
+// when the group does not directly continue the previous output. matchLine is
+// the line number of the match that opens the group.
+func (g *grepper) emitGroupSeparator(ring []ctxLine, matchLine, lastPrinted int) {
+	if !g.printedAny {
+		return
+	}
+	first := matchLine
+	if len(ring) > 0 {
+		first = ring[0].no
+	}
+	if first > lastPrinted+1 {
+		_, _ = fmt.Fprintln(g.stdio.Out, "--")
+	}
+}
+
+// printMatchLine prints a matching line, applying color highlighting when
+// enabled.
+func (g *grepper) printMatchLine(name string, lineNo, byteOff int, line string, lastPrinted *int) {
+	g.writeLine(name, lineNo, byteOff, line, ':', true)
+	*lastPrinted = lineNo
+	g.printedAny = true
+}
+
+// printContextLine prints a non-matching context line using the '-' separator.
+func (g *grepper) printContextLine(name string, lineNo, byteOff int, line string, lastPrinted *int) {
+	g.writeLine(name, lineNo, byteOff, line, '-', false)
+	*lastPrinted = lineNo
+	g.printedAny = true
+}
+
+// writeLine assembles the prefix (file name, line number, byte offset) and the
+// line body, using sep as the field separator. When highlight is true and color
+// is enabled, the matched substrings are wrapped in ANSI escapes.
+func (g *grepper) writeLine(name string, lineNo, byteOff int, line string, sep byte, highlight bool) {
+	var bld strings.Builder
 	if g.showName() {
-		b.WriteString(name)
-		b.WriteByte(':')
+		bld.WriteString(name)
+		bld.WriteByte(sep)
 	}
 	if g.opts.lineNum {
-		fmt.Fprintf(&b, "%d:", lineNo)
+		bld.WriteString(strconv.Itoa(lineNo))
+		bld.WriteByte(sep)
 	}
-	b.WriteString(line)
-	_, _ = fmt.Fprintln(g.stdio.Out, b.String())
+	if g.opts.byteOffset {
+		bld.WriteString(strconv.Itoa(byteOff))
+		bld.WriteByte(sep)
+	}
+	if g.opts.color && highlight {
+		bld.WriteString(g.colorize(line))
+	} else {
+		bld.WriteString(line)
+	}
+	_, _ = fmt.Fprintln(g.stdio.Out, bld.String())
+}
+
+// colorize wraps every non-overlapping match in line with the GNU highlight
+// escapes. Non-matching text passes through unchanged.
+func (g *grepper) colorize(line string) string {
+	idx := g.re.FindAllStringIndex(line, -1)
+	if len(idx) == 0 {
+		return line
+	}
+	var bld strings.Builder
+	last := 0
+	for _, m := range idx {
+		if m[0] < last { // overlapping; skip
+			continue
+		}
+		bld.WriteString(line[last:m[0]])
+		bld.WriteString(colorStart)
+		bld.WriteString(line[m[0]:m[1]])
+		bld.WriteString(colorReset)
+		last = m[1]
+	}
+	bld.WriteString(line[last:])
+	return bld.String()
 }
 
 // showName reports whether output lines should be prefixed with the file name.

--- a/internal/applets/findutils/grep/grep_gnu_test.go
+++ b/internal/applets/findutils/grep/grep_gnu_test.go
@@ -1,0 +1,258 @@
+package grep_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAfterContext covers -A NUM: trailing context lines printed with the '-'
+// separator.
+func TestAfterContext(t *testing.T) {
+	t.Parallel()
+	in := "1\n2\nMATCH\n4\n5\n6\n"
+	out, _, err := run(t, in, "-A2", "MATCH")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "MATCH\n4\n5\n"
+	if out != want {
+		t.Errorf("-A2 out = %q, want %q", out, want)
+	}
+}
+
+// TestBeforeContext covers -B NUM: leading context lines printed before the
+// match.
+func TestBeforeContext(t *testing.T) {
+	t.Parallel()
+	in := "1\n2\n3\nMATCH\n5\n"
+	out, _, err := run(t, in, "-B2", "MATCH")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "2\n3\nMATCH\n"
+	if out != want {
+		t.Errorf("-B2 out = %q, want %q", out, want)
+	}
+}
+
+// TestContext covers -C NUM: surrounding context on both sides.
+func TestContext(t *testing.T) {
+	t.Parallel()
+	in := "1\n2\n3\nMATCH\n5\n6\n7\n"
+	out, _, err := run(t, in, "-C1", "MATCH")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "3\nMATCH\n5\n"
+	if out != want {
+		t.Errorf("-C1 out = %q, want %q", out, want)
+	}
+}
+
+// TestContextWithLineNumbers verifies that context lines use '-' and match lines
+// use ':' as the separator under -n.
+func TestContextWithLineNumbers(t *testing.T) {
+	t.Parallel()
+	in := "a\nMATCH\nb\n"
+	out, _, err := run(t, in, "-n", "-C1", "MATCH")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "1-a\n2:MATCH\n3-b\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestContextGroupSeparator verifies that two non-contiguous match groups are
+// separated by a "--" line.
+func TestContextGroupSeparator(t *testing.T) {
+	t.Parallel()
+	in := "MATCH\nb\nc\nd\ne\nf\nMATCH\n"
+	out, _, err := run(t, in, "-A1", "MATCH")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "MATCH\nb\n--\nMATCH\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestContextOverlapNoSeparator verifies overlapping/contiguous groups merge
+// without a "--" separator.
+func TestContextOverlapNoSeparator(t *testing.T) {
+	t.Parallel()
+	in := "MATCH\nb\nMATCH\nd\n"
+	out, _, err := run(t, in, "-A1", "MATCH")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	// Trailing context of the first match (b) is followed immediately by the
+	// second match, so no separator appears.
+	want := "MATCH\nb\nMATCH\nd\n"
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+}
+
+// TestIncludeExclude covers --include and --exclude on a recursive search.
+func TestIncludeExclude(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	goFile := filepath.Join(dir, "main.go")
+	txtFile := filepath.Join(dir, "notes.txt")
+	logFile := filepath.Join(dir, "app.log")
+	for _, f := range []string{goFile, txtFile, logFile} {
+		if err := os.WriteFile(f, []byte("needle\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// --include only *.go
+	out, _, err := run(t, "", "-r", "--include=*.go", "needle", dir)
+	if err != nil {
+		t.Fatalf("--include err = %v", err)
+	}
+	if !strings.Contains(out, goFile) || strings.Contains(out, txtFile) || strings.Contains(out, logFile) {
+		t.Errorf("--include out = %q, want only %q", out, goFile)
+	}
+
+	// --exclude *.log
+	out, _, err = run(t, "", "-r", "--exclude=*.log", "needle", dir)
+	if err != nil {
+		t.Fatalf("--exclude err = %v", err)
+	}
+	if strings.Contains(out, logFile) {
+		t.Errorf("--exclude out = %q, should not contain %q", out, logFile)
+	}
+	if !strings.Contains(out, goFile) || !strings.Contains(out, txtFile) {
+		t.Errorf("--exclude out = %q, want go and txt files", out)
+	}
+}
+
+// TestExcludeDir covers --exclude-dir on a recursive search.
+func TestExcludeDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	keep := filepath.Join(dir, "src")
+	skip := filepath.Join(dir, "vendor")
+	if err := os.MkdirAll(keep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(skip, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	keepFile := filepath.Join(keep, "a.txt")
+	skipFile := filepath.Join(skip, "b.txt")
+	if err := os.WriteFile(keepFile, []byte("needle\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skipFile, []byte("needle\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := run(t, "", "-r", "--exclude-dir=vendor", "needle", dir)
+	if err != nil {
+		t.Fatalf("--exclude-dir err = %v", err)
+	}
+	if !strings.Contains(out, keepFile) {
+		t.Errorf("out = %q, want %q", out, keepFile)
+	}
+	if strings.Contains(out, skipFile) {
+		t.Errorf("out = %q, should not contain %q (excluded dir)", out, skipFile)
+	}
+}
+
+// TestColorAlways covers --color=always: the matched substring is wrapped in
+// ANSI escapes.
+func TestColorAlways(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "hello world\n", "--color=always", "world")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "hello \x1b[01;31mworld\x1b[0m\n"
+	if out != want {
+		t.Errorf("--color=always out = %q, want %q", out, want)
+	}
+}
+
+// TestColorNever covers --color=never: no escapes emitted.
+func TestColorNever(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "hello world\n", "--color=never", "world")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("--color=never out = %q, should have no escapes", out)
+	}
+}
+
+// TestColorInvalid covers an invalid --color value exiting 2.
+func TestColorInvalid(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "--color=bogus", "x")
+	if code := exitCode(t, err); code != 2 {
+		t.Errorf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "grep:") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+// TestByteOffset covers -b: the 0-based byte offset of each matching line.
+func TestByteOffset(t *testing.T) {
+	t.Parallel()
+	// "aaa\n" is 4 bytes, so the second line begins at offset 4.
+	out, _, err := run(t, "aaa\nbbb\nccc\n", "-b", "bbb")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "4:bbb\n"
+	if out != want {
+		t.Errorf("-b out = %q, want %q", out, want)
+	}
+}
+
+// TestByteOffsetWithLineNumber verifies the prefix order: line number then byte
+// offset.
+func TestByteOffsetWithLineNumber(t *testing.T) {
+	t.Parallel()
+	out, _, err := run(t, "aaa\nbbb\n", "-n", "-b", "bbb")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := "2:4:bbb\n"
+	if out != want {
+		t.Errorf("-nb out = %q, want %q", out, want)
+	}
+}
+
+// TestFilesWithoutMatch covers -L: print only file names with NO match.
+func TestFilesWithoutMatch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	hit := filepath.Join(dir, "hit.txt")
+	miss := filepath.Join(dir, "miss.txt")
+	if err := os.WriteFile(hit, []byte("needle\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(miss, []byte("nothing here\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := run(t, "", "-L", "needle", hit, miss)
+	if err != nil {
+		t.Fatalf("-L err = %v", err)
+	}
+	if strings.Contains(out, hit) {
+		t.Errorf("-L out = %q, should not contain matching file %q", out, hit)
+	}
+	if !strings.Contains(out, miss) {
+		t.Errorf("-L out = %q, want non-matching file %q", out, miss)
+	}
+}

--- a/internal/applets/textutils/split/split.go
+++ b/internal/applets/textutils/split/split.go
@@ -34,11 +34,20 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		Examples: []command.Example{
 			{Command: "split -l 100 big.txt part_", Explain: "Split big.txt into files of 100 lines each, named part_aa, part_ab, ..."},
 			{Command: "split -b 1M data.bin", Explain: "Split data.bin into 1 MiB pieces named xaa, xab, ..."},
+			{Command: "split -d -a 3 big.txt part_", Explain: "Use 3-digit numeric suffixes: part_000, part_001, ..."},
+			{Command: "split -l 100 --additional-suffix=.txt big.txt part_", Explain: "Append .txt to each output name: part_aa.txt, part_ab.txt, ..."},
 		},
 		ExitStatus: "0  success.\n1  an error occurred (e.g. the input could not be read or an option was invalid).",
 	})
 	lines := fs.IntP("lines", "l", 1000, "put NUMBER lines per output file")
 	byteSpec := fs.StringP("bytes", "b", "", "put SIZE bytes per output file (suffixes K, M allowed)")
+	// numeric-suffixes is a string so it can accept an optional =FROM value while
+	// still serving as the -d shorthand. NoOptDefVal makes the bare flag (-d or
+	// --numeric-suffixes) mean "start at 0".
+	numericSpec := fs.StringP("numeric-suffixes", "d", "", "use numeric suffixes starting at FROM (default 0)")
+	fs.Lookup("numeric-suffixes").NoOptDefVal = "0"
+	addSuffix := fs.String("additional-suffix", "", "append an additional SUFFIX to file names")
+	suffixLen := fs.IntP("suffix-length", "a", 2, "generate suffixes of length N")
 
 	proceed, err := fs.Parse(stdio, args)
 	if err != nil || !proceed {
@@ -55,6 +64,12 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		prefix = rest[1]
 	}
 
+	naming, nerr := newNamingScheme(fs.Changed("numeric-suffixes"), *numericSpec, *addSuffix, *suffixLen)
+	if nerr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "split: %v\n", nerr)
+		return command.SilentFailure()
+	}
+
 	r, err := command.Open(stdio, input)
 	if err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "split: %s\n", command.FileError(input, err))
@@ -68,13 +83,58 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 			_, _ = fmt.Fprintf(stdio.Err, "split: invalid number of bytes: %q\n", *byteSpec)
 			return command.SilentFailure()
 		}
-		return c.byBytes(stdio, r, prefix, size)
+		return c.byBytes(stdio, r, prefix, size, naming)
 	}
 	if *lines <= 0 {
 		_, _ = fmt.Fprintf(stdio.Err, "split: invalid number of lines: %d\n", *lines)
 		return command.SilentFailure()
 	}
-	return c.byLines(stdio, r, prefix, *lines)
+	return c.byLines(stdio, r, prefix, *lines, naming)
+}
+
+// namingScheme describes how successive output file names are built from the
+// index: alphabetic (aa, ab, ...) or numeric (00, 01, ...), the suffix width,
+// and an optional trailing suffix appended after the index part.
+type namingScheme struct {
+	numeric   bool
+	from      int
+	addSuffix string
+	suffixLen int
+}
+
+// newNamingScheme validates and assembles a namingScheme from the parsed flags.
+// changed reports whether --numeric-suffixes/-d was supplied; spec is its
+// (optional) =FROM value.
+func newNamingScheme(changed bool, spec, addSuffix string, suffixLen int) (namingScheme, error) {
+	if suffixLen <= 0 {
+		return namingScheme{}, fmt.Errorf("invalid suffix length: %d", suffixLen)
+	}
+	ns := namingScheme{addSuffix: addSuffix, suffixLen: suffixLen}
+	if changed {
+		ns.numeric = true
+		if spec != "" {
+			from, err := strconv.Atoi(spec)
+			if err != nil || from < 0 {
+				return namingScheme{}, fmt.Errorf("invalid start value for numeric suffixes: %q", spec)
+			}
+			ns.from = from
+		}
+	}
+	return ns, nil
+}
+
+// name returns the output file name for the idx-th piece (idx counts from 0).
+func (ns namingScheme) name(prefix string, idx int) string {
+	return prefix + ns.suffixPart(idx) + ns.addSuffix
+}
+
+// suffixPart returns the index portion of the file name (without prefix or the
+// additional suffix), padded to suffixLen.
+func (ns namingScheme) suffixPart(idx int) string {
+	if ns.numeric {
+		return fmt.Sprintf("%0*d", ns.suffixLen, ns.from+idx)
+	}
+	return alphaSuffix(idx, ns.suffixLen)
 }
 
 // parseSize parses a byte count that may carry a K (1024) or M (1048576) suffix.
@@ -94,7 +154,7 @@ func parseSize(s string) (int, error) {
 }
 
 // byLines writes perFile lines into each successive output file.
-func (c *Command) byLines(stdio command.IO, r io.Reader, prefix string, perFile int) error {
+func (c *Command) byLines(stdio command.IO, r io.Reader, prefix string, perFile int, ns namingScheme) error {
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
@@ -110,7 +170,7 @@ func (c *Command) byLines(stdio command.IO, r io.Reader, prefix string, perFile 
 	}
 	for sc.Scan() {
 		if w == nil {
-			f, err := create(prefix, idx)
+			f, err := create(ns, prefix, idx)
 			if err != nil {
 				_, _ = fmt.Fprintf(stdio.Err, "split: %v\n", err)
 				return command.SilentFailure()
@@ -137,14 +197,14 @@ func (c *Command) byLines(stdio command.IO, r io.Reader, prefix string, perFile 
 }
 
 // byBytes writes perFile bytes into each successive output file.
-func (c *Command) byBytes(stdio command.IO, r io.Reader, prefix string, perFile int) error {
+func (c *Command) byBytes(stdio command.IO, r io.Reader, prefix string, perFile int, ns namingScheme) error {
 	br := bufio.NewReader(r)
 	buf := make([]byte, perFile)
 	idx := 0
 	for {
 		n, err := io.ReadFull(br, buf)
 		if n > 0 {
-			f, cerr := create(prefix, idx)
+			f, cerr := create(ns, prefix, idx)
 			if cerr != nil {
 				_, _ = fmt.Fprintf(stdio.Err, "split: %v\n", cerr)
 				return command.SilentFailure()
@@ -167,14 +227,20 @@ func (c *Command) byBytes(stdio command.IO, r io.Reader, prefix string, perFile 
 	}
 }
 
-// create opens the idx-th output file, named prefix followed by a two-letter
-// suffix (aa, ab, ...).
-func create(prefix string, idx int) (*os.File, error) {
-	name := prefix + suffix(idx)
+// create opens the idx-th output file, named according to the naming scheme.
+func create(ns namingScheme, prefix string, idx int) (*os.File, error) {
+	name := ns.name(prefix, idx)
 	return os.Create(name) //nolint:gosec // writing a user-named output file is the point
 }
 
-// suffix returns the two-letter split suffix for the idx-th file.
-func suffix(idx int) string {
-	return string(rune('a'+idx/26)) + string(rune('a'+idx%26))
+// alphaSuffix returns the alphabetic split suffix for the idx-th file padded to
+// width characters (aa, ab, ..., az, ba, ...). It mirrors GNU's base-26 scheme:
+// the least-significant position varies fastest.
+func alphaSuffix(idx, width int) string {
+	b := make([]byte, width)
+	for i := width - 1; i >= 0; i-- {
+		b[i] = byte('a' + idx%26)
+		idx /= 26
+	}
+	return string(b)
 }

--- a/internal/applets/textutils/split/split_test.go
+++ b/internal/applets/textutils/split/split_test.go
@@ -47,6 +47,90 @@ func TestByBytes(t *testing.T) {
 	checkFile(t, prefix+"ac", "g")
 }
 
+func TestNumericSuffixes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "part-")
+	_, _, err := run(t, "1\n2\n3\n4\n5\n", "-l", "2", "-d", "-", prefix)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"00", "1\n2\n")
+	checkFile(t, prefix+"01", "3\n4\n")
+	checkFile(t, prefix+"02", "5\n")
+}
+
+func TestNumericSuffixesFrom(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "p-")
+	_, _, err := run(t, "1\n2\n3\n", "-l", "1", "--numeric-suffixes=5", "-", prefix)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"05", "1\n")
+	checkFile(t, prefix+"06", "2\n")
+	checkFile(t, prefix+"07", "3\n")
+}
+
+func TestAdditionalSuffix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "part-")
+	_, _, err := run(t, "1\n2\n3\n", "-l", "2", "--additional-suffix=.txt", "-", prefix)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"aa.txt", "1\n2\n")
+	checkFile(t, prefix+"ab.txt", "3\n")
+}
+
+func TestSuffixLength(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "part-")
+	_, _, err := run(t, "1\n2\n", "-l", "1", "-a", "3", "-", prefix)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"aaa", "1\n")
+	checkFile(t, prefix+"aab", "2\n")
+}
+
+func TestNumericSuffixLengthCombined(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prefix := filepath.Join(dir, "part-")
+	_, _, err := run(t, "1\n2\n", "-l", "1", "-d", "-a", "3", "--additional-suffix=.bin", "-", prefix)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	checkFile(t, prefix+"000.bin", "1\n")
+	checkFile(t, prefix+"001.bin", "2\n")
+}
+
+func TestInvalidSuffixLength(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "-a", "0")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid suffix length") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestInvalidNumericStart(t *testing.T) {
+	t.Parallel()
+	_, errOut, err := run(t, "x\n", "--numeric-suffixes=abc")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(errOut, "invalid start value") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
 func TestInvalidLines(t *testing.T) {
 	t.Parallel()
 	_, errOut, err := run(t, "x\n", "-l", "0")

--- a/test/it/fileutils/stat_test.sh
+++ b/test/it/fileutils/stat_test.sh
@@ -3,3 +3,23 @@ CleanUp() { rm -rf ${MIMIXBOX_IT_ROOT}; }
 TestStatSize() {
     stat -c '%s' ${MIMIXBOX_IT_ROOT}/stat_file
 }
+TestStatPrintf() {
+    # --printf interprets \t and adds no trailing newline; pipe through od to
+    # make the absence of a trailing newline observable.
+    stat --printf '%n=%s' ${MIMIXBOX_IT_ROOT}/stat_file
+}
+TestStatPrintfName() {
+    stat --printf '%n %s\n' ${MIMIXBOX_IT_ROOT}/stat_file
+}
+TestStatFormatNewline() {
+    # --format/-c append a trailing newline (wc -l counts it).
+    stat --format '%s' ${MIMIXBOX_IT_ROOT}/stat_file | wc -l | tr -d ' '
+}
+TestStatTerseFieldCount() {
+    # --terse prints one space-separated line; assert the field count.
+    stat --terse ${MIMIXBOX_IT_ROOT}/stat_file | awk '{print NF}'
+}
+TestStatTerseSize() {
+    # Second terse field is the size in bytes.
+    stat --terse ${MIMIXBOX_IT_ROOT}/stat_file | awk '{print $2}'
+}

--- a/test/it/findutils/grep_gnu_test.sh
+++ b/test/it/findutils/grep_gnu_test.sh
@@ -1,0 +1,58 @@
+Setup() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    mkdir -p ${TEST_DIR}/src ${TEST_DIR}/vendor
+    printf '1\n2\nMATCH\nb\nc\n' > ${TEST_DIR}/ctx.txt
+    printf 'a\nMATCH\nb\n' > ${TEST_DIR}/ctx2.txt
+    printf 'MATCH\nb\nc\nd\ne\nf\nMATCH\n' > ${TEST_DIR}/groups.txt
+    printf 'needle\n' > ${TEST_DIR}/keep.go
+    printf 'needle\n' > ${TEST_DIR}/skip.txt
+    printf 'needle\n' > ${TEST_DIR}/app.log
+    printf 'needle\n' > ${TEST_DIR}/src/a.txt
+    printf 'needle\n' > ${TEST_DIR}/vendor/b.txt
+    printf 'aaa\nbbb\nccc\n' > ${TEST_DIR}/off.txt
+    printf 'needle\n' > ${TEST_DIR}/hit.txt
+    printf 'nothing\n' > ${TEST_DIR}/miss.txt
+}
+CleanUp() { rm -rf ${MIMIXBOX_IT_ROOT}/grep_gnu; }
+
+TestGrepAfter() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -A1 MATCH ${TEST_DIR}/ctx.txt
+}
+TestGrepBefore() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -B1 MATCH ${TEST_DIR}/ctx2.txt
+}
+TestGrepContext() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -C1 MATCH ${TEST_DIR}/ctx2.txt
+}
+TestGrepGroupSeparator() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -A1 MATCH ${TEST_DIR}/groups.txt
+}
+TestGrepInclude() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -r --include='*.go' needle ${TEST_DIR}
+}
+TestGrepExclude() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -r --exclude='*.log' needle ${TEST_DIR}
+}
+TestGrepExcludeDir() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -r --exclude-dir=vendor needle ${TEST_DIR}
+}
+TestGrepColor() {
+    grep --color=always world <<'EOF'
+hello world
+EOF
+}
+TestGrepByteOffset() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -b bbb ${TEST_DIR}/off.txt
+}
+TestGrepFilesWithoutMatch() {
+    export TEST_DIR=${MIMIXBOX_IT_ROOT}/grep_gnu
+    grep -L needle ${TEST_DIR}/hit.txt ${TEST_DIR}/miss.txt
+}

--- a/test/it/spec/find_spec.sh
+++ b/test/it/spec/find_spec.sh
@@ -27,6 +27,24 @@ Describe 'find'
         The status should be success
     End
 
+    It 'lists an Options block with --help and --version in --help'
+        When call TestFindHelp
+        The output should include 'Options:'
+        The output should include '--help'
+        The output should include '--version'
+        The status should be success
+    End
+
+    It 'documents the supported subset tokens in --help'
+        When call TestFindHelp
+        The output should include '-name'
+        The output should include '-type'
+        The output should include '-print0'
+        The output should include '-maxdepth'
+        The output should include '-mindepth'
+        The status should be success
+    End
+
     It 'prints the version line for --version'
         When call TestFindVersion
         The output should include 'find (mimixbox)'

--- a/test/it/spec/grep_gnu_spec.sh
+++ b/test/it/spec/grep_gnu_spec.sh
@@ -1,0 +1,71 @@
+Describe 'grep GNU flags'
+    Include findutils/grep_gnu_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints trailing context with -A1'
+        When call TestGrepAfter
+        The output should equal 'MATCH
+b'
+        The status should be success
+    End
+
+    It 'prints leading context with -B1'
+        When call TestGrepBefore
+        The output should equal 'a
+MATCH'
+        The status should be success
+    End
+
+    It 'prints surrounding context with -C1'
+        When call TestGrepContext
+        The output should equal 'a
+MATCH
+b'
+        The status should be success
+    End
+
+    It 'separates non-contiguous groups with --'
+        When call TestGrepGroupSeparator
+        The line 3 of output should equal '--'
+        The status should be success
+    End
+
+    It 'searches only included files with --include'
+        When call TestGrepInclude
+        The output should include 'keep.go'
+        The output should not include 'skip.txt'
+        The status should be success
+    End
+
+    It 'skips excluded files with --exclude'
+        When call TestGrepExclude
+        The output should not include 'app.log'
+        The status should be success
+    End
+
+    It 'skips excluded directories with --exclude-dir'
+        When call TestGrepExcludeDir
+        The output should not include 'vendor'
+        The status should be success
+    End
+
+    It 'highlights matches with --color=always'
+        When call TestGrepColor
+        The output should include 'world'
+        The status should be success
+    End
+
+    It 'prints byte offsets with -b'
+        When call TestGrepByteOffset
+        The output should equal '4:bbb'
+        The status should be success
+    End
+
+    It 'prints files without a match with -L'
+        When call TestGrepFilesWithoutMatch
+        The output should include 'miss.txt'
+        The output should not include 'hit.txt'
+        The status should be success
+    End
+End

--- a/test/it/spec/readlink_gnu_spec.sh
+++ b/test/it/spec/readlink_gnu_spec.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=sh
+# Integration tests for the GNU flags added to readlink (issue #734):
+#   --canonicalize-existing/-e, --canonicalize-missing/-m, --zero/-z.
+
+Describe 'readlink GNU flags'
+    setup() {
+        WORK="${MIMIXBOX_IT_ROOT}/readlink_gnu"
+        rm -rf "$WORK"
+        mkdir -p "$WORK"
+        : > "$WORK/target"
+        ln -s "$WORK/target" "$WORK/link"
+    }
+    cleanup() {
+        rm -rf "$WORK"
+    }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    It 'fails when -e is given a missing path'
+        When run readlink -e "$WORK/does-not-exist"
+        The status should be failure
+        The stdout should equal ''
+    End
+
+    It 'succeeds when -e is given an existing symlink'
+        When run readlink -e "$WORK/link"
+        The status should be success
+        The stdout should equal "$WORK/target"
+    End
+
+    It 'succeeds with -m on a missing path'
+        When run readlink -m "$WORK/a/b/c"
+        The status should be success
+        The stdout should equal "$WORK/a/b/c"
+    End
+
+    It 'terminates output with NUL under -z'
+        check() {
+            # Capture the raw output and confirm it ends with a NUL byte and not
+            # a newline. od shows the trailing byte sequence.
+            readlink -z "$WORK/link" | od -An -c | tr -s ' ' | grep -q '\\0$' && printf 'nul'
+        }
+        When call check
+        The output should equal 'nul'
+        The status should be success
+    End
+End

--- a/test/it/spec/rm_gnu_spec.sh
+++ b/test/it/spec/rm_gnu_spec.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=sh
+# Integration tests for the GNU flags added to rm (issue #732):
+#   --preserve-root (default), --no-preserve-root, --one-file-system.
+
+Describe 'rm GNU flags'
+    setup() {
+        WORK="${MIMIXBOX_IT_ROOT}/rm_gnu"
+        rm -rf "$WORK"
+        mkdir -p "$WORK"
+    }
+    cleanup() {
+        rm -rf "$WORK"
+    }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    # The default --preserve-root must refuse to recurse on "/" and exit
+    # nonzero. This NEVER deletes anything: the guard returns before any
+    # removal, so running it against the real "/" is safe.
+    It 'refuses to recurse on / by default (--preserve-root)'
+        When run rm -r /
+        The status should be failure
+        The stderr should include "it is dangerous to operate recursively on '/'"
+        The stderr should include 'use --no-preserve-root to override this failsafe'
+    End
+
+    It 'removes an ordinary directory recursively (guard does not interfere)'
+        prepare() {
+            mkdir -p "$WORK/tree/sub"
+            : > "$WORK/tree/sub/leaf.txt"
+        }
+        check() {
+            prepare
+            rm -r "$WORK/tree"
+            [ ! -e "$WORK/tree" ] && printf 'gone'
+        }
+        When call check
+        The output should equal 'gone'
+        The status should be success
+    End
+
+    It 'removes a single-filesystem tree with --one-file-system'
+        prepare() {
+            mkdir -p "$WORK/ofs/a/b"
+            : > "$WORK/ofs/a/b/leaf.txt"
+            : > "$WORK/ofs/top.txt"
+        }
+        check() {
+            prepare
+            rm -r --one-file-system "$WORK/ofs"
+            [ ! -e "$WORK/ofs" ] && printf 'gone'
+        }
+        When call check
+        The output should equal 'gone'
+        The status should be success
+    End
+
+    It 'removes / when --no-preserve-root is given (verified via guard-message absence on a safe target)'
+        prepare() {
+            mkdir -p "$WORK/victim/sub"
+            : > "$WORK/victim/sub/f"
+        }
+        check() {
+            prepare
+            rm -r --no-preserve-root "$WORK/victim"
+            [ ! -e "$WORK/victim" ] && printf 'gone'
+        }
+        When call check
+        The output should equal 'gone'
+        The status should be success
+    End
+End

--- a/test/it/spec/split_gnu_spec.sh
+++ b/test/it/spec/split_gnu_spec.sh
@@ -1,0 +1,29 @@
+Describe 'split GNU flags'
+    Include textutils/split_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'uses numeric suffixes with -d'
+        When call TestSplitNumeric
+        The output should equal 'num-00 num-01 num-02'
+        The status should be success
+    End
+
+    It 'writes the expected content to the first numeric piece'
+        When call TestSplitNumericContent
+        The output should equal "$(printf '1\n2')"
+        The status should be success
+    End
+
+    It 'appends an additional suffix to each name'
+        When call TestSplitAdditionalSuffix
+        The output should equal 'add-aa.txt add-ab.txt'
+        The status should be success
+    End
+
+    It 'honors a custom suffix length with -a'
+        When call TestSplitSuffixLength
+        The output should equal 'len-aaa len-aab'
+        The status should be success
+    End
+End

--- a/test/it/spec/stat_gnu_spec.sh
+++ b/test/it/spec/stat_gnu_spec.sh
@@ -1,0 +1,35 @@
+Describe 'stat GNU flags'
+    Include fileutils/stat_test.sh
+    BeforeEach 'Setup'
+    AfterEach 'CleanUp'
+
+    It 'prints name and size via --printf with no trailing newline'
+        When call TestStatPrintf
+        The output should equal "${MIMIXBOX_IT_ROOT}/stat_file=5"
+        The status should be success
+    End
+
+    It 'interprets backslash escapes in --printf'
+        When call TestStatPrintfName
+        The output should equal "${MIMIXBOX_IT_ROOT}/stat_file 5"
+        The status should be success
+    End
+
+    It 'appends a trailing newline for --format'
+        When call TestStatFormatNewline
+        The output should equal '1'
+        The status should be success
+    End
+
+    It 'prints a single space-separated terse line'
+        When call TestStatTerseFieldCount
+        The output should equal '15'
+        The status should be success
+    End
+
+    It 'reports the size as the second terse field'
+        When call TestStatTerseSize
+        The output should equal '5'
+        The status should be success
+    End
+End

--- a/test/it/spec/touch_gnu_spec.sh
+++ b/test/it/spec/touch_gnu_spec.sh
@@ -1,0 +1,78 @@
+# shellcheck shell=sh
+# Integration tests for the GNU flags added to touch (issue #733):
+#   --reference/-r, --date/-d, --time=WORD, --no-dereference/-h.
+
+Describe 'touch GNU flags'
+    setup() {
+        WORK="${MIMIXBOX_IT_ROOT}/touch_gnu"
+        rm -rf "$WORK"
+        mkdir -p "$WORK"
+    }
+    cleanup() {
+        rm -rf "$WORK"
+    }
+    BeforeEach 'setup'
+    AfterEach 'cleanup'
+
+    # SYSSTAT is the system stat(1), addressed by absolute path so the mimixbox
+    # 'stat' applet on PATH does not shadow it. %Y is the mtime in epoch seconds.
+    SYSSTAT=/usr/bin/stat
+
+    It 'copies the reference file mtime (--reference)'
+        check() {
+            : > "$WORK/ref"
+            : > "$WORK/dst"
+            # Give ref a known mtime, then copy it onto dst.
+            touch -d '2001-02-03 04:05:06' "$WORK/ref"
+            touch --reference="$WORK/ref" "$WORK/dst"
+            r=$("$SYSSTAT" -c '%Y' "$WORK/ref")
+            d=$("$SYSSTAT" -c '%Y' "$WORK/dst")
+            [ "$r" = "$d" ] && printf 'match'
+        }
+        When call check
+        The output should equal 'match'
+        The status should be success
+    End
+
+    It 'sets a known time with --date'
+        check() {
+            : > "$WORK/f"
+            touch -d '2020-06-15 12:34:56' "$WORK/f"
+            # Expected epoch for that local time, computed by the system date.
+            want=$(/bin/date -d '2020-06-15 12:34:56' '+%s')
+            got=$("$SYSSTAT" -c '%Y' "$WORK/f")
+            [ "$want" = "$got" ] && printf 'match'
+        }
+        When call check
+        The output should equal 'match'
+        The status should be success
+    End
+
+    It 'accepts --time=atime without error'
+        When run touch --time=atime "$WORK/g"
+        The status should be success
+        The path "$WORK/g" should be exist
+    End
+
+    It 'rejects an invalid --time word'
+        When run touch --time=bogus "$WORK/h"
+        The status should be failure
+        The stderr should include 'invalid argument'
+    End
+
+    It 'changes the symlink itself with --no-dereference (-h)'
+        check() {
+            : > "$WORK/target"
+            touch -d '2005-05-05 05:05:05' "$WORK/target"
+            ln -s "$WORK/target" "$WORK/link"
+            # -h must touch the link, leaving the target's mtime untouched.
+            touch -h -d '2030-01-01 00:00:00' "$WORK/link"
+            want=$(/bin/date -d '2005-05-05 05:05:05' '+%s')
+            got=$("$SYSSTAT" -c '%Y' "$WORK/target")
+            [ "$want" = "$got" ] && printf 'target-unchanged'
+        }
+        When call check
+        The output should equal 'target-unchanged'
+        The status should be success
+    End
+End

--- a/test/it/textutils/split_test.sh
+++ b/test/it/textutils/split_test.sh
@@ -9,3 +9,19 @@ TestSplitLines() {
     printf '1\n2\n3\n' | split -l 2 - ${MIMIXBOX_IT_ROOT}/part-
     cat ${MIMIXBOX_IT_ROOT}/part-aa
 }
+TestSplitNumeric() {
+    printf '1\n2\n3\n4\n5\n' | split -l 2 -d - ${MIMIXBOX_IT_ROOT}/num-
+    ls ${MIMIXBOX_IT_ROOT}/num-* | sed "s#${MIMIXBOX_IT_ROOT}/##" | sort | tr '\n' ' ' | sed 's/ $//'
+}
+TestSplitNumericContent() {
+    printf '1\n2\n3\n4\n5\n' | split -l 2 -d - ${MIMIXBOX_IT_ROOT}/num-
+    cat ${MIMIXBOX_IT_ROOT}/num-00
+}
+TestSplitAdditionalSuffix() {
+    printf '1\n2\n3\n' | split -l 2 --additional-suffix=.txt - ${MIMIXBOX_IT_ROOT}/add-
+    ls ${MIMIXBOX_IT_ROOT}/add-* | sed "s#${MIMIXBOX_IT_ROOT}/##" | sort | tr '\n' ' ' | sed 's/ $//'
+}
+TestSplitSuffixLength() {
+    printf '1\n2\n' | split -l 1 -a 3 - ${MIMIXBOX_IT_ROOT}/len-
+    ls ${MIMIXBOX_IT_ROOT}/len-* | sed "s#${MIMIXBOX_IT_ROOT}/##" | sort | tr '\n' ' ' | sed 's/ $//'
+}


### PR DESCRIPTION
Third wave of GNU-compatibility flags with unit + ShellSpec coverage; existing behavior unchanged.

- grep: `-A`/`-B`/`-C` context, `--include`/`--exclude`/`--exclude-dir`, `--color`, `-b`/`--byte-offset`, `-L`/`--files-without-match`.
- rm: `--preserve-root` (default), `--no-preserve-root`, `--one-file-system`.
- touch: `--reference`/`-r`, `--date`/`-d`, `--time`, `--no-dereference`/`-h`.
- readlink: `--canonicalize-existing`/`-e`, `--canonicalize-missing`/`-m`, `--zero`/`-z`.
- stat: `--printf`, `--format`, `--terse`, extra directives.
- split: `--numeric-suffixes`/`-d`, `--additional-suffix`, `--suffix-length`/`-a`.
- find: GNU-style help page with `Options:` listing `--help`/`--version`.

`go build ./...`, full `go test ./...`, `golangci-lint`, and full `make test-e2e` (1796 examples, 0 failures) all pass.

Closes #732
Closes #733
Closes #734
Closes #735
Closes #736
Closes #737
Closes #738
Closes #746
Closes #760