### PR TITLE
fix: remove hard line-length caps and surface grep read errors

### DIFF
--- a/internal/applets/editors/awk/awk.go
+++ b/internal/applets/editors/awk/awk.go
@@ -118,7 +118,7 @@ func (st *state) process(stdio command.IO, files []string, rules []rule) error {
 			return fmt.Errorf("%s", command.FileError(f, err))
 		}
 		scanner := bufio.NewScanner(r)
-		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		scanner.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 		for scanner.Scan() {
 			st.nr++
 			st.setLine(scanner.Text())

--- a/internal/applets/editors/ed/ed.go
+++ b/internal/applets/editors/ed/ed.go
@@ -57,7 +57,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 
 	sc := bufio.NewScanner(stdio.In)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 
 	e := &editor{dot: 0, in: sc, out: stdio.Out, errw: stdio.Err}
 	if rest := fs.Args(); len(rest) > 0 {

--- a/internal/applets/editors/patch/patch.go
+++ b/internal/applets/editors/patch/patch.go
@@ -59,7 +59,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	} else {
 		var b strings.Builder
 		sc := bufio.NewScanner(stdio.In)
-		sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+		sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 		for sc.Scan() {
 			b.WriteString(sc.Text())
 			b.WriteByte('\n')

--- a/internal/applets/editors/sed/sed.go
+++ b/internal/applets/editors/sed/sed.go
@@ -214,7 +214,7 @@ func readLines(stdio command.IO, name string) ([]string, error) {
 
 	var lines []string
 	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}

--- a/internal/applets/findutils/grep/grep.go
+++ b/internal/applets/findutils/grep/grep.go
@@ -307,7 +307,7 @@ func (g *grepper) searchFile(name string) {
 	}
 
 	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 
 	contextNeeded := g.opts.after > 0 || g.opts.before > 0
 	if g.opts.count || g.opts.filesMatch || g.opts.filesNoMat || g.opts.quiet {
@@ -365,6 +365,14 @@ func (g *grepper) searchFile(name string) {
 		}
 
 		g.printMatchLine(display, lineNo, byteOff, line, &lastPrinted)
+	}
+
+	// A read failure must surface as a grep error (exit 2), not be hidden behind
+	// a silent "no matches" result (issue #950).
+	if err := scanner.Err(); err != nil {
+		_, _ = fmt.Fprintf(g.stdio.Err, "grep: %s\n", command.FileError(display, err))
+		g.failed = true
+		return
 	}
 
 	if g.opts.filesMatch && count > 0 {

--- a/internal/applets/findutils/grep/grep_test.go
+++ b/internal/applets/findutils/grep/grep_test.go
@@ -108,6 +108,27 @@ func TestNoMatchExit1(t *testing.T) {
 	}
 }
 
+// errReader fails on the first read, modeling an unreadable input stream.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("input error") }
+
+func TestStdinReadErrorExitsTwoNotSilentNoMatch(t *testing.T) {
+	t.Parallel()
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	io := command.IO{In: errReader{}, Out: out, Err: errBuf}
+	// A real read failure must be reported as a grep error (exit 2), not hidden
+	// behind the "no matches" exit 1 with empty stderr (issue #950).
+	err := grep.New().Run(context.Background(), io, []string{"foo"})
+	if code := exitCode(t, err); code != 2 {
+		t.Fatalf("exit = %d, want 2 on read error", code)
+	}
+	if !strings.Contains(errBuf.String(), "grep:") {
+		t.Errorf("stderr should report the read error, got %q", errBuf.String())
+	}
+}
+
 func TestInvalidRegexExit2(t *testing.T) {
 	t.Parallel()
 	_, errOut, err := run(t, "x\n", "[")

--- a/internal/applets/findutils/xargs/xargs.go
+++ b/internal/applets/findutils/xargs/xargs.go
@@ -125,7 +125,7 @@ func readItems(stdio command.IO, opts options) ([]string, []int, error) {
 	// Default: split on whitespace but remember which input line each item came
 	// from so -L can group by line.
 	scanner := bufio.NewScanner(stdio.In)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	scanner.Split(bufio.ScanLines)
 
 	var items []string
@@ -145,7 +145,7 @@ func readItems(stdio command.IO, opts options) ([]string, []int, error) {
 // readDelimited reads items separated by NUL (-0) or a custom delimiter (-d).
 func readDelimited(stdio command.IO, opts options) ([]string, error) {
 	scanner := bufio.NewScanner(stdio.In)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	if opts.null {
 		scanner.Split(splitOn(0))
 	} else {

--- a/internal/applets/mailutils/sendmail/sendmail.go
+++ b/internal/applets/mailutils/sendmail/sendmail.go
@@ -87,7 +87,7 @@ func appendMbox(path, from string, body []byte) error {
 	w := bufio.NewWriter(f)
 	fmt.Fprintf(w, "From %s %s\n", from, now().UTC().Format("Mon Jan  2 15:04:05 2006"))
 	sc := bufio.NewScanner(strings.NewReader(string(body)))
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		line := sc.Text()
 		if strings.HasPrefix(line, "From ") {

--- a/internal/applets/netutils/whois/whois.go
+++ b/internal/applets/netutils/whois/whois.go
@@ -87,7 +87,7 @@ func tcpQuery(server, object string) (string, error) {
 
 	var b []byte
 	sc := bufio.NewScanner(conn)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		b = append(b, sc.Bytes()...)
 		b = append(b, '\n')

--- a/internal/applets/securityutils/pwcrack/pwcrack.go
+++ b/internal/applets/securityutils/pwcrack/pwcrack.go
@@ -143,7 +143,7 @@ func (c *Command) loadWords(stdio command.IO, path string) ([]string, error) {
 
 	var words []string
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		words = append(words, sc.Text())
 	}

--- a/internal/applets/shellutils/bc/bc.go
+++ b/internal/applets/shellutils/bc/bc.go
@@ -69,7 +69,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	files := fs.Args()
 	if len(files) == 0 {
 		sc := bufio.NewScanner(stdio.In)
-		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 		for sc.Scan() {
 			m.run(sc.Text())
 		}

--- a/internal/applets/shellutils/cut/cut.go
+++ b/internal/applets/shellutils/cut/cut.go
@@ -188,7 +188,7 @@ func run(stdio command.IO, opts options, files []string) error {
 // terminates each emitted line.
 func cutReader(w io.Writer, r io.Reader, opts options) error {
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	sc.Split(splitOn(opts.lineDelim))
 	bw := bufio.NewWriter(w)
 	for sc.Scan() {

--- a/internal/applets/shellutils/cut/cut_test.go
+++ b/internal/applets/shellutils/cut/cut_test.go
@@ -19,6 +19,20 @@ func runStdin(t *testing.T, stdin string, args ...string) (string, string, error
 	return out.String(), errBuf.String(), err
 }
 
+func TestCutLongLineBeyondDefaultScannerCap(t *testing.T) {
+	t.Parallel()
+	// A 2 MiB single line must be processed like GNU cut, not rejected with
+	// "token too long" (issue #950).
+	line := strings.Repeat("a", 2*1024*1024)
+	out, errOut, err := runStdin(t, line+"\n", "-c", "1-3")
+	if err != nil {
+		t.Fatalf("cut error = %v (stderr: %s)", err, errOut)
+	}
+	if want := "aaa\n"; out != want {
+		t.Errorf("cut -c1-3 of a 2 MiB line = %q, want %q", out, want)
+	}
+}
+
 func TestRunCut(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/applets/shellutils/dc/dc.go
+++ b/internal/applets/shellutils/dc/dc.go
@@ -81,7 +81,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 	}
 	if len(exprs) == 0 && len(files) == 0 {
 		sc := bufio.NewScanner(stdio.In)
-		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 		for sc.Scan() {
 			m.eval(sc.Text())
 		}

--- a/internal/applets/shellutils/uniq/uniq.go
+++ b/internal/applets/shellutils/uniq/uniq.go
@@ -110,7 +110,7 @@ func openOutput(stdio command.IO, operands []string) (io.Writer, func(), error) 
 func readLines(r io.Reader) ([]string, error) {
 	var lines []string
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		lines = append(lines, sc.Text())
 	}

--- a/internal/applets/textutils/comm/comm.go
+++ b/internal/applets/textutils/comm/comm.go
@@ -180,7 +180,7 @@ func readLines(stdio command.IO, name string, zero bool) ([]string, error) {
 
 	var lines []string
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	if zero {
 		sc.Split(scanNUL)
 	}

--- a/internal/applets/textutils/fmt/fmt.go
+++ b/internal/applets/textutils/fmt/fmt.go
@@ -74,7 +74,7 @@ func (c *Command) fmtFile(stdio command.IO, name string, width int) error {
 	defer func() { _ = r.Close() }()
 
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 
 	var para []string
 	flush := func() error {

--- a/internal/applets/textutils/fold/fold.go
+++ b/internal/applets/textutils/fold/fold.go
@@ -74,7 +74,7 @@ func (c *Command) foldFile(stdio command.IO, name string, width int, spaces bool
 	defer func() { _ = r.Close() }()
 
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		for _, piece := range foldLine(sc.Text(), width, spaces) {
 			if _, err := io.WriteString(stdio.Out, piece+"\n"); err != nil {

--- a/internal/applets/textutils/paste/paste.go
+++ b/internal/applets/textutils/paste/paste.go
@@ -165,7 +165,7 @@ func readLines(stdio command.IO, name string) ([]string, error) {
 
 	var lines []string
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		lines = append(lines, sc.Text())
 	}

--- a/internal/applets/textutils/rev/rev.go
+++ b/internal/applets/textutils/rev/rev.go
@@ -68,7 +68,7 @@ func (c *Command) revFile(stdio command.IO, name string) error {
 	defer func() { _ = r.Close() }()
 
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		if _, err := io.WriteString(stdio.Out, reverseRunes(sc.Text())+"\n"); err != nil {
 			return err

--- a/internal/applets/textutils/rev/rev_test.go
+++ b/internal/applets/textutils/rev/rev_test.go
@@ -19,6 +19,20 @@ func run(t *testing.T, stdin string, args ...string) (string, string, error) {
 	return out.String(), errBuf.String(), err
 }
 
+func TestLongLineBeyondDefaultScannerCap(t *testing.T) {
+	t.Parallel()
+	// A 2 MiB single line exceeds the old fixed scanner cap; rev must handle it
+	// like GNU rev instead of failing with "token too long" (issue #950).
+	line := strings.Repeat("a", 2*1024*1024)
+	out, errOut, err := run(t, line+"\n")
+	if err != nil {
+		t.Fatalf("rev error = %v (stderr: %s)", err, errOut)
+	}
+	if want := line + "\n"; out != want {
+		t.Errorf("rev of a 2 MiB line: got %d bytes, want %d", len(out), len(want))
+	}
+}
+
 func TestRun(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/applets/textutils/shuf/shuf.go
+++ b/internal/applets/textutils/shuf/shuf.go
@@ -110,7 +110,7 @@ func readLines(stdio command.IO, name string) ([]string, error) {
 
 	var lines []string
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		lines = append(lines, sc.Text())
 	}

--- a/internal/applets/textutils/split/split.go
+++ b/internal/applets/textutils/split/split.go
@@ -156,7 +156,7 @@ func parseSize(s string) (int, error) {
 // byLines writes perFile lines into each successive output file.
 func (c *Command) byLines(stdio command.IO, r io.Reader, prefix string, perFile int, ns namingScheme) error {
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 
 	idx, count := 0, 0
 	var w *os.File

--- a/internal/applets/textutils/sqluv/loader.go
+++ b/internal/applets/textutils/sqluv/loader.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/nao1215/mimixbox/internal/command"
 	"github.com/ulikunitz/xz"
 )
 
@@ -142,7 +143,7 @@ func readSeparated(r io.Reader, t *table, format fileFormat) error {
 // fields; the union of labels (in first-seen order) becomes the columns.
 func readLTSV(r io.Reader, t *table) error {
 	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 
 	colIndex := map[string]int{}
 	var records []map[string]string

--- a/internal/applets/textutils/uucode/uucode.go
+++ b/internal/applets/textutils/uucode/uucode.go
@@ -195,7 +195,7 @@ func runUudecode(stdio command.IO, args []string) error {
 // the decoded bytes.
 func decode(r io.Reader) (string, []byte, error) {
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 
 	name := ""
 	base64Mode := false

--- a/internal/applets/textutils/xxd/xxd.go
+++ b/internal/applets/textutils/xxd/xxd.go
@@ -114,7 +114,7 @@ func formatLine(offset int, data []byte) string {
 // text between ": " and the two-space gap that precedes the ASCII column.
 func (c *Command) revert(stdio command.IO, r io.Reader) error {
 	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
 	for sc.Scan() {
 		line := sc.Text()
 		colon := strings.Index(line, ": ")

--- a/internal/command/input.go
+++ b/internal/command/input.go
@@ -7,6 +7,17 @@ import (
 	"os"
 )
 
+// MaxLineSize is the largest single line (token) the line-oriented applets
+// accept when reading through a bufio.Scanner. The default scanner cap is only
+// 64 KiB, which made applets like rev, fold, cut, grep, sed, and awk reject
+// valid long lines with "token too long" while their GNU counterparts handled
+// them. Pass this as the scanner's max so a line is bounded only by available
+// memory, matching the host tools:
+//
+//	sc := bufio.NewScanner(r)
+//	sc.Buffer(make([]byte, 0, 64*1024), command.MaxLineSize)
+const MaxLineSize = 1 << 30 // 1 GiB
+
 // Open resolves an operand to a reader the way the GNU file utilities do: the
 // name "-" means standard input (taken from the injected IO so tests stay in
 // memory), and any other name is opened as a file. The caller must Close the


### PR DESCRIPTION
## Summary

Many line-oriented applets created a `bufio.Scanner` with a fixed token cap (1, 4, 8, or 16 MiB), so they rejected valid long lines with `bufio.Scanner: token too long` while the corresponding GNU tools handle them. The bug report observed this on rev, fold, fmt, shuf, cut, uniq, comm, split, paste, grep, awk, and sed with 2 MiB / 5 MiB single-line inputs. Separately, `grep` scanned without ever checking `scanner.Err()`, so a real read failure surfaced as a silent "no matches" (exit 1, empty stderr) instead of an error.

## Changes

- Added `command.MaxLineSize` (1 GiB) and used it as the scanner buffer cap in every applet that previously set an explicit fixed cap (23 files). A single line is now bounded only by available memory, matching the host tools, instead of a small artificial limit.
- `grep` now checks `scanner.Err()` after scanning and reports a read failure as a grep error (exit 2) with a `grep: ...` message, instead of a silent no-match.

## Design Decisions

The shared `command.MaxLineSize` constant replaces the scattered magic numbers so the cap is defined once and documented. 1 GiB is far beyond any realistic line yet avoids unbounded growth surprises; it comfortably covers the reported 2–5 MiB reproductions. Added regression tests: a 2 MiB single line through `rev` and `cut`, and a grep read-error test asserting exit 2 with a non-empty stderr. Verified against the real binary that rev/fold/fmt/shuf/uniq/cut/grep (2 MiB) and awk/sed (5 MiB) all now exit 0.

Closes #950