### PR TITLE
ci: bump atago to v0.13.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.2.0
+          version: v0.13.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the E2E suite
       # runs a `go build -cover` mimixbox and collects covdata via GOCOVERDIR),

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.2.0
+          version: v0.13.0
 
       # `make it` (e2e) builds MimixBox and stages its applets in an isolated
       # PATH directory itself, so the workflow and the local target exercise


### PR DESCRIPTION
## Summary

Moves the atago E2E jobs to v0.13.0, the current release.

## Changes

- Bump the `nao1215/setup-atago` version input to `v0.13.0` in the workflows that run atago.

## Design Decisions

v0.13.0 changes two contracts that can turn a previously green spec red, so this is worth noting rather than treating as a routine bump. A command killed by its timeout now fails the step unless an assert reads its result, and the spec loader rejects explicit YAML tags. The specs in this repository author no YAML tags, and any step that sets a timeout is followed by an assert on the result, so neither change applies here. CI is the check that confirms it.