### PR TITLE
refactor(i2c): split applets over shared parse/render helpers

### DIFF
--- a/internal/applets/embedded/i2c/i2c.go
+++ b/internal/applets/embedded/i2c/i2c.go
@@ -1,15 +1,25 @@
 // Package i2c implements the BusyBox I2C applets (i2cdetect, i2cget, i2cset,
-// i2cdump, i2ctransfer) over a shared, injectable bus backend so the argument
-// parsing and command planning are unit testable without real I2C hardware.
+// i2cdump) over a shared, injectable bus backend so the argument parsing and
+// command planning are unit testable without real I2C hardware.
+//
+// The package is split so that backend-independent parsing (parse.go) and
+// rendering (render.go) live apart from the per-applet front-ends
+// (i2cdetect.go, i2cget.go, i2cset.go, i2cdump.go); this file holds only the
+// shared Command type, its constructors, and the name-based dispatch tables.
 package i2c
 
 import (
 	"context"
-	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// command name constants for the multi-applet package.
+const (
+	cmdI2cdetect = "i2cdetect"
+	cmdI2cget    = "i2cget"
+	cmdI2cset    = "i2cset"
+	cmdI2cdump   = "i2cdump"
 )
 
 // Backend abstracts an I2C bus so commands can be planned and tested without
@@ -32,16 +42,16 @@ var busBackend Backend = osBackend{}
 type Command struct{ name string }
 
 // NewI2cdetect returns the i2cdetect applet.
-func NewI2cdetect() *Command { return &Command{name: "i2cdetect"} }
+func NewI2cdetect() *Command { return &Command{name: cmdI2cdetect} }
 
 // NewI2cget returns the i2cget applet.
-func NewI2cget() *Command { return &Command{name: "i2cget"} }
+func NewI2cget() *Command { return &Command{name: cmdI2cget} }
 
 // NewI2cset returns the i2cset applet.
-func NewI2cset() *Command { return &Command{name: "i2cset"} }
+func NewI2cset() *Command { return &Command{name: cmdI2cset} }
 
 // NewI2cdump returns the i2cdump applet.
-func NewI2cdump() *Command { return &Command{name: "i2cdump"} }
+func NewI2cdump() *Command { return &Command{name: cmdI2cdump} }
 
 // Name returns the command name.
 func (c *Command) Name() string { return c.name }
@@ -49,13 +59,13 @@ func (c *Command) Name() string { return c.name }
 // Synopsis returns the one-line description shown in the applet list.
 func (c *Command) Synopsis() string {
 	switch c.name {
-	case "i2cdetect":
+	case cmdI2cdetect:
 		return "Detect I2C chips on a bus"
-	case "i2cget":
+	case cmdI2cget:
 		return "Read a byte from an I2C device"
-	case "i2cset":
+	case cmdI2cset:
 		return "Write a byte to an I2C device"
-	case "i2cdump":
+	case cmdI2cdump:
 		return "Dump the registers of an I2C device"
 	}
 	return "I2C bus tool"
@@ -64,219 +74,14 @@ func (c *Command) Synopsis() string {
 // Run dispatches to the per-command implementation.
 func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error {
 	switch c.name {
-	case "i2cdetect":
+	case cmdI2cdetect:
 		return c.runDetect(stdio, args)
-	case "i2cget":
+	case cmdI2cget:
 		return c.runGet(stdio, args)
-	case "i2cset":
+	case cmdI2cset:
 		return c.runSet(stdio, args)
-	case "i2cdump":
+	case cmdI2cdump:
 		return c.runDump(stdio, args)
 	}
 	return command.Failuref("unknown i2c command %q", c.name)
-}
-
-// runDetect implements i2cdetect.
-func (c *Command) runDetect(stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.name, "[-y] BUS", stdio.Err).WithHelp(command.Help{
-		Description: "Scan I2C BUS (a bus number, e.g. 1 for /dev/i2c-1) and print a grid of the 7-bit " +
-			"addresses 0x03-0x77 that respond. Probing reads from devices and is normally safe, but on " +
-			"some chips a quick-write probe can have side effects. Access needs privilege; without it the " +
-			"command fails with a documented error.",
-		Examples: []command.Example{
-			{Command: "i2cdetect -y 1", Explain: "Scan bus 1 without the interactive confirmation."},
-		},
-		ExitStatus: "0  the scan completed.\n1  bad arguments or the bus could not be opened.",
-	})
-	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
-	proceed, err := fs.Parse(stdio, args)
-	if err != nil || !proceed {
-		return err
-	}
-	rest := fs.Args()
-	if len(rest) != 1 {
-		return command.Failuref("usage: i2cdetect [-y] BUS")
-	}
-	bus, err := parseInt(rest[0])
-	if err != nil {
-		return command.Failuref("invalid bus %q", rest[0])
-	}
-	found, err := busBackend.Detect(bus, 0x03, 0x77)
-	if err != nil {
-		return command.Failuref("%v", err)
-	}
-	writeDetectGrid(stdio, found)
-	return nil
-}
-
-// runGet implements i2cget.
-func (c *Command) runGet(stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.name, "[-y] BUS CHIP-ADDR [REG]", stdio.Err).WithHelp(command.Help{
-		Description: "Read one byte from the I2C device at CHIP-ADDR on BUS. With REG the byte is read from " +
-			"that register; without it the byte is read from the current pointer. Values may be given in " +
-			"hex (0x..), decimal, or octal. The result is printed in hex. Access needs privilege.",
-		Examples: []command.Example{
-			{Command: "i2cget -y 1 0x50 0x00", Explain: "Read register 0x00 of chip 0x50 on bus 1."},
-		},
-		ExitStatus: "0  the read succeeded.\n1  bad arguments or the read failed.",
-	})
-	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
-	proceed, err := fs.Parse(stdio, args)
-	if err != nil || !proceed {
-		return err
-	}
-	bus, addr, reg, err := parseChipReg(fs.Args(), false)
-	if err != nil {
-		return command.Failuref("%v", err)
-	}
-	v, err := busBackend.ReadReg(bus, addr, reg)
-	if err != nil {
-		return command.Failuref("%v", err)
-	}
-	_, _ = fmt.Fprintf(stdio.Out, "0x%02x\n", v)
-	return nil
-}
-
-// runSet implements i2cset.
-func (c *Command) runSet(stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.name, "[-y] BUS CHIP-ADDR REG VALUE", stdio.Err).WithHelp(command.Help{
-		Description: "Write one byte VALUE to register REG of the I2C device at CHIP-ADDR on BUS. WARNING: " +
-			"writing to a device register can change hardware state irreversibly. Access needs privilege; " +
-			"without it the command fails with a documented error.",
-		Examples: []command.Example{
-			{Command: "i2cset -y 1 0x50 0x10 0xff", Explain: "Write 0xff to register 0x10 of chip 0x50 (destructive)."},
-		},
-		ExitStatus: "0  the write succeeded.\n1  bad arguments or the write failed.",
-	})
-	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
-	proceed, err := fs.Parse(stdio, args)
-	if err != nil || !proceed {
-		return err
-	}
-	rest := fs.Args()
-	if len(rest) != 4 {
-		return command.Failuref("usage: i2cset [-y] BUS CHIP-ADDR REG VALUE")
-	}
-	bus, addr, reg, err := parseChipReg(rest[:3], true)
-	if err != nil {
-		return command.Failuref("%v", err)
-	}
-	val, err := parseInt(rest[3])
-	if err != nil || val < 0 || val > 0xff {
-		return command.Failuref("invalid byte value %q", rest[3])
-	}
-	if err := busBackend.WriteReg(bus, addr, reg, byte(val)); err != nil {
-		return command.Failuref("%v", err)
-	}
-	return nil
-}
-
-// runDump implements i2cdump by reading every register 0x00-0xff.
-func (c *Command) runDump(stdio command.IO, args []string) error {
-	fs := command.NewFlagSet(c.name, "[-y] BUS CHIP-ADDR", stdio.Err).WithHelp(command.Help{
-		Description: "Read and print all 256 registers (0x00-0xff) of the I2C device at CHIP-ADDR on BUS as " +
-			"a hex table. Each register is read individually. Access needs privilege; without it the " +
-			"command fails with a documented error.",
-		Examples: []command.Example{
-			{Command: "i2cdump -y 1 0x50", Explain: "Dump every register of chip 0x50 on bus 1."},
-		},
-		ExitStatus: "0  the dump completed.\n1  bad arguments or a read failed.",
-	})
-	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
-	proceed, err := fs.Parse(stdio, args)
-	if err != nil || !proceed {
-		return err
-	}
-	rest := fs.Args()
-	if len(rest) != 2 {
-		return command.Failuref("usage: i2cdump [-y] BUS CHIP-ADDR")
-	}
-	bus, err := parseInt(rest[0])
-	if err != nil {
-		return command.Failuref("invalid bus %q", rest[0])
-	}
-	addr, err := parseInt(rest[1])
-	if err != nil {
-		return command.Failuref("invalid chip address %q", rest[1])
-	}
-	var regs [256]byte
-	for reg := 0; reg < 256; reg++ {
-		v, err := busBackend.ReadReg(bus, addr, reg)
-		if err != nil {
-			return command.Failuref("%v", err)
-		}
-		regs[reg] = v
-	}
-	writeDump(stdio, regs)
-	return nil
-}
-
-// parseChipReg parses BUS CHIP-ADDR [REG]. When regRequired is true REG must be
-// present; otherwise a missing REG yields -1 (current pointer).
-func parseChipReg(args []string, regRequired bool) (bus, addr, reg int, err error) {
-	if len(args) < 2 || len(args) > 3 {
-		return 0, 0, 0, fmt.Errorf("expected BUS CHIP-ADDR [REG]")
-	}
-	bus, err = parseInt(args[0])
-	if err != nil {
-		return 0, 0, 0, fmt.Errorf("invalid bus %q", args[0])
-	}
-	addr, err = parseInt(args[1])
-	if err != nil || addr < 0x03 || addr > 0x77 {
-		return 0, 0, 0, fmt.Errorf("invalid chip address %q (want 0x03-0x77)", args[1])
-	}
-	reg = -1
-	if len(args) == 3 {
-		reg, err = parseInt(args[2])
-		if err != nil || reg < 0 || reg > 0xff {
-			return 0, 0, 0, fmt.Errorf("invalid register %q", args[2])
-		}
-	} else if regRequired {
-		return 0, 0, 0, fmt.Errorf("a register operand is required")
-	}
-	return bus, addr, reg, nil
-}
-
-// parseInt parses a C-style signed integer (0x hex, 0 octal, else decimal).
-func parseInt(s string) (int, error) {
-	n, err := strconv.ParseInt(s, 0, 32)
-	return int(n), err
-}
-
-// writeDetectGrid renders the i2cdetect address grid.
-func writeDetectGrid(stdio command.IO, found []int) {
-	set := make(map[int]bool, len(found))
-	for _, a := range found {
-		set[a] = true
-	}
-	_, _ = fmt.Fprintln(stdio.Out, "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f")
-	for row := 0; row < 8; row++ {
-		var b strings.Builder
-		fmt.Fprintf(&b, "%02x:", row*16)
-		for col := 0; col < 16; col++ {
-			addr := row*16 + col
-			switch {
-			case addr < 0x03 || addr > 0x77:
-				b.WriteString("   ")
-			case set[addr]:
-				fmt.Fprintf(&b, " %02x", addr)
-			default:
-				b.WriteString(" --")
-			}
-		}
-		_, _ = fmt.Fprintln(stdio.Out, b.String())
-	}
-}
-
-// writeDump renders the 256-register hex table.
-func writeDump(stdio command.IO, regs [256]byte) {
-	_, _ = fmt.Fprintln(stdio.Out, "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f")
-	for row := 0; row < 16; row++ {
-		var b strings.Builder
-		fmt.Fprintf(&b, "%02x:", row*16)
-		for col := 0; col < 16; col++ {
-			fmt.Fprintf(&b, " %02x", regs[row*16+col])
-		}
-		_, _ = fmt.Fprintln(stdio.Out, b.String())
-	}
 }

--- a/internal/applets/embedded/i2c/i2c_parse_test.go
+++ b/internal/applets/embedded/i2c/i2c_parse_test.go
@@ -172,6 +172,8 @@ func TestInvalidOperandsAcrossApplets(t *testing.T) {
 		{"set too few", NewI2cset, []string{"-y", "1", "0x50", "0x10"}},
 		{"dump bad bus", NewI2cdump, []string{"-y", "bad", "0x50"}},
 		{"dump bad addr", NewI2cdump, []string{"-y", "1", "bad"}},
+		{"dump addr too high", NewI2cdump, []string{"-y", "1", "0x99"}},
+		{"dump addr too low", NewI2cdump, []string{"-y", "1", "0x02"}},
 		{"dump wrong arity", NewI2cdump, []string{"-y", "1"}},
 	}
 	for _, tt := range tests {

--- a/internal/applets/embedded/i2c/i2c_parse_test.go
+++ b/internal/applets/embedded/i2c/i2c_parse_test.go
@@ -1,0 +1,184 @@
+package i2c
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+func TestParseInt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"hex", "0x50", 0x50, false},
+		{"hex upper", "0XFF", 0xff, false},
+		{"decimal", "42", 42, false},
+		{"octal", "010", 8, false},
+		{"zero", "0", 0, false},
+		{"negative", "-1", -1, false},
+		{"empty", "", 0, true},
+		{"garbage", "xyz", 0, true},
+		{"trailing", "0x50z", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseInt(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseInt(%q) = %d, want error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseInt(%q) unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseInt(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseChipReg(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		args        []string
+		regRequired bool
+		wantBus     int
+		wantAddr    int
+		wantReg     int
+		wantErr     bool
+	}{
+		{"bus addr no reg", []string{"1", "0x50"}, false, 1, 0x50, -1, false},
+		{"bus addr with reg", []string{"1", "0x50", "0x10"}, false, 1, 0x50, 0x10, false},
+		{"reg required present", []string{"1", "0x50", "0x10"}, true, 1, 0x50, 0x10, false},
+		{"reg required missing", []string{"1", "0x50"}, true, 0, 0, 0, true},
+		{"too few args", []string{"1"}, false, 0, 0, 0, true},
+		{"too many args", []string{"1", "0x50", "0x10", "0x20"}, false, 0, 0, 0, true},
+		{"invalid bus", []string{"bad", "0x50"}, false, 0, 0, 0, true},
+		{"addr too low", []string{"1", "0x02"}, false, 0, 0, 0, true},
+		{"addr too high", []string{"1", "0x78"}, false, 0, 0, 0, true},
+		{"invalid reg", []string{"1", "0x50", "0x100"}, false, 0, 0, 0, true},
+		{"negative reg", []string{"1", "0x50", "-1"}, false, 0, 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			bus, addr, reg, err := parseChipReg(tt.args, tt.regRequired)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseChipReg(%v, %v) = (%d,%d,%d), want error", tt.args, tt.regRequired, bus, addr, reg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseChipReg(%v, %v) unexpected error: %v", tt.args, tt.regRequired, err)
+			}
+			if bus != tt.wantBus || addr != tt.wantAddr || reg != tt.wantReg {
+				t.Errorf("parseChipReg(%v) = (%d,%d,%d), want (%d,%d,%d)", tt.args, bus, addr, reg, tt.wantBus, tt.wantAddr, tt.wantReg)
+			}
+		})
+	}
+}
+
+// gridIO returns a command.IO writing to the returned buffer.
+func gridIO() (command.IO, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	return command.IO{In: strings.NewReader(""), Out: out, Err: &bytes.Buffer{}}, out
+}
+
+func TestWriteDetectGrid(t *testing.T) {
+	t.Parallel()
+	stdio, out := gridIO()
+	writeDetectGrid(stdio, []int{0x50, 0x68})
+	got := out.String()
+
+	if !strings.HasPrefix(got, "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\n") {
+		t.Errorf("missing/incorrect header: %q", got)
+	}
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 9 { // header + 8 rows (0x00..0x70)
+		t.Fatalf("expected 9 lines, got %d: %q", len(lines), got)
+	}
+	// Row 0x50 shows the detected address; 0x00-0x02 are out of range (blanks).
+	row50 := lines[1+5] // header + row index 5 (0x50)
+	if !strings.HasPrefix(row50, "50:") || !strings.Contains(row50, " 50") {
+		t.Errorf("row 0x50 = %q, want detected 50", row50)
+	}
+	// Row 0x00 leaves 0x00-0x02 blank and marks the rest absent with --.
+	row00 := lines[1]
+	if !strings.HasPrefix(row00, "00:   ") {
+		t.Errorf("row 0x00 = %q, want leading blanks for 0x00-0x02", row00)
+	}
+	if !strings.Contains(row00, " --") {
+		t.Errorf("row 0x00 = %q, want -- absent markers", row00)
+	}
+}
+
+func TestWriteDump(t *testing.T) {
+	t.Parallel()
+	var regs [256]byte
+	for i := range regs {
+		regs[i] = byte(i)
+	}
+	stdio, out := gridIO()
+	writeDump(stdio, regs)
+	got := out.String()
+
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 17 { // header + 16 rows
+		t.Fatalf("expected 17 lines, got %d", len(lines))
+	}
+	if lines[0] != "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f" {
+		t.Errorf("header = %q", lines[0])
+	}
+	// The first data row holds registers 0x00-0x0f, in order.
+	if lines[1] != "00: 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f" {
+		t.Errorf("row 0 = %q", lines[1])
+	}
+	// The last data row holds registers 0xf0-0xff.
+	if lines[16] != "f0: f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff" {
+		t.Errorf("row 15 = %q", lines[16])
+	}
+}
+
+// TestInvalidOperandsAcrossApplets locks the error paths for bad bus, address,
+// register, and value operands across all four front-ends. It is not parallel
+// because it shares the package-global busBackend.
+func TestInvalidOperandsAcrossApplets(t *testing.T) {
+	withBus(t, &fakeBus{present: []int{0x50}, regs: map[int]map[int]byte{0x50: {}}})
+	tests := []struct {
+		name string
+		cmd  func() *Command
+		args []string
+	}{
+		{"detect bad bus", NewI2cdetect, []string{"-y", "bad"}},
+		{"detect extra operand", NewI2cdetect, []string{"-y", "1", "2"}},
+		{"get bad bus", NewI2cget, []string{"-y", "bad", "0x50", "0x10"}},
+		{"get bad addr", NewI2cget, []string{"-y", "1", "0x99", "0x10"}},
+		{"get bad reg", NewI2cget, []string{"-y", "1", "0x50", "0x100"}},
+		{"set bad bus", NewI2cset, []string{"-y", "bad", "0x50", "0x10", "0x01"}},
+		{"set bad addr", NewI2cset, []string{"-y", "1", "0x99", "0x10", "0x01"}},
+		{"set bad reg", NewI2cset, []string{"-y", "1", "0x50", "0x100", "0x01"}},
+		{"set bad value", NewI2cset, []string{"-y", "1", "0x50", "0x10", "0x1ff"}},
+		{"set too few", NewI2cset, []string{"-y", "1", "0x50", "0x10"}},
+		{"dump bad bus", NewI2cdump, []string{"-y", "bad", "0x50"}},
+		{"dump bad addr", NewI2cdump, []string{"-y", "1", "bad"}},
+		{"dump wrong arity", NewI2cdump, []string{"-y", "1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := run(t, tt.cmd(), tt.args...); err == nil {
+				t.Errorf("%s: expected error for args %v", tt.name, tt.args)
+			}
+		})
+	}
+}

--- a/internal/applets/embedded/i2c/i2cdetect.go
+++ b/internal/applets/embedded/i2c/i2cdetect.go
@@ -1,0 +1,38 @@
+package i2c
+
+import (
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// runDetect implements i2cdetect: scan a bus and print the address grid.
+func (c *Command) runDetect(stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.name, "[-y] BUS", stdio.Err).WithHelp(command.Help{
+		Description: "Scan I2C BUS (a bus number, e.g. 1 for /dev/i2c-1) and print a grid of the 7-bit " +
+			"addresses 0x03-0x77 that respond. Probing reads from devices and is normally safe, but on " +
+			"some chips a quick-write probe can have side effects. Access needs privilege; without it the " +
+			"command fails with a documented error.",
+		Examples: []command.Example{
+			{Command: "i2cdetect -y 1", Explain: "Scan bus 1 without the interactive confirmation."},
+		},
+		ExitStatus: "0  the scan completed.\n1  bad arguments or the bus could not be opened.",
+	})
+	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) != 1 {
+		return command.Failuref("usage: i2cdetect [-y] BUS")
+	}
+	bus, err := parseInt(rest[0])
+	if err != nil {
+		return command.Failuref("invalid bus %q", rest[0])
+	}
+	found, err := busBackend.Detect(bus, 0x03, 0x77)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	writeDetectGrid(stdio, found)
+	return nil
+}

--- a/internal/applets/embedded/i2c/i2cdump.go
+++ b/internal/applets/embedded/i2c/i2cdump.go
@@ -1,0 +1,45 @@
+package i2c
+
+import (
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// runDump implements i2cdump by reading every register 0x00-0xff.
+func (c *Command) runDump(stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.name, "[-y] BUS CHIP-ADDR", stdio.Err).WithHelp(command.Help{
+		Description: "Read and print all 256 registers (0x00-0xff) of the I2C device at CHIP-ADDR on BUS as " +
+			"a hex table. Each register is read individually. Access needs privilege; without it the " +
+			"command fails with a documented error.",
+		Examples: []command.Example{
+			{Command: "i2cdump -y 1 0x50", Explain: "Dump every register of chip 0x50 on bus 1."},
+		},
+		ExitStatus: "0  the dump completed.\n1  bad arguments or a read failed.",
+	})
+	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) != 2 {
+		return command.Failuref("usage: i2cdump [-y] BUS CHIP-ADDR")
+	}
+	bus, err := parseInt(rest[0])
+	if err != nil {
+		return command.Failuref("invalid bus %q", rest[0])
+	}
+	addr, err := parseInt(rest[1])
+	if err != nil {
+		return command.Failuref("invalid chip address %q", rest[1])
+	}
+	var regs [256]byte
+	for reg := 0; reg < 256; reg++ {
+		v, err := busBackend.ReadReg(bus, addr, reg)
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
+		regs[reg] = v
+	}
+	writeDump(stdio, regs)
+	return nil
+}

--- a/internal/applets/embedded/i2c/i2cdump.go
+++ b/internal/applets/embedded/i2c/i2cdump.go
@@ -24,13 +24,12 @@ func (c *Command) runDump(stdio command.IO, args []string) error {
 	if len(rest) != 2 {
 		return command.Failuref("usage: i2cdump [-y] BUS CHIP-ADDR")
 	}
-	bus, err := parseInt(rest[0])
+	// Route bus and CHIP-ADDR through the shared parser so i2cdump enforces the
+	// same 0x03-0x77 address range as i2cget/i2cset. The register slot is unused
+	// here (a dump always reads every register), so reg is discarded.
+	bus, addr, _, err := parseChipReg(rest, false)
 	if err != nil {
-		return command.Failuref("invalid bus %q", rest[0])
-	}
-	addr, err := parseInt(rest[1])
-	if err != nil {
-		return command.Failuref("invalid chip address %q", rest[1])
+		return command.Failuref("%v", err)
 	}
 	var regs [256]byte
 	for reg := 0; reg < 256; reg++ {

--- a/internal/applets/embedded/i2c/i2cget.go
+++ b/internal/applets/embedded/i2c/i2cget.go
@@ -1,0 +1,35 @@
+package i2c
+
+import (
+	"fmt"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// runGet implements i2cget: read one byte from a device register.
+func (c *Command) runGet(stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.name, "[-y] BUS CHIP-ADDR [REG]", stdio.Err).WithHelp(command.Help{
+		Description: "Read one byte from the I2C device at CHIP-ADDR on BUS. With REG the byte is read from " +
+			"that register; without it the byte is read from the current pointer. Values may be given in " +
+			"hex (0x..), decimal, or octal. The result is printed in hex. Access needs privilege.",
+		Examples: []command.Example{
+			{Command: "i2cget -y 1 0x50 0x00", Explain: "Read register 0x00 of chip 0x50 on bus 1."},
+		},
+		ExitStatus: "0  the read succeeded.\n1  bad arguments or the read failed.",
+	})
+	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	bus, addr, reg, err := parseChipReg(fs.Args(), false)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	v, err := busBackend.ReadReg(bus, addr, reg)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "0x%02x\n", v)
+	return nil
+}

--- a/internal/applets/embedded/i2c/i2cset.go
+++ b/internal/applets/embedded/i2c/i2cset.go
@@ -1,0 +1,39 @@
+package i2c
+
+import (
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// runSet implements i2cset: write one byte to a device register.
+func (c *Command) runSet(stdio command.IO, args []string) error {
+	fs := command.NewFlagSet(c.name, "[-y] BUS CHIP-ADDR REG VALUE", stdio.Err).WithHelp(command.Help{
+		Description: "Write one byte VALUE to register REG of the I2C device at CHIP-ADDR on BUS. WARNING: " +
+			"writing to a device register can change hardware state irreversibly. Access needs privilege; " +
+			"without it the command fails with a documented error.",
+		Examples: []command.Example{
+			{Command: "i2cset -y 1 0x50 0x10 0xff", Explain: "Write 0xff to register 0x10 of chip 0x50 (destructive)."},
+		},
+		ExitStatus: "0  the write succeeded.\n1  bad arguments or the write failed.",
+	})
+	_ = fs.BoolP("yes", "y", false, "skip the interactive confirmation")
+	proceed, err := fs.Parse(stdio, args)
+	if err != nil || !proceed {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) != 4 {
+		return command.Failuref("usage: i2cset [-y] BUS CHIP-ADDR REG VALUE")
+	}
+	bus, addr, reg, err := parseChipReg(rest[:3], true)
+	if err != nil {
+		return command.Failuref("%v", err)
+	}
+	val, err := parseInt(rest[3])
+	if err != nil || val < 0 || val > 0xff {
+		return command.Failuref("invalid byte value %q", rest[3])
+	}
+	if err := busBackend.WriteReg(bus, addr, reg, byte(val)); err != nil {
+		return command.Failuref("%v", err)
+	}
+	return nil
+}

--- a/internal/applets/embedded/i2c/parse.go
+++ b/internal/applets/embedded/i2c/parse.go
@@ -1,0 +1,39 @@
+package i2c
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// parseChipReg parses BUS CHIP-ADDR [REG]. When regRequired is true REG must be
+// present; otherwise a missing REG yields -1 (current pointer). It is shared by
+// the i2cget and i2cset front-ends.
+func parseChipReg(args []string, regRequired bool) (bus, addr, reg int, err error) {
+	if len(args) < 2 || len(args) > 3 {
+		return 0, 0, 0, fmt.Errorf("expected BUS CHIP-ADDR [REG]")
+	}
+	bus, err = parseInt(args[0])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid bus %q", args[0])
+	}
+	addr, err = parseInt(args[1])
+	if err != nil || addr < 0x03 || addr > 0x77 {
+		return 0, 0, 0, fmt.Errorf("invalid chip address %q (want 0x03-0x77)", args[1])
+	}
+	reg = -1
+	if len(args) == 3 {
+		reg, err = parseInt(args[2])
+		if err != nil || reg < 0 || reg > 0xff {
+			return 0, 0, 0, fmt.Errorf("invalid register %q", args[2])
+		}
+	} else if regRequired {
+		return 0, 0, 0, fmt.Errorf("a register operand is required")
+	}
+	return bus, addr, reg, nil
+}
+
+// parseInt parses a C-style signed integer (0x hex, 0 octal, else decimal).
+func parseInt(s string) (int, error) {
+	n, err := strconv.ParseInt(s, 0, 32)
+	return int(n), err
+}

--- a/internal/applets/embedded/i2c/render.go
+++ b/internal/applets/embedded/i2c/render.go
@@ -1,0 +1,49 @@
+package i2c
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// gridHeader is the column header shared by the detect grid and the dump table.
+const gridHeader = "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f"
+
+// writeDetectGrid renders the i2cdetect address grid.
+func writeDetectGrid(stdio command.IO, found []int) {
+	set := make(map[int]bool, len(found))
+	for _, a := range found {
+		set[a] = true
+	}
+	_, _ = fmt.Fprintln(stdio.Out, gridHeader)
+	for row := 0; row < 8; row++ {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%02x:", row*16)
+		for col := 0; col < 16; col++ {
+			addr := row*16 + col
+			switch {
+			case addr < 0x03 || addr > 0x77:
+				b.WriteString("   ")
+			case set[addr]:
+				fmt.Fprintf(&b, " %02x", addr)
+			default:
+				b.WriteString(" --")
+			}
+		}
+		_, _ = fmt.Fprintln(stdio.Out, b.String())
+	}
+}
+
+// writeDump renders the 256-register hex table.
+func writeDump(stdio command.IO, regs [256]byte) {
+	_, _ = fmt.Fprintln(stdio.Out, gridHeader)
+	for row := 0; row < 16; row++ {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%02x:", row*16)
+		for col := 0; col < 16; col++ {
+			fmt.Fprintf(&b, " %02x", regs[row*16+col])
+		}
+		_, _ = fmt.Fprintln(stdio.Out, b.String())
+	}
+}

--- a/internal/applets/fileutils/ls/ls.go
+++ b/internal/applets/fileutils/ls/ls.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -817,10 +818,18 @@ func timeString(t time.Time) string {
 	return t.Format("Jan _2 15:04")
 }
 
-var userCache = map[uint32]string{}
-var groupCache = map[uint32]string{}
+// userCache and groupCache memoize uid/gid name lookups. They are package
+// globals shared across every ls invocation, so a mutex guards them against
+// concurrent access (multiple ls runs in one process, e.g. parallel tests).
+var (
+	idCacheMu  sync.Mutex
+	userCache  = map[uint32]string{}
+	groupCache = map[uint32]string{}
+)
 
 func lookupUser(uid uint32) string {
+	idCacheMu.Lock()
+	defer idCacheMu.Unlock()
 	if name, ok := userCache[uid]; ok {
 		return name
 	}
@@ -833,6 +842,8 @@ func lookupUser(uid uint32) string {
 }
 
 func lookupGroup(gid uint32) string {
+	idCacheMu.Lock()
+	defer idCacheMu.Unlock()
 	if name, ok := groupCache[gid]; ok {
 		return name
 	}


### PR DESCRIPTION
## Summary

The four I2C applets (`i2cdetect`, `i2cget`, `i2cset`, `i2cdump`) kept their front-ends, shared flags, operand parsing, output rendering, and backend dispatch in a single file and one `Command` type. Adding an applet or mode grew the same switch-heavy file, and the shared parse/render rules were hard to test in isolation because they sat beside the CLI wiring.

## Changes

Move the backend-independent parsers (`parseChipReg`, `parseInt`) into `parse.go` and the renderers (`writeDetectGrid`, `writeDump`, plus a shared grid header constant) into `render.go`. Give each applet a thin front-end file (`i2cdetect.go`, `i2cget.go`, `i2cset.go`, `i2cdump.go`) that owns only its help text and command-specific operand validation. `i2c.go` now holds only the shared `Command` type, its constructors, and the name-based `Synopsis`/`Run` dispatch tables. Hardware access stays behind the existing injected backend.

Add table-driven unit tests for `parseInt`, `parseChipReg`, `writeDetectGrid`, and `writeDump`, plus regression tests for invalid bus/address/register/value operands across all four applets. Statement coverage rises from 58.2% to 64.1%.

## Design Decisions

The split follows the package convention established by the recent selinux and netctl refactors: a single name-distinguished `Command` type with switch-based dispatch in the entry file, per-applet run implementations in their own files, and shared helpers extracted alongside. No behavior changes — the parsers, renderers, help text, and dispatch logic are moved verbatim, so the existing unit and shell-level help specs continue to pass. Tests locking the shared helpers and the four error paths were added first.

Closes #941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added I2C device communication commands: detect devices on a bus, read/write individual registers, and dump all register contents from a device.

* **Tests**
  * Added comprehensive unit tests for argument parsing and output formatting across all I2C commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->