### PR TITLE
feat(rpmfile): add xz and zstd payload support

### DIFF
--- a/internal/applets/archival/rpmfile/rpmfile.go
+++ b/internal/applets/archival/rpmfile/rpmfile.go
@@ -10,6 +10,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
 )
 
 // Common RPM header tags (from the main header).
@@ -91,9 +94,9 @@ func Open(r io.Reader) (*File, error) {
 }
 
 // Payload returns a reader over the decompressed cpio payload, detecting the
-// compression from its magic bytes. gzip and bzip2 payloads are supported with
-// the standard library; xz and zstd payloads are recognized but reported as
-// unsupported rather than pulling in extra dependencies.
+// compression from its magic bytes. gzip and bzip2 payloads are decompressed
+// with the standard library, while xz and zstd payloads use github.com/ulikunitz/xz
+// and github.com/klauspost/compress/zstd respectively.
 func (f *File) Payload() (io.Reader, error) {
 	br := bufio.NewReader(f.payload)
 	magic, err := br.Peek(6)
@@ -107,9 +110,17 @@ func (f *File) Payload() (io.Reader, error) {
 		return bzip2.NewReader(br), nil
 	case len(magic) >= 6 && magic[0] == 0xfd && magic[1] == '7' && magic[2] == 'z' &&
 		magic[3] == 'X' && magic[4] == 'Z' && magic[5] == 0x00:
-		return nil, fmt.Errorf("xz payload is not supported yet")
+		xr, err := xz.NewReader(br)
+		if err != nil {
+			return nil, fmt.Errorf("xz payload: %w", err)
+		}
+		return xr, nil
 	case len(magic) >= 4 && magic[0] == 0x28 && magic[1] == 0xb5 && magic[2] == 0x2f && magic[3] == 0xfd:
-		return nil, fmt.Errorf("zstd payload is not supported yet")
+		zr, err := zstd.NewReader(br)
+		if err != nil {
+			return nil, fmt.Errorf("zstd payload: %w", err)
+		}
+		return zr.IOReadCloser(), nil
 	default:
 		return nil, fmt.Errorf("unsupported or missing payload compression")
 	}

--- a/internal/applets/archival/rpmfile/rpmfile_test.go
+++ b/internal/applets/archival/rpmfile/rpmfile_test.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/nao1215/mimixbox/internal/applets/archival/rpmfile"
+	"github.com/ulikunitz/xz"
 )
 
 // tagval is one header entry for the fixture builder.
@@ -85,6 +87,38 @@ func gz(data string) []byte {
 	return b.Bytes()
 }
 
+func xzc(t *testing.T, data string) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	w, err := xz.NewWriter(&b)
+	if err != nil {
+		t.Fatalf("xz.NewWriter error = %v", err)
+	}
+	if _, err := w.Write([]byte(data)); err != nil {
+		t.Fatalf("xz write error = %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("xz close error = %v", err)
+	}
+	return b.Bytes()
+}
+
+func zstdc(t *testing.T, data string) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	w, err := zstd.NewWriter(&b)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter error = %v", err)
+	}
+	if _, err := w.Write([]byte(data)); err != nil {
+		t.Fatalf("zstd write error = %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("zstd close error = %v", err)
+	}
+	return b.Bytes()
+}
+
 func TestParseAndPayloadGzip(t *testing.T) {
 	t.Parallel()
 	rpmBytes := buildRPM(
@@ -108,29 +142,41 @@ func TestParseAndPayloadGzip(t *testing.T) {
 	}
 }
 
-func TestPayloadXzUnsupported(t *testing.T) {
+func TestPayloadXz(t *testing.T) {
 	t.Parallel()
-	// xz magic: FD 37 7A 58 5A 00
-	xzMagic := []byte{0xfd, '7', 'z', 'X', 'Z', 0x00, 0x00, 0x00}
-	f, err := rpmfile.Open(bytes.NewReader(buildRPM(nil, xzMagic)))
+	f, err := rpmfile.Open(bytes.NewReader(buildRPM(nil, xzc(t, "CPIO-XZ-PAYLOAD"))))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f.Payload(); err == nil {
-		t.Error("expected xz payload to be reported as unsupported")
+	p, err := f.Payload()
+	if err != nil {
+		t.Fatalf("Payload error = %v", err)
+	}
+	data, err := io.ReadAll(p)
+	if err != nil {
+		t.Fatalf("read error = %v", err)
+	}
+	if string(data) != "CPIO-XZ-PAYLOAD" {
+		t.Errorf("payload = %q, want CPIO-XZ-PAYLOAD", data)
 	}
 }
 
-func TestPayloadZstdUnsupported(t *testing.T) {
+func TestPayloadZstd(t *testing.T) {
 	t.Parallel()
-	// zstd magic: 28 B5 2F FD
-	zMagic := []byte{0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x00}
-	f, err := rpmfile.Open(bytes.NewReader(buildRPM(nil, zMagic)))
+	f, err := rpmfile.Open(bytes.NewReader(buildRPM(nil, zstdc(t, "CPIO-ZSTD-PAYLOAD"))))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f.Payload(); err == nil {
-		t.Error("expected zstd payload to be reported as unsupported")
+	p, err := f.Payload()
+	if err != nil {
+		t.Fatalf("Payload error = %v", err)
+	}
+	data, err := io.ReadAll(p)
+	if err != nil {
+		t.Fatalf("read error = %v", err)
+	}
+	if string(data) != "CPIO-ZSTD-PAYLOAD" {
+		t.Errorf("payload = %q, want CPIO-ZSTD-PAYLOAD", data)
 	}
 }
 


### PR DESCRIPTION
## Summary

`rpmfile.File.Payload` recognized xz and zstd compression magic bytes but returned "xz payload is not supported yet" / "zstd payload is not supported yet". This adds real decompression for both formats.

## Changes

- Implement xz payload decompression using `github.com/ulikunitz/xz` (already a direct dependency, used by xzcomp/debpkg/sqluv).
- Implement zstd payload decompression using `github.com/klauspost/compress/zstd` (already a direct dependency, used by sqluv).
- No new dependencies added; `go.mod`/`go.sum` unchanged.

## Tests

- TDD: replaced the placeholder `TestPayloadXzUnsupported`/`TestPayloadZstdUnsupported` tests with round-trip tests (`TestPayloadXz`, `TestPayloadZstd`) that compress a known payload in-test and assert `Payload()` returns the original bytes.
- Existing `TestParseAndPayloadGzip`, `TestPayloadBzip2` cover gzip/bzip2; `TestUnsupportedPayload` covers the error path for an unrecognized compression magic.

## Verification

- `go test ./internal/applets/archival/... -race` — pass
- `go build ./...`, `go vet ./...` — clean
- `gofmt -l` on changed files — clean

Closes #968
