### PR TITLE
fix(mimixbox): keep top-level options working when the binary is renamed

### DIFF
--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -53,8 +53,13 @@ func main() {
 func run(argv []string, stdio command.IO) int {
 	invoked := path.Base(argv[0])
 
-	// Symlink invocation: the binary was called as an applet name.
-	if invoked != cmdName {
+	// Symlink invocation: the binary was called through a name that matches a
+	// known applet (e.g. a "cat" symlink). The basename alone is not enough —
+	// the binary may simply have been renamed, copied, or wrapped under another
+	// name (mimixbox-review, mimixbox.bin, ...). In that case it is still the
+	// MimixBox driver, so fall through to normal option/applet parsing instead
+	// of treating the binary name as an unknown applet (issue #949).
+	if invoked != cmdName && applets.HasApplet(invoked) {
 		return runApplet(invoked, argv[1:], stdio)
 	}
 

--- a/cmd/mimixbox/main_test.go
+++ b/cmd/mimixbox/main_test.go
@@ -111,6 +111,51 @@ func TestRunSymlinkDispatch(t *testing.T) {
 	}
 }
 
+func TestRunRenamedBinaryKeepsTopLevelOptions(t *testing.T) {
+	// The binary is renamed/copied/wrapped under a name that is not "mimixbox"
+	// and is not a known applet. Top-level options must keep working instead of
+	// being treated as an unknown applet (issue #949).
+	cases := []struct {
+		name string
+		argv []string
+		want string // substring expected on stdout
+	}{
+		{"version", []string{"/opt/pkg/mimixbox-review", "--version"}, "mimixbox"},
+		{"help", []string{"/opt/pkg/mimixbox-review", "--help"}, "Usage: mimixbox"},
+		{"list", []string{"./mimixbox-review", "--list"}, "cat"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			io, out, errBuf := newIO()
+			if code := run(tc.argv, io); code != command.ExitSuccess {
+				t.Fatalf("exit = %d, want 0 (stderr=%q)", code, errBuf.String())
+			}
+			if !strings.Contains(out.String(), tc.want) {
+				t.Errorf("stdout = %q, want substring %q", out.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRunRenamedBinaryDispatchesAppletByName(t *testing.T) {
+	// A renamed binary must still dispatch applets given as the first argument,
+	// e.g. "mimixbox-review cat file.txt" runs cat.
+	var gotName string
+	var gotArgs []string
+	orig := runApplet
+	runApplet = func(name string, args []string, _ command.IO) int {
+		gotName, gotArgs = name, args
+		return 0
+	}
+	t.Cleanup(func() { runApplet = orig })
+
+	io, _, _ := newIO()
+	run([]string{"/opt/pkg/mimixbox-review", "cat", "file.txt"}, io)
+	if gotName != "cat" || strings.Join(gotArgs, ",") != "file.txt" {
+		t.Errorf("renamed-binary applet dispatch = %q %v", gotName, gotArgs)
+	}
+}
+
 func TestRunAppletFlagsReachApplet(t *testing.T) {
 	// "mimixbox cp -f a b": -f must be passed to cp, not parsed as
 	// --full-install.


### PR DESCRIPTION
## Summary

MimixBox decided "symlink/applet mode" solely by checking whether `path.Base(argv[0]) != "mimixbox"`. When the binary was renamed, copied, or wrapped under another name (`mimixbox-review`, `mimixbox.bin`, ...), top-level options such as `--help`, `--version`, `--list`, `--install`, and `--remove` stopped working: the binary name itself was treated as an unknown applet and the process exited `1`.

## Changes

- `run()` now treats an invocation as a symlink applet call only when `path.Base(argv[0])` matches a known applet. Otherwise it falls through to normal option/applet parsing, so a renamed driver still behaves like `mimixbox`.
- Added table-driven tests covering a renamed binary with `--version`, `--help`, and `--list`, plus applet-by-name dispatch through a renamed binary. The existing symlink-dispatch test (`cat` symlink) still guards the symlink path.

## Design Decisions

The basename alone is not a reliable signal of symlink invocation. A known-applet basename still routes to that applet (preserving busybox-style symlink behavior), while any other name is the MimixBox driver and gets full option parsing. This keeps applet flags reaching applets unchanged.

Closes #949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed command dispatch behavior when MimixBox is renamed or symlinked. Top-level options (`--version`, `--help`, `--list`) and applet dispatching now work predictably based on the actual command name and known applets.

* **Tests**
  * Added test coverage for CLI behavior with renamed binaries, verifying that top-level options and applet dispatching function correctly under various invocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->