### PR TITLE
build(coverage): combine unit and self-hosted E2E coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,21 +9,31 @@ on:
 
 jobs:
   coverage:
-    name: Unit test (linux)
+    name: Coverage (unit + e2e)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - name: Prepare test fixtures
-        run: make pre_ut
+      # The E2E half of `make coverage` runs the atago suite against a
+      # coverage-instrumented mimixbox. atago is the runner; install it with the
+      # same pinned action ref the integration_test workflow uses.
+      - name: Install atago
+        uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
+        with:
+          version: v0.2.0
 
-      - name: Run tests with coverage report output
-        run: go test -cover -coverpkg=./... -coverprofile=cover.out ./...
+      # Combines unit-test coverage with self-hosted E2E coverage (the E2E suite
+      # runs a `go build -cover` mimixbox and collects covdata via GOCOVERDIR),
+      # then merges both into cover.out.
+      - name: Run combined unit + E2E coverage
+        run: make coverage
 
       - uses: k1LoW/octocov-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ dist/
 cover.out
 cover.html
 
+# `make coverage` scratch: raw covdata (unit + e2e), the instrumented binary,
+# and the merged dir. The final cover.out / cover.html are the only kept
+# artifacts.
+.coverage/
+
 # Man-pages
 *.1.gz
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ clean: ## Clean project
 	-rm -rf dist
 	-rm -rf licenses
 	-rm -rf $(E2E_BIN_DIR)
+	-rm -rf .coverage
 
 docker: ## Run container for testing mimixbox
 	docker image build -t mimixbox/test:latest .
@@ -58,6 +59,14 @@ test: pre_ut  ## Run unit tests with coverage (writes cover.out / cover.html)
 # (ShellSpec was sequential too).
 e2e: ## Run the atago end-to-end tests against MimixBox applets in an isolated PATH
 	./e2e/run.sh --parallel 1
+
+# Combine unit-test coverage with self-hosted E2E coverage into one cover.out.
+# Builds a `go build -cover` mimixbox, runs the atago E2E suite so every applet
+# invocation contributes covdata, then merges it with unit covdata. Scratch
+# under .coverage/ (gitignored); only cover.out / cover.html are kept. Override
+# scenario concurrency with PARALLEL (defaults to 1, matching `make e2e`).
+coverage: ## Combine unit + self-hosted E2E coverage into cover.out / cover.html
+	env PARALLEL=$(PARALLEL) sh ./scripts/coverage.sh
 
 lint: ## Run golangci-lint
 	golangci-lint run ./...
@@ -104,7 +113,7 @@ ut: test  ## Alias for "make test"
 it: e2e  ## Alias for "make e2e"
 
 .DEFAULT_GOAL := help
-.PHONY: build clean docker install full-install remove test e2e lint generate command-list jail release licenses pre_ut ut it help
+.PHONY: build clean docker install full-install remove test e2e coverage lint generate command-list jail release licenses pre_ut ut it help
 
 help:
 	@grep -E '^[0-9a-zA-Z_-]+[[:blank:]]*:.*?## .*$$' $(MAKEFILE_LIST) | sort \

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -31,8 +31,17 @@ cleanup() { rm -rf "$TMP"; }
 trap cleanup EXIT
 mkdir -p "$TMP/applets"
 
-echo "e2e: building the mimixbox binary..."
-(cd "$REPO_ROOT" && go build -trimpath -o "$TMP/applets/mimixbox" ./cmd/mimixbox)
+# COVER=1 (used by scripts/coverage.sh) builds a coverage-instrumented binary
+# so every applet invocation writes covdata to GOCOVERDIR. The default path is
+# byte-for-byte the plain build, keeping `make e2e` fast and unchanged.
+if [ -n "${COVER:-}" ]; then
+	: "${GOCOVERDIR:?COVER=1 requires GOCOVERDIR to be set}"
+	echo "e2e: building the coverage-instrumented mimixbox binary..."
+	(cd "$REPO_ROOT" && go build -cover -covermode=atomic -coverpkg=./... -trimpath -o "$TMP/applets/mimixbox" ./cmd/mimixbox)
+else
+	echo "e2e: building the mimixbox binary..."
+	(cd "$REPO_ROOT" && go build -trimpath -o "$TMP/applets/mimixbox" ./cmd/mimixbox)
+fi
 
 echo "e2e: installing applets via --full-install..."
 "$TMP/applets/mimixbox" --full-install "$TMP/applets" >/dev/null

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Combine unit-test coverage with self-hosted E2E coverage into a single
+# cover.out. Unit tests report line coverage, but they never exercise the real
+# multi-call mimixbox binary the way an end user does; the atago E2E specs do
+# (every applet on PATH is a symlink to the one instrumented binary). Go 1.20+
+# lets us instrument a built binary (`go build -cover`) and collect its runtime
+# coverage via GOCOVERDIR, so we can merge "what the unit tests cover" with
+# "what real applet invocations cover" and get one honest number.
+#
+# This is intentionally a separate, heavier target: `make test` / `make e2e`
+# stay fast and unchanged. Everything lands under .coverage/ (gitignored) except
+# the final cover.out / cover.html, which are the same artifacts `make test`
+# already produces so octocov and local tooling need no changes.
+#
+# Override scenario concurrency with PARALLEL (defaults to 1, matching `make
+# e2e`: the kill-family applets signal by name and race under concurrency).
+set -eu
+
+cd "$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+root="$(pwd)"
+cov="${root}/.coverage"
+parallel="${PARALLEL:-1}"
+
+rm -rf "${cov}"
+mkdir -p "${cov}/unit" "${cov}/e2e" "${cov}/merged"
+
+# Unit tests read fixtures under /tmp/mimixbox/ut prepared by this script
+# (the same step `make pre_ut` runs before `make test`).
+echo ">> preparing unit-test fixtures"
+"${root}/test/ut/prepareUnitTest.sh"
+
+# 1. Unit-test coverage as raw covdata (GOCOVERDIR form) so it can be merged
+#    with the E2E covdata below. -covermode=atomic must match the binary build.
+echo ">> unit coverage -> ${cov}/unit"
+go test -count=1 -cover -covermode=atomic -coverpkg=./... ./... \
+	-args -test.gocoverdir="${cov}/unit"
+
+# 2 + 3. Self-hosted E2E via a coverage-instrumented mimixbox binary. run.sh
+#    with COVER set builds `go build -cover` instead of a plain build and
+#    installs its applets as symlinks to that one binary; GOCOVERDIR is
+#    inherited by every applet child atago spawns, so each writes its own
+#    covdata. No spec uses clear_env, so every invocation contributes.
+echo ">> e2e coverage -> ${cov}/e2e"
+COVER=1 GOCOVERDIR="${cov}/e2e" "${root}/e2e/run.sh" --parallel "${parallel}"
+
+# 4. Merge the raw covdata and render the combined text profile + reports.
+echo ">> merging unit + e2e covdata -> cover.out"
+go tool covdata merge -i="${cov}/unit,${cov}/e2e" -o="${cov}/merged"
+go tool covdata textfmt -i="${cov}/merged" -o="${root}/cover.out"
+
+go tool cover -func=cover.out | tail -n 1
+go tool cover -html=cover.out -o cover.html
+echo ">> wrote cover.out and cover.html (unit + e2e combined)"


### PR DESCRIPTION
## What

Make the coverage number combine **unit-test coverage** with **self-hosted E2E coverage**. The atago E2E suite runs the real multi-call `mimixbox` binary via applet symlinks on an isolated PATH, exercising code paths unit tests never reach. This merges both into one honest `cover.out`.

## How

- **`scripts/coverage.sh` + `make coverage`**: runs unit tests as raw covdata (`-test.gocoverdir`), builds a `go build -cover -coverpkg=./...` mimixbox, runs the atago E2E suite so every applet invocation (each a symlink to that one instrumented binary) writes covdata to `GOCOVERDIR`, then `go tool covdata merge`/`textfmt` into `cover.out` + `cover.html`.
- **`e2e/run.sh` COVER switch**: when `COVER` is set it builds the coverage-instrumented binary and requires `GOCOVERDIR`; the default path is byte-for-byte unchanged, so `make e2e` stays fast and hermetic.
- **`.github/workflows/coverage.yml`**: installs atago via the same pinned `nao1215/setup-atago` ref the integration_test workflow uses, runs `make coverage`, and feeds the combined `cover.out` to octocov exactly as before.
- **`.gitignore` / `make clean`**: ignore and clean the `.coverage/` scratch dir. Only `cover.out` / `cover.html` are kept (same artifacts as `make test`).

No change to the mimixbox binary/CLI. `make test` and `make e2e` are unchanged and fast.

## Result

- Local: unit-only **87.6%** -> combined **88.0%** (E2E adds coverage).
- Verified: `make test` green, `make e2e` green (1520 passed / 2 skipped / 0 failed), `make coverage` green with **zero** `GOCOVERDIR not set` warnings, `cover.out` + `cover.html` written.
- No spec uses `clear_env`, so every applet invocation contributes coverage.

The README already carries the octocov coverage badge near the top; the combined coverage now flows through the same octocov job, so the badge % reflects unit+E2E. No badge change.