### PR TITLE
chore(ci): bump atago to v0.20.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.20.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the E2E suite
       # runs a `go build -cover` mimixbox and collects covdata via GOCOVERDIR),

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.20.0
 
       # `make it` (e2e) builds MimixBox and stages its applets in an isolated
       # PATH directory itself, so the workflow and the local target exercise

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/mimixbox/coverage.svg)
+[![tested with atago](https://img.shields.io/badge/tested%20with-atago-7c3aed?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI%2BPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTMuNiA0LjIgMTEuOSAxMmwtOC4zIDcuOC0xLjktMi4yTDcuOSAxMiAxLjcgNi40eiIvPjxyZWN0IGZpbGw9IiNmZmYiIHg9IjEyLjYiIHk9IjE3LjIiIHdpZHRoPSI5LjciIGhlaWdodD0iMi44IiByeD0iMS40Ii8%2BPC9zdmc%2B&logoColor=white)](https://github.com/nao1215/atago)
 [![Build](https://github.com/nao1215/mimixbox/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/nao1215/mimixbox/actions/workflows/build.yml)
 [![UnitTest](https://github.com/nao1215/mimixbox/actions/workflows/unit_test.yml/badge.svg?branch=main&event=push)](https://github.com/nao1215/mimixbox/actions/workflows/unit_test.yml)
 [![IntegrationTest](https://github.com/nao1215/mimixbox/actions/workflows/integration_test.yml/badge.svg?event=push)](https://github.com/nao1215/mimixbox/actions/workflows/integration_test.yml)


### PR DESCRIPTION
Move the pinned atago used by this repo's workflows from v0.16.0 to v0.20.0.

Four releases, and two of them change a run's verdict rather than only its output:

- v0.18.0: a flaky scenario — one that failed and then passed on a re-run, or that failed some `--repeat` iterations — now fails the run instead of exiting 0. This suite passes neither flag, so nothing here changes; it is the entry to know about if one is ever added.
- v0.19.0: `--fail-fast` stops for every outcome that fails the run, and a flag written after the spec paths is read as a flag rather than as a spec path.
- v0.20.0: `file:`'s `exists:` and `executable:` stat their target without following a symlink, matching what `contains:` and `size:` already did.

All 1,522 scenarios pass locally on v0.20.0 with no spec changes (1,520 passed, 2 skipped, the same two as before).

Also adds a tested-with-atago badge next to the coverage badge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Atago testing badge to the README.

* **Chores**
  * Updated automated coverage and integration testing to use Atago v0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
