### PR TITLE
chore(ci): bump atago to v0.17.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the E2E suite
       # runs a `go build -cover` mimixbox and collects covdata via GOCOVERDIR),

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # `make it` (e2e) builds MimixBox and stages its applets in an isolated
       # PATH directory itself, so the workflow and the local target exercise

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.25-bookworm AS builder
 ENV ROOT=/go/app
 ENV IT_SHELL=/home/mimixbox/do_integration_test.sh
 # Pin atago to a tagged release for reproducible integration tests.
-ENV ATAGO_VERSION=v0.2.0
+ENV ATAGO_VERSION=v0.17.0
 WORKDIR ${ROOT}
 
 # 1) Setting root user password


### PR DESCRIPTION
Pins the E2E suites to [atago v0.17.0](https://github.com/nao1215/atago/releases/tag/v0.17.0).

That release adds a Scoop bucket for Windows installs and carries two failure-message fixes: an assertion whose observed value was empty now renders `(empty)` instead of omitting the `Actual:` section, and a run step whose output capture was cut short now names the exit code the process reached instead of reporting `failed to execute`.

No spec changes are needed — neither fix alters an assertion's verdict, only how a failure reads.

The Dockerfile moves too, and it moves further: `ATAGO_VERSION` was still pinned at `v0.2.0` while the workflows had been tracking each release, so the in-image integration tests were running an atago fifteen releases behind the one CI used. The Docker job builds this image on every pull request and runs the integration script inside it, so this jump is verified here rather than assumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Atago version used in automated coverage and integration testing.
  * Updated the Atago version included in the integration test container.
  * Ensures testing environments use the newer Atago release consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->