### PR TITLE
fix: propagate write errors in streaming od, hexdump, and uuencode

### DIFF
--- a/internal/applets/shellutils/od/od.go
+++ b/internal/applets/shellutils/od/od.go
@@ -116,11 +116,18 @@ func dumpStream(stdio command.IO, files []string, r radix, ft formatType) error 
 		_, cerr := io.Copy(d, rc)
 		_ = rc.Close()
 		if cerr != nil {
+			if d.err != nil {
+				// The output stream failed (e.g. a closed downstream pipe);
+				// stop draining input and report it directly.
+				return command.Failure(cerr)
+			}
 			_, _ = fmt.Fprintf(stdio.Err, "od: %s\n", command.FileError(name, cerr))
 			firstErr = keep(firstErr)
 		}
 	}
-	d.finish()
+	if err := d.finish(); err != nil && firstErr == nil {
+		return command.Failure(err)
+	}
 	if err := bw.Flush(); err != nil && firstErr == nil {
 		return command.Failure(err)
 	}
@@ -138,15 +145,21 @@ type rowDumper struct {
 	n     int // bytes currently buffered for the in-progress row
 	off   int // file offset of the first byte in buf
 	total int // total bytes seen
+	err   error
 }
 
 func (d *rowDumper) Write(p []byte) (int, error) {
-	for _, b := range p {
+	if d.err != nil {
+		return 0, d.err
+	}
+	for i, b := range p {
 		d.buf[d.n] = b
 		d.n++
 		d.total++
 		if d.n == bytesPerLine {
-			d.flushRow()
+			if err := d.flushRow(); err != nil {
+				return i + 1, err
+			}
 			d.off += bytesPerLine
 			d.n = 0
 		}
@@ -154,19 +167,29 @@ func (d *rowDumper) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (d *rowDumper) flushRow() {
-	_, _ = d.w.WriteString(line(d.buf[:d.n], d.off, d.radix, d.ft))
-	_ = d.w.WriteByte('\n')
+func (d *rowDumper) flushRow() error {
+	if _, d.err = d.w.WriteString(line(d.buf[:d.n], d.off, d.radix, d.ft)); d.err != nil {
+		return d.err
+	}
+	d.err = d.w.WriteByte('\n')
+	return d.err
 }
 
-func (d *rowDumper) finish() {
+func (d *rowDumper) finish() error {
 	if d.n > 0 {
-		d.flushRow()
+		if err := d.flushRow(); err != nil {
+			return err
+		}
 	}
 	if addr := address(d.total, d.radix); addr != "" {
-		_, _ = d.w.WriteString(addr)
-		_ = d.w.WriteByte('\n')
+		if _, err := d.w.WriteString(addr); err != nil {
+			return err
+		}
+		if err := d.w.WriteByte('\n'); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func keep(existing error) error {

--- a/internal/applets/shellutils/od/od_test.go
+++ b/internal/applets/shellutils/od/od_test.go
@@ -30,12 +30,30 @@ type dripReader struct {
 }
 
 func (d *dripReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	if d.pos >= len(d.data) {
 		return 0, io.EOF
 	}
 	p[0] = d.data[d.pos]
 	d.pos++
 	return 1, nil
+}
+
+// failWriter fails every write, modeling a closed downstream pipe.
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestWriteErrorIsReported(t *testing.T) {
+	t.Parallel()
+	// A failing output stream must surface an error rather than silently
+	// draining the input and exiting 0.
+	io1 := command.IO{In: bytes.NewReader(bytes.Repeat([]byte("x"), 200000)), Out: failWriter{}, Err: &bytes.Buffer{}}
+	if err := od.New().Run(context.Background(), io1, nil); err == nil {
+		t.Error("od must report a write error to stdout")
+	}
 }
 
 func TestStreamingMatchesSingleRead(t *testing.T) {

--- a/internal/applets/textutils/cksum/cksum_test.go
+++ b/internal/applets/textutils/cksum/cksum_test.go
@@ -55,6 +55,9 @@ type dripReader struct {
 }
 
 func (d *dripReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	if d.pos >= len(d.data) {
 		return 0, io.EOF
 	}

--- a/internal/applets/textutils/tr/tr_test.go
+++ b/internal/applets/textutils/tr/tr_test.go
@@ -38,6 +38,9 @@ type dripReader struct {
 }
 
 func (d *dripReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	if d.pos >= len(d.data) {
 		return 0, io.EOF
 	}

--- a/internal/applets/textutils/uucode/uucode.go
+++ b/internal/applets/textutils/uucode/uucode.go
@@ -106,17 +106,11 @@ func writeUU(w io.Writer, name string, r io.Reader) error {
 	for {
 		n, err := io.ReadFull(r, buf)
 		if n > 0 {
-			line := buf[:n]
-			_ = bw.WriteByte(enc(byte(len(line))))
-			for i := 0; i < len(line); i += 3 {
-				var g [3]byte
-				copy(g[:], line[i:])
-				_ = bw.WriteByte(enc(g[0] >> 2))
-				_ = bw.WriteByte(enc((g[0]<<4 | g[1]>>4) & 0x3f))
-				_ = bw.WriteByte(enc((g[1]<<2 | g[2]>>6) & 0x3f))
-				_ = bw.WriteByte(enc(g[2] & 0x3f))
+			// Stop as soon as the output stream fails (e.g. a closed downstream
+			// pipe) instead of draining the rest of the input.
+			if werr := writeUULine(bw, buf[:n]); werr != nil {
+				return werr
 			}
-			_ = bw.WriteByte('\n')
 		}
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			break
@@ -126,8 +120,26 @@ func writeUU(w io.Writer, name string, r io.Reader) error {
 		}
 	}
 	_ = bw.WriteByte(enc(0))
-	_, _ = bw.WriteString("\nend\n")
+	if _, err := bw.WriteString("\nend\n"); err != nil {
+		return err
+	}
 	return bw.Flush()
+}
+
+// writeUULine encodes one uuencode body line (a length character followed by the
+// 4-character groups) and returns the first write error. bufio.Writer is sticky,
+// so the final WriteByte reflects any earlier failure.
+func writeUULine(bw *bufio.Writer, line []byte) error {
+	_ = bw.WriteByte(enc(byte(len(line))))
+	for i := 0; i < len(line); i += 3 {
+		var g [3]byte
+		copy(g[:], line[i:])
+		_ = bw.WriteByte(enc(g[0] >> 2))
+		_ = bw.WriteByte(enc((g[0]<<4 | g[1]>>4) & 0x3f))
+		_ = bw.WriteByte(enc((g[1]<<2 | g[2]>>6) & 0x3f))
+		_ = bw.WriteByte(enc(g[2] & 0x3f))
+	}
+	return bw.WriteByte('\n')
 }
 
 func writeBase64(w io.Writer, name string, r io.Reader) error {

--- a/internal/applets/util-linux/hexdump/hexdump.go
+++ b/internal/applets/util-linux/hexdump/hexdump.go
@@ -82,7 +82,9 @@ func (c *Command) Run(_ context.Context, stdio command.IO, args []string) error 
 		_, _ = fmt.Fprintf(stdio.Err, "%s: %v\n", c.Name(), err)
 		return command.SilentFailure()
 	}
-	d.finish()
+	if err := d.finish(); err != nil {
+		return command.Failure(err)
+	}
 	if err := bw.Flush(); err != nil {
 		return command.Failure(err)
 	}
@@ -124,15 +126,21 @@ type rowDumper struct {
 	canonical bool
 	buf       [16]byte
 	n         int
-	off       int // offset (relative to base) of the first byte in buf
+	off       int64 // offset (relative to base) of the first byte in buf
+	err       error
 }
 
 func (d *rowDumper) Write(p []byte) (int, error) {
-	for _, b := range p {
+	if d.err != nil {
+		return 0, d.err
+	}
+	for i, b := range p {
 		d.buf[d.n] = b
 		d.n++
 		if d.n == 16 {
-			d.flushRow()
+			if err := d.flushRow(); err != nil {
+				return i + 1, err
+			}
 			d.off += 16
 			d.n = 0
 		}
@@ -140,29 +148,35 @@ func (d *rowDumper) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (d *rowDumper) flushRow() {
+func (d *rowDumper) flushRow() error {
 	if d.canonical {
-		writeCanonicalRow(d.w, d.base+int64(d.off), d.buf[:d.n])
+		d.err = writeCanonicalRow(d.w, d.base+d.off, d.buf[:d.n])
 	} else {
-		writeTwoByteRow(d.w, d.base+int64(d.off), d.buf[:d.n])
+		d.err = writeTwoByteRow(d.w, d.base+d.off, d.buf[:d.n])
 	}
+	return d.err
 }
 
-func (d *rowDumper) finish() {
-	end := d.off + d.n
+func (d *rowDumper) finish() error {
+	end := d.off + int64(d.n)
 	if d.n > 0 {
-		d.flushRow()
+		if err := d.flushRow(); err != nil {
+			return err
+		}
 	}
+	var err error
 	if d.canonical {
-		_, _ = fmt.Fprintf(d.w, "%08x\n", d.base+int64(end))
+		_, err = fmt.Fprintf(d.w, "%08x\n", d.base+end)
 	} else {
-		_, _ = fmt.Fprintf(d.w, "%07x\n", d.base+int64(end))
+		_, err = fmt.Fprintf(d.w, "%07x\n", d.base+end)
 	}
+	return err
 }
 
 // writeCanonicalRow writes one "hexdump -C" / hd row for the bytes in row, whose
-// first byte is at absolute offset addr.
-func writeCanonicalRow(b *bufio.Writer, addr int64, row []byte) {
+// first byte is at absolute offset addr. It returns the first write error so a
+// broken output stream stops the dump instead of draining the rest of the input.
+func writeCanonicalRow(b *bufio.Writer, addr int64, row []byte) error {
 	_, _ = fmt.Fprintf(b, "%08x  ", addr)
 	for i := 0; i < 16; i++ {
 		if i == 8 {
@@ -182,12 +196,15 @@ func writeCanonicalRow(b *bufio.Writer, addr int64, row []byte) {
 			_ = b.WriteByte('.')
 		}
 	}
-	_, _ = b.WriteString("|\n")
+	// bufio.Writer is sticky: this final write returns any earlier error too.
+	_, err := b.WriteString("|\n")
+	return err
 }
 
 // writeTwoByteRow writes one default-layout row (two-byte little-endian words)
-// for the bytes in row, whose first byte is at absolute offset addr.
-func writeTwoByteRow(b *bufio.Writer, addr int64, row []byte) {
+// for the bytes in row, whose first byte is at absolute offset addr. It returns
+// the first write error (see writeCanonicalRow).
+func writeTwoByteRow(b *bufio.Writer, addr int64, row []byte) error {
 	_, _ = fmt.Fprintf(b, "%07x", addr)
 	for i := 0; i < 16; i += 2 {
 		switch {
@@ -199,7 +216,7 @@ func writeTwoByteRow(b *bufio.Writer, addr int64, row []byte) {
 			_, _ = b.WriteString("     ") // pad missing words to keep 8 columns
 		}
 	}
-	_ = b.WriteByte('\n')
+	return b.WriteByte('\n')
 }
 
 func (c *Command) help() command.Help {

--- a/internal/applets/util-linux/hexdump/hexdump_test.go
+++ b/internal/applets/util-linux/hexdump/hexdump_test.go
@@ -28,12 +28,30 @@ type dripReader struct {
 }
 
 func (d *dripReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	if d.pos >= len(d.data) {
 		return 0, io.EOF
 	}
 	p[0] = d.data[d.pos]
 	d.pos++
 	return 1, nil
+}
+
+// failWriter fails every write, modeling a closed downstream pipe.
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestWriteErrorIsReported(t *testing.T) {
+	t.Parallel()
+	// A failing output stream must surface an error rather than silently
+	// draining the input and exiting 0.
+	io1 := command.IO{In: bytes.NewReader(bytes.Repeat([]byte("x"), 200000)), Out: failWriter{}, Err: &bytes.Buffer{}}
+	if err := NewHexdump().Run(context.Background(), io1, nil); err == nil {
+		t.Error("hexdump must report a write error to stdout")
+	}
 }
 
 func TestStreamingMatchesSingleRead(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to the streaming work in #960 / #961, addressing CodeRabbit review feedback on PR #963. The streaming row dumpers (`od`, `hexdump`) and the `uuencode` line encoder ignored every `bufio.Writer` write error, so `io.Copy` kept draining the whole input after the output stream had failed (for example a closed downstream pipe) before the error finally surfaced at `Flush`. On a long-lived pipe that wastes work and delays exit, which undermines the streaming goal.

## Changes

- `od` and `hexdump` `rowDumper.Write` now return the first write error so `io.Copy` stops immediately; `flushRow`/`finish` propagate it and `Run` reports it (a stdout failure is no longer misattributed to a file read error).
- `uuencode` `writeUU` stops on the first write error via a new `writeUULine` helper.
- `hexdump` row offsets use `int64` to avoid overflow on very large inputs.
- Test `dripReader`s handle a zero-length buffer; new `failWriter` tests confirm a write failure is reported instead of silently draining the input.

## Notes

`base32`/`base64`/`uuencode -m` already propagate write errors because they stream through `io.Copy` into encoders whose `Write` returns errors. `od`'s `line`/`address` helpers take `int`, and MimixBox ships 64-bit only (amd64/arm64), so `od` offsets are left as `int`; only `hexdump`, whose row writers already take `int64`, was switched. Verified output still matches GNU `od`/`hexdump -C` and uuencode round-trips.