### PR TITLE
refactor(cp): unify overwrite planning for direct and recursive copies

### DIFF
--- a/internal/applets/fileutils/cp/cp.go
+++ b/internal/applets/fileutils/cp/cp.go
@@ -304,6 +304,17 @@ func cpFile(stdio command.IO, src, dest string, info os.FileInfo, opts options) 
 		return fmt.Errorf("'%s' and '%s' are the same file", src, target)
 	}
 
+	return copyRegularFile(stdio, src, target, info, opts)
+}
+
+// copyRegularFile is the single per-file execution path for copying a regular
+// file's contents to target. It centralizes the overwrite policy — -n
+// (no-clobber), -u (update), -i (interactive prompt), and --backup — so that
+// direct copies (cpFile) and files discovered during a recursive walk (cpDir)
+// share exactly one decision path. Traversal stays in the callers; per-file
+// policy lives here. The caller resolves target (including same-file guards)
+// before calling.
+func copyRegularFile(stdio command.IO, src, target string, info os.FileInfo, opts options) error {
 	// -n: never overwrite an existing destination.
 	if opts.noClobber {
 		if _, err := os.Stat(target); err == nil {
@@ -318,6 +329,7 @@ func cpFile(stdio command.IO, src, dest string, info os.FileInfo, opts options) 
 		}
 	}
 
+	// -i: prompt before overwriting an existing destination.
 	if opts.interactive {
 		if _, err := os.Stat(target); err == nil {
 			if !question(stdio, fmt.Sprintf("cp: overwrite '%s'? ", target)) {
@@ -380,18 +392,9 @@ func cpDir(stdio command.IO, src, dest string, opts options) error {
 				// recursed into; copying its contents is out of scope.
 				return nil
 			}
-			if opts.noClobber {
-				if _, statErr := os.Stat(target); statErr == nil {
-					return nil
-				}
-			}
-			if err := copyFileContents(p, target, ti, opts); err != nil {
-				return err
-			}
-			if opts.verbose {
-				_, _ = fmt.Fprintf(stdio.Out, "'%s' -> '%s'\n", p, target)
-			}
-			return nil
+			// A followed symlink yields a regular file; route it through the
+			// shared overwrite policy just like any other walked file.
+			return copyRegularFile(stdio, p, target, ti, opts)
 		}
 
 		if info.IsDir() {
@@ -407,18 +410,8 @@ func cpDir(stdio command.IO, src, dest string, opts options) error {
 			}
 			return nil
 		}
-		if opts.noClobber {
-			if _, statErr := os.Stat(target); statErr == nil {
-				return nil // -n: skip existing file
-			}
-		}
-		if err := copyFileContents(p, target, info, opts); err != nil {
-			return err
-		}
-		if opts.verbose {
-			_, _ = fmt.Fprintf(stdio.Out, "'%s' -> '%s'\n", p, target)
-		}
-		return nil
+		// Regular files share the same overwrite policy as direct copies.
+		return copyRegularFile(stdio, p, target, info, opts)
 	})
 }
 

--- a/internal/applets/fileutils/cp/cp_test.go
+++ b/internal/applets/fileutils/cp/cp_test.go
@@ -1134,6 +1134,156 @@ func TestRunBackupInvalidControl(t *testing.T) {
 	}
 }
 
+// --- #940: recursive copies must share the same overwrite policy ----------
+
+// TestRunDirUpdateSkipsNewerInTree proves recursive -u does not overwrite a
+// destination file inside the tree that is newer than its source (the direct
+// -u path already did this; the recursive path must too).
+func TestRunDirUpdateSkipsNewerInTree(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcFile := filepath.Join(src, "f.txt")
+	if err := os.WriteFile(srcFile, []byte("from-src\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Destination already holds src/f.txt that is NEWER than the source.
+	dstTree := filepath.Join(dir, "dst", "src")
+	if err := os.MkdirAll(dstTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dstFile := filepath.Join(dstTree, "f.txt")
+	if err := os.WriteFile(dstFile, []byte("newer-dst\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-1 * time.Hour)
+	newer := time.Now()
+	if err := os.Chtimes(srcFile, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dstFile, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst")
+	if _, stderr, err := run(t, "-r", "-u", src, dst); err != nil {
+		t.Fatalf("cp -ru error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dstFile); string(got) != "newer-dst\n" {
+		t.Errorf("cp -ru overwrote a newer file in the tree: %q, want newer-dst", got)
+	}
+}
+
+// TestRunDirInteractiveNoKeepsInTree proves recursive -i prompts before
+// overwriting a file inside the tree and honors a "n" answer.
+func TestRunDirInteractiveNoKeepsInTree(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "f.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dstTree := filepath.Join(dir, "dst", "src")
+	if err := os.MkdirAll(dstTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dstFile := filepath.Join(dstTree, "f.txt")
+	if err := os.WriteFile(dstFile, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst")
+	out, stderr, err := runStdin(t, "n\n", "-r", "-i", src, dst)
+	if err != nil {
+		t.Fatalf("cp -ri error = %v (%s)", err, stderr)
+	}
+	if !strings.Contains(out, "overwrite") {
+		t.Errorf("cp -ri did not prompt before overwriting in the tree: out=%q", out)
+	}
+	if got, _ := os.ReadFile(dstFile); string(got) != "old\n" {
+		t.Errorf("cp -ri overwrote despite 'n': %q, want old", got)
+	}
+}
+
+// TestRunDirBackupInTree proves recursive --backup makes a backup of an
+// overwritten file inside the tree, like the direct path does.
+func TestRunDirBackupInTree(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "f.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dstTree := filepath.Join(dir, "dst", "src")
+	if err := os.MkdirAll(dstTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dstFile := filepath.Join(dstTree, "f.txt")
+	if err := os.WriteFile(dstFile, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst")
+	if _, stderr, err := run(t, "-r", "--backup=simple", src, dst); err != nil {
+		t.Fatalf("cp -r --backup error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dstFile); string(got) != "new\n" {
+		t.Errorf("dst f.txt = %q, want new", got)
+	}
+	if got, _ := os.ReadFile(dstFile + "~"); string(got) != "old\n" {
+		t.Errorf("cp -r --backup did not create a backup in the tree: %q, want old", got)
+	}
+}
+
+// TestRunDirSymlinkFollowedUpdateSkipsNewer proves the shared overwrite policy
+// also covers files reached by following a symlink within the tree: a newer
+// destination must survive cp -ru.
+func TestRunDirSymlinkFollowedUpdateSkipsNewer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "real.txt"), []byte("from-src\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink within the tree pointing at a sibling file; the default deref
+	// mode follows it and copies the target as a regular file named "lnk".
+	if err := os.Symlink("real.txt", filepath.Join(src, "lnk")); err != nil {
+		t.Fatal(err)
+	}
+	dstTree := filepath.Join(dir, "dst", "src")
+	if err := os.MkdirAll(dstTree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dstLnk := filepath.Join(dstTree, "lnk")
+	if err := os.WriteFile(dstLnk, []byte("newer-dst\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-1 * time.Hour)
+	newer := time.Now()
+	if err := os.Chtimes(filepath.Join(src, "real.txt"), old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dstLnk, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst")
+	if _, stderr, err := run(t, "-r", "-u", src, dst); err != nil {
+		t.Fatalf("cp -ru error = %v (%s)", err, stderr)
+	}
+	if got, _ := os.ReadFile(dstLnk); string(got) != "newer-dst\n" {
+		t.Errorf("cp -ru overwrote a newer followed-symlink file: %q, want newer-dst", got)
+	}
+}
+
 func TestRunArchivePreservesLinkInTree(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/test/it/spec/cp_gnu_spec.sh
+++ b/test/it/spec/cp_gnu_spec.sh
@@ -94,4 +94,36 @@ Describe 'cp GNU flags'
         The output should equal "dstdata"
         The status should be success
     End
+
+    # #940: recursive copies must share the same overwrite policy as direct
+    # copies. -u inside a copied tree must leave a newer destination untouched.
+    It 'skips a newer file inside the tree with -ru (#940)'
+        TestRecursiveUpdate() {
+            cd "${WORK}" || exit 1
+            mkdir -p src dst/src
+            printf 'from-src\n' > src/f.txt
+            sleep 1.1
+            printf 'newer-dst\n' > dst/src/f.txt
+            cp -ru src dst
+            cat dst/src/f.txt
+        }
+        When call TestRecursiveUpdate
+        The output should equal "newer-dst"
+        The status should be success
+    End
+
+    # #940: --backup inside a copied tree must move the existing file aside.
+    It 'backs up a file inside the tree with -r --backup (#940)'
+        TestRecursiveBackup() {
+            cd "${WORK}" || exit 1
+            mkdir -p src dst/src
+            printf 'new\n' > src/f.txt
+            printf 'old\n' > dst/src/f.txt
+            cp -r --backup=simple src dst
+            cat dst/src/f.txt dst/src/f.txt~
+        }
+        When call TestRecursiveBackup
+        The output should equal "$(printf 'new\nold')"
+        The status should be success
+    End
 End


### PR DESCRIPTION
## Summary

`cp`'s recursive path (`cpDir`) reimplemented only a subset of the overwrite policy that `cpFile` applied to direct copies. It honored `-n` but silently dropped `-u`, `-i`, and `--backup`, so copy semantics depended on whether a file was copied directly or discovered during `filepath.Walk`. This let `cp -ru` overwrite newer files inside a copied tree, `cp -ri` skip the overwrite prompt, and `cp -r --backup` overwrite without making backups.

## Changes

Extract `copyRegularFile` as the single per-file execution path that centralizes the `-n`/`-u`/`-i`/`--backup` decisions. `cpFile` (direct copies) and `cpDir`'s walk (regular files and files reached by following a symlink within the tree) now both route through it, keeping traversal separate from per-file policy. Add unit tests for recursive `-u`, `-i`, `--backup`, and a followed-symlink `-u` case, plus shellspec E2E coverage for recursive `-ru` and `-r --backup`.

## Design Decisions

`copyRegularFile` takes an already-resolved target so the same-file guards and directory-target resolution stay in `cpFile`, while the walk supplies targets from `filepath.Walk`. This keeps one overwrite decision path shared by both callers without entangling traversal with policy. Tests were written first (TDD): they reproduced all three regressions on `main` before the extraction made them pass.

Closes #940