### PR TITLE
fix: surface stdin read errors instead of treating input as empty

### DIFF
--- a/internal/applets/editors/vi/editor_test.go
+++ b/internal/applets/editors/vi/editor_test.go
@@ -302,7 +302,9 @@ func TestRunInteractiveFallsBackOnPipe(t *testing.T) {
 
 	e := newEditor("f", "abc")
 	out := &bytes.Buffer{}
-	runInteractive(command.IO{In: r, Out: out, Err: &bytes.Buffer{}}, e)
+	if err := runInteractive(command.IO{In: r, Out: out, Err: &bytes.Buffer{}}, e); err != nil {
+		t.Fatalf("runInteractive batch fallback error = %v", err)
+	}
 
 	if e.lines[0] != "bc" {
 		t.Errorf("batch fallback should have applied 'x': lines[0] = %q", e.lines[0])

--- a/internal/applets/editors/vi/vi.go
+++ b/internal/applets/editors/vi/vi.go
@@ -69,10 +69,15 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 
 	ed := newEditor(filename, content)
 
+	var runErr error
 	if isTerminal(stdio.In) {
-		runInteractive(stdio, ed)
+		runErr = runInteractive(stdio, ed)
 	} else {
-		runBatch(stdio, ed)
+		runErr = runBatch(stdio, ed)
+	}
+	if runErr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "vi: %v\n", runErr)
+		return command.SilentFailure()
 	}
 
 	if ed.save {
@@ -88,10 +93,16 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	return nil
 }
 
-// runBatch feeds all input bytes to the editor as a keystroke script.
-func runBatch(stdio command.IO, ed *editor) {
-	data, _ := io.ReadAll(stdio.In)
+// runBatch feeds all input bytes to the editor as a keystroke script. It
+// returns any error encountered while reading standard input so the caller can
+// surface an unreadable stdin instead of silently editing an empty buffer.
+func runBatch(stdio command.IO, ed *editor) error {
+	data, err := io.ReadAll(stdio.In)
+	if err != nil {
+		return err
+	}
 	ed.feedString(string(data))
+	return nil
 }
 
 // isTerminal reports whether r is a character device (a real terminal).
@@ -108,25 +119,23 @@ func isTerminal(r io.Reader) bool {
 }
 
 // runInteractive drives the editor in raw mode, redrawing the screen after each
-// keystroke until the editor asks to quit.
-func runInteractive(stdio command.IO, ed *editor) {
+// keystroke until the editor asks to quit. When standard input is not a real
+// terminal it falls back to batch mode and propagates any read error.
+func runInteractive(stdio command.IO, ed *editor) error {
 	f, ok := stdio.In.(*os.File)
 	if !ok {
-		runBatch(stdio, ed)
-		return
+		return runBatch(stdio, ed)
 	}
 	fd := int(f.Fd())
 	old, err := unix.IoctlGetTermios(fd, unix.TCGETS)
 	if err != nil {
-		runBatch(stdio, ed)
-		return
+		return runBatch(stdio, ed)
 	}
 	raw := *old
 	raw.Lflag &^= unix.ECHO | unix.ICANON | unix.ISIG | unix.IEXTEN
 	raw.Iflag &^= unix.IXON | unix.ICRNL | unix.BRKINT | unix.INPCK | unix.ISTRIP
 	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &raw); err != nil {
-		runBatch(stdio, ed)
-		return
+		return runBatch(stdio, ed)
 	}
 	defer func() { _ = unix.IoctlSetTermios(fd, unix.TCSETS, old) }()
 
@@ -135,12 +144,13 @@ func runInteractive(stdio command.IO, ed *editor) {
 		redraw(stdio.Out, ed)
 		n, err := f.Read(buf)
 		if err != nil || n == 0 {
-			return
+			return nil
 		}
 		ed.feed(buf[0])
 	}
 	ed.flush()
 	redraw(stdio.Out, ed)
+	return nil
 }
 
 // redraw clears the screen and paints the buffer, a status line and the cursor.

--- a/internal/applets/editors/vi/vi_test.go
+++ b/internal/applets/editors/vi/vi_test.go
@@ -3,6 +3,7 @@ package vi_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,26 @@ func run(t *testing.T, stdin string, args ...string) (string, string, error) {
 	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
 	err := vi.New().Run(context.Background(), io, args)
 	return out.String(), errBuf.String(), err
+}
+
+// errReader fails on the first read, modeling an unreadable stdin (e.g. stdin
+// redirected from a directory, which makes read(0) fail with EISDIR).
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("is a directory") }
+
+func TestBatchStdinReadErrorIsReported(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: errReader{}, Out: out, Err: errBuf}
+	err := vi.New().Run(context.Background(), io, nil)
+	if err == nil {
+		t.Fatal("vi must report an unreadable stdin instead of treating it as empty")
+	}
+	if !strings.Contains(errBuf.String(), "is a directory") {
+		t.Errorf("stderr = %q, want the read error", errBuf.String())
+	}
 }
 
 func TestNameSynopsis(t *testing.T) {

--- a/internal/applets/mailutils/reformime/reformime.go
+++ b/internal/applets/mailutils/reformime/reformime.go
@@ -89,8 +89,12 @@ func parse(r io.Reader) ([]part, error) {
 	}
 	mediatype, params, err := mime.ParseMediaType(ctype)
 	if err != nil {
-		// Treat an unparseable Content-Type as a single opaque part.
-		body, _ := io.ReadAll(msg.Body)
+		// Treat an unparseable Content-Type as a single opaque part, but still
+		// surface a body read error instead of returning an empty part.
+		body, rerr := io.ReadAll(msg.Body)
+		if rerr != nil {
+			return nil, rerr
+		}
 		return []part{{contentType: ctype, body: body}}, nil
 	}
 

--- a/internal/applets/mailutils/reformime/reformime_test.go
+++ b/internal/applets/mailutils/reformime/reformime_test.go
@@ -3,6 +3,7 @@ package reformime
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -35,6 +36,31 @@ func run(t *testing.T, input string, args ...string) (string, error) {
 	io := command.IO{In: strings.NewReader(input), Out: out, Err: &bytes.Buffer{}}
 	err := New().Run(context.Background(), io, args)
 	return out.String(), err
+}
+
+// headerThenErr yields the message header on its first read and then fails,
+// modeling a body that becomes unreadable after the header is parsed.
+type headerThenErr struct {
+	header []byte
+	done   bool
+}
+
+func (r *headerThenErr) Read(p []byte) (int, error) {
+	if !r.done {
+		r.done = true
+		return copy(p, r.header), nil
+	}
+	return 0, errors.New("body read failed")
+}
+
+func TestParseUnparseableContentTypeSurfacesBodyError(t *testing.T) {
+	// "text/plain; x" is a non-empty but unparseable Content-Type, so parse()
+	// takes the opaque-fallback path. A failing body read must be reported, not
+	// swallowed into an empty part.
+	hdr := "Content-Type: text/plain; x\r\n\r\n"
+	if _, err := parse(&headerThenErr{header: []byte(hdr)}); err == nil {
+		t.Fatal("parse must surface a body read error on the invalid Content-Type path")
+	}
 }
 
 func TestListSingle(t *testing.T) {

--- a/internal/applets/procps/logger/logger.go
+++ b/internal/applets/procps/logger/logger.go
@@ -83,7 +83,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	if rest := fs.Args(); len(rest) > 0 {
 		message = strings.Join(rest, " ")
 	} else {
-		data, _ := io.ReadAll(stdio.In)
+		data, err := io.ReadAll(stdio.In)
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
 		message = strings.TrimRight(string(data), "\n")
 	}
 

--- a/internal/applets/procps/logger/logger_test.go
+++ b/internal/applets/procps/logger/logger_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/syslog"
 	"strings"
 	"testing"
@@ -64,6 +65,21 @@ func TestMessageFromStdin(t *testing.T) {
 	}
 	if got.msg != "from stdin" {
 		t.Errorf("stdin msg = %q", got.msg)
+	}
+}
+
+// errReader fails on the first read, modeling an unreadable stdin.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("is a directory") }
+
+func TestStdinReadErrorIsReported(t *testing.T) {
+	withStub(t)
+	io := command.IO{In: errReader{}, Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
+	// No message operand: logger reads the message from stdin. An unreadable
+	// stdin must fail instead of logging an empty message.
+	if err := New().Run(context.Background(), io, []string{"-t", "x"}); err == nil {
+		t.Fatal("logger must report an unreadable stdin instead of treating it as empty")
 	}
 }
 

--- a/internal/applets/util-linux/wall/wall.go
+++ b/internal/applets/util-linux/wall/wall.go
@@ -73,7 +73,10 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	if rest := fs.Args(); len(rest) > 0 {
 		message = strings.Join(rest, " ")
 	} else {
-		data, _ := io.ReadAll(stdio.In)
+		data, err := io.ReadAll(stdio.In)
+		if err != nil {
+			return command.Failuref("%v", err)
+		}
 		message = strings.TrimRight(string(data), "\n")
 	}
 

--- a/internal/applets/util-linux/wall/wall_test.go
+++ b/internal/applets/util-linux/wall/wall_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,6 +50,22 @@ func runWall(t *testing.T, in string, args ...string) {
 	io := command.IO{In: strings.NewReader(in), Out: &bytes.Buffer{}, Err: &bytes.Buffer{}}
 	if err := New().Run(context.Background(), io, args); err != nil {
 		t.Fatalf("Run error = %v", err)
+	}
+}
+
+// errReader fails on the first read, modeling an unreadable stdin.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("is a directory") }
+
+func TestStdinReadErrorIsReported(t *testing.T) {
+	setup(t, "pts/0")
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: errReader{}, Out: &bytes.Buffer{}, Err: errBuf}
+	// No message operand: wall reads the broadcast text from stdin. An
+	// unreadable stdin must fail instead of broadcasting an empty message.
+	if err := New().Run(context.Background(), io, nil); err == nil {
+		t.Fatal("wall must report an unreadable stdin instead of treating it as empty")
 	}
 }
 


### PR DESCRIPTION
## Summary

Several applets read all of standard input with `io.ReadAll(...)` and discarded the returned error. When stdin was unreadable — for example redirected from a directory, which makes `read(0)` fail with `EISDIR` on Linux — they continued as if the input were empty and still exited `0`, hiding real I/O failures from the caller. This turns "input unreadable" into "empty input", which is hard for scripts to diagnose.

## Changes

- `vi` (batch mode) now propagates the stdin read error from `runBatch`/`runInteractive` and exits non-zero with a `vi: ...` message.
- `logger` reports the read error in the no-operand stdin path instead of logging an empty message.
- `wall` reports the read error in the no-operand stdin path instead of broadcasting an empty message.
- `reformime` surfaces a body read error on the unparseable Content-Type fallback path instead of swallowing it into an empty part.

## Design Decisions

The fixes follow the existing `sendmail` pattern (`io.ReadAll` error checked, reported with the applet name, non-zero exit), so behavior is consistent across applets. Each fix is covered by a unit test that injects an error-returning reader; the `vi` interactive read loop still treats a mid-edit terminal read error/EOF as a normal end of session.

Closes #954