### PR TITLE
fix(mimixbox): base install decisions on the target dir, not the host PATH

### DIFF
--- a/cmd/mimixbox/install_path_test.go
+++ b/cmd/mimixbox/install_path_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nao1215/mimixbox/internal/command"
+)
+
+// stubSelf points resolveSelf at a fixed binary path so install decisions and
+// symlink targets are deterministic regardless of the test host.
+func stubSelf(t *testing.T, path string) {
+	t.Helper()
+	orig := osExecutable
+	osExecutable = func() (string, error) { return path, nil }
+	t.Cleanup(func() { osExecutable = orig })
+}
+
+func TestInstallEmptyDirDoesNotDependOnHostPath(t *testing.T) {
+	// An empty target directory must receive applet symlinks regardless of
+	// whether commands of the same name happen to exist on the host PATH
+	// (issue #948, reproduction 1). "cat" exists on essentially every host, so
+	// the old host-PATH gate would have skipped it.
+	dir := t.TempDir()
+	stubSelf(t, "/fresh/mimixbox")
+
+	io, _, errBuf := newIO()
+	if code := run([]string{"mimixbox", "--install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("install exit = %d (stderr: %s)", code, errBuf.String())
+	}
+	if fi, err := os.Lstat(filepath.Join(dir, "cat")); err != nil {
+		t.Fatalf("expected cat symlink in an empty target dir: %v", err)
+	} else if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("cat should be a symlink")
+	}
+}
+
+func TestPlainInstallDoesNotOverwriteForeignSymlink(t *testing.T) {
+	// --install must not replace a foreign symlink in the target directory
+	// (issue #948, reproduction 2).
+	dir := t.TempDir()
+	foreign := filepath.Join(dir, "nyancat")
+	if err := os.Symlink("/bin/true", foreign); err != nil {
+		t.Fatal(err)
+	}
+	stubSelf(t, "/fresh/mimixbox")
+
+	io, _, _ := newIO()
+	if code := run([]string{"mimixbox", "--install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("install exit = %d", code)
+	}
+	if got, _ := os.Readlink(foreign); got != "/bin/true" {
+		t.Errorf("foreign symlink target = %q, want it left as /bin/true", got)
+	}
+}
+
+func TestFullInstallDoesNotOverwriteForeignSymlink(t *testing.T) {
+	// --full-install must not replace a foreign symlink either (issue #948,
+	// reproduction 3).
+	dir := t.TempDir()
+	foreign := filepath.Join(dir, "cat")
+	if err := os.Symlink("/bin/true", foreign); err != nil {
+		t.Fatal(err)
+	}
+	stubSelf(t, "/fresh/mimixbox")
+
+	io, _, _ := newIO()
+	if code := run([]string{"mimixbox", "--full-install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("full-install exit = %d", code)
+	}
+	if got, _ := os.Readlink(foreign); got != "/bin/true" {
+		t.Errorf("foreign symlink target = %q, want it left as /bin/true", got)
+	}
+}
+
+func TestPlainInstallSkipsRealFileInTargetDir(t *testing.T) {
+	// A real file occupying an applet name in the target directory must be left
+	// untouched: ownership is decided by the target dir, not the host PATH.
+	dir := t.TempDir()
+	real := filepath.Join(dir, "cat")
+	if err := os.WriteFile(real, []byte("not mimixbox"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stubSelf(t, "/fresh/mimixbox")
+
+	io, _, _ := newIO()
+	if code := run([]string{"mimixbox", "--install", dir}, io); code != command.ExitSuccess {
+		t.Fatalf("install exit = %d", code)
+	}
+	if fi, err := os.Lstat(real); err != nil {
+		t.Fatalf("real file vanished: %v", err)
+	} else if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("real file was replaced by a symlink")
+	}
+	if data, _ := os.ReadFile(real); string(data) != "not mimixbox" {
+		t.Errorf("real file content changed to %q", data)
+	}
+}

--- a/cmd/mimixbox/main.go
+++ b/cmd/mimixbox/main.go
@@ -246,42 +246,89 @@ Run "mimixbox APPLET --help" for an applet's description, options, and examples.
 `)
 }
 
+// slot classifies what currently occupies an applet name in the target
+// directory, so install() can decide what to do without ever consulting the
+// host PATH.
+type slot int
+
+const (
+	slotFree    slot = iota // nothing occupies the name; safe to create
+	slotOwned               // a symlink that already points at this MimixBox
+	slotForeign             // a real file, or a symlink owned by something else
+)
+
+// classifySlot reports the state of path relative to the running binary self.
+// Anything that is not provably ours (a real file, a foreign symlink, or an
+// entry we cannot inspect) is treated as foreign so it is never removed.
+func classifySlot(path, self string) slot {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return slotFree
+		}
+		return slotForeign
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return slotForeign // a real file or directory occupies the name
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		return slotForeign
+	}
+	if ownedBySelf(target, self) {
+		return slotOwned
+	}
+	return slotForeign
+}
+
 func install(mimixboxPath string, installPath string, full bool, stdio command.IO) error {
 	targetPath := os.ExpandEnv(installPath)
 	if !mb.IsDir(targetPath) {
 		return errors.New(targetPath + ": no such directory")
 	}
 
-	mimixboxAbsPath, err := resolveSelf(mimixboxPath)
+	self, err := resolveSelf(mimixboxPath)
 	if err != nil {
 		return err
 	}
 
 	for _, applet := range applets.SortApplet() {
-		if !full && mb.ExistCmd(applet) {
-			_, _ = fmt.Fprintf(stdio.Err, "Same name command(%s) already exists. Not create symbolic link.\n", applet)
-			continue // if same name command already exists, not install for safety.
-		}
-
-		// If a symbolic link with the same name already exists, delete it. If a
-		// real binary has the same name, leave it: the former is likely ours,
-		// the latter probably belongs to another package.
 		newPath := filepath.Join(targetPath, applet)
-		if mb.IsSymlink(newPath) {
-			if err := os.Remove(newPath); err != nil {
-				_, _ = fmt.Fprintln(stdio.Err, err)
-				continue
+		// The decision depends only on the target directory and explicit
+		// ownership, never on whether a same-named command exists somewhere on
+		// the host PATH (issue #948).
+		switch classifySlot(newPath, self) {
+		case slotFree:
+			createLink(self, newPath, stdio)
+		case slotOwned:
+			// Already an up-to-date MimixBox symlink. Plain --install leaves it
+			// alone; --full-install refreshes it so its target is corrected if
+			// the binary moved.
+			if full {
+				if err := os.Remove(newPath); err != nil {
+					_, _ = fmt.Fprintln(stdio.Err, err)
+					continue
+				}
+				_, _ = fmt.Fprintf(stdio.Out, "Delete              : %s\n", newPath)
+				createLink(self, newPath, stdio)
 			}
-			_, _ = fmt.Fprintf(stdio.Out, "Delete              : %s\n", newPath)
+		case slotForeign:
+			// A real file or a symlink owned by another package occupies this
+			// name. Never remove it; both install modes skip it for safety.
+			_, _ = fmt.Fprintf(stdio.Err, "%s already exists and is not owned by MimixBox. Not creating symbolic link.\n", newPath)
 		}
-
-		if err := os.Symlink(mimixboxAbsPath, newPath); err != nil {
-			_, _ = fmt.Fprintln(stdio.Err, err)
-			continue
-		}
-		_, _ = fmt.Fprintf(stdio.Out, "Create symbolic link: %s\n", newPath)
 	}
 	return nil
+}
+
+// createLink creates a DIR/applet symlink pointing at the running binary and
+// reports the action, or the error if it fails.
+func createLink(self, newPath string, stdio command.IO) {
+	if err := os.Symlink(self, newPath); err != nil {
+		_, _ = fmt.Fprintln(stdio.Err, err)
+		return
+	}
+	_, _ = fmt.Fprintf(stdio.Out, "Create symbolic link: %s\n", newPath)
 }
 
 // osExecutable is os.Executable, indirected so tests can substitute it.

--- a/cmd/mimixbox/main_helpers_test.go
+++ b/cmd/mimixbox/main_helpers_test.go
@@ -79,16 +79,17 @@ func TestResolveSelfFallsBackToArgv0(t *testing.T) {
 	}
 }
 
-func TestInstallReplacesExistingSymlink(t *testing.T) {
-	// When a stale symlink already occupies an applet's name, full-install must
-	// delete it and recreate it, reporting both actions.
+func TestFullInstallRefreshesOwnSymlink(t *testing.T) {
+	// When a symlink already owned by this MimixBox occupies an applet's name,
+	// --full-install refreshes it: it deletes and recreates the link, reporting
+	// both actions. (A foreign symlink, by contrast, must be left alone.)
 	dir := t.TempDir()
-	stale := filepath.Join(dir, "cat")
-	if err := os.Symlink("/some/old/target", stale); err != nil {
+	const wantTarget = "/fresh/mimixbox"
+	own := filepath.Join(dir, "cat")
+	if err := os.Symlink(wantTarget, own); err != nil {
 		t.Fatal(err)
 	}
 
-	const wantTarget = "/fresh/mimixbox"
 	orig := osExecutable
 	osExecutable = func() (string, error) { return wantTarget, nil }
 	t.Cleanup(func() { osExecutable = orig })
@@ -97,10 +98,10 @@ func TestInstallReplacesExistingSymlink(t *testing.T) {
 	if code := run([]string{"mimixbox", "--full-install", dir}, io); code != command.ExitSuccess {
 		t.Fatalf("full-install exit = %d (stderr: %s)", code, errBuf.String())
 	}
-	if !strings.Contains(out.String(), "Delete              : "+stale) {
-		t.Errorf("stdout should report deleting the stale symlink, got %q", out.String())
+	if !strings.Contains(out.String(), "Delete              : "+own) {
+		t.Errorf("stdout should report refreshing our own symlink, got %q", out.String())
 	}
-	target, err := os.Readlink(stale)
+	target, err := os.Readlink(own)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,22 +110,28 @@ func TestInstallReplacesExistingSymlink(t *testing.T) {
 	}
 }
 
-func TestPlainInstallSkipsExistingSystemCommand(t *testing.T) {
-	// With -i/--install (full=false), an applet whose name collides with a
-	// command already on the system is skipped with a warning, and no symlink is
-	// created for it. "ls" is essentially always present on the test host.
-	if _, err := os.Stat("/bin/ls"); err != nil {
-		if _, err2 := os.Stat("/usr/bin/ls"); err2 != nil {
-			t.Skip("ls not found on this host; cannot exercise the skip-existing branch")
-		}
-	}
+func TestPlainInstallSkipsForeignEntry(t *testing.T) {
+	// With -i/--install, an applet name already occupied by something not owned
+	// by MimixBox is skipped with a warning, and the foreign entry is left in
+	// place. The decision is based on the target directory, not the host PATH.
 	dir := t.TempDir()
+	foreign := filepath.Join(dir, "cat")
+	if err := os.Symlink("/bin/true", foreign); err != nil {
+		t.Fatal(err)
+	}
+	orig := osExecutable
+	osExecutable = func() (string, error) { return "/fresh/mimixbox", nil }
+	t.Cleanup(func() { osExecutable = orig })
+
 	io, _, errBuf := newIO()
 	if code := run([]string{"mimixbox", "--install", dir}, io); code != command.ExitSuccess {
 		t.Fatalf("install exit = %d (stderr: %s)", code, errBuf.String())
 	}
-	if !strings.Contains(errBuf.String(), "already exists. Not create symbolic link.") {
-		t.Errorf("stderr should warn about at least one existing command, got %q", errBuf.String())
+	if !strings.Contains(errBuf.String(), "not owned by MimixBox") {
+		t.Errorf("stderr should warn about the foreign entry, got %q", errBuf.String())
+	}
+	if got, _ := os.Readlink(foreign); got != "/bin/true" {
+		t.Errorf("foreign symlink target = %q, want it left as /bin/true", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`--install` decided whether to create each applet symlink by checking whether the applet name existed anywhere on the host PATH, so an empty target directory could end up missing common applets like `cat` purely because unrelated commands existed on the host (the bug report saw only 183 of 451 applets installed into an empty dir). Worse, both `--install` and `--full-install` removed and replaced foreign symlinks in the target directory, even when the symlink clearly belonged to another package.

## Changes

- New `classifySlot` reports whether a `DIR/applet` slot is free, owned by this MimixBox (a symlink pointing at the running binary), or foreign (a real file, a symlink owned by something else, or an entry that cannot be inspected).
- `install` now acts only on that classification: create symlinks in free slots, refresh our own links on `--full-install`, and never remove a foreign symlink or a real file. The host PATH is no longer consulted at all.
- Reused the existing `ownedBySelf` check (already used by `remove()`) so install and remove share one ownership model.

## Design Decisions

The decision now depends solely on the target directory and explicit ownership, matching the issue's expected behavior. `--full-install` refreshes self-owned symlinks (so a moved binary's links are corrected) while `--install` leaves them untouched; neither mode ever clobbers a foreign entry. Verified against all three reproductions in the issue: an empty dir now receives all 451 applets, and foreign `nyancat`/`cat` symlinks are preserved.

Closes #948