### PR TITLE
chore(ci): bump atago to v0.15.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the E2E suite
       # runs a `go build -cover` mimixbox and collects covdata via GOCOVERDIR),

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       # `make it` (e2e) builds MimixBox and stages its applets in an isolated
       # PATH directory itself, so the workflow and the local target exercise


### PR DESCRIPTION
Move the pinned atago used by this repo's workflows from v0.13.0 to v0.15.0.

Two changes in that range can turn a passing spec red:

- `changes:` now tracks symlinks, so a step that plants or retargets a link is a
  creation or a modification instead of being invisible.
- `file: exists` / `file: executable` no longer accept a directory.

Neither affects the specs in this repo (checked: no `changes:` assertion here
covers a symlink-creating step, and no `file:` assertion targets a directory).
Everything else in v0.14.0 and v0.15.0 is additive or improves failure messages.