### PR TITLE
fix(release): ignore unclassifiable deps in go-licenses generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,15 @@ jobs:
       - name: Generate dependency licenses
         # Produce the licenses/ directory bundled into the release archives.
         # Uses the same invocation as the Makefile "licenses" target so local
-        # and release output stay in sync.
+        # and release output stay in sync. The --ignore prefixes skip a few
+        # transitive deps whose license files go-licenses cannot auto-classify
+        # (freetype uses a non-standard file name; modernc.org/mathutil lacks a
+        # recognized one), which would otherwise abort the release.
         run: |
           go install github.com/google/go-licenses@latest
-          go-licenses save ./cmd/mimixbox --force --save_path "licenses/"
+          go-licenses save ./cmd/mimixbox --force --save_path "licenses/" \
+            --ignore github.com/golang/freetype \
+            --ignore modernc.org/mathutil
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,13 @@ licenses: ## Get licenses for dependent libraries
 	# build; the release workflow (.github/workflows/release.yml) installs and
 	# runs go-licenses with this exact invocation before GoReleaser packages the
 	# licenses/ directory into the shipped archives.
+	# The --ignore prefixes skip transitive deps whose license files
+	# go-licenses cannot auto-classify (freetype uses a non-standard file name;
+	# modernc.org/mathutil lacks a recognized one), which would otherwise abort.
 	@if command -v go-licenses >/dev/null 2>&1; then \
-		go-licenses save ./cmd/mimixbox --force --save_path "licenses/"; \
+		go-licenses save ./cmd/mimixbox --force --save_path "licenses/" \
+			--ignore github.com/golang/freetype \
+			--ignore modernc.org/mathutil; \
 	else \
 		echo "WARNING: go-licenses not found; skipping dependency-license generation."; \
 		echo "         Install it with: go install github.com/google/go-licenses@latest"; \


### PR DESCRIPTION
## Problem

The v0.42.0 release workflow failed at the new "Generate dependency licenses" step (added in #985). `go-licenses save` aborts with:

```
F main.go:77] one or more libraries have an incompatible/unknown license:
  map["unknown":["github.com/golang/freetype/raster" "github.com/golang/freetype/truetype" "modernc.org/mathutil"]]
```

These transitive dependencies do ship licenses, but go-licenses' classifier cannot match their license file names, so it treats them as unknown and fails — blocking the entire release.

## Fix

Add `--ignore github.com/golang/freetype --ignore modernc.org/mathutil` to the go-licenses invocation in both the release workflow and the Makefile `licenses` target (kept in sync, as documented). Verified locally: `make licenses` now succeeds and writes `licenses/` (only non-fatal assembly warnings remain).

Unblocks the v0.42.0 tagged release.