### PR TITLE
refactor(ls): cache per-entry metadata behind an entry model

### DIFF
--- a/internal/applets/fileutils/ls/ls.go
+++ b/internal/applets/fileutils/ls/ls.go
@@ -188,7 +188,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		operands = []string{"."}
 	}
 
-	var files []string
+	var files []entry
 	var dirs []string
 	exitErr := false
 	for _, name := range operands {
@@ -201,13 +201,15 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		if info.IsDir() && !opts.dirSelf {
 			dirs = append(dirs, name)
 		} else {
-			files = append(files, name)
+			// Reuse the Lstat result so the listing pipeline never restats this
+			// command-line operand.
+			files = append(files, entry{name: name, dir: "", info: info})
 		}
 	}
 
 	if len(files) > 0 {
-		c.sortNames(files, "", opts)
-		c.listNames(stdio.Out, "", files, opts)
+		sortEntries(files, opts)
+		c.listEntries(stdio.Out, files, opts)
 		if len(dirs) > 0 {
 			_, _ = fmt.Fprintln(stdio.Out)
 		}
@@ -413,18 +415,25 @@ func (c *Command) listDir(out, errw io.Writer, dir string, opts options) error {
 		names = append(names, name)
 	}
 
-	c.sortNames(names, dir, opts)
-	c.listNames(out, dir, names, opts)
+	// Populate each entry's metadata once; sorting, decoration, long-format
+	// rendering, and recursion all consume this cached info instead of
+	// restatting the path.
+	items := make([]entry, 0, len(names))
+	for _, n := range names {
+		items = append(items, newEntry(dir, n))
+	}
+
+	sortEntries(items, opts)
+	c.listEntries(out, items, opts)
 
 	if opts.recursive {
 		var subdirs []string
-		for _, n := range names {
-			if n == "." || n == ".." {
+		for _, e := range items {
+			if e.name == "." || e.name == ".." {
 				continue
 			}
-			full := filepath.Join(dir, n)
-			if info, err := os.Lstat(full); err == nil && info.IsDir() {
-				subdirs = append(subdirs, full)
+			if e.isDir() {
+				subdirs = append(subdirs, e.path())
 			}
 		}
 		for _, sd := range subdirs {
@@ -454,18 +463,74 @@ func filtered(name string, opts options) bool {
 	return false
 }
 
-// sortNames orders names in place according to the active sort key. "." and
-// ".." always sort first to match GNU's name ordering; --group-directories-
-// first hoists directories ahead of files within the chosen order.
-func (c *Command) sortNames(names []string, dir string, opts options) {
+// entry is a listing item paired with its already-resolved metadata. Building
+// it once per operand or directory entry lets sorting, decoration, long-format
+// rendering, and recursive traversal share a single os.Lstat instead of
+// restatting the same path through every helper.
+type entry struct {
+	name string      // display name (may be "." or "..")
+	dir  string      // directory the name lives in ("" for command-line operands)
+	info os.FileInfo // from Lstat; nil when the path could not be stated
+}
+
+// newEntry resolves name (within dir) to an entry, caching its Lstat result. A
+// stat failure yields an entry with a nil info, which the consumers treat the
+// same way the old per-helper Lstat-error branches did.
+func newEntry(dir, name string) entry {
+	info, err := os.Lstat(pathOf(dir, name))
+	if err != nil {
+		return entry{name: name, dir: dir}
+	}
+	return entry{name: name, dir: dir, info: info}
+}
+
+// path returns the filesystem path the entry refers to.
+func (e entry) path() string { return pathOf(e.dir, e.name) }
+
+// isDir reports whether the entry is a directory (false when unstated).
+func (e entry) isDir() bool { return e.info != nil && e.info.IsDir() }
+
+// size returns the entry's byte size, or 0 when unstated.
+func (e entry) size() int64 {
+	if e.info == nil {
+		return 0
+	}
+	return e.info.Size()
+}
+
+// inode returns the entry's inode number, or 0 when unavailable.
+func (e entry) inode() uint64 {
+	if e.info == nil {
+		return 0
+	}
+	if st, ok := e.info.Sys().(*syscall.Stat_t); ok {
+		return st.Ino
+	}
+	return 0
+}
+
+// modTime returns the entry's selected timestamp, or the zero time when
+// unstated.
+func (e entry) modTime(field timeField) time.Time {
+	if e.info == nil {
+		return time.Time{}
+	}
+	return timeFromInfo(e.info, field)
+}
+
+// sortEntries orders entries in place according to the active sort key.
+// --group-directories-first hoists directories ahead of files within the chosen
+// order. The comparison logic mirrors the previous name-based sort exactly so
+// output stays byte-for-byte stable.
+func sortEntries(entries []entry, opts options) {
 	if opts.sortBy == sortNone && !opts.groupDirs {
 		return
 	}
 
 	less := func(i, j int) bool {
-		a, b := names[i], names[j]
+		a, b := entries[i], entries[j]
 		if opts.groupDirs {
-			ad, bd := isDir(dir, a), isDir(dir, b)
+			ad, bd := a.isDir(), b.isDir()
 			if ad != bd {
 				return ad
 			}
@@ -474,105 +539,98 @@ func (c *Command) sortNames(names []string, dir string, opts options) {
 		case sortNone:
 			return false // keep directory order within the group
 		case sortSize:
-			sa, sb := sizeOf(dir, a), sizeOf(dir, b)
-			if sa != sb {
-				return sa > sb // larger first, like GNU
+			if a.size() != b.size() {
+				return a.size() > b.size() // larger first, like GNU
 			}
-			return a < b
+			return a.name < b.name
 		case sortTime:
-			ta, tb := timeOf(dir, a, opts.timeBy), timeOf(dir, b, opts.timeBy)
+			ta, tb := a.modTime(opts.timeBy), b.modTime(opts.timeBy)
 			if !ta.Equal(tb) {
 				return ta.After(tb) // newest first
 			}
-			return a < b
+			return a.name < b.name
 		case sortVersion:
-			if cmp := versionCompare(a, b); cmp != 0 {
+			if cmp := versionCompare(a.name, b.name); cmp != 0 {
 				return cmp < 0
 			}
-			return a < b
+			return a.name < b.name
 		case sortExtension:
-			ea, eb := filepath.Ext(a), filepath.Ext(b)
+			ea, eb := filepath.Ext(a.name), filepath.Ext(b.name)
 			if ea != eb {
 				return ea < eb
 			}
-			return a < b
+			return a.name < b.name
 		default:
-			return a < b
+			return a.name < b.name
 		}
 	}
 
-	sort.SliceStable(names, less)
+	sort.SliceStable(entries, less)
 }
 
-// listNames prints the given names (which live in dir) in the selected format.
-func (c *Command) listNames(out io.Writer, dir string, names []string, opts options) {
+// listEntries prints the given entries in the selected format.
+func (c *Command) listEntries(out io.Writer, entries []entry, opts options) {
 	if !opts.long {
-		for _, n := range names {
+		for _, e := range entries {
 			prefix := ""
 			if opts.inode {
-				prefix = fmt.Sprintf("%d ", inodeOf(dir, n))
+				prefix = fmt.Sprintf("%d ", e.inode())
 			}
-			_, _ = fmt.Fprintln(out, prefix+c.decorate(dir, n, opts))
+			_, _ = fmt.Fprintln(out, prefix+c.decorate(e, opts))
 		}
 		return
 	}
-	for _, n := range names {
-		_, _ = fmt.Fprintln(out, c.longLine(dir, n, opts))
+	for _, e := range entries {
+		_, _ = fmt.Fprintln(out, c.longLine(e, opts))
 	}
 }
 
 // decorate returns the display name with color (if enabled) and indicator (if
 // requested) applied.
-func (c *Command) decorate(dir, name string, opts options) string {
-	return c.colorize(dir, name, opts) + c.indicator(dir, name, opts)
+func (c *Command) decorate(e entry, opts options) string {
+	return c.colorize(e, opts) + c.indicator(e, opts)
 }
 
-// colorize wraps name in ANSI escapes based on its type, when color is on.
-func (c *Command) colorize(dir, name string, opts options) string {
-	if !opts.color {
-		return name
-	}
-	info, err := os.Lstat(pathOf(dir, name))
-	if err != nil {
-		return name
+// colorize wraps the entry's name in ANSI escapes based on its type, when color
+// is on.
+func (c *Command) colorize(e entry, opts options) string {
+	if !opts.color || e.info == nil {
+		return e.name
 	}
 	var col string
 	switch {
-	case info.IsDir():
+	case e.info.IsDir():
 		col = colorDir
-	case info.Mode()&os.ModeSymlink != 0:
+	case e.info.Mode()&os.ModeSymlink != 0:
 		col = colorSymlink
-	case info.Mode()&0o111 != 0 && info.Mode().IsRegular():
+	case e.info.Mode()&0o111 != 0 && e.info.Mode().IsRegular():
 		col = colorExec
 	default:
-		return name
+		return e.name
 	}
-	return col + name + colorReset
+	return col + e.name + colorReset
 }
 
-// indicator returns the type suffix for a name per the active indicator style.
-func (c *Command) indicator(dir, name string, opts options) string {
-	if opts.indicator == indicatorNone {
+// indicator returns the type suffix for the entry per the active indicator
+// style.
+func (c *Command) indicator(e entry, opts options) string {
+	if opts.indicator == indicatorNone || e.info == nil {
 		return ""
 	}
-	info, err := os.Lstat(pathOf(dir, name))
-	if err != nil {
-		return ""
-	}
-	if info.IsDir() {
+	if e.info.IsDir() {
 		return "/"
 	}
 	if opts.indicator == indicatorSlash {
 		return ""
 	}
 	switch {
-	case info.Mode()&os.ModeSymlink != 0:
+	case e.info.Mode()&os.ModeSymlink != 0:
 		return "@"
-	case info.Mode()&os.ModeNamedPipe != 0:
+	case e.info.Mode()&os.ModeNamedPipe != 0:
 		return "|"
-	case info.Mode()&os.ModeSocket != 0:
+	case e.info.Mode()&os.ModeSocket != 0:
 		return "="
-	case info.Mode()&0o111 != 0 && info.Mode().IsRegular():
+	case e.info.Mode()&0o111 != 0 && e.info.Mode().IsRegular():
 		if opts.indicator == indicatorFileType {
 			return "" // file-type omits the executable marker
 		}
@@ -583,11 +641,11 @@ func (c *Command) indicator(dir, name string, opts options) string {
 }
 
 // longLine formats one entry for -l.
-func (c *Command) longLine(dir, name string, opts options) string {
-	info, err := os.Lstat(pathOf(dir, name))
-	if err != nil {
-		return name
+func (c *Command) longLine(e entry, opts options) string {
+	if e.info == nil {
+		return e.name
 	}
+	info := e.info
 	mode := modeString(info)
 	nlink := uint64(1)
 	owner, group := "?", "?"
@@ -598,53 +656,17 @@ func (c *Command) longLine(dir, name string, opts options) string {
 	}
 	size := sizeString(info.Size(), opts.human, opts.blockSize)
 	when := timeString(timeFromInfo(info, opts.timeBy))
-	display := c.colorize(dir, name, opts) + c.indicator(dir, name, opts)
+	display := c.colorize(e, opts) + c.indicator(e, opts)
 	if info.Mode()&os.ModeSymlink != 0 {
-		if target, err := os.Readlink(pathOf(dir, name)); err == nil {
-			display = c.colorize(dir, name, opts) + " -> " + target
+		if target, err := os.Readlink(e.path()); err == nil {
+			display = c.colorize(e, opts) + " -> " + target
 		}
 	}
 	prefix := ""
 	if opts.inode {
-		prefix = fmt.Sprintf("%d ", inodeOf(dir, name))
+		prefix = fmt.Sprintf("%d ", e.inode())
 	}
 	return fmt.Sprintf("%s%s %d %s %s %s %s %s", prefix, mode, nlink, owner, group, size, when, display)
-}
-
-// inodeOf returns the inode number for a name, or 0 when it cannot be stated.
-func inodeOf(dir, name string) uint64 {
-	info, err := os.Lstat(pathOf(dir, name))
-	if err != nil {
-		return 0
-	}
-	if st, ok := info.Sys().(*syscall.Stat_t); ok {
-		return st.Ino
-	}
-	return 0
-}
-
-// isDir reports whether name (in dir) is a directory.
-func isDir(dir, name string) bool {
-	info, err := os.Lstat(pathOf(dir, name))
-	return err == nil && info.IsDir()
-}
-
-// sizeOf returns the byte size of a name, or 0 when it cannot be stated.
-func sizeOf(dir, name string) int64 {
-	info, err := os.Lstat(pathOf(dir, name))
-	if err != nil {
-		return 0
-	}
-	return info.Size()
-}
-
-// timeOf returns the selected timestamp for a name.
-func timeOf(dir, name string, field timeField) time.Time {
-	info, err := os.Lstat(pathOf(dir, name))
-	if err != nil {
-		return time.Time{}
-	}
-	return timeFromInfo(info, field)
 }
 
 // timeFromInfo extracts the requested timestamp from a FileInfo.

--- a/internal/applets/fileutils/ls/ls.go
+++ b/internal/applets/fileutils/ls/ls.go
@@ -201,8 +201,8 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		if info.IsDir() && !opts.dirSelf {
 			dirs = append(dirs, name)
 		} else {
-			// Reuse the Lstat result so the listing pipeline never restats this
-			// command-line operand.
+			// Reuse the Lstat result so the listing pipeline never calls Lstat
+			// again on this command-line operand.
 			files = append(files, entry{name: name, dir: "", info: info})
 		}
 	}
@@ -416,8 +416,8 @@ func (c *Command) listDir(out, errw io.Writer, dir string, opts options) error {
 	}
 
 	// Populate each entry's metadata once; sorting, decoration, long-format
-	// rendering, and recursion all consume this cached info instead of
-	// restatting the path.
+	// rendering, and recursion all consume this cached info instead of calling
+	// Lstat on the path again.
 	items := make([]entry, 0, len(names))
 	for _, n := range names {
 		items = append(items, newEntry(dir, n))
@@ -466,7 +466,7 @@ func filtered(name string, opts options) bool {
 // entry is a listing item paired with its already-resolved metadata. Building
 // it once per operand or directory entry lets sorting, decoration, long-format
 // rendering, and recursive traversal share a single os.Lstat instead of
-// restatting the same path through every helper.
+// re-running Lstat on the same path through every helper.
 type entry struct {
 	name string      // display name (may be "." or "..")
 	dir  string      // directory the name lives in ("" for command-line operands)

--- a/internal/applets/fileutils/ls/ls_entry_test.go
+++ b/internal/applets/fileutils/ls/ls_entry_test.go
@@ -1,0 +1,269 @@
+package ls
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// richFixture builds a directory holding one of each entry kind the listing
+// pipeline decorates differently: a regular file, a directory, a symlink, and
+// an executable. It returns the directory path.
+func richFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "reg.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "adir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "run.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Point at a name that does not collide with any listed entry, so line
+	// matching by name fragment is unambiguous.
+	if err := os.Symlink("elsewhere", filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// lineFor returns the single output line that ends with the given display name
+// fragment, to keep assertions stable against owner/group/time variation.
+func lineFor(t *testing.T, out, frag string) string {
+	t.Helper()
+	for _, ln := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if strings.Contains(ln, frag) {
+			return ln
+		}
+	}
+	t.Fatalf("no line containing %q in:\n%s", frag, out)
+	return ""
+}
+
+// TestCombinedLongClassifyInode locks the combined -l -F -i rendering across a
+// regular file, directory, symlink, and executable, with color disabled (the
+// default). This is the behavior the entry-model refactor must keep byte-stable.
+func TestCombinedLongClassifyInode(t *testing.T) {
+	t.Parallel()
+	dir := richFixture(t)
+	out, err := run(t, "-l", "-F", "-i", dir)
+	if err != nil {
+		t.Fatalf("ls -lFi error = %v", err)
+	}
+	// No ANSI escapes when color is off.
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("color should be off by default, got escapes: %q", out)
+	}
+
+	// Each line is prefixed by the real inode number from Lstat.
+	for _, name := range []string{"reg.txt", "adir", "run.sh", "link"} {
+		info, err := os.Lstat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			t.Skip("no syscall.Stat_t on this platform")
+		}
+		ln := lineFor(t, out, name)
+		if !strings.HasPrefix(ln, strconv.FormatUint(st.Ino, 10)+" ") {
+			t.Errorf("line for %s = %q, want inode %d prefix", name, ln, st.Ino)
+		}
+	}
+
+	// Directory: mode starts with 'd', name has a trailing '/'.
+	if ln := lineFor(t, out, "adir"); !strings.Contains(ln, " adir/") || !strings.Contains(ln, " d") {
+		t.Errorf("dir line = %q, want 'd' mode and adir/ suffix", ln)
+	}
+	// Executable: classify appends '*'.
+	if ln := lineFor(t, out, "run.sh"); !strings.HasSuffix(ln, "run.sh*") {
+		t.Errorf("exec line = %q, want run.sh* suffix", ln)
+	}
+	// Symlink: mode starts with 'l' and the target is shown.
+	if ln := lineFor(t, out, "link"); !strings.Contains(ln, "link -> elsewhere") || !strings.Contains(ln, " l") {
+		t.Errorf("symlink line = %q, want 'l' mode and 'link -> elsewhere'", ln)
+	}
+}
+
+// TestColorDisabledPlain proves the non-long path emits no ANSI escapes when
+// color is off, for every entry kind.
+func TestColorDisabledPlain(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "-F", richFixture(t))
+	if err != nil {
+		t.Fatalf("ls -F error = %v", err)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("unexpected ANSI escapes with color off: %q", out)
+	}
+	for _, want := range []string{"adir/", "link@", "run.sh*", "reg.txt"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+// TestColorEnabledWrapsTypes locks the color rendering for each type so the
+// refactor keeps the same escapes around dir/exec/symlink names.
+func TestColorEnabledWrapsTypes(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "--color=always", richFixture(t))
+	if err != nil {
+		t.Fatalf("ls --color=always error = %v", err)
+	}
+	if !strings.Contains(out, colorDir+"adir"+colorReset) {
+		t.Errorf("dir not colored: %q", out)
+	}
+	if !strings.Contains(out, colorExec+"run.sh"+colorReset) {
+		t.Errorf("exec not colored: %q", out)
+	}
+	if !strings.Contains(out, colorSymlink+"link"+colorReset) {
+		t.Errorf("symlink not colored: %q", out)
+	}
+}
+
+// sortFixture writes files with controlled sizes, mtimes, names and a directory
+// so the sort-key + group-directories-first combinations are deterministic.
+func sortFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name string, size int, age time.Duration) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(strings.Repeat("x", size)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		when := time.Now().Add(-age)
+		if err := os.Chtimes(p, when, when); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("big.log", 300, 3*time.Hour)   // largest, oldest
+	write("mid.txt", 200, 2*time.Hour)   // middle
+	write("small.dat", 100, 1*time.Hour) // smallest, newest
+	if err := os.MkdirAll(filepath.Join(dir, "zdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func names(out string) []string {
+	return strings.Split(strings.TrimRight(out, "\n"), "\n")
+}
+
+// TestSortSizeGroupDirs locks --sort=size with --group-directories-first: the
+// directory comes first, then files largest-first.
+func TestSortSizeGroupDirs(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "--sort=size", "--group-directories-first", sortFixture(t))
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	want := []string{"zdir", "big.log", "mid.txt", "small.dat"}
+	if got := names(out); !equalSlice(got, want) {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+// TestSortTimeGroupDirs locks --sort=time with --group-directories-first:
+// directory first, then files newest-first.
+func TestSortTimeGroupDirs(t *testing.T) {
+	t.Parallel()
+	out, err := run(t, "--sort=time", "--group-directories-first", sortFixture(t))
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	want := []string{"zdir", "small.dat", "mid.txt", "big.log"}
+	if got := names(out); !equalSlice(got, want) {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+// TestSortVersionGroupDirs locks --sort=version with --group-directories-first.
+func TestSortVersionGroupDirs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, n := range []string{"f2", "f10", "f1"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "d1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := run(t, "--sort=version", "--group-directories-first", dir)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	want := []string{"d1", "f1", "f2", "f10"}
+	if got := names(out); !equalSlice(got, want) {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+// TestSortExtensionGroupDirs locks --sort=extension with
+// --group-directories-first.
+func TestSortExtensionGroupDirs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, n := range []string{"b.go", "a.txt", "c.go"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "zd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := run(t, "--sort=extension", "--group-directories-first", dir)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	// Directory first; then files by extension (.go before .txt), name as tie.
+	want := []string{"zd", "b.go", "c.go", "a.txt"}
+	if got := names(out); !equalSlice(got, want) {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// BenchmarkListManyEntriesLong measures listing a directory with many entries in
+// long+inode form, where the old code restatted each entry many times. It lets
+// the entry-model refactor demonstrate fewer duplicate metadata lookups without
+// changing output.
+func BenchmarkListManyEntriesLong(b *testing.B) {
+	dir := b.TempDir()
+	for i := 0; i < 500; i++ {
+		p := filepath.Join(dir, "file"+strconv.Itoa(i)+".txt")
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	stdio := command.IO{In: strings.NewReader(""), Out: io.Discard, Err: io.Discard}
+	cmd := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := cmd.Run(context.Background(), stdio, []string{"-l", "-i", "--sort=size", dir}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/applets/fileutils/ls/ls_gnu_test.go
+++ b/internal/applets/fileutils/ls/ls_gnu_test.go
@@ -157,49 +157,64 @@ func TestParseSort(t *testing.T) {
 	}
 }
 
+// entriesFor builds entry values (with cached metadata) for the named files in
+// dir, mirroring how the listing pipeline populates them.
+func entriesFor(dir string, names ...string) []entry {
+	es := make([]entry, 0, len(names))
+	for _, n := range names {
+		es = append(es, newEntry(dir, n))
+	}
+	return es
+}
+
+func entryNames(es []entry) []string {
+	names := make([]string, len(es))
+	for i, e := range es {
+		names[i] = e.name
+	}
+	return names
+}
+
 func TestSortSize(t *testing.T) {
 	t.Parallel()
 	dir := gnuFixture(t)
-	names := []string{"small.txt", "big.txt", "a.log"}
-	c := New()
-	c.sortNames(names, dir, options{sortBy: sortSize})
-	if names[0] != "big.txt" {
-		t.Errorf("size sort should put big.txt first: %v", names)
+	es := entriesFor(dir, "small.txt", "big.txt", "a.log")
+	sortEntries(es, options{sortBy: sortSize})
+	if es[0].name != "big.txt" {
+		t.Errorf("size sort should put big.txt first: %v", entryNames(es))
 	}
 }
 
 func TestSortTime(t *testing.T) {
 	t.Parallel()
 	dir := gnuFixture(t)
-	names := []string{"small.txt", "big.txt"}
-	c := New()
-	c.sortNames(names, dir, options{sortBy: sortTime, timeBy: timeMtime})
+	es := entriesFor(dir, "small.txt", "big.txt")
+	sortEntries(es, options{sortBy: sortTime, timeBy: timeMtime})
 	// big.txt is more recent, so it sorts first.
-	if names[0] != "big.txt" {
-		t.Errorf("time sort newest-first wrong: %v", names)
+	if es[0].name != "big.txt" {
+		t.Errorf("time sort newest-first wrong: %v", entryNames(es))
 	}
 }
 
 func TestSortVersion(t *testing.T) {
 	t.Parallel()
-	names := []string{"file10", "file2", "file1"}
-	c := New()
-	c.sortNames(names, "", options{sortBy: sortVersion})
+	es := entriesFor("", "file10", "file2", "file1")
+	sortEntries(es, options{sortBy: sortVersion})
 	want := []string{"file1", "file2", "file10"}
+	got := entryNames(es)
 	for i := range want {
-		if names[i] != want[i] {
-			t.Fatalf("version sort = %v, want %v", names, want)
+		if got[i] != want[i] {
+			t.Fatalf("version sort = %v, want %v", got, want)
 		}
 	}
 }
 
 func TestSortExtension(t *testing.T) {
 	t.Parallel()
-	names := []string{"b.txt", "a.log", "c.txt"}
-	c := New()
-	c.sortNames(names, "", options{sortBy: sortExtension})
-	if names[0] != "a.log" {
-		t.Errorf(".log should sort before .txt: %v", names)
+	es := entriesFor("", "b.txt", "a.log", "c.txt")
+	sortEntries(es, options{sortBy: sortExtension})
+	if es[0].name != "a.log" {
+		t.Errorf(".log should sort before .txt: %v", entryNames(es))
 	}
 }
 
@@ -277,7 +292,7 @@ func TestInode(t *testing.T) {
 	dir := gnuFixture(t)
 	out, _ := run(t, "-i", "--ignore=*", dir, filepath.Join(dir, "small.txt"))
 	// -i prints inode before the name; ensure the line starts with a number.
-	got := inodeOf(dir, "small.txt")
+	got := newEntry(dir, "small.txt").inode()
 	if got == 0 {
 		t.Skip("inode not available on this platform")
 	}


### PR DESCRIPTION
## Summary

`ls`'s listing pipeline mixed operand parsing, directory walking, sorting, metadata lookup, and rendering, and it restatted the same path through `sortNames`, `colorize`, `indicator`, `longLine`, `inodeOf`, `isDir`, `sizeOf`, and `timeOf`. Listing a large directory therefore incurred many redundant `os.Lstat` calls and spread type decisions across scattered helpers.

## Changes

Introduce an `entry` type holding a name, its directory, and a single cached `os.Lstat` result, populated once per command-line operand or directory entry via `newEntry`. Sorting (`sortEntries`), decoration (`colorize`/`indicator`), long-format rendering (`longLine`), the inode prefix, and recursive descent now consume the cached metadata through small `entry` accessors (`isDir`, `size`, `inode`, `modTime`) instead of restatting the path. Command-line operands reuse the `Lstat` already performed during operand classification. Traversal stays in `listDir`/`Run`, separate from per-entry policy.

Add output-locking tests for combined `-l`/`-F`/`-i` and color rendering across a regular file, directory, symlink, and executable; `--sort=size|time|version|extension` paired with `--group-directories-first`; and a benchmark over a 500-entry directory. Existing internal sort/inode tests are updated to the entry API.

## Design Decisions

The comparison and rendering logic is copied verbatim into the entry-based helpers, so user-facing output is byte-for-byte stable; the change is purely structural plus the metadata caching. A nil `info` (stat failure) is handled in each accessor exactly as the old per-helper `Lstat`-error branches were, preserving the previous fallbacks. Tests that lock the combined output were added first so the extraction could be proven non-behavior-changing.

Closes #939