### PR TITLE
docs(readme): update repository badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![UnitTest](https://github.com/nao1215/mimixbox/actions/workflows/unit_test.yml/badge.svg?branch=main&event=push)](https://github.com/nao1215/mimixbox/actions/workflows/unit_test.yml)
 [![IntegrationTest](https://github.com/nao1215/mimixbox/actions/workflows/integration_test.yml/badge.svg?event=push)](https://github.com/nao1215/mimixbox/actions/workflows/integration_test.yml)
 ![GitHub](https://img.shields.io/github/license/nao1215/mimixbox)
-![GitHub all releases](https://img.shields.io/github/downloads/nao1215/mimixbox/total)
+[![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/nao1215/mimixbox/total)](https://github.com/nao1215/mimixbox/releases)
 
 ![mimixbox-logo](./doc/image/mimixbox-logo-truss.jpg)
 


### PR DESCRIPTION
## Summary
Refresh the README badge section to show total GitHub downloads and remove the deprecated Go Report Card badge where it still appears.

## Changes
- add the GitHub downloads badge to the main README badge row
- remove the Go Report Card badge from repositories that still reference it
- keep existing badge ordering while normalizing the downloads badge link to the releases page

## Design Decisions
- use the same Shields.io GitHub downloads badge format across repositories
- keep the change documentation-only with no behavioral impact
