### PR TITLE
fix: process binary and non-UTF-8 input byte-faithfully in tr and wc

### DIFF
--- a/internal/applets/textutils/tr/tr.go
+++ b/internal/applets/textutils/tr/tr.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
+	"unicode/utf8"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
@@ -95,8 +95,8 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.Failuref("%v", readErr)
 	}
 
-	result := transform(string(data), set1, set2, opts)
-	if _, err := io.WriteString(stdio.Out, result); err != nil {
+	result := transform(data, set1, set2, opts)
+	if _, err := stdio.Out.Write(result); err != nil {
 		return command.Failure(err)
 	}
 	return nil
@@ -124,68 +124,115 @@ func validate(stdio command.IO, opts options, operands []string) error {
 	return nil
 }
 
+// cell is one decoded input symbol. A valid UTF-8 sequence becomes a normal
+// rune (raw=false); an invalid byte is preserved verbatim as a raw byte
+// (raw=true, r in 0..255). Keeping the raw flag lets tr behave like GNU tr on
+// binary input — matching SET entries by byte value and writing untranslated
+// bytes back unchanged instead of corrupting them into U+FFFD (issue #953).
+type cell struct {
+	r   rune
+	raw bool
+}
+
+// decodeCells splits raw input into cells, preserving invalid UTF-8 bytes.
+func decodeCells(data []byte) []cell {
+	cells := make([]cell, 0, len(data))
+	for i := 0; i < len(data); {
+		r, size := utf8.DecodeRune(data[i:])
+		if r == utf8.RuneError && size == 1 {
+			cells = append(cells, cell{r: rune(data[i]), raw: true})
+			i++
+			continue
+		}
+		cells = append(cells, cell{r: r, raw: false})
+		i += size
+	}
+	return cells
+}
+
+// appendCell writes a cell to out: a raw byte as itself, a normal rune as UTF-8.
+func appendCell(out []byte, c cell) []byte {
+	if c.raw {
+		return append(out, byte(c.r))
+	}
+	return utf8.AppendRune(out, c.r)
+}
+
+func appendCells(out []byte, cells []cell) []byte {
+	for _, c := range cells {
+		out = appendCell(out, c)
+	}
+	return out
+}
+
 // transform applies the requested operation (delete, squeeze, translate, or a
-// combination) to s and returns the result.
-func transform(s string, set1, set2 []rune, opts options) string {
-	in := []rune(s)
+// combination) to data and returns the result.
+func transform(data []byte, set1, set2 []rune, opts options) []byte {
+	in := decodeCells(data)
 
 	// Resolve which runes SET1 selects, honoring -c/-C complement.
 	inSet1 := membership(set1, opts.complement)
 
-	var b strings.Builder
-	b.Grow(len(in))
+	out := make([]byte, 0, len(data))
 
 	switch {
 	case opts.delete:
 		// Delete chars in SET1, then optionally squeeze repeats from SET2.
-		var del strings.Builder
-		for _, r := range in {
-			if !inSet1(r) {
-				del.WriteRune(r)
+		kept := make([]cell, 0, len(in))
+		for _, c := range in {
+			if !inSet1(c.r) {
+				kept = append(kept, c)
 			}
 		}
 		if opts.squeeze && len(set2) > 0 {
 			inSet2 := membership(set2, false)
-			writeSqueezed(&b, []rune(del.String()), inSet2)
+			out = writeSqueezed(out, kept, inSet2)
 		} else {
-			b.WriteString(del.String())
+			out = appendCells(out, kept)
 		}
 	case opts.squeeze && len(set2) == 0:
 		// Squeeze only: collapse runs of characters in SET1.
-		writeSqueezed(&b, in, inSet1)
+		out = writeSqueezed(out, in, inSet1)
 	default:
 		// Translate SET1 -> SET2, then optionally squeeze repeats from SET2.
-		mapped := translateRunes(in, set1, set2, opts.complement)
+		mapped := translateCells(in, set1, set2, opts.complement)
 		if opts.squeeze {
 			inSet2 := membership(set2, false)
-			writeSqueezed(&b, mapped, inSet2)
+			out = writeSqueezed(out, mapped, inSet2)
 		} else {
-			b.WriteString(string(mapped))
+			out = appendCells(out, mapped)
 		}
 	}
-	return b.String()
+	return out
 }
 
-// translateRunes maps each rune of in according to SET1 -> SET2. With the
-// complement flag, every rune not in SET1 maps to the last rune of SET2 (GNU
+// mapped returns c translated to rune to, keeping the raw-byte representation
+// when the result still fits in a single byte (so a translated binary byte is
+// written as a byte, not as multi-byte UTF-8).
+func (c cell) mapped(to rune) cell {
+	return cell{r: to, raw: c.raw && to <= 0xFF}
+}
+
+// translateCells maps each cell of in according to SET1 -> SET2. With the
+// complement flag, every cell not in SET1 maps to the last rune of SET2 (GNU
 // behavior). Otherwise the i-th rune of SET1 maps to the i-th rune of SET2; when
 // SET2 is shorter, its last rune is repeated to pad it.
-func translateRunes(in, set1, set2 []rune, complement bool) []rune {
+func translateCells(in []cell, set1, set2 []rune, complement bool) []cell {
 	if len(set2) == 0 {
 		return in
 	}
-	out := make([]rune, 0, len(in))
+	out := make([]cell, 0, len(in))
 	if complement {
 		inSet1 := make(map[rune]struct{}, len(set1))
 		for _, r := range set1 {
 			inSet1[r] = struct{}{}
 		}
 		last := set2[len(set2)-1]
-		for _, r := range in {
-			if _, ok := inSet1[r]; ok {
-				out = append(out, r)
+		for _, c := range in {
+			if _, ok := inSet1[c.r]; ok {
+				out = append(out, c)
 			} else {
-				out = append(out, last)
+				out = append(out, c.mapped(last))
 			}
 		}
 		return out
@@ -199,11 +246,11 @@ func translateRunes(in, set1, set2 []rune, complement bool) []rune {
 			m[r] = set2[len(set2)-1]
 		}
 	}
-	for _, r := range in {
-		if to, ok := m[r]; ok {
-			out = append(out, to)
+	for _, c := range in {
+		if to, ok := m[c.r]; ok {
+			out = append(out, c.mapped(to))
 		} else {
-			out = append(out, r)
+			out = append(out, c)
 		}
 	}
 	return out
@@ -225,19 +272,20 @@ func membership(set []rune, complement bool) func(rune) bool {
 	}
 }
 
-// writeSqueezed writes runes to b, collapsing each run of repeated characters
+// writeSqueezed appends cells to out, collapsing each run of repeated characters
 // for which selected reports true into a single occurrence.
-func writeSqueezed(b *strings.Builder, in []rune, selected func(rune) bool) {
+func writeSqueezed(out []byte, in []cell, selected func(rune) bool) []byte {
 	var prev rune
 	havePrev := false
-	for _, r := range in {
-		if havePrev && r == prev && selected(r) {
+	for _, c := range in {
+		if havePrev && c.r == prev && selected(c.r) {
 			continue
 		}
-		b.WriteRune(r)
-		prev = r
+		out = appendCell(out, c)
+		prev = c.r
 		havePrev = true
 	}
+	return out
 }
 
 // expandSet expands a tr SET specification into its sequence of runes,

--- a/internal/applets/textutils/tr/tr_test.go
+++ b/internal/applets/textutils/tr/tr_test.go
@@ -19,6 +19,54 @@ func run(t *testing.T, stdin string, args ...string) (string, string, error) {
 	return out.String(), errBuf.String(), err
 }
 
+// runBytes drives tr with raw byte input/output so non-UTF-8 data can be
+// exercised without lossy string conversion.
+func runBytes(t *testing.T, stdin []byte, args ...string) ([]byte, error) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	io := command.IO{In: bytes.NewReader(stdin), Out: out, Err: &bytes.Buffer{}}
+	err := tr.New().Run(context.Background(), io, args)
+	return out.Bytes(), err
+}
+
+func TestTranslatesRawByteMatchingOctalSet(t *testing.T) {
+	// tr '\377' X on a lone 0xFF byte must translate it like GNU tr (byte
+	// oriented), not corrupt it into the UTF-8 replacement character (issue
+	// #953).
+	got, err := runBytes(t, []byte{0xFF, '\n'}, `\377`, "X")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{'X', '\n'}
+	if !bytes.Equal(got, want) {
+		t.Errorf("tr output = % x, want % x", got, want)
+	}
+}
+
+func TestPreservesUntranslatedBinaryBytes(t *testing.T) {
+	// tr A Z must leave unrelated non-UTF-8 bytes untouched (issue #953).
+	got, err := runBytes(t, []byte{0xFF, 'A', 0xFE, '\n'}, "A", "Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{0xFF, 'Z', 0xFE, '\n'}
+	if !bytes.Equal(got, want) {
+		t.Errorf("tr output = % x, want % x", got, want)
+	}
+}
+
+func TestDeletesRawBinaryBytes(t *testing.T) {
+	// Deleting a raw byte by its octal value must work on binary input.
+	got, err := runBytes(t, []byte{0xFF, 'a', 0xFF, 'b'}, "-d", `\377`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{'a', 'b'}
+	if !bytes.Equal(got, want) {
+		t.Errorf("tr output = % x, want % x", got, want)
+	}
+}
+
 func TestRun(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/textproc/textproc.go
+++ b/internal/textproc/textproc.go
@@ -57,9 +57,17 @@ func CountReader(r io.Reader) (Count, error) {
 			} else {
 				lineWidth++
 			}
-			if unicode.IsSpace(ru) {
+			// Word boundaries follow GNU wc: only a printable, non-space
+			// character starts a word. White space ends the current word, while
+			// control bytes and invalid UTF-8 bytes are transparent — they
+			// neither start nor end a word — so "a\x01b" is one word and a lone
+			// NUL/control byte is zero words (issue #953). An invalid byte is
+			// reported by ReadRune as RuneError with size 1.
+			invalidByte := ru == unicode.ReplacementChar && size == 1
+			switch {
+			case unicode.IsSpace(ru):
 				inWord = false
-			} else if !inWord {
+			case !invalidByte && unicode.IsPrint(ru) && !inWord:
 				inWord = true
 				c.Words++
 			}

--- a/internal/textproc/textproc_test.go
+++ b/internal/textproc/textproc_test.go
@@ -43,6 +43,30 @@ func TestCountReader(t *testing.T) {
 			input: "",
 			want:  textproc.Count{},
 		},
+		{
+			// A lone NUL byte is not a word: GNU wc counts only printable,
+			// non-space characters as starting a word (issue #953).
+			name:  "lone NUL is not a word",
+			input: "\x00",
+			want:  textproc.Count{Lines: 0, Words: 0, Runes: 1, Bytes: 1, MaxLineWidth: 1},
+		},
+		{
+			name:  "lone control byte is not a word",
+			input: "\x01",
+			want:  textproc.Count{Lines: 0, Words: 0, Runes: 1, Bytes: 1, MaxLineWidth: 1},
+		},
+		{
+			// A control byte between letters is transparent: it neither starts
+			// nor ends a word, so "a\x01b" is a single word like GNU wc.
+			name:  "control byte does not split a word",
+			input: "a\x01b",
+			want:  textproc.Count{Lines: 0, Words: 1, Runes: 3, Bytes: 3, MaxLineWidth: 3},
+		},
+		{
+			name:  "invalid UTF-8 byte is not a word",
+			input: "\xff",
+			want:  textproc.Count{Lines: 0, Words: 0, Runes: 1, Bytes: 1, MaxLineWidth: 1},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
## Summary

Two byte-oriented applets decoded input as UTF-8 text and then operated on runes, diverging from GNU on binary or invalid-UTF-8 input (issue #953):

- `tr` decoded its whole input with `string(data)`/`[]rune`, so invalid UTF-8 bytes were normalized to U+FFFD. `tr '\377' X` corrupted a lone `0xFF` byte into the replacement character instead of translating it, and `tr A Z` rewrote unrelated non-UTF-8 bytes while translating valid ones.
- `wc` counted a lone NUL or control byte as a word, because it treated every non-space rune as a word start.

## Changes

- `tr` now decodes input into cells that preserve invalid bytes verbatim (a cell is either a valid rune or a raw byte). Set membership, translation, deletion, and squeezing operate per cell, and untranslated raw bytes are written back unchanged. This matches GNU `tr`'s byte-oriented behavior on binary input while keeping multi-byte UTF-8 text behavior for valid input.
- `wc` (`textproc.CountReader`) now starts a word only at a printable, non-space character; control bytes and invalid UTF-8 bytes are transparent — they neither start nor end a word. So `a\x01b` is one word and a lone NUL/control/invalid byte is zero words, matching GNU `wc`.

## Design Decisions

`tr` keeps a `raw` flag per symbol so a translated binary byte is emitted as a single byte rather than multi-byte UTF-8, and an octal escape like `\377` matches input byte `0xFF`. `wc` uses `unicode.IsPrint` plus an explicit invalid-byte check (`RuneError` with size 1) to mirror glibc `iswprint`/`iswspace`. Verified byte-for-byte against GNU `tr` and `wc` for every reproduction in the issue. The applets listed in the issue as "worth auditing next" (rev, fold, fmt, cut) are left for a separate follow-up as the issue notes they are not yet catalogued.

Closes #953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `tr` command now properly preserves binary and invalid UTF-8 data without corruption
  * Word-counting logic updated to align with GNU `wc` behavior for control bytes and word boundaries

* **Tests**
  * Added coverage for binary data handling and word counting edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->