### PR TITLE
fix(timeout): kill the whole process group so descendants are not leaked

### DIFF
--- a/internal/applets/shellutils/timeout/timeout.go
+++ b/internal/applets/shellutils/timeout/timeout.go
@@ -91,6 +91,11 @@ func (c *Command) runWithTimeout(stdio command.IO, dur, killGrace time.Duration,
 	cmd.Stdin = stdio.In
 	cmd.Stdout = stdio.Out
 	cmd.Stderr = stdio.Err
+	// Run the command in its own process group so that, on timeout, the whole
+	// group can be signalled instead of only the direct child. Otherwise a
+	// wrapper that backgrounds work (e.g. a shell script) would leak its
+	// descendants after timeout returns (issue #951).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
@@ -107,12 +112,12 @@ func (c *Command) runWithTimeout(stdio command.IO, dur, killGrace time.Duration,
 
 	select {
 	case <-timer.C:
-		_ = cmd.Process.Signal(sig)
+		signalGroup(cmd.Process.Pid, sig)
 		if killGrace > 0 {
 			select {
 			case <-done:
 			case <-time.After(killGrace):
-				_ = cmd.Process.Kill()
+				signalGroup(cmd.Process.Pid, syscall.SIGKILL)
 				<-done
 			}
 		} else {
@@ -128,6 +133,17 @@ func (c *Command) runWithTimeout(stdio command.IO, dur, killGrace time.Duration,
 			return &command.ExitError{Code: ee.ExitCode()}
 		}
 		return &command.ExitError{Code: exitCannotRun, Err: err}
+	}
+}
+
+// signalGroup sends sig to the entire process group led by pid. The child is
+// started with Setpgid, so its PID is also its process-group ID; a negative
+// PID addresses the whole group (see kill(2)). If the group is already gone the
+// resulting ESRCH is ignored. As a safety net, the direct child is signalled
+// too in case the group could not be addressed.
+func signalGroup(pid int, sig syscall.Signal) {
+	if err := syscall.Kill(-pid, sig); err != nil {
+		_ = syscall.Kill(pid, sig)
 	}
 }
 

--- a/internal/applets/shellutils/timeout/timeout_test.go
+++ b/internal/applets/shellutils/timeout/timeout_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -46,6 +49,60 @@ func TestTimesOut(t *testing.T) {
 	if code := exitCode(err); code != exitTimedOut {
 		t.Errorf("exit code = %d, want %d", code, exitTimedOut)
 	}
+}
+
+// processAlive reports whether pid is still a live process. Signal 0 performs
+// only the existence/permission check without delivering a signal.
+func processAlive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+func TestKillsDescendantProcesses(t *testing.T) {
+	// A wrapped script backgrounds a child, records its PID, then sleeps. When
+	// the timeout fires the whole process group must be terminated, so the
+	// backgrounded descendant must not be left running (issue #951).
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pid")
+	script := filepath.Join(dir, "child.sh")
+	content := "#!/bin/sh\nsleep 30 &\necho $! > \"" + pidFile + "\"\nsleep 30\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Back the child's stdio with real files (not in-memory buffers). With a
+	// pipe-backed buffer, exec's copy goroutines keep cmd.Wait() blocked until
+	// the inherited pipe write end is closed by the descendant, which would
+	// mask the leak; a real file makes Wait return as soon as the direct child
+	// is signalled, exactly as a terminal does in the bug report.
+	devnull, derr := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if derr != nil {
+		t.Fatal(derr)
+	}
+	defer func() { _ = devnull.Close() }()
+	io := command.IO{In: devnull, Out: devnull, Err: devnull}
+	err := New().Run(context.Background(), io, []string{"0.3", "sh", script})
+	if code := exitCode(err); code != exitTimedOut {
+		t.Fatalf("exit code = %d, want %d", code, exitTimedOut)
+	}
+
+	data, rerr := os.ReadFile(pidFile)
+	if rerr != nil {
+		t.Fatalf("read pid file: %v", rerr)
+	}
+	pid, perr := strconv.Atoi(strings.TrimSpace(string(data)))
+	if perr != nil || pid <= 0 {
+		t.Fatalf("bad pid %q: %v", data, perr)
+	}
+
+	// The kill is asynchronous; poll briefly for the descendant to disappear.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("descendant pid %d still alive after timeout (process group not killed)", pid)
 }
 
 func TestCommandNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

MimixBox `timeout` terminated only the direct child via `cmd.Process.Signal`, so a wrapper that backgrounds work (for example a shell script running `sleep 30 &`) left its descendant alive after `timeout` returned `124`. GNU `timeout` does not leak the child in the same reproduction.

## Changes

- Start the wrapped command in its own process group (`SysProcAttr{Setpgid: true}`).
- On timeout, send the configured signal to the entire process group via a negative PID; the same group-wide delivery is used for the `-k/--kill-after` SIGKILL path.
- A new `signalGroup` helper addresses the group and falls back to signalling the direct child if the group cannot be addressed (already-exited group yields ESRCH, which is ignored).

## Design Decisions

The child's PID equals its process-group ID because it is started with `Setpgid`, so `kill(-pid, sig)` reaches every descendant (see kill(2)). The added test backs the child's stdio with real files rather than in-memory buffers: with a pipe-backed buffer, exec's copy goroutines keep `cmd.Wait()` blocked until the inherited pipe is closed by the descendant, which would mask the leak. A real file makes `Wait` return as soon as the direct child is signalled, exactly as a terminal does in the bug report. MimixBox ships Linux-only (see .goreleaser.yml), so `Setpgid` and negative-PID signalling are always available.

Closes #951