### PR TITLE
test(gnu): lock in printf/test first-argument --help/--version

### DIFF
--- a/internal/applets/shellutils/printf/printf_test.go
+++ b/internal/applets/shellutils/printf/printf_test.go
@@ -82,3 +82,29 @@ func TestHelpSections(t *testing.T) {
 		}
 	}
 }
+
+// TestMetaOnlyAsFirstArg proves --help/--version are honored only as the first
+// operand (GitHub issue #758): a later --help is an ordinary operand.
+func TestMetaOnlyAsFirstArg(t *testing.T) {
+	t.Parallel()
+	// --version as the first operand prints the version banner.
+	out, _, err := run(t, "--version")
+	if err != nil {
+		t.Fatalf("--version err = %v", err)
+	}
+	if !strings.Contains(out, "printf (mimixbox)") {
+		t.Errorf("--version = %q, want version banner", out)
+	}
+	// A later --help is a normal operand: the format is printed and no usage
+	// block appears.
+	out, _, err = run(t, "foo --help\n")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.Contains(out, "Usage:") {
+		t.Errorf("a non-first --help must not trigger help: %q", out)
+	}
+	if !strings.Contains(out, "foo --help") {
+		t.Errorf("expected the format to be printed, got %q", out)
+	}
+}

--- a/internal/applets/shellutils/test/test_test.go
+++ b/internal/applets/shellutils/test/test_test.go
@@ -108,3 +108,26 @@ func TestHelpSections(t *testing.T) {
 		}
 	}
 }
+
+// TestMetaOnlyWhenSoleArg proves --help/--version are honored only as the sole
+// argument (GitHub issue #759): `test foo --help` evaluates as an expression.
+func TestMetaOnlyWhenSoleArg(t *testing.T) {
+	t.Parallel()
+	capture := func(args ...string) (string, int) {
+		out := &bytes.Buffer{}
+		io := command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}
+		code := command.Execute(context.Background(), testcmd.New(), io, args)
+		return out.String(), code
+	}
+	// Sole --help / --version produce metadata and exit 0.
+	if out, code := capture("--help"); code != 0 || !strings.Contains(out, "Usage: test") {
+		t.Errorf("test --help: code=%d out=%q", code, out)
+	}
+	if out, code := capture("--version"); code != 0 || !strings.Contains(out, "test (mimixbox)") {
+		t.Errorf("test --version: code=%d out=%q", code, out)
+	}
+	// A non-sole --help is an ordinary operand: it is evaluated, not shown as help.
+	if out, _ := capture("foo", "--help"); strings.Contains(out, "Usage: test") {
+		t.Errorf("test foo --help must not print help: %q", out)
+	}
+}

--- a/test/it/spec/printf_meta_spec.sh
+++ b/test/it/spec/printf_meta_spec.sh
@@ -1,0 +1,20 @@
+Describe 'printf honors first-argument --help/--version (issue #758)'
+    It 'prints help for a leading --help'
+        When run env printf --help
+        The status should be success
+        The output should include 'Examples:'
+        The line 1 of output should start with 'Usage: printf'
+    End
+
+    It 'prints the version banner for a leading --version'
+        When run env printf --version
+        The status should be success
+        The output should include 'printf (mimixbox)'
+    End
+
+    It 'treats a later --help as an ordinary operand'
+        When run env printf 'foo --help\n'
+        The status should be success
+        The output should equal 'foo --help'
+    End
+End

--- a/test/it/spec/test_meta_spec.sh
+++ b/test/it/spec/test_meta_spec.sh
@@ -1,0 +1,21 @@
+Describe 'test honors --help/--version only as the sole argument (issue #759)'
+    It 'prints help for a sole --help'
+        When run env test --help
+        The status should be success
+        The output should include 'Usage: test'
+    End
+
+    It 'prints the version banner for a sole --version'
+        When run env test --version
+        The status should be success
+        The output should include 'test (mimixbox)'
+    End
+
+    It 'evaluates an expression when --help is not the sole argument'
+        # `test foo = --help` is a string comparison (false), proving --help is an
+        # ordinary operand here, not a help request.
+        When run env test foo = --help
+        The status should be failure
+        The output should not include 'Usage: test'
+    End
+End


### PR DESCRIPTION
printf and test already honor a leading `--help`/`--version` (from the structured-help work); this adds the unit + ShellSpec tests the issues require, proving metadata shows for the meta-option while a later/non-sole `--help` stays an ordinary operand.

Closes #758
Closes #759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for `--help` and `--version` flag behavior in printf and test commands
  * Tests verify that metadata flags produce help/version output only when used as standalone arguments
  * Confirms proper handling when flags are combined with other operands as normal arguments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->