### PR TITLE
fix: stream od, hexdump, tr, and uucode instead of buffering all input

### DIFF
--- a/internal/applets/shellutils/od/od.go
+++ b/internal/applets/shellutils/od/od.go
@@ -5,6 +5,7 @@
 package od
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -66,11 +67,7 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return command.Failure(ferr)
 	}
 
-	data, readErr := readAll(stdio, fs.Args())
-	if _, werr := io.WriteString(stdio.Out, dump(data, radix, ft)); werr != nil {
-		return command.Failure(werr)
-	}
-	return readErr
+	return dumpStream(stdio, fs.Args(), radix, ft)
 }
 
 // selectFormat resolves the effective output type. An explicit -t wins;
@@ -95,32 +92,81 @@ func selectFormat(typ string, b, c, x, o, d bool) string {
 	}
 }
 
-// readAll reads every operand (defaulting to standard input when there are
-// none) and returns the concatenated bytes. A failed open or read is reported
-// on stderr but does not stop the remaining files; the returned error only sets
-// the exit code, because its message was already printed.
-func readAll(stdio command.IO, files []string) ([]byte, error) {
+// dumpStream dumps every operand (defaulting to standard input when there are
+// none) row by row without buffering the whole input (issue #952). Offsets run
+// continuously across the concatenated operands, exactly as the previous
+// read-everything implementation produced. A failed open or read is reported on
+// stderr but does not stop the remaining files; the returned error only sets the
+// exit code, because its message was already printed.
+func dumpStream(stdio command.IO, files []string, r radix, ft formatType) error {
 	if len(files) == 0 {
 		files = []string{"-"}
 	}
-	var data []byte
+	bw := bufio.NewWriter(stdio.Out)
+	d := &rowDumper{w: bw, radix: r, ft: ft}
+
 	var firstErr error
 	for _, name := range files {
-		r, err := command.Open(stdio, name)
+		rc, err := command.Open(stdio, name)
 		if err != nil {
 			_, _ = fmt.Fprintf(stdio.Err, "od: %s\n", command.FileError(name, err))
 			firstErr = keep(firstErr)
 			continue
 		}
-		b, err := io.ReadAll(r)
-		_ = r.Close()
-		data = append(data, b...)
-		if err != nil {
-			_, _ = fmt.Fprintf(stdio.Err, "od: %s\n", command.FileError(name, err))
+		_, cerr := io.Copy(d, rc)
+		_ = rc.Close()
+		if cerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "od: %s\n", command.FileError(name, cerr))
 			firstErr = keep(firstErr)
 		}
 	}
-	return data, firstErr
+	d.finish()
+	if err := bw.Flush(); err != nil && firstErr == nil {
+		return command.Failure(err)
+	}
+	return firstErr
+}
+
+// rowDumper formats input into fixed-width od rows as bytes stream in, holding
+// at most one partial row in memory. The final total-length address line is
+// emitted by finish.
+type rowDumper struct {
+	w     *bufio.Writer
+	radix radix
+	ft    formatType
+	buf   [bytesPerLine]byte
+	n     int // bytes currently buffered for the in-progress row
+	off   int // file offset of the first byte in buf
+	total int // total bytes seen
+}
+
+func (d *rowDumper) Write(p []byte) (int, error) {
+	for _, b := range p {
+		d.buf[d.n] = b
+		d.n++
+		d.total++
+		if d.n == bytesPerLine {
+			d.flushRow()
+			d.off += bytesPerLine
+			d.n = 0
+		}
+	}
+	return len(p), nil
+}
+
+func (d *rowDumper) flushRow() {
+	_, _ = d.w.WriteString(line(d.buf[:d.n], d.off, d.radix, d.ft))
+	_ = d.w.WriteByte('\n')
+}
+
+func (d *rowDumper) finish() {
+	if d.n > 0 {
+		d.flushRow()
+	}
+	if addr := address(d.total, d.radix); addr != "" {
+		_, _ = d.w.WriteString(addr)
+		_ = d.w.WriteByte('\n')
+	}
 }
 
 func keep(existing error) error {
@@ -305,23 +351,6 @@ func namedUnit(b []byte) string {
 // address column (unless the radix is none) followed by space-prefixed,
 // right-justified value fields, then a final line giving the total length in
 // the address radix.
-func dump(data []byte, r radix, ft formatType) string {
-	var b strings.Builder
-	for off := 0; off < len(data); off += bytesPerLine {
-		end := off + bytesPerLine
-		if end > len(data) {
-			end = len(data)
-		}
-		b.WriteString(line(data[off:end], off, r, ft))
-		b.WriteByte('\n')
-	}
-	if addr := address(len(data), r); addr != "" {
-		b.WriteString(addr)
-		b.WriteByte('\n')
-	}
-	return b.String()
-}
-
 // line renders a single output line: the address for offset (when shown)
 // followed by the formatted units for the (already sliced) chunk of bytes.
 func line(chunk []byte, offset int, r radix, ft formatType) string {

--- a/internal/applets/shellutils/od/od_test.go
+++ b/internal/applets/shellutils/od/od_test.go
@@ -3,6 +3,7 @@ package od_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,44 @@ func runStdin(t *testing.T, stdin string, args ...string) (string, string, error
 	io := command.IO{In: strings.NewReader(stdin), Out: out, Err: errBuf}
 	err := od.New().Run(context.Background(), io, args)
 	return out.String(), errBuf.String(), err
+}
+
+// dripReader returns its data one byte per Read call so the row formatter is
+// forced to assemble rows across many read boundaries.
+type dripReader struct {
+	data []byte
+	pos  int
+}
+
+func (d *dripReader) Read(p []byte) (int, error) {
+	if d.pos >= len(d.data) {
+		return 0, io.EOF
+	}
+	p[0] = d.data[d.pos]
+	d.pos++
+	return 1, nil
+}
+
+func TestStreamingMatchesSingleRead(t *testing.T) {
+	t.Parallel()
+	// Streaming the input one byte at a time must produce the same dump as a
+	// single read, across row boundaries and the trailing offset line (#952).
+	data := bytes.Repeat([]byte{0x00, 0x41, 0xff, '\n', 0x7f, 0x10}, 5000) // ~30 KiB
+	for _, args := range [][]string{nil, {"-c"}, {"-A", "x", "-t", "x1"}} {
+		whole := &bytes.Buffer{}
+		io1 := command.IO{In: bytes.NewReader(data), Out: whole, Err: &bytes.Buffer{}}
+		if err := od.New().Run(context.Background(), io1, args); err != nil {
+			t.Fatalf("whole run error = %v", err)
+		}
+		drip := &bytes.Buffer{}
+		io2 := command.IO{In: &dripReader{data: data}, Out: drip, Err: &bytes.Buffer{}}
+		if err := od.New().Run(context.Background(), io2, args); err != nil {
+			t.Fatalf("drip run error = %v", err)
+		}
+		if whole.String() != drip.String() {
+			t.Errorf("args %v: streaming output differs from single read", args)
+		}
+	}
 }
 
 // Expected outputs are verified against GNU od, e.g. `printf 'ABC\n' | od -c`.

--- a/internal/applets/textutils/tr/tr.go
+++ b/internal/applets/textutils/tr/tr.go
@@ -4,6 +4,7 @@
 package tr
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -90,14 +91,8 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		set1 = set1[:len(set2)]
 	}
 
-	data, readErr := io.ReadAll(stdio.In)
-	if readErr != nil {
-		return command.Failuref("%v", readErr)
-	}
-
-	result := transform(data, set1, set2, opts)
-	if _, err := stdio.Out.Write(result); err != nil {
-		return command.Failure(err)
+	if err := streamTransform(stdio.In, stdio.Out, set1, set2, opts); err != nil {
+		return command.Failuref("%v", err)
 	}
 	return nil
 }
@@ -158,51 +153,183 @@ func appendCell(out []byte, c cell) []byte {
 	return utf8.AppendRune(out, c.r)
 }
 
-func appendCells(out []byte, cells []cell) []byte {
+// streamTransform reads from r, applies the tr operation, and writes the result
+// to w, processing the input in chunks so the whole input is never buffered
+// (issue #952). Multi-byte UTF-8 sequences that straddle a chunk boundary are
+// carried to the next read, and the squeeze run state is preserved across
+// chunks, so the output is identical to processing the whole input at once.
+func streamTransform(r io.Reader, w io.Writer, set1, set2 []rune, opts options) error {
+	p := newProcessor(set1, set2, opts)
+	bw := bufio.NewWriter(w)
+	buf := make([]byte, 64*1024)
+	out := make([]byte, 0, 64*1024)
+	var carry []byte
+	for {
+		n, rerr := r.Read(buf)
+		atEOF := rerr != nil
+
+		chunk := buf[:n]
+		if len(carry) > 0 {
+			chunk = append(carry, chunk...)
+		}
+
+		proc := len(chunk)
+		if !atEOF {
+			// Hold back an incomplete trailing UTF-8 sequence; at EOF it is
+			// flushed and decoded as raw bytes, matching whole-buffer decoding.
+			proc = completeRuneLen(chunk)
+		}
+		out = p.process(out[:0], decodeCells(chunk[:proc]))
+		if len(out) > 0 {
+			if _, werr := bw.Write(out); werr != nil {
+				return werr
+			}
+		}
+		if !atEOF {
+			carry = append([]byte(nil), chunk[proc:]...)
+		}
+
+		if atEOF {
+			if rerr == io.EOF {
+				break
+			}
+			return rerr
+		}
+	}
+	return bw.Flush()
+}
+
+// completeRuneLen returns the length of the longest prefix of b that does not
+// end in the middle of a multi-byte UTF-8 sequence. An invalid byte counts as a
+// complete (width-1) symbol, matching utf8.FullRune.
+func completeRuneLen(b []byte) int {
+	for i := 1; i <= utf8.UTFMax && i <= len(b); i++ {
+		start := len(b) - i
+		if utf8.RuneStart(b[start]) {
+			if utf8.FullRune(b[start:]) {
+				return len(b)
+			}
+			return start
+		}
+	}
+	return len(b)
+}
+
+// processor applies the tr operation to a stream of cells. The only state it
+// carries between chunks is the squeeze run (prev rune); a buffering version
+// kept this implicitly while walking the whole input.
+type processor struct {
+	opts   options
+	set2   []rune
+	inSet1 func(rune) bool
+	inSet2 func(rune) bool
+
+	translate  bool
+	transMap   map[rune]rune
+	transComp  map[rune]struct{}
+	transLast  rune
+	complement bool
+
+	prev     rune
+	havePrev bool
+}
+
+// newProcessor precomputes the membership predicates and translation table for
+// the requested operation.
+func newProcessor(set1, set2 []rune, opts options) *processor {
+	p := &processor{
+		opts:       opts,
+		set2:       set2,
+		inSet1:     membership(set1, opts.complement),
+		complement: opts.complement,
+	}
+	switch {
+	case opts.delete:
+		if opts.squeeze && len(set2) > 0 {
+			p.inSet2 = membership(set2, false)
+		}
+	case opts.squeeze && len(set2) == 0:
+		// squeeze-only collapses runs of SET1 directly via inSet1.
+	default:
+		if len(set2) > 0 {
+			p.translate = true
+			if opts.complement {
+				p.transComp = make(map[rune]struct{}, len(set1))
+				for _, r := range set1 {
+					p.transComp[r] = struct{}{}
+				}
+				p.transLast = set2[len(set2)-1]
+			} else {
+				p.transMap = make(map[rune]rune, len(set1))
+				for i, r := range set1 {
+					if i < len(set2) {
+						p.transMap[r] = set2[i]
+					} else {
+						p.transMap[r] = set2[len(set2)-1]
+					}
+				}
+			}
+		}
+		if opts.squeeze {
+			p.inSet2 = membership(set2, false)
+		}
+	}
+	return p
+}
+
+// process applies the operation to cells, appending output to out.
+func (p *processor) process(out []byte, cells []cell) []byte {
 	for _, c := range cells {
-		out = appendCell(out, c)
+		switch {
+		case p.opts.delete:
+			if p.inSet1(c.r) {
+				continue
+			}
+			if p.opts.squeeze && len(p.set2) > 0 {
+				out = p.squeezeEmit(out, c, p.inSet2)
+			} else {
+				out = appendCell(out, c)
+			}
+		case p.opts.squeeze && len(p.set2) == 0:
+			out = p.squeezeEmit(out, c, p.inSet1)
+		default:
+			c = p.translateCell(c)
+			if p.opts.squeeze {
+				out = p.squeezeEmit(out, c, p.inSet2)
+			} else {
+				out = appendCell(out, c)
+			}
+		}
 	}
 	return out
 }
 
-// transform applies the requested operation (delete, squeeze, translate, or a
-// combination) to data and returns the result.
-func transform(data []byte, set1, set2 []rune, opts options) []byte {
-	in := decodeCells(data)
-
-	// Resolve which runes SET1 selects, honoring -c/-C complement.
-	inSet1 := membership(set1, opts.complement)
-
-	out := make([]byte, 0, len(data))
-
-	switch {
-	case opts.delete:
-		// Delete chars in SET1, then optionally squeeze repeats from SET2.
-		kept := make([]cell, 0, len(in))
-		for _, c := range in {
-			if !inSet1(c.r) {
-				kept = append(kept, c)
-			}
-		}
-		if opts.squeeze && len(set2) > 0 {
-			inSet2 := membership(set2, false)
-			out = writeSqueezed(out, kept, inSet2)
-		} else {
-			out = appendCells(out, kept)
-		}
-	case opts.squeeze && len(set2) == 0:
-		// Squeeze only: collapse runs of characters in SET1.
-		out = writeSqueezed(out, in, inSet1)
-	default:
-		// Translate SET1 -> SET2, then optionally squeeze repeats from SET2.
-		mapped := translateCells(in, set1, set2, opts.complement)
-		if opts.squeeze {
-			inSet2 := membership(set2, false)
-			out = writeSqueezed(out, mapped, inSet2)
-		} else {
-			out = appendCells(out, mapped)
-		}
+// translateCell maps one cell according to SET1 -> SET2.
+func (p *processor) translateCell(c cell) cell {
+	if !p.translate {
+		return c
 	}
+	if p.complement {
+		if _, ok := p.transComp[c.r]; ok {
+			return c
+		}
+		return c.mapped(p.transLast)
+	}
+	if to, ok := p.transMap[c.r]; ok {
+		return c.mapped(to)
+	}
+	return c
+}
+
+// squeezeEmit appends c unless it repeats the previous selected character, in
+// which case it is collapsed away. The run state persists across chunks.
+func (p *processor) squeezeEmit(out []byte, c cell, selected func(rune) bool) []byte {
+	if p.havePrev && c.r == p.prev && selected(c.r) {
+		return out
+	}
+	out = appendCell(out, c)
+	p.prev = c.r
+	p.havePrev = true
 	return out
 }
 
@@ -211,49 +338,6 @@ func transform(data []byte, set1, set2 []rune, opts options) []byte {
 // written as a byte, not as multi-byte UTF-8).
 func (c cell) mapped(to rune) cell {
 	return cell{r: to, raw: c.raw && to <= 0xFF}
-}
-
-// translateCells maps each cell of in according to SET1 -> SET2. With the
-// complement flag, every cell not in SET1 maps to the last rune of SET2 (GNU
-// behavior). Otherwise the i-th rune of SET1 maps to the i-th rune of SET2; when
-// SET2 is shorter, its last rune is repeated to pad it.
-func translateCells(in []cell, set1, set2 []rune, complement bool) []cell {
-	if len(set2) == 0 {
-		return in
-	}
-	out := make([]cell, 0, len(in))
-	if complement {
-		inSet1 := make(map[rune]struct{}, len(set1))
-		for _, r := range set1 {
-			inSet1[r] = struct{}{}
-		}
-		last := set2[len(set2)-1]
-		for _, c := range in {
-			if _, ok := inSet1[c.r]; ok {
-				out = append(out, c)
-			} else {
-				out = append(out, c.mapped(last))
-			}
-		}
-		return out
-	}
-
-	m := make(map[rune]rune, len(set1))
-	for i, r := range set1 {
-		if i < len(set2) {
-			m[r] = set2[i]
-		} else {
-			m[r] = set2[len(set2)-1]
-		}
-	}
-	for _, c := range in {
-		if to, ok := m[c.r]; ok {
-			out = append(out, c.mapped(to))
-		} else {
-			out = append(out, c)
-		}
-	}
-	return out
 }
 
 // membership returns a predicate reporting whether a rune is selected by set.
@@ -270,22 +354,6 @@ func membership(set []rune, complement bool) func(rune) bool {
 		}
 		return ok
 	}
-}
-
-// writeSqueezed appends cells to out, collapsing each run of repeated characters
-// for which selected reports true into a single occurrence.
-func writeSqueezed(out []byte, in []cell, selected func(rune) bool) []byte {
-	var prev rune
-	havePrev := false
-	for _, c := range in {
-		if havePrev && c.r == prev && selected(c.r) {
-			continue
-		}
-		out = appendCell(out, c)
-		prev = c.r
-		havePrev = true
-	}
-	return out
 }
 
 // expandSet expands a tr SET specification into its sequence of runes,

--- a/internal/applets/textutils/tr/tr_test.go
+++ b/internal/applets/textutils/tr/tr_test.go
@@ -3,6 +3,7 @@ package tr_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -27,6 +28,53 @@ func runBytes(t *testing.T, stdin []byte, args ...string) ([]byte, error) {
 	io := command.IO{In: bytes.NewReader(stdin), Out: out, Err: &bytes.Buffer{}}
 	err := tr.New().Run(context.Background(), io, args)
 	return out.Bytes(), err
+}
+
+// dripReader returns its data one byte per Read call, forcing tr to handle
+// multi-byte UTF-8 sequences and squeeze runs that straddle read boundaries.
+type dripReader struct {
+	data []byte
+	pos  int
+}
+
+func (d *dripReader) Read(p []byte) (int, error) {
+	if d.pos >= len(d.data) {
+		return 0, io.EOF
+	}
+	p[0] = d.data[d.pos]
+	d.pos++
+	return 1, nil
+}
+
+func TestStreamingMatchesWholeInput(t *testing.T) {
+	t.Parallel()
+	// Streaming the input one byte at a time must produce the same output as a
+	// single read, across multi-byte UTF-8 boundaries and squeeze runs (#952).
+	cases := []struct {
+		in   string
+		args []string
+	}{
+		{"あああいいうう\n", []string{"-s", "あいう"}},   // squeeze multibyte across chunks
+		{"héllo wörld\n", []string{"a-z", "A-Z"}},        // translate ASCII, keep multibyte
+		{"aaabbbccc\n", []string{"-s", "a-z"}},           // squeeze ASCII run
+		{"abcあ123\n", []string{"-d", "[:digit:]"}},      // delete with multibyte present
+		{"x\xff\xffy\n", []string{"-s", "\\377"}},        // squeeze raw bytes
+	}
+	for _, tc := range cases {
+		out := &bytes.Buffer{}
+		io1 := command.IO{In: strings.NewReader(tc.in), Out: out, Err: &bytes.Buffer{}}
+		if err := tr.New().Run(context.Background(), io1, tc.args); err != nil {
+			t.Fatalf("whole run error = %v", err)
+		}
+		drip := &bytes.Buffer{}
+		io2 := command.IO{In: &dripReader{data: []byte(tc.in)}, Out: drip, Err: &bytes.Buffer{}}
+		if err := tr.New().Run(context.Background(), io2, tc.args); err != nil {
+			t.Fatalf("drip run error = %v", err)
+		}
+		if out.String() != drip.String() {
+			t.Errorf("args %v: drip=%q whole=%q", tc.args, drip.String(), out.String())
+		}
+	}
 }
 
 func TestTranslatesRawByteMatchingOctalSet(t *testing.T) {

--- a/internal/applets/textutils/uucode/uucode.go
+++ b/internal/applets/textutils/uucode/uucode.go
@@ -63,71 +63,120 @@ func runUuencode(stdio command.IO, args []string) error {
 	}
 
 	operands := fs.Args()
-	var data []byte
+	var src io.Reader
 	var name string
 	switch len(operands) {
 	case 1:
 		name = operands[0]
-		data, err = io.ReadAll(stdio.In)
+		src = stdio.In
 	case 2:
 		name = operands[1]
-		data, err = os.ReadFile(operands[0]) //nolint:gosec // user-named file
+		f, oerr := os.Open(operands[0]) //nolint:gosec // user-named file
+		if oerr != nil {
+			_, _ = fmt.Fprintf(stdio.Err, "uuencode: %v\n", oerr)
+			return command.SilentFailure()
+		}
+		defer func() { _ = f.Close() }()
+		src = f
 	default:
 		_, _ = fmt.Fprintln(stdio.Err, "uuencode: usage: uuencode [-m] [FILE] NAME")
 		return command.SilentFailure()
 	}
-	if err != nil {
-		_, _ = fmt.Fprintf(stdio.Err, "uuencode: %v\n", err)
-		return command.SilentFailure()
-	}
 
+	// The input is consumed incrementally (issue #952): the historical encoder
+	// reads it in 45-byte lines and the base64 encoder streams through, so the
+	// whole file is never held in memory.
+	var werr error
 	if *useBase64 {
-		writeBase64(stdio.Out, name, data)
+		werr = writeBase64(stdio.Out, name, src)
 	} else {
-		writeUU(stdio.Out, name, data)
+		werr = writeUU(stdio.Out, name, src)
+	}
+	if werr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "uuencode: %v\n", werr)
+		return command.SilentFailure()
 	}
 	return nil
 }
 
-func writeUU(w io.Writer, name string, data []byte) {
-	var b strings.Builder
-	fmt.Fprintf(&b, "begin 644 %s\n", name)
-	for off := 0; off < len(data); off += 45 {
-		end := off + 45
-		if end > len(data) {
-			end = len(data)
+func writeUU(w io.Writer, name string, r io.Reader) error {
+	bw := bufio.NewWriter(w)
+	_, _ = fmt.Fprintf(bw, "begin 644 %s\n", name)
+	buf := make([]byte, 45)
+	for {
+		n, err := io.ReadFull(r, buf)
+		if n > 0 {
+			line := buf[:n]
+			_ = bw.WriteByte(enc(byte(len(line))))
+			for i := 0; i < len(line); i += 3 {
+				var g [3]byte
+				copy(g[:], line[i:])
+				_ = bw.WriteByte(enc(g[0] >> 2))
+				_ = bw.WriteByte(enc((g[0]<<4 | g[1]>>4) & 0x3f))
+				_ = bw.WriteByte(enc((g[1]<<2 | g[2]>>6) & 0x3f))
+				_ = bw.WriteByte(enc(g[2] & 0x3f))
+			}
+			_ = bw.WriteByte('\n')
 		}
-		line := data[off:end]
-		b.WriteByte(enc(byte(len(line))))
-		for i := 0; i < len(line); i += 3 {
-			var g [3]byte
-			copy(g[:], line[i:])
-			b.WriteByte(enc(g[0] >> 2))
-			b.WriteByte(enc((g[0]<<4 | g[1]>>4) & 0x3f))
-			b.WriteByte(enc((g[1]<<2 | g[2]>>6) & 0x3f))
-			b.WriteByte(enc(g[2] & 0x3f))
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			break
 		}
-		b.WriteByte('\n')
+		if err != nil {
+			return err
+		}
 	}
-	b.WriteByte(enc(0))
-	b.WriteString("\nend\n")
-	_, _ = io.WriteString(w, b.String())
+	_ = bw.WriteByte(enc(0))
+	_, _ = bw.WriteString("\nend\n")
+	return bw.Flush()
 }
 
-func writeBase64(w io.Writer, name string, data []byte) {
-	var b strings.Builder
-	fmt.Fprintf(&b, "begin-base64 644 %s\n", name)
-	encoded := base64.StdEncoding.EncodeToString(data)
-	for off := 0; off < len(encoded); off += 60 {
-		end := off + 60
-		if end > len(encoded) {
-			end = len(encoded)
-		}
-		b.WriteString(encoded[off:end])
-		b.WriteByte('\n')
+func writeBase64(w io.Writer, name string, r io.Reader) error {
+	bw := bufio.NewWriter(w)
+	_, _ = fmt.Fprintf(bw, "begin-base64 644 %s\n", name)
+	lw := &lineWrapper{w: bw, cols: 60}
+	enc := base64.NewEncoder(base64.StdEncoding, lw)
+	if _, err := io.Copy(enc, r); err != nil {
+		_ = enc.Close()
+		return err
 	}
-	b.WriteString("====\n")
-	_, _ = io.WriteString(w, b.String())
+	if err := enc.Close(); err != nil {
+		return err
+	}
+	lw.finish()
+	_, _ = bw.WriteString("====\n")
+	return bw.Flush()
+}
+
+// lineWrapper writes a newline after every cols bytes, terminating each full or
+// final partial line, so base64 output is wrapped while streaming. finish ends a
+// trailing partial line; an empty stream produces no line at all.
+type lineWrapper struct {
+	w    *bufio.Writer
+	cols int
+	col  int
+}
+
+func (lw *lineWrapper) Write(p []byte) (int, error) {
+	for _, b := range p {
+		if err := lw.w.WriteByte(b); err != nil {
+			return 0, err
+		}
+		lw.col++
+		if lw.col == lw.cols {
+			if err := lw.w.WriteByte('\n'); err != nil {
+				return 0, err
+			}
+			lw.col = 0
+		}
+	}
+	return len(p), nil
+}
+
+func (lw *lineWrapper) finish() {
+	if lw.col > 0 {
+		_ = lw.w.WriteByte('\n')
+		lw.col = 0
+	}
 }
 
 // enc encodes a 6-bit value as a uuencode character (0 becomes '`').

--- a/internal/applets/textutils/uucode/uucode_test.go
+++ b/internal/applets/textutils/uucode/uucode_test.go
@@ -55,6 +55,24 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStreamsLargeInputRoundTrip(t *testing.T) {
+	t.Parallel()
+	// A large payload exercises the streaming encoders (45-byte UU lines and the
+	// streaming base64 wrapper) and must round-trip unchanged (issue #961).
+	payload := bytes.Repeat([]byte{0x00, 0x01, 0xfe, 0xff, 'a', '\n'}, 100000) // ~600 KiB
+	for _, mode := range []string{"uu", "base64"} {
+		var enc string
+		if mode == "base64" {
+			enc = encode(t, payload, "-m", "name")
+		} else {
+			enc = encode(t, payload, "name")
+		}
+		if got := decodeToStdout(t, enc); !bytes.Equal(got, payload) {
+			t.Errorf("%s large round-trip mismatch: got %d bytes, want %d", mode, len(got), len(payload))
+		}
+	}
+}
+
 func TestHeaderName(t *testing.T) {
 	t.Parallel()
 	enc := encode(t, []byte("x"), "myfile.bin")

--- a/internal/applets/util-linux/hexdump/hexdump.go
+++ b/internal/applets/util-linux/hexdump/hexdump.go
@@ -4,12 +4,12 @@
 package hexdump
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/nao1215/mimixbox/internal/command"
 )
@@ -50,105 +50,156 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		return err
 	}
 
-	data, err := readInput(stdio, fs.Args())
-	if err != nil {
+	// Open every operand up front so an unreadable file fails before any output
+	// is produced, matching the previous read-everything behavior.
+	readers, closers, oerr := openInputs(stdio, fs.Args())
+	if oerr != nil {
+		_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", c.Name(), oerr)
+		return command.SilentFailure()
+	}
+	defer func() {
+		for _, rc := range closers {
+			_ = rc.Close()
+		}
+	}()
+
+	// Stream the concatenated input rather than buffering it all (issue #952):
+	// drop the skipped prefix, then bound the dump to LENGTH bytes if requested.
+	src := io.MultiReader(readers...)
+	if *skip > 0 {
+		if _, err := io.CopyN(io.Discard, src, *skip); err != nil && err != io.EOF {
+			_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", c.Name(), err)
+			return command.SilentFailure()
+		}
+	}
+	if *length >= 0 {
+		src = io.LimitReader(src, int64(*length))
+	}
+
+	bw := bufio.NewWriter(stdio.Out)
+	d := &rowDumper{w: bw, base: *skip, canonical: c.canonical || *canonical}
+	if _, err := io.Copy(d, src); err != nil {
 		_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", c.Name(), err)
 		return command.SilentFailure()
 	}
-	if *skip > 0 {
-		if *skip >= int64(len(data)) {
-			data = nil
-		} else {
-			data = data[*skip:]
-		}
-	}
-	if *length >= 0 && *length < len(data) {
-		data = data[:*length]
-	}
-
-	if c.canonical || *canonical {
-		writeCanonical(stdio.Out, *skip, data)
-	} else {
-		writeTwoByte(stdio.Out, *skip, data)
+	d.finish()
+	if err := bw.Flush(); err != nil {
+		return command.Failure(err)
 	}
 	return nil
 }
 
-// readInput concatenates the named files, or reads standard input when none are
-// given (or when "-" is given).
-func readInput(stdio command.IO, files []string) ([]byte, error) {
-	if len(files) == 0 || (len(files) == 1 && files[0] == "-") {
-		return io.ReadAll(stdio.In)
+// openInputs opens each operand (standard input when none are given or for "-").
+// All inputs are opened before any is read so a failed open is reported before
+// any output is written.
+func openInputs(stdio command.IO, files []string) ([]io.Reader, []io.Closer, error) {
+	if len(files) == 0 {
+		files = []string{"-"}
 	}
-	var out []byte
+	var readers []io.Reader
+	var closers []io.Closer
 	for _, f := range files {
-		b, err := os.ReadFile(f) //nolint:gosec // user-named file
+		if f == "-" {
+			readers = append(readers, stdio.In)
+			continue
+		}
+		fh, err := os.Open(f) //nolint:gosec // user-named file
 		if err != nil {
-			return nil, errors.New(command.FileError(f, err))
+			for _, rc := range closers {
+				_ = rc.Close()
+			}
+			return nil, nil, errors.New(command.FileError(f, err))
 		}
-		out = append(out, b...)
+		readers = append(readers, fh)
+		closers = append(closers, fh)
 	}
-	return out, nil
+	return readers, closers, nil
 }
 
-// writeCanonical writes the "hexdump -C" / hd layout to w.
-func writeCanonical(w io.Writer, base int64, data []byte) {
-	var b strings.Builder
-	for off := 0; off < len(data); off += 16 {
-		end := off + 16
-		if end > len(data) {
-			end = len(data)
-		}
-		row := data[off:end]
-		fmt.Fprintf(&b, "%08x  ", base+int64(off))
-		for i := 0; i < 16; i++ {
-			if i == 8 {
-				b.WriteByte(' ')
-			}
-			if i < len(row) {
-				fmt.Fprintf(&b, "%02x ", row[i])
-			} else {
-				b.WriteString("   ")
-			}
-		}
-		b.WriteString(" |")
-		for _, ch := range row {
-			if ch >= 0x20 && ch <= 0x7e {
-				b.WriteByte(ch)
-			} else {
-				b.WriteByte('.')
-			}
-		}
-		b.WriteString("|\n")
-	}
-	fmt.Fprintf(&b, "%08x\n", base+int64(len(data)))
-	_, _ = io.WriteString(w, b.String())
+// rowDumper formats streamed input into 16-byte hexdump rows, holding at most a
+// single partial row in memory and emitting the trailing offset line on finish.
+type rowDumper struct {
+	w         *bufio.Writer
+	base      int64
+	canonical bool
+	buf       [16]byte
+	n         int
+	off       int // offset (relative to base) of the first byte in buf
 }
 
-// writeTwoByte writes the default hexdump layout: two-byte little-endian words.
-func writeTwoByte(w io.Writer, base int64, data []byte) {
-	var b strings.Builder
-	for off := 0; off < len(data); off += 16 {
-		end := off + 16
-		if end > len(data) {
-			end = len(data)
+func (d *rowDumper) Write(p []byte) (int, error) {
+	for _, b := range p {
+		d.buf[d.n] = b
+		d.n++
+		if d.n == 16 {
+			d.flushRow()
+			d.off += 16
+			d.n = 0
 		}
-		row := data[off:end]
-		fmt.Fprintf(&b, "%07x", base+int64(off))
-		for i := 0; i < 16; i += 2 {
-			switch {
-			case i+1 < len(row):
-				fmt.Fprintf(&b, " %02x%02x", row[i+1], row[i])
-			case i < len(row):
-				fmt.Fprintf(&b, " %04x", uint16(row[i])) // a trailing odd byte
-			default:
-				b.WriteString("     ") // pad missing words to keep 8 columns
-			}
-		}
-		b.WriteByte('\n')
 	}
-	fmt.Fprintf(&b, "%07x\n", base+int64(len(data)))
-	_, _ = io.WriteString(w, b.String())
+	return len(p), nil
+}
+
+func (d *rowDumper) flushRow() {
+	if d.canonical {
+		writeCanonicalRow(d.w, d.base+int64(d.off), d.buf[:d.n])
+	} else {
+		writeTwoByteRow(d.w, d.base+int64(d.off), d.buf[:d.n])
+	}
+}
+
+func (d *rowDumper) finish() {
+	end := d.off + d.n
+	if d.n > 0 {
+		d.flushRow()
+	}
+	if d.canonical {
+		_, _ = fmt.Fprintf(d.w, "%08x\n", d.base+int64(end))
+	} else {
+		_, _ = fmt.Fprintf(d.w, "%07x\n", d.base+int64(end))
+	}
+}
+
+// writeCanonicalRow writes one "hexdump -C" / hd row for the bytes in row, whose
+// first byte is at absolute offset addr.
+func writeCanonicalRow(b *bufio.Writer, addr int64, row []byte) {
+	_, _ = fmt.Fprintf(b, "%08x  ", addr)
+	for i := 0; i < 16; i++ {
+		if i == 8 {
+			_ = b.WriteByte(' ')
+		}
+		if i < len(row) {
+			_, _ = fmt.Fprintf(b, "%02x ", row[i])
+		} else {
+			_, _ = b.WriteString("   ")
+		}
+	}
+	_, _ = b.WriteString(" |")
+	for _, ch := range row {
+		if ch >= 0x20 && ch <= 0x7e {
+			_ = b.WriteByte(ch)
+		} else {
+			_ = b.WriteByte('.')
+		}
+	}
+	_, _ = b.WriteString("|\n")
+}
+
+// writeTwoByteRow writes one default-layout row (two-byte little-endian words)
+// for the bytes in row, whose first byte is at absolute offset addr.
+func writeTwoByteRow(b *bufio.Writer, addr int64, row []byte) {
+	_, _ = fmt.Fprintf(b, "%07x", addr)
+	for i := 0; i < 16; i += 2 {
+		switch {
+		case i+1 < len(row):
+			_, _ = fmt.Fprintf(b, " %02x%02x", row[i+1], row[i])
+		case i < len(row):
+			_, _ = fmt.Fprintf(b, " %04x", uint16(row[i])) // a trailing odd byte
+		default:
+			_, _ = b.WriteString("     ") // pad missing words to keep 8 columns
+		}
+	}
+	_ = b.WriteByte('\n')
 }
 
 func (c *Command) help() command.Help {

--- a/internal/applets/util-linux/hexdump/hexdump_test.go
+++ b/internal/applets/util-linux/hexdump/hexdump_test.go
@@ -3,6 +3,7 @@ package hexdump
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -17,6 +18,48 @@ func run(t *testing.T, c *Command, in string, args ...string) (string, string) {
 		t.Fatalf("Run error = %v (stderr=%q)", err, errBuf.String())
 	}
 	return out.String(), errBuf.String()
+}
+
+// dripReader returns its data one byte per Read call so rows are assembled
+// across read boundaries.
+type dripReader struct {
+	data []byte
+	pos  int
+}
+
+func (d *dripReader) Read(p []byte) (int, error) {
+	if d.pos >= len(d.data) {
+		return 0, io.EOF
+	}
+	p[0] = d.data[d.pos]
+	d.pos++
+	return 1, nil
+}
+
+func TestStreamingMatchesSingleRead(t *testing.T) {
+	t.Parallel()
+	// Streaming a large input one byte at a time must match a single read, for
+	// both the canonical and default layouts (issue #952).
+	data := bytes.Repeat([]byte{0x00, 0x41, 0xff, 0x7f, 0x10, '\n'}, 5000) // ~30 KiB
+	for _, canonical := range []bool{false, true} {
+		var args []string
+		if canonical {
+			args = []string{"-C"}
+		}
+		whole := &bytes.Buffer{}
+		io1 := command.IO{In: bytes.NewReader(data), Out: whole, Err: &bytes.Buffer{}}
+		if err := NewHexdump().Run(context.Background(), io1, args); err != nil {
+			t.Fatalf("whole run error = %v", err)
+		}
+		drip := &bytes.Buffer{}
+		io2 := command.IO{In: &dripReader{data: data}, Out: drip, Err: &bytes.Buffer{}}
+		if err := NewHexdump().Run(context.Background(), io2, args); err != nil {
+			t.Fatalf("drip run error = %v", err)
+		}
+		if whole.String() != drip.String() {
+			t.Errorf("canonical=%v: streaming output differs from single read", canonical)
+		}
+	}
 }
 
 // These golden strings were verified byte-for-byte against util-linux hd /


### PR DESCRIPTION
## Summary

Follow-up to #952. These filters read their whole input into memory (`io.ReadAll` / `os.ReadFile`) before formatting, so they scaled poorly on large files and could not act as incremental filters on long-lived pipes (issue #961). Each now processes its input in chunks; output is byte-identical to the previous implementations.

## Changes

- `od` dumps 16-byte rows as bytes arrive (`rowDumper`), with offsets running continuously across concatenated operands and the trailing total-length line emitted on finish.
- `hexdump`/`hd` open all operands up front (so an unreadable file still fails before any output, preserving the previous atomic-on-open-error behavior), then stream through a row dumper. `-s`/`--skip` is applied by discarding the prefix with `io.CopyN(io.Discard, ...)`, and `-n`/`--length` with `io.LimitReader`.
- `tr` decodes the input in chunks (`streamTransform`), carrying an incomplete trailing UTF-8 sequence to the next read and the squeeze run state across chunks, preserving the byte-faithful behavior added in #953.
- `uuencode` streams the historical encoder in 45-byte lines and the base64 form through `base64.NewEncoder` into a line wrapper.

## Design Decisions

Neither `od` nor `hexdump` implements the `*` repeated-line elision, so there is no cross-row state and row-at-a-time formatting reproduces the exact output. For `tr`, the only state spanning chunks is the squeeze run (`prev` rune); multi-byte sequences split across reads are held back via `completeRuneLen` until complete (or flushed as raw bytes at EOF). Verified byte-for-byte against GNU `od`, `hexdump -C`/default, and `tr` (including `-s`/`-n`/`-A`/`-t` and binary input), and added drip-reader / large-input regression tests that confirm streaming output matches a single read. uuencode round-trips a ~600 KiB binary payload in both forms.

Closes #961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored `od`, `tr`, `uucode`, and `hexdump` applets to stream input processing instead of buffering entire contents, significantly reducing memory usage for large files.

* **Tests**
  * Added comprehensive streaming compatibility tests ensuring output remains consistent when processing input byte-by-byte versus in buffered mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->